### PR TITLE
Test Arrow and DuckDB from P3M binaries

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,9 +46,9 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       # P3M does not publish binaries for the development R series. Base R can
-      # install P3M's Linux binaries directly, after which pak keeps the already
-      # installed versions while resolving the rest of the check dependencies.
-      - name: Install P3M binary backends for R-devel
+      # install binaries for the compatible release series directly. Preinstall
+      # all check dependencies so pak does not rebuild them for R-devel.
+      - name: Install P3M binary dependencies for R-devel
         if: matrix.config.r == 'devel'
         run: |
           user_agent <- getOption("HTTPUserAgent")
@@ -77,11 +77,26 @@ jobs:
           )
           message("Using P3M binary repository: ", p3m)
 
-          install.packages(
-            c("arrow", "duckdb"),
-            repos = p3m,
-            dependencies = NA
+          description <- read.dcf("DESCRIPTION")
+          fields <- intersect(
+            c("Depends", "Imports", "Suggests", "LinkingTo"),
+            colnames(description)
           )
+          references <- unlist(strsplit(
+            paste(description[1, fields], collapse = ","),
+            ",",
+            fixed = TRUE
+          ))
+          dependencies <- trimws(sub(" *[(].*[)] *$", "", references))
+          bundled <- rownames(installed.packages(
+            priority = c("base", "recommended")
+          ))
+          dependencies <- sort(unique(setdiff(
+            c(dependencies, "rcmdcheck"),
+            c("", "R", bundled)
+          )))
+          message("Installing P3M binaries: ", paste(dependencies, collapse = ", "))
+          install.packages(dependencies, repos = p3m, dependencies = NA)
 
           packages <- c("arrow", "duckdb")
           built <- vapply(
@@ -102,7 +117,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-          cache-version: 2
+          cache-version: 3
 
       - name: Verify P3M binary backends on R-devel
         if: matrix.config.r == 'devel'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,10 +45,11 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      # pak defaults to the development R series, for which P3M does not publish
-      # binaries. setup-r's release user agent tells us which compatible release
-      # series to request instead, without hard-coding it.
-      - name: Select P3M release binaries for R-devel
+      # P3M does not publish binaries for the development R series. Point pak at
+      # P3M's explicit Linux binary repository for the compatible release series.
+      # setup-r's release user agent lets us derive that series without hard-coding
+      # an R version that would become stale.
+      - name: Select P3M binary repository for R-devel
         if: matrix.config.r == 'devel'
         run: |
           user_agent <- getOption("HTTPUserAgent")
@@ -57,13 +58,25 @@ jobs:
           if (is.na(release) || !grepl("^[0-9]+[.][0-9]+$", release)) {
             stop("Could not derive the release R series from: ", user_agent)
           }
-          cat(
-            "PKG_R_VERSIONS=", release, "\n",
+          p3m <- sprintf(
+            paste0(
+              "https://packagemanager.posit.co/cran/latest/bin/linux/",
+              "noble-x86_64/%s"
+            ),
+            release
+          )
+          variables <- c(
+            PKG_R_VERSIONS = release,
+            PKG_CRAN_MIRROR = p3m,
+            RSPM = p3m,
+            RENV_CONFIG_REPOS_OVERRIDE = p3m
+          )
+          write(
+            paste(names(variables), variables, sep = "="),
             file = Sys.getenv("GITHUB_ENV"),
-            sep = "",
             append = TRUE
           )
-          message("Using P3M binaries built for R ", release)
+          message("Using P3M binary repository: ", p3m)
         shell: Rscript {0}
 
       - name: Install full dependencies

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,11 +45,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      # P3M does not publish binaries for the development R series. Point pak at
-      # P3M's explicit Linux binary repository for the compatible release series.
-      # setup-r's release user agent lets us derive that series without hard-coding
-      # an R version that would become stale.
-      - name: Select P3M binary repository for R-devel
+      # P3M does not publish binaries for the development R series. Base R can
+      # install P3M's Linux binaries directly, after which pak keeps the already
+      # installed versions while resolving the rest of the check dependencies.
+      - name: Install P3M binary backends for R-devel
         if: matrix.config.r == 'devel'
         run: |
           user_agent <- getOption("HTTPUserAgent")
@@ -77,6 +76,25 @@ jobs:
             append = TRUE
           )
           message("Using P3M binary repository: ", p3m)
+
+          install.packages(
+            c("arrow", "duckdb"),
+            repos = p3m,
+            dependencies = NA
+          )
+
+          packages <- c("arrow", "duckdb")
+          built <- vapply(
+            packages,
+            packageDescription,
+            FUN.VALUE = character(1),
+            fields = "Built"
+          )
+          print(data.frame(package = packages, built = unname(built)))
+          expected <- paste0("R ", release, ".")
+          if (!all(startsWith(built, expected))) {
+            stop("P3M did not serve release binaries for Arrow and DuckDB")
+          }
         shell: Rscript {0}
 
       - name: Install full dependencies
@@ -84,6 +102,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          cache-version: 2
 
       - name: Verify P3M binary backends on R-devel
         if: matrix.config.r == 'devel'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,34 +45,52 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      # Release jobs exercise every suggested backend. On R-devel, compiled
-      # Suggests such as arrow and duckdb are built from source and can consume
-      # the entire job timeout, so keep that job focused on core compatibility.
+      # pak defaults to the development R series, for which P3M does not publish
+      # binaries. setup-r's release user agent tells us which compatible release
+      # series to request instead, without hard-coding it.
+      - name: Select P3M release binaries for R-devel
+        if: matrix.config.r == 'devel'
+        run: |
+          user_agent <- getOption("HTTPUserAgent")
+          match <- regexec("R [(]([0-9]+[.][0-9]+)[.]", user_agent)
+          release <- regmatches(user_agent, match)[[1]][2]
+          if (is.na(release) || !grepl("^[0-9]+[.][0-9]+$", release)) {
+            stop("Could not derive the release R series from: ", user_agent)
+          }
+          cat(
+            "PKG_R_VERSIONS=", release, "\n",
+            file = Sys.getenv("GITHUB_ENV"),
+            sep = "",
+            append = TRUE
+          )
+          message("Using P3M binaries built for R ", release)
+        shell: Rscript {0}
+
       - name: Install full dependencies
-        if: matrix.config.r != 'devel'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Install core dependencies for R-devel
+      - name: Verify P3M binary backends on R-devel
         if: matrix.config.r == 'devel'
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck, any::testthat, any::RSQLite
-          dependencies: '"hard"'
-          install-quarto: false
+        run: |
+          packages <- c("arrow", "duckdb")
+          built <- vapply(
+            packages,
+            packageDescription,
+            FUN.VALUE = character(1),
+            fields = "Built"
+          )
+          print(data.frame(package = packages, built = unname(built)))
+          expected <- paste0("R ", Sys.getenv("PKG_R_VERSIONS"), ".")
+          if (!all(startsWith(built, expected))) {
+            stop("Arrow and DuckDB were not installed from P3M release binaries")
+          }
+        shell: Rscript {0}
 
       - name: Check package
-        if: matrix.config.r != 'devel'
         uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
-
-      - name: Check package on R-devel
-        if: matrix.config.r == 'devel'
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
-          build_args: 'c("--no-manual","--no-build-vignettes")'

--- a/investigation/p3m-binary-actions.md
+++ b/investigation/p3m-binary-actions.md
@@ -1,0 +1,52 @@
+# P3M binaries in GitHub Actions
+
+Investigated on 2026-07-19 for `marginplyr`.
+
+## Findings
+
+- Posit Package Manager (P3M) supports Linux binaries for Ubuntu 24.04
+  (Noble), x86_64. Its explicit repository URL includes the distribution,
+  architecture, and R release series, for example:
+  `https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/4.6`.
+- P3M currently serves Arrow and DuckDB from that repository as binaries. HEAD
+  requests for Arrow 25.0.0 and DuckDB 1.5.4.3 returned
+  `X-Package-Type: binary` and `X-Package-Binary-Tag: 4.6-noble`.
+- The generic `__linux__/noble/latest` repository also content-negotiates
+  binaries from R's HTTP user agent. P3M documents both this mechanism and the
+  explicit environment URL.
+- `r-lib/actions/setup-r@v2` uses public P3M by default on supported x86_64
+  Linux runners. Its `http-user-agent: release` input is useful for an R-devel
+  job because P3M publishes binaries for release R series, not R-devel.
+- pak still resolves CRAN packages against the running R-devel series. Setting
+  `PKG_R_VERSIONS` or only replacing the repository URL did not stop pak from
+  selecting source builds in the observed workflow. Base R's
+  `install.packages()` did install the P3M Linux binaries, as documented by
+  Posit. pak then keeps packages whose versions are already installed.
+- `usethis::use_github_action("check-standard")` is a useful way to copy the
+  current standard r-lib/actions check workflow. It is scaffolding, not a P3M
+  binary installer, and rerunning it would overwrite project-specific workflow
+  changes. The existing workflow should therefore keep its explicit P3M step.
+
+## Implemented approach
+
+For the Ubuntu R-devel matrix job:
+
+1. Keep `http-user-agent: release` in `setup-r`.
+2. Derive the current release minor version from that user agent, avoiding a
+   hard-coded R version.
+3. Construct the explicit Noble x86_64 P3M repository URL.
+4. Preinstall the package's check dependencies from P3M with base R
+   `install.packages()`.
+5. Run `setup-r-dependencies` for system requirements and any missing package.
+6. Before and after pak runs, assert that Arrow and DuckDB have `Built` metadata
+   from the release R series. A source build on R-devel therefore fails the job.
+7. Run the full package check, including Arrow and DuckDB backend tests.
+
+## Primary sources
+
+- [Posit Package Manager: Serving Package Binaries](https://packagemanager.posit.co/__docs__/admin/serving-binaries.html)
+- [r-lib/actions setup-r documentation](https://github.com/r-lib/actions/blob/v2/setup-r/README.md)
+- [r-lib/actions standard check workflow](https://github.com/r-lib/actions/blob/v2/examples/check-standard.yaml)
+- [pak configuration](https://pak.r-lib.org/reference/pak-config.html)
+- [pak FAQ](https://pak.r-lib.org/reference/faq.html)
+- [usethis `use_github_action()`](https://usethis.r-lib.org/reference/use_github_action.html)


### PR DESCRIPTION
Use pak's PKG_R_VERSIONS override on R-devel so Posit Public Package Manager selects binaries from the compatible R release series. Restore the full Suggests test matrix and fail explicitly unless Arrow and DuckDB were installed from release binaries.