### PR TITLE
Make Suggested dependencies genuinely optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://sayuks.github.io/marginplyr/, https://github.com/sayuks/marginplyr
 BugReports: https://github.com/sayuks/marginplyr/issues
 Depends:
     R (>= 4.1.0)
-Imports:
+Imports: 
     dbplyr (>= 2.6.0),
     dplyr (>= 1.1.1),
     glue,
@@ -22,7 +22,7 @@ Imports:
     stats,
     tidyselect (>= 1.2.0),
     utils
-Suggests:
+Suggests: 
     altdoc (>= 0.7.3),
     arrow (>= 13.0.0),
     DBI,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://sayuks.github.io/marginplyr/, https://github.com/sayuks/marginplyr
 BugReports: https://github.com/sayuks/marginplyr/issues
 Depends:
     R (>= 4.1.0)
-Imports: 
+Imports:
     dbplyr (>= 2.6.0),
     dplyr (>= 1.1.1),
     glue,
@@ -22,32 +22,26 @@ Imports:
     stats,
     tidyselect (>= 1.2.0),
     utils
-Suggests: 
+Suggests:
     altdoc (>= 0.7.3),
     arrow (>= 13.0.0),
-    data.table,
     DBI,
     dtplyr (>= 1.3.2),
     duckdb,
-    ggplot2,
     knitr,
-    purrr,
     quartabs (>= 0.1.1),
     quarto (>= 1.4),
     RSQLite,
-    sessioninfo,
     spelling,
-    stringr,
     testthat (>= 3.0.0),
     tibble,
-    tidyr,
+    tidyr
 Config/testthat/edition: 3
 VignetteBuilder:
     quarto
 SystemRequirements: Quarto command line tool
 Config/Needs/website:
     altdoc,
-    data.table,
     DBI,
     dtplyr,
     duckdb,

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -46,16 +46,20 @@
 #' dplyr::group_vars(grouped_expansion)
 #'
 #' # SQLite has no native GROUPING SETS support in marginplyr, so a simulated
-#' # lazy table makes the portable UNION ALL translation visible.
-#' sqlite_sales <- dbplyr::tbl_lazy(
-#'   january_sales,
-#'   con = dbplyr::simulate_sqlite()
-#' )
-#' sqlite_sales |>
-#'   expand_with_margins(
-#'     .grouping = rollup(region, store)
-#'   ) |>
-#'   dplyr::show_query()
+#' # lazy table makes the portable UNION ALL translation visible. Rendering
+#' # SQLite SQL reads the driver version from the optional RSQLite package,
+#' # even though the simulator opens no connection.
+#' if (requireNamespace("RSQLite", quietly = TRUE)) {
+#'   sqlite_sales <- dbplyr::tbl_lazy(
+#'     january_sales,
+#'     con = dbplyr::simulate_sqlite()
+#'   )
+#'   sqlite_sales |>
+#'     expand_with_margins(
+#'       .grouping = rollup(region, store)
+#'     ) |>
+#'     dplyr::show_query()
+#' }
 expand_with_margins <- function(.data,
                                 .by = NULL,
                                 .grouping = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,7 +45,8 @@ assert_lazy_table <- function(x) {
   }
 }
 
-# Required when dtplyr/data.table are optional Suggests rather than Imports.
+# Required because dtplyr is an optional Suggest rather than an Import: it
+# brings data.table, which reads this flag from the calling namespace.
 # data.table fixes the spelling of this name, so it cannot follow the package's
 # object naming convention.
 .datatable.aware <- TRUE # nolint: object_name_linter

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -203,16 +203,20 @@ grouped_expansion <- january_sales |>
 dplyr::group_vars(grouped_expansion)
 
 # SQLite has no native GROUPING SETS support in marginplyr, so a simulated
-# lazy table makes the portable UNION ALL translation visible.
-sqlite_sales <- dbplyr::tbl_lazy(
-  january_sales,
-  con = dbplyr::simulate_sqlite()
-)
-sqlite_sales |>
-  expand_with_margins(
-    .grouping = rollup(region, store)
-  ) |>
-  dplyr::show_query()
+# lazy table makes the portable UNION ALL translation visible. Rendering
+# SQLite SQL reads the driver version from the optional RSQLite package,
+# even though the simulator opens no connection.
+if (requireNamespace("RSQLite", quietly = TRUE)) {
+  sqlite_sales <- dbplyr::tbl_lazy(
+    january_sales,
+    con = dbplyr::simulate_sqlite()
+  )
+  sqlite_sales |>
+    expand_with_margins(
+      .grouping = rollup(region, store)
+    ) |>
+    dplyr::show_query()
+}
 }
 \seealso{
 Other summarize and expand data with margins:

--- a/tests/testthat/helper-sqlite-simulation.R
+++ b/tests/testthat/helper-sqlite-simulation.R
@@ -1,0 +1,13 @@
+# dbplyr's SQLite simulator opens no connection, but rendering SQL from it
+# reads the installed driver version through `RSQLite::rsqliteVersion()`.
+# Simulated SQLite queries therefore need the optional RSQLite package even
+# though nothing is executed.
+sqlite_simulation_available <- function() {
+  requireNamespace("RSQLite", quietly = TRUE)
+}
+
+skip_if_no_sqlite_simulation <- function() {
+  if (!sqlite_simulation_available()) {
+    skip("RSQLite is not installed")
+  }
+}

--- a/tests/testthat/helper-sqlite-simulation.R
+++ b/tests/testthat/helper-sqlite-simulation.R
@@ -11,3 +11,12 @@ skip_if_no_sqlite_simulation <- function() {
     skip("RSQLite is not installed")
   }
 }
+
+# Drops the dialects whose SQL cannot be rendered without an optional driver
+# package, so the remaining ones stay under test.
+available_simulators <- function(simulators) {
+  if (!sqlite_simulation_available()) {
+    simulators <- setdiff(simulators, "simulate_sqlite")
+  }
+  simulators
+}

--- a/tests/testthat/test-expand-operation.R
+++ b/tests/testthat/test-expand-operation.R
@@ -213,6 +213,7 @@ test_that("DuckDB expansion acquires one typed selection proxy", {
 })
 
 test_that("portable SQL expansion stays lazy and uses UNION ALL", {
+  skip_if_no_sqlite_simulation()
   remote <- dbplyr::tbl_lazy(
     data.frame(
       check.names = FALSE,

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -457,6 +457,9 @@ test_that("documented SQL dialects use portable margin label checks", {
     "simulate_sqlite",
     "simulate_teradata"
   )
+  if (!sqlite_simulation_available()) {
+    simulators <- setdiff(simulators, "simulate_sqlite")
+  }
 
   for (simulator in simulators) {
     con <- getExportedValue("dbplyr", simulator)()
@@ -1055,8 +1058,12 @@ test_that("native grouping sets remain a subquery after downstream verbs", {
 test_that("unconfirmed SQL dialects use UNION ALL", {
   skip_if_not_installed("dbplyr")
   data <- data.frame(a = "x", b = "u", value = 1)
+  connections <- list(dbplyr::simulate_mysql())
+  if (sqlite_simulation_available()) {
+    connections <- c(connections, list(dbplyr::simulate_sqlite()))
+  }
 
-  for (con in list(dbplyr::simulate_mysql(), dbplyr::simulate_sqlite())) {
+  for (con in connections) {
     remote <- dbplyr::tbl_lazy(data, con = con)
     query <- summarize_with_margins(
       remote,
@@ -1090,6 +1097,9 @@ test_that("documented fallback dialects render portable UNION ALL SQL", {
     "simulate_sqlite",
     "simulate_teradata"
   )
+  if (!sqlite_simulation_available()) {
+    simulators <- setdiff(simulators, "simulate_sqlite")
+  }
 
   for (simulator in simulators) {
     con <- getExportedValue("dbplyr", simulator)()

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -439,7 +439,7 @@ test_that("documented SQL dialects use portable margin label checks", {
     margin_check_collect,
     envir = asNamespace("dbplyr")
   )
-  simulators <- c(
+  simulators <- available_simulators(c(
     "simulate_access",
     "simulate_dbi",
     "simulate_hana",
@@ -456,10 +456,7 @@ test_that("documented SQL dialects use portable margin label checks", {
     "simulate_spark_sql",
     "simulate_sqlite",
     "simulate_teradata"
-  )
-  if (!sqlite_simulation_available()) {
-    simulators <- setdiff(simulators, "simulate_sqlite")
-  }
+  ))
 
   for (simulator in simulators) {
     con <- getExportedValue("dbplyr", simulator)()
@@ -703,51 +700,54 @@ test_that("column-wise summaries share one lazy-backend selection", {
     value = c(1, 2, 3)
   )
 
-  skip_if_not_installed("dtplyr")
-  dt_result <- summarize_with_margins(
-    dtplyr::lazy_dt(data),
-    dplyr::across(
-      dplyr::everything(),
-      dplyr::n_distinct,
-      .names = "n_{.col}"
-    ),
-    .grouping = rollup(group)
-  ) |>
-    dplyr::collect()
-  expect_equal(names(dt_result), c("group", "n_value"))
-  expect_setequal(dt_result$n_value, c(2L, 1L, 3L))
+  if (rlang::is_installed("dtplyr")) {
+    dt_result <- summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      dplyr::across(
+        dplyr::everything(),
+        dplyr::n_distinct,
+        .names = "n_{.col}"
+      ),
+      .grouping = rollup(group)
+    ) |>
+      dplyr::collect()
+    expect_equal(names(dt_result), c("group", "n_value"))
+    expect_setequal(dt_result$n_value, c(2L, 1L, 3L))
+  }
 
-  skip_if_not_installed("arrow")
-  arrow_result <- summarize_with_margins(
-    arrow::Table$create(data),
-    dplyr::across(
-      dplyr::everything(),
-      dplyr::n_distinct,
-      .names = "n_{.col}"
-    ),
-    .grouping = rollup(group)
-  ) |>
-    dplyr::collect()
-  expect_equal(names(arrow_result), c("group", "n_value"))
-  expect_setequal(arrow_result$n_value, c(2L, 1L, 3L))
+  if (rlang::is_installed("arrow")) {
+    arrow_result <- summarize_with_margins(
+      arrow::Table$create(data),
+      dplyr::across(
+        dplyr::everything(),
+        dplyr::n_distinct,
+        .names = "n_{.col}"
+      ),
+      .grouping = rollup(group)
+    ) |>
+      dplyr::collect()
+    expect_equal(names(arrow_result), c("group", "n_value"))
+    expect_setequal(arrow_result$n_value, c(2L, 1L, 3L))
+  }
 
-  skip_if_not_installed("dbplyr")
-  sqlite <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_sqlite())
-  sqlite_query <- summarize_with_margins(
-    sqlite,
-    dplyr::across(value, mean, .names = "mean_{.col}"),
-    .grouping = rollup(group)
-  )
-  expect_match(
-    dbplyr::sql_render(sqlite_query),
-    "UNION ALL",
-    fixed = TRUE
-  )
-  expect_false(grepl(
-    "mean_group",
-    dbplyr::sql_render(sqlite_query),
-    fixed = TRUE
-  ))
+  if (sqlite_simulation_available()) {
+    sqlite <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_sqlite())
+    sqlite_query <- summarize_with_margins(
+      sqlite,
+      dplyr::across(value, mean, .names = "mean_{.col}"),
+      .grouping = rollup(group)
+    )
+    expect_match(
+      dbplyr::sql_render(sqlite_query),
+      "UNION ALL",
+      fixed = TRUE
+    )
+    expect_false(grepl(
+      "mean_group",
+      dbplyr::sql_render(sqlite_query),
+      fixed = TRUE
+    ))
+  }
 
   postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
   expect_error(
@@ -1080,7 +1080,7 @@ test_that("unconfirmed SQL dialects use UNION ALL", {
 test_that("documented fallback dialects render portable UNION ALL SQL", {
   skip_if_not_installed("dbplyr")
   data <- data.frame(a = "x", b = "u", value = 1)
-  simulators <- c(
+  simulators <- available_simulators(c(
     "simulate_access",
     "simulate_dbi",
     "simulate_hana",
@@ -1096,10 +1096,7 @@ test_that("documented fallback dialects render portable UNION ALL SQL", {
     "simulate_spark_sql",
     "simulate_sqlite",
     "simulate_teradata"
-  )
-  if (!sqlite_simulation_available()) {
-    simulators <- setdiff(simulators, "simulate_sqlite")
-  }
+  ))
 
   for (simulator in simulators) {
     con <- getExportedValue("dbplyr", simulator)()

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -361,6 +361,7 @@ test_that("DuckDB native and portable summaries agree on .id", {
 })
 
 test_that("portable .id paths remain lazy", {
+  skip_if_no_sqlite_simulation()
   remote <- dbplyr::tbl_lazy(
     data.frame(group = c("x", "y"), value = 1:2),
     con = dbplyr::simulate_sqlite()

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -272,6 +272,7 @@ test_that("Arrow applies mixed named labels lazily with typed missing values", {
 })
 
 test_that("portable SQL consumes named per-column labels lazily", {
+  skip_if_no_sqlite_simulation()
   remote <- dbplyr::tbl_lazy(
     data.frame(first = "a", second = "b", value = 1L),
     con = dbplyr::simulate_sqlite()

--- a/tests/testthat/test-parent-share-backends.R
+++ b/tests/testthat/test-parent-share-backends.R
@@ -718,7 +718,7 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
     group = NA_character_,
     value = 1
   )
-  simulators <- c(
+  simulators <- available_simulators(c(
     "simulate_access",
     "simulate_dbi",
     "simulate_hana",
@@ -734,10 +734,7 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
     "simulate_spark_sql",
     "simulate_sqlite",
     "simulate_teradata"
-  )
-  if (!sqlite_simulation_available()) {
-    simulators <- setdiff(simulators, "simulate_sqlite")
-  }
+  ))
 
   for (simulator in simulators) {
     remote <- dbplyr::tbl_lazy(

--- a/tests/testthat/test-parent-share-backends.R
+++ b/tests/testthat/test-parent-share-backends.R
@@ -23,14 +23,16 @@ test_that("Parent shares preserve columns, grouping, and laziness", {
   expect_identical(names(local), expected_names)
   expect_identical(dplyr::group_vars(local), character())
 
-  sql <- summarize(dbplyr::tbl_lazy(
-    data,
-    con = dbplyr::simulate_sqlite()
-  ))
-  expect_s3_class(sql, "tbl_lazy")
-  expect_identical(as.character(dplyr::tbl_vars(sql)), expected_names)
-  expect_identical(dplyr::group_vars(sql), character())
-  expect_no_error(dbplyr::sql_render(sql))
+  if (sqlite_simulation_available()) {
+    sql <- summarize(dbplyr::tbl_lazy(
+      data,
+      con = dbplyr::simulate_sqlite()
+    ))
+    expect_s3_class(sql, "tbl_lazy")
+    expect_identical(as.character(dplyr::tbl_vars(sql)), expected_names)
+    expect_identical(dplyr::group_vars(sql), character())
+    expect_no_error(dbplyr::sql_render(sql))
+  }
 
   if (rlang::is_installed("dtplyr")) {
     lazy <- summarize(dtplyr::lazy_dt(data))
@@ -733,6 +735,9 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
     "simulate_sqlite",
     "simulate_teradata"
   )
+  if (!sqlite_simulation_available()) {
+    simulators <- setdiff(simulators, "simulate_sqlite")
+  }
 
   for (simulator in simulators) {
     remote <- dbplyr::tbl_lazy(
@@ -1125,15 +1130,17 @@ test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
   }
 
   expected <- summarize(data)
-  simulated <- summarize(dbplyr::tbl_lazy(
-    data,
-    con = dbplyr::simulate_sqlite()
-  ))
-  expect_identical(
-    as.character(dplyr::tbl_vars(simulated)),
-    names(expected)
-  )
-  expect_no_error(dbplyr::sql_render(simulated))
+  if (sqlite_simulation_available()) {
+    simulated <- summarize(dbplyr::tbl_lazy(
+      data,
+      con = dbplyr::simulate_sqlite()
+    ))
+    expect_identical(
+      as.character(dplyr::tbl_vars(simulated)),
+      names(expected)
+    )
+    expect_no_error(dbplyr::sql_render(simulated))
+  }
 
   skip_if_not_installed("duckdb")
   skip_if_not_installed("DBI")

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -26,6 +26,19 @@ library(marginplyr)
 library(dplyr)
 ```
 
+Only dplyr and dbplyr are required. The tidyr and SQLite sections below need
+optional packages, so their chunks evaluate only when those packages are
+installed. Where a package is missing the code is still shown, but its output
+is absent.
+
+```{r}
+#| include: false
+
+has_tidyr <- requireNamespace("tidyr", quietly = TRUE)
+has_sqlite <- requireNamespace("DBI", quietly = TRUE) &&
+  requireNamespace("RSQLite", quietly = TRUE)
+```
+
 ## Why completion is a separate operation
 
 marginplyr does not provide `.complete`, `.fill`, or `.empty` arguments, and it
@@ -54,7 +67,7 @@ This small fact table does not contain every product for every observed
 region-store relationship:
 
 ```{r}
-facts <- tibble::tibble(
+facts <- tibble(
   fact_id = 1:3,
   region = c("East", "East", "West"),
   store = c("A", "B", "C"),
@@ -71,6 +84,8 @@ facts
 relationships while crossing each relationship with the product domain:
 
 ```{r}
+#| eval: !expr has_tidyr
+
 completed_facts <- facts |>
   mutate(is_fact = TRUE) |>
   tidyr::complete(
@@ -89,6 +104,8 @@ completed_facts
 The inserted zeros now participate in every level of the rollup:
 
 ```{r}
+#| eval: !expr has_tidyr
+
 completed_facts |>
   summarize_with_margins(
     rows = dplyr::n(),
@@ -130,7 +147,7 @@ cross product. Union it with observed keys before joining so facts outside the
 scaffold are not accidentally discarded:
 
 ```{r}
-requested_keys <- tibble::tribble(
+requested_keys <- tribble(
   ~region, ~store, ~product,
   "East", "A", "Laptop",
   "East", "A", "Monitor",
@@ -163,54 +180,51 @@ table is the natural source of a reusable key domain:
 
 ```{r}
 #| message: false
+#| eval: !expr has_sqlite
 
-has_sqlite <- requireNamespace("DBI", quietly = TRUE) &&
-  requireNamespace("RSQLite", quietly = TRUE)
-if (has_sqlite) {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
 
-  facts_db <- copy_to(
-    con,
-    facts,
-    name = "facts",
-    temporary = TRUE,
-    overwrite = TRUE
+facts_db <- copy_to(
+  con,
+  facts,
+  name = "facts",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+dimension_db <- copy_to(
+  con,
+  requested_keys,
+  name = "store_product_dimension",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+
+observed_keys_db <- facts_db |>
+  distinct(region, store, product)
+all_keys_db <- dimension_db |>
+  select(region, store, product) |>
+  union(observed_keys_db)
+
+completed_db <- all_keys_db |>
+  left_join(
+    facts_db,
+    by = c("region", "store", "product")
+  ) |>
+  mutate(
+    is_fact = !is.na(fact_id),
+    units = dplyr::coalesce(units, 0L),
+    revenue = dplyr::coalesce(revenue, 0)
   )
-  dimension_db <- copy_to(
-    con,
-    requested_keys,
-    name = "store_product_dimension",
-    temporary = TRUE,
-    overwrite = TRUE
+
+completed_query <- completed_db |>
+  summarize_with_margins(
+    observed_facts = sum(is_fact),
+    revenue = sum(revenue),
+    .grouping = rollup(region, store, product)
   )
 
-  observed_keys_db <- facts_db |>
-    distinct(region, store, product)
-  all_keys_db <- dimension_db |>
-    select(region, store, product) |>
-    union(observed_keys_db)
-
-  completed_db <- all_keys_db |>
-    left_join(
-      facts_db,
-      by = c("region", "store", "product")
-    ) |>
-    mutate(
-      is_fact = !is.na(fact_id),
-      units = dplyr::coalesce(units, 0L),
-      revenue = dplyr::coalesce(revenue, 0)
-    )
-
-  completed_query <- completed_db |>
-    summarize_with_margins(
-      observed_facts = sum(is_fact),
-      revenue = sum(revenue),
-      .grouping = rollup(region, store, product)
-    )
-
-  show_query(completed_query)
-  DBI::dbDisconnect(con)
-}
+show_query(completed_query)
+DBI::dbDisconnect(con)
 ```
 
 The union, join, completion expressions, and Margin summary remain lazy.
@@ -224,45 +238,42 @@ query text grow with the number of keys:
 
 ```{r}
 #| message: false
+#| eval: !expr has_sqlite
 
-has_sqlite <- requireNamespace("DBI", quietly = TRUE) &&
-  requireNamespace("RSQLite", quietly = TRUE)
-if (has_sqlite) {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  facts_db <- copy_to(
-    con,
-    facts,
-    name = "facts",
-    temporary = TRUE,
-    overwrite = TRUE
+con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+facts_db <- copy_to(
+  con,
+  facts,
+  name = "facts",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+
+inline_keys <- dbplyr::copy_inline(con, requested_keys)
+inline_query <- inline_keys |>
+  union(distinct(facts_db, region, store, product)) |>
+  left_join(
+    facts_db,
+    by = c("region", "store", "product")
   )
+show_query(inline_query)
 
-  inline_keys <- dbplyr::copy_inline(con, requested_keys)
-  inline_query <- inline_keys |>
-    union(distinct(facts_db, region, store, product)) |>
-    left_join(
-      facts_db,
-      by = c("region", "store", "product")
-    )
-  show_query(inline_query)
-
-  reusable_keys <- copy_to(
-    con,
-    requested_keys,
-    name = "requested_keys",
-    temporary = TRUE,
-    overwrite = TRUE
+reusable_keys <- copy_to(
+  con,
+  requested_keys,
+  name = "requested_keys",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+reusable_query <- reusable_keys |>
+  union(distinct(facts_db, region, store, product)) |>
+  left_join(
+    facts_db,
+    by = c("region", "store", "product")
   )
-  reusable_query <- reusable_keys |>
-    union(distinct(facts_db, region, store, product)) |>
-    left_join(
-      facts_db,
-      by = c("region", "store", "product")
-    )
-  show_query(reusable_query)
+show_query(reusable_query)
 
-  DBI::dbDisconnect(con)
-}
+DBI::dbDisconnect(con)
 ```
 
 Use explicit `dplyr::copy_to()` for a larger or reusable local key relation.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -31,8 +31,8 @@ Install the development version of marginplyr from GitHub:
 install.packages("pak")
 pak::pkg_install("sayuks/marginplyr")
 
-# Used for the live DuckDB example in this guide.
-install.packages(c("DBI", "duckdb"))
+# Used for the optional backend sections of this guide.
+install.packages(c("DBI", "duckdb", "RSQLite", "dtplyr"))
 ```
 
 ```{r setup}
@@ -40,6 +40,22 @@ install.packages(c("DBI", "duckdb"))
 
 library(marginplyr)
 library(dplyr)
+```
+
+Only dplyr and dbplyr are required. The DuckDB, SQLite, and dtplyr sections
+below need optional packages, so their chunks evaluate only when those
+packages are installed. Where a package is missing the code is still shown,
+but its output is absent.
+
+```{r}
+#| include: false
+
+has_duckdb <- requireNamespace("DBI", quietly = TRUE) &&
+  requireNamespace("duckdb", quietly = TRUE)
+# dbplyr's SQLite simulator opens no connection, but rendering its SQL reads
+# the installed driver version through RSQLite.
+has_sqlite_simulator <- requireNamespace("RSQLite", quietly = TRUE)
+has_dtplyr <- requireNamespace("dtplyr", quietly = TRUE)
 ```
 
 ## One report, two execution locations
@@ -138,6 +154,8 @@ The simulator above verifies SQL rendering without a server. DuckDB lets the
 same workflow execute against a live in-memory database:
 
 ```{r}
+#| eval: !expr has_duckdb
+
 con <- DBI::dbConnect(duckdb::duckdb())
 
 sales_db <- copy_to(
@@ -164,6 +182,8 @@ At this point `duckdb_query` is still lazy. `collect()` asks DuckDB to execute
 the grouping sets and transfers only the summarized result:
 
 ```{r}
+#| eval: !expr has_duckdb
+
 duckdb_result <- collect(duckdb_query)
 DBI::dbDisconnect(con)
 
@@ -186,6 +206,8 @@ sets. For an unconfirmed backend, it expands the plan into one query branch
 per grouping set and joins those branches with `UNION ALL`.
 
 ```{r}
+#| eval: !expr has_sqlite_simulator
+
 sqlite_sales <- dbplyr::tbl_lazy(
   january_sales,
   con = dbplyr::simulate_sqlite()
@@ -210,6 +232,8 @@ grouping specification.
 the row-expansion branches explicit:
 
 ```{r}
+#| eval: !expr has_sqlite_simulator
+
 sqlite_sales |>
   expand_with_margins(
     .grouping = rollup(region, store)
@@ -271,6 +295,8 @@ dtplyr is lazy without being a SQL connection. `show_query()` displays the
 generated data.table expression:
 
 ```{r}
+#| eval: !expr has_dtplyr
+
 dt_query <- january_sales |>
   dtplyr::lazy_dt() |>
   summarize_with_margins(

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -40,6 +40,21 @@ library(marginplyr)
 library(dplyr)
 ```
 
+Only dplyr and dbplyr are required. A few sections below illustrate optional
+tooling, so their chunks evaluate only when that tooling is installed. Where a
+package is missing the code is still shown, but its output is absent.
+
+```{r}
+#| include: false
+
+# dbplyr's SQLite simulator opens no connection, but rendering its SQL reads
+# the installed driver version through RSQLite.
+has_sqlite_simulator <- requireNamespace("RSQLite", quietly = TRUE)
+has_dtplyr <- requireNamespace("dtplyr", quietly = TRUE)
+has_tabsets <- requireNamespace("knitr", quietly = TRUE) &&
+  requireNamespace("quartabs", quietly = TRUE)
+```
+
 ## Start with the report question
 
 `retail_sales` contains two years of monthly sales for a fictional retail
@@ -690,6 +705,8 @@ The same verb stays lazy for database tables. Its SQLite SQL makes the
 row-expansion branches explicit:
 
 ```{r}
+#| eval: !expr has_sqlite_simulator
+
 dbplyr::tbl_lazy(
   january_sales,
   con = dbplyr::simulate_sqlite()
@@ -741,6 +758,8 @@ A dtplyr input performs the expansion and nesting lazily until `collect()`.
 `show_query()` displays the generated data.table expression:
 
 ```{r}
+#| eval: !expr has_dtplyr
+
 nested_dt <- january_sales |>
   dtplyr::lazy_dt() |>
   nest_with_margins(
@@ -773,6 +792,8 @@ nested_by$data[[1]]
 The row-wise result is local even when the input is a dtplyr step:
 
 ```{r}
+#| eval: !expr has_dtplyr
+
 nested_by_dt <- january_sales |>
   dtplyr::lazy_dt() |>
   nest_by_with_margins(
@@ -860,6 +881,7 @@ Quarto tabset markup.
 
 ```{r}
 #| results: asis
+#| eval: !expr has_tabsets
 
 tabbed_report <- january_sales |>
   nest_by_with_margins(


### PR DESCRIPTION
## Summary

- Guard every executable use of a Suggested package in examples, tests, and vignettes: dbplyr's SQLite simulator needs RSQLite to render SQL (even though it opens no connection), and several tests/vignette chunks assumed DuckDB, dtplyr, tidyr, knitr, or quartabs without checking.
- Fix a hazard where a broad `skip_if_not_installed()` mid-test silently swallowed coverage for backends listed after it, masking one ungated SQLite render that a dependency-only check would otherwise catch.
- Remove `data.table`, `ggplot2`, `purrr`, `sessioninfo`, `stringr` from `Suggests` after a repository-wide usage audit found none of them used. Nothing promoted to Imports.

Closes #34.

## Test plan

- [x] `_R_CHECK_DEPENDS_ONLY_=true R CMD check` on the built tarball: 3 ERRORs → 1 NOTE (pre-existing, unrelated `.x` no-visible-binding finding — tracked in #45)
- [x] Normal `R CMD check` on the built tarball: 1 NOTE (same pre-existing finding)
- [x] Full testthat suite with every Suggest installed: green
- [x] Suite re-run against a library with RSQLite (only) removed: 0 failures, explicit skips only
- [x] `pkgload::load_all()` + `lintr::lint_package()`: no lints