### PR TITLE
Name the data.table lambda pronoun instead of quoting it bare

### DIFF
--- a/R/parent-share.R
+++ b/R/parent-share.R
@@ -883,13 +883,19 @@ wrap_dtplyr_parent_across <- function(expr, checks, call) {
   rlang::call2(expr[[1L]], !!!call_args)
 }
 
+# The argument a dtplyr lambda binds to each column it is mapped over. Named
+# as a string rather than written bare, so that static analysis reads the
+# pronoun as data rather than as a variable this function expects to find.
+dtplyr_lambda_pronoun <- function() {
+  rlang::sym(".x")
+}
+
 inline_dtplyr_forwarded_fn <- function(fn, forwarded_args) {
   rlang::call2(
     "~",
     rlang::call2(
       fn,
-      # `.x` is the data.table lambda pronoun, quoted here rather than bound.
-      rlang::expr(.x), # nolint: object_usage_linter.
+      dtplyr_lambda_pronoun(),
       !!!forwarded_args
     )
   )
@@ -901,15 +907,13 @@ wrap_dtplyr_parent_function <- function(fn, mapping, forwarded_args, call) {
   } else {
     rlang::call2(
       fn,
-      # `.x` is the data.table lambda pronoun, quoted here rather than bound.
-      rlang::expr(.x), # nolint: object_usage_linter.
+      dtplyr_lambda_pronoun(),
       !!!forwarded_args
     )
   }
   input <- rlang::call2(
     parent_private_call("dtplyr_parent_input_name"),
-    # `.x` is the data.table lambda pronoun, quoted here rather than bound.
-    rlang::expr(.x) # nolint: object_usage_linter.
+    dtplyr_lambda_pronoun()
   )
   mapping_expr <- rlang::call2(
     parent_private_call("new_parent_validation_mapping"),


### PR DESCRIPTION
Closes #45.

## What changed

`R/parent-share.R`: the three `rlang::expr(.x)` sites now call a new
`dtplyr_lambda_pronoun()` returning `rlang::sym(".x")`. All three
`# nolint: object_usage_linter` comments are gone.

`rlang::expr(.x)` writes `.x` as a bare symbol, which codetools reads as a free
variable, so `R CMD check` reported a `no visible binding for global variable
'.x'` NOTE in every check mode. A `# nolint` comment cannot suppress a check
NOTE, so the three inline suppressions never actually settled the finding — it
stayed visible to CRAN.

`rlang::sym(".x")` returns the `identical()` symbol while presenting only a
string to the static analysis. Routing the three sites through one named
constructor follows `parent_private_call()` next door: the name records what
the pronoun is at each call site, and the reason it is spelled as a string is
stated once on the definition rather than repeated three times.

No `utils::globalVariables(".x")` was added — per `AGENTS.md`, that would be a
suppression rather than a fix.

## Verification

| Acceptance criterion (#45) | Result |
|---|---|
| Three sites rewritten, codetools sees no free variable | `codetools::checkUsage()` silent on all three functions (was 3 findings) |
| `# nolint` deleted, pronoun explanation survives | Removed; the fact now lives in the constructor's name plus one comment on its definition |
| No `utils::globalVariables(".x")` | Only the pre-existing `.data` and `:=` remain |
| `R CMD check` from tarball, 0 NOTEs, both modes | `Status: OK` in normal and under `_R_CHECK_DEPENDS_ONLY_=true`; `checking R code for possible problems ... OK` in both logs |
| `load_all()` + `lint_package()` | No lints found |
| dtplyr Parent-share suite passes | 508 assertions, **0 skipped** |

Full suite: 1468 passing, 0 failures, 0 warnings, 0 skips.

On the last row — #45 asked specifically that the execution-time type and
cardinality conditions and their call context still hold, since the rewritten
expressions are translated into the data.table query and equality of the
generated expression is not sufficient evidence on its own. dtplyr is installed
locally, so those `skip_if_not_installed("dtplyr")` tests genuinely executed
rather than passing vacuously; the 0-skip count is what establishes that.

## Reviewed

`/code-review` (Standards + Spec). Spec: nothing missing, no scope creep,
nothing implemented wrong. Standards: no hard violation. The first pass
duplicated a two-line comment verbatim at all three sites and explained the
linter rather than the code — both axes flagged it independently, and the
constructor extraction is the fix.

## Deliberately not touched

`R/parent-share.R:794` still builds `rlang::expr(~.x)`. Codetools does not
descend into formula operands, so it never contributed to the NOTE and carries
no suppression — verified directly, not inferred. It also builds a different
thing: the identity lambda that is the default `.fns`, not the pronoun alone.
Rewriting it would be less readable and would blur why the constructor exists.

A separate observation from the review — `AGENTS.md` describes a `.lintr` that
does not exist in this repo — is filed as #48. Not part of this diff.
