### PR TITLE
Modernize GitHub Actions workflows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,4 +10,5 @@
 ^altdoc$
 ^_quarto$
 ^sandbox$
+^investigation$
 ^cran-comments\.md$

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,11 +7,17 @@ on:
 
 name: R-CMD-check.yaml
 
-permissions: read-all
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 60
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
@@ -30,7 +36,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -38,7 +44,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -2,47 +2,40 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
-  release:
-    types: [published]
+    branches: [main]
   workflow_dispatch:
 
 name: altdoc
 
-concurrency:
-  group: altdoc-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+permissions:
+  contents: read
+  pages: read
 
 jobs:
   altdoc:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: altdoc-build-${{ github.ref }}
+      cancel-in-progress: true
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
 
       - uses: quarto-dev/quarto-actions/setup@v2
 
-      - name: Get Script
-        run: curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
-
-      - name: Bootstrap
-        run: ./run.sh bootstrap
-
-      - name: Dependencies
-        run: ./run.sh install_all
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: local::.
+          needs: website
 
       - name: Build site
         run: |
-          # If parallel = TRUE in render_docs()
-          # future::plan(future::multicore)
-          install.packages(".", repos = NULL, type = "source")
-          install.packages("pkgload")
-          pkgload::load_all()
           altdoc::render_docs(parallel = FALSE, freeze = FALSE)
         shell: Rscript {0}
 
@@ -50,10 +43,33 @@ jobs:
         run: |
           Rscript -e 'required <- c("docs/index.html", "docs/vignettes/get_started.html", "docs/man/grouping.html", "docs/man/grouping_set.html", "docs/.nojekyll"); missing <- required[!file.exists(required)]; if (length(missing)) stop("Missing site output: ", paste(missing, collapse = ", ")); article <- paste(readLines("docs/vignettes/get_started.html", warn = FALSE), collapse = "\n"); markers <- c("panel-tabset", "Quarto tabset reports with quartabs", "Total"); absent <- markers[!vapply(markers, grepl, logical(1), x = article, fixed = TRUE)]; if (length(absent)) stop("Missing rendered markers: ", paste(absent, collapse = ", "))'
 
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Configure GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v5
         with:
-          clean: true
-          branch: gh-pages
-          folder: docs
+          path: docs
+          include-hidden-files: true
+
+  deploy:
+    name: Deploy GitHub Pages
+    if: github.ref == 'refs/heads/main'
+    needs: altdoc
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,19 +7,23 @@ on:
 
 name: lint.yaml
 
-permissions: read-all
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -7,20 +7,24 @@ on:
 
 name: test-coverage.yaml
 
-permissions: read-all
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -38,7 +42,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
@@ -56,7 +60,8 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package
+          retention-days: 7

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,11 @@ Suggests:
     tibble,
     tidyr,
 Config/testthat/edition: 3
+Config/Needs/website:
+    altdoc,
+    knitr,
+    quartabs,
+    tibble
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/investigation/github-actions-modernization.md
+++ b/investigation/github-actions-modernization.md
@@ -1,0 +1,84 @@
+# GitHub Actions modernization
+
+Research date: 2026-07-18
+
+## Findings
+
+The R-specific actions are already on the supported major version. The
+[`r-lib/actions` project](https://github.com/r-lib/actions) continues to
+recommend `@v2`, and its current release notes state that its JavaScript
+actions use Node.js 24. The explicit `use-public-rspm: true` inputs can be
+removed because this is now the default on supported Linux and Windows
+runners.
+
+The general-purpose actions were behind their current releases:
+
+| Area | Previous | Selected |
+|---|---|---|
+| Checkout | `actions/checkout@v4` | `actions/checkout@v7` |
+| Codecov upload | `codecov/codecov-action@v5` | v7, pinned to the SHA used by the current r-lib template |
+| Failure artifact | `actions/upload-artifact@v4` | `actions/upload-artifact@v7` |
+| Quarto setup | `quarto-dev/quarto-actions/setup@v2` | unchanged |
+| R setup/check | `r-lib/actions/*@v2` | unchanged |
+
+`checkout` v7 is the current release and includes safer handling of fork
+checkouts for privileged event types. The workflows here use ordinary
+`pull_request`, so the change is compatible. See the
+[`checkout` v7 release](https://github.com/actions/checkout/releases/tag/v7.0.0).
+
+The current r-lib coverage example uses Codecov v7 at the immutable commit
+`fb8b3582c8e4def4969c97caa2f19720cb33a72f`; its existing `files`,
+`plugins: noop`, `disable_search`, token, and failure behavior remain valid.
+See the [current r-lib coverage
+template](https://raw.githubusercontent.com/r-lib/actions/v2/examples/test-coverage.yaml)
+and [Codecov v7 release](https://github.com/codecov/codecov-action/releases/tag/v7.0.0).
+The failure artifact update follows the current
+[`upload-artifact` release](https://github.com/actions/upload-artifact/releases/tag/v7.0.1).
+
+The lintr command itself is current: `lintr::lint_package()` with
+`LINTR_ERROR_ON_LINT=true` matches the
+[lintr CI guide](https://lintr.r-lib.org/articles/continuous-integration.html).
+
+## altdoc and GitHub Pages
+
+The previous altdoc workflow downloaded and executed a remote `run.sh`, then
+used a third-party action to push generated files to `gh-pages`. The current
+[GitHub Pages custom-workflow
+guidance](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+uses a Pages artifact and a dedicated deployment job instead.
+
+The replacement therefore:
+
+- installs R and website dependencies with `r-lib/actions`;
+- builds and verifies the altdoc site on pull requests without deploying it;
+- uses `actions/configure-pages@v6` and
+  `actions/upload-pages-artifact@v5` on `main`;
+- preserves `docs/.nojekyll` with `include-hidden-files: true`;
+- deploys with `actions/deploy-pages@v5`, `pages: write`, `id-token: write`,
+  and the `github-pages` environment;
+- serializes production deployments with `group: pages` and does not cancel
+  one already in progress.
+
+These majors are the current Node.js 24 releases: [configure-pages
+v6](https://github.com/actions/configure-pages/releases/tag/v6.0.0),
+[upload-pages-artifact
+v5](https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0),
+and [deploy-pages
+v5](https://github.com/actions/deploy-pages/releases/tag/v5.0.0).
+
+The repository initially used the legacy `gh-pages` publishing source. Before
+the first deployment of the new workflow, its Pages `build_type` must be
+changed to `workflow`, as described by the
+[GitHub Pages REST API](https://docs.github.com/en/rest/pages/pages).
+
+## Maintenance and permissions
+
+Routine CI jobs now request only `contents: read`; the Pages build additionally
+requests `pages: read`, and only the deployment job receives write/OIDC
+permissions. This follows GitHub's least-privilege guidance in
+[Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use).
+
+Weekly Dependabot checks for the `github-actions` ecosystem were added so new
+major releases are proposed automatically. See GitHub's guide to
+[automatically updating
+actions](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions).


### PR DESCRIPTION
## Summary
- update Checkout, Codecov, and artifact actions to current Node 24 releases
- replace the altdoc gh-pages push with the official GitHub Pages artifact/deploy flow
- minimize token permissions, add timeouts/concurrency, and enable weekly Dependabot updates
- document the primary-source research in investigation/github-actions-modernization.md

## Local verification
- 136 tests pass
- lintr reports no lints
- altdoc site renders and required output markers pass
- R CMD check --no-manual: Status OK
- workflow and Dependabot YAML parse successfully

The repository Pages source must be changed from legacy gh-pages to GitHub Actions immediately before merging so the first main deployment can authenticate correctly.