### PR TITLE
Prove the remaining secondary package contracts

### DIFF
--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -202,6 +202,51 @@ test_that("nesting option errors use the package condition seam", {
   }
 })
 
+test_that("nesting drops duplicate grouping sets", {
+  input <- data.frame(group = c("x", "y"), value = 1:2)
+  # `rollup(group)` contributes `{group}` and `{}`; the extra `grouping_set()`
+  # repeats `{group}`. Dropping must remove only that repeat and leave the
+  # distinct total in place.
+  spec <- grouping_sets(rollup(group), grouping_set(group))
+  verbs <- list(
+    nest_with_margins = nest_with_margins,
+    nest_by_with_margins = nest_by_with_margins
+  )
+  dropped <- list()
+
+  for (verb_name in names(verbs)) {
+    verb <- verbs[[verb_name]]
+
+    expect_error(verb(input, .grouping = spec), "Duplicate grouping sets")
+
+    # Result row order is unspecified, so sort before comparing positions.
+    result <- verb(
+      input,
+      .grouping = spec,
+      .duplicates = "drop",
+      .id = "set"
+    ) |>
+      dplyr::arrange(set, group)
+
+    expect_identical(names(result), c("group", "set", "data"))
+    expect_identical(result$group, c("x", "y", "Total"))
+    expect_identical(result$set, c(1L, 1L, 2L))
+    expect_identical(vapply(result$data, nrow, integer(1)), c(1L, 1L, 2L))
+    expect_identical(names(result$data[[1L]]), "value")
+    expect_setequal(result$data[[3L]]$value, 1:2)
+
+    dropped[[verb_name]] <- result
+  }
+
+  expect_identical(dplyr::group_vars(dropped$nest_with_margins), character())
+
+  # The row-wise return shape is what makes per-margin summaries work.
+  by_result <- dropped$nest_by_with_margins
+  expect_s3_class(by_result, "rowwise_df")
+  expect_identical(dplyr::group_vars(by_result), c("group", "set"))
+  expect_identical(dplyr::mutate(by_result, n = nrow(data))$n, c(1L, 1L, 2L))
+})
+
 test_that("nesting rejects unsupported sources with a package condition", {
   remote <- dbplyr::tbl_lazy(
     data.frame(group = c("x", "y"), value = 1:2),

--- a/tests/testthat/test-retail-sales.R
+++ b/tests/testthat/test-retail-sales.R
@@ -9,3 +9,23 @@ test_that("retail_sales is a tibble with the documented columns", {
     )
   )
 })
+
+test_that("retail_sales has missing stores only on online-direct records", {
+  # `store` is the only column documented to carry missing values; the
+  # examples rely on every other column being complete.
+  expect_identical(
+    colSums(is.na(retail_sales)),
+    c(
+      year = 0, month = 0, region = 0, store = 4, product = 0, channel = 0,
+      units = 0, revenue = 0
+    )
+  )
+  expect_identical(
+    unique(retail_sales$channel[is.na(retail_sales$store)]),
+    "Online"
+  )
+  # The documentation uses this data to show that an omitted dimension and a
+  # genuinely missing source value are different things, which only holds
+  # while no source store is spelled like the default Margin label.
+  expect_false("Total" %in% retail_sales$store)
+})


### PR DESCRIPTION
## Summary
- Add a public-interface regression for `.duplicates = "drop"` on both `nest_with_margins()` and `nest_by_with_margins()`, asserting deduplicated outer rows, `.id` values, nested row counts, and the row-wise class/grouping contract.
- Add regressions for the documented `retail_sales` missing `store` value: only `Online` rows are missing, no other column is missing, and no source store collides with the default Margin label.
- Record prior-coverage evidence in a comment on #35 for the three "identify rather than duplicate" acceptance criteria (contextual Grouping helpers outside Margin verbs, integer `.id` on zero-row results, factor/ADR 0012 cases) for the #39 disposition ledger to consume.

Closes #35

## Test plan
- [x] `lintr::lint_package()` (after `pkgload::load_all()`) — no lints
- [x] Full `testthat` suite — green
- [x] Mutation-checked the new drop-policy assertion (forced `"drop"` to behave like `"keep"`) to confirm it actually fails
- [x] Two-axis `/code-review` (Standards + Spec) run and findings applied