### PR TITLE
Make function references the canonical user contract

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -123,10 +123,10 @@ assert_markers(
     "collect",
     "Parent shares use a staged lazy query",
     "Completion stays in the lazy input pipeline",
-    "Live native execution tested",
-    "Native SQL generation tested",
-    "Fallback SQL generation tested",
-    "Microsoft SQL Server"
+    "Only DuckDB and SQLite are exercised as live SQL databases",
+    "DuckDB covers native SQL end to end",
+    "dozen-plus fallback dialects",
+    "Arrow and dtplyr are tested for the lazy"
   ),
   "Database and lazy backends"
 )
@@ -146,8 +146,9 @@ assert_markers(
     "Relationship to dplyr summaries",
     "Display labels and grouping identity",
     "Parent shares",
-    "Empty inputs follow this Parent-share contract",
     "Backend extension design",
+    "Database backend coverage",
+    "Microsoft SQL Server",
     "NA is already a factor level",
     "cannot select any column named in the complete grouping plan",
     "cur_group_id"
@@ -174,6 +175,7 @@ assert_page_markers(
     "Column-wise Parent shares",
     "Rejected forms and supported rewrites",
     "Lazy execution boundaries",
+    "Parent shares never synthesize or complete keys",
     "revenue_quantile",
     "Missing fixed and included keys",
     "where(is.numeric)",

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -16,6 +16,7 @@
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
 #' @inheritSection summarize_with_margins Grouping set identifiers
+#' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Database backend coverage
 #' @inheritSection summarize_with_margins Backend extension design
 #' @return An ungrouped data frame, or a lazy table when `.data` is lazy.

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -18,6 +18,12 @@
 #' column belongs to every grouping set, [grouping_bit()] is always `0L` for it
 #' and it contributes a zero bit to [grouping_id()].
 #'
+#' @section Grouping identity values:
+#' marginplyr exposes four related values. Two describe *where* a Grouping-set
+#' occurrence sits in one ordered Grouping plan; two describe *which*
+#' dimensions are absent from a row. Only the first pair can tell repeated
+#' identical Grouping sets apart:
+#'
 #' | Value | Meaning | Duplicate Grouping-set occurrences |
 #' |---|---|---|
 #' | `.id` | One-based position in the resolved Grouping plan | Distinct with `.duplicates = "keep"` | # nolint: line_length_linter
@@ -25,18 +31,47 @@
 #' | [grouping_bit()] | Whether one chosen dimension is absent | The same for identical absence patterns | # nolint: line_length_linter
 #' | [grouping_id()] | Bit mask for chosen absent dimensions | The same for identical absence patterns | # nolint: line_length_linter
 #'
-#' See the [grouping identity guide][guide] for the comparison with `.id` and
-#' [inspect_grouping()], rollup and cube masks, physical row order, Margin
-#' labels, and factor missingness.
+#' The correspondence between `.id` and `set_id` holds for one resolved `.by`,
+#' `.grouping`, and `.duplicates`. Reordering or deduplicating a Grouping
+#' specification changes both, so `.id` is not a durable business key.
+#'
+#' Grouping identifiers encode absence and need not be consecutive. A
+#' `rollup(region, store)` plan therefore has `.id` values `1L`, `2L`, and
+#' `3L` but [grouping_id()] values `0L`, `1L`, and `3L`: identifier `2` would
+#' mean `region` absent while `store` remains, which the declared hierarchy
+#' never produces. A `cube(region, store)` plan contains every mask, so its
+#' identifiers are `0L`, `1L`, `2L`, and `3L`.
+#'
+#' Neither value records physical row order. Call [dplyr::arrange()] whenever
+#' presentation order matters.
+#'
+#' Displayed Margin labels are not identity. A source value can equal its
+#' Margin label, and a source missing value can print exactly like a
+#' typed-missing Margin value, so retain one of these helpers or `.id` when
+#' structural identity matters. See
+#' *[Display labels and grouping identity][summarize_with_margins]* for the
+#' complete label, factor, and missing-value contract.
+#'
+#' The [grouping identity guide][guide] works through these values with
+#' executable examples.
 #'
 #' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
 #'
 #' @param x A bare grouping column.
 #' @param ... Bare grouping columns.
 #'
-#' @return A numeric grouping flag or identifier when used inside
-#'   [summarize_with_margins()]. Local results use integer vectors; database
-#'   result types follow the backend.
+#' @return A grouping flag or identifier when used inside
+#'   [summarize_with_margins()]. Local data frames and `dtplyr` steps return R
+#'   integers, because the value is known for each Grouping-set branch and is
+#'   substituted before execution. Arrow and every backend taking the portable
+#'   `UNION ALL` path receive that same constant as a literal in their own
+#'   query. Only a backend actually running native `GROUP BY GROUPING SETS`
+#'   emits SQL `GROUPING()`, so PostgreSQL falls back to the literal whenever
+#'   `.duplicates = "keep"` sends it down the portable path. In every remote
+#'   case the collected type comes from the backend, so cast explicitly when a
+#'   downstream calculation depends on it.
+#' @family grouping plans and grouping identity
+#' @family contextual summary helpers
 #' @export
 #' @examples
 #' # Online-direct sales have a source NA store. grouping_bit(store) is 0 for

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -17,9 +17,10 @@
 #' A [grouping_set()] nested directly inside [rollup()] or [cube()] is a
 #' composite dimension. Its columns are added or removed together.
 #'
-#' See the [grouping identity guide][guide] for how a resolved Grouping plan
-#' relates to `.id`, [inspect_grouping()], [grouping_bit()], and
-#' [grouping_id()].
+#' A resolved Grouping plan can be read back in four ways: `.id`,
+#' [inspect_grouping()]`$set_id`, [grouping_bit()], and [grouping_id()].
+#' [grouping_bit()] compares them; the [grouping identity guide][guide] works
+#' through the same values with executable examples.
 #'
 #' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
 #'
@@ -38,6 +39,10 @@
 #'   identity product (the empty grouping set).
 #'
 #' @return A grouping specification for use in `.grouping`.
+#' @family grouping plans and grouping identity
+#' @seealso [summarize_with_margins()], [expand_with_margins()],
+#'   [nest_with_margins()], and [nest_by_with_margins()], the Margin verbs
+#'   that consume a grouping specification.
 #' @export
 #' @examples
 #' # The operations team needs store, region, and company totals for each

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -28,6 +28,9 @@
 #' that absence pattern as a bit mask. `grouping_id` is `NA_integer_` beyond
 #' 31 variable dimensions, while `grouping_bits` remains complete.
 #'
+#' [grouping_bit()] is the canonical reference for how these four values
+#' relate and which of them distinguish duplicate Grouping-set occurrences.
+#'
 #' @section Formats and ordinary tibble behavior:
 #' The default `.format = "text"` represents column collections as `()`,
 #' `(region)`, or `(region, store)`, and Grouping bits as text such as
@@ -51,10 +54,14 @@
 #' [dplyr::show_query()] for generated SQL and backend-native tools for an
 #' optimizer plan.
 #'
-#' See the [grouping identity guide][guide] for the full comparison.
+#' The [grouping identity guide][guide] walks through inspecting a plan and
+#' reading it back off a Margin result.
 #'
 #' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
 #'
+#' @family grouping plans and grouping identity
+#' @seealso [summarize_with_margins()] to run a Margin operation on the
+#'   inspected plan.
 #' @export
 #' @examples
 #' inspect_grouping(

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -6,6 +6,7 @@
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
 #' @inheritSection summarize_with_margins Grouping set identifiers
+#' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Backend extension design
 #' @inheritSection nest_with_margins Relationship to tidyr and dplyr
 #' @param .key A non-missing string naming the list column. Unlike

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -7,6 +7,7 @@
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
 #' @inheritSection summarize_with_margins Grouping set identifiers
+#' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Backend extension design
 #' @param .data A local data frame or a `dtplyr` step. Other lazy tables are
 #'   not supported because nesting creates list columns.

--- a/R/parent-share.R
+++ b/R/parent-share.R
@@ -322,12 +322,29 @@
 #' Parent-share execution supports local data frames and lazy dbplyr and dtplyr
 #' inputs for one pure [rollup()], including composite dimensions. Lazy results
 #' remain lazy: ordinary summaries are followed by one Parent-share mapping and
-#' join shared by every requested measure.
+#' join shared by every requested measure, however many measures are requested.
+#'
+#' Syntax, source-name, written-order, and `across()` errors are always
+#' reported locally, before execution, on every backend. Only the *result*
+#' rules — eligible numeric type and exactly-one-value cardinality — depend on
+#' what the backend can prove:
+#'
+#' | Backend | Where source type and cardinality are checked |
+#' |---|---|
+#' | Local data frame | Before any Parent share is calculated |
+#' | `dtplyr` step | At explicit execution, before an invalid row is emitted |
+#' | Arrow | Not reached; Parent shares are rejected outright |
+#' | General dbplyr | Not by marginplyr; the database may error at collection |
 #'
 #' Arrow inputs reject Parent shares after expression planning and common
 #' Margin-operation validation but before constructing a summary query. Other
 #' Arrow Margin operations remain supported and lazy. Explicitly collect an
 #' Arrow input first when local Parent-share execution is appropriate.
+#'
+#' A `dtplyr` step remains a native lazy query: no validation-only query is
+#' added and nothing is collected on your behalf. Its execution-time
+#' diagnostics keep the Parent-share output name, the source summary name, and
+#' the original public call, so they read like the local ones.
 #'
 #' General dbplyr backends are not queried solely to discover an arbitrary
 #' summary result's type or cardinality. Statically detectable syntax and
@@ -347,6 +364,9 @@
 #' @param x The bare name of one preceding eligible ordinary summary.
 #'
 #' @return A double vector when used inside [summarize_with_margins()].
+#' @family contextual summary helpers
+#' @seealso [summarize_with_margins()], the only verb this helper can be used
+#'   in, and [rollup()], the only Grouping specification it accepts.
 #' @export
 #' @examples
 #' summarize_with_margins(

--- a/R/retail_sales.R
+++ b/R/retail_sales.R
@@ -18,6 +18,10 @@
 #'   \item{revenue}{Revenue in US dollars.}
 #' }
 #' @source Synthetic data created for marginplyr examples.
+#' @seealso [summarize_with_margins()], [expand_with_margins()],
+#'   [nest_with_margins()], and [nest_by_with_margins()] for the Margin verbs
+#'   these columns are used with, and [grouping_bit()] for telling the missing
+#'   `store` values apart from a subtotal.
 #' @keywords datasets
 #' @usage data(retail_sales)
 #' @name retail_sales

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -116,21 +116,11 @@
 #' and is not included inside the nested data. For
 #' [nest_by_with_margins()], it is also a row-wise grouping key.
 #'
-#' | Value | Meaning | Duplicate occurrences |
-#' |---|---|---|
-#' | `.id` | Position in this ordered Grouping plan | Distinct with `"keep"` |
-#' | [inspect_grouping()] `set_id` | The same position before execution | Distinct with `"keep"` | # nolint: line_length_linter
-#' | [grouping_bit()] | Whether one dimension is omitted (`0L` or `1L`) | Same |
-#' | [grouping_id()] | Bit mask of omitted dimensions | Same |
-#'
-#' Thus a two-dimension rollup has `.id` values `1L`, `2L`, and `3L`, while
-#' its [grouping_id()] values are `0L`, `1L`, and `3L`. `.id` is not a
-#' durable business key and can change when the Grouping plan is reordered or
-#' deduplicated. It records plan occurrence, not physical result order; use
-#' [dplyr::arrange()] when order matters.
-#' See the [grouping identity guide][guide] for the complete comparison.
-#'
-#' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
+#' `.id` records plan occurrence, not physical result order, and is not a
+#' durable business key: reordering or deduplicating the Grouping
+#' specification changes it. Use [dplyr::arrange()] when order matters.
+#' [grouping_bit()] documents how `.id` compares with
+#' [inspect_grouping()]`$set_id`, [grouping_bit()], and [grouping_id()].
 #'
 #' @section Relationship to dplyr summaries:
 #' The `...` expressions use [dplyr::summarize()] data-masking semantics.
@@ -178,19 +168,17 @@
 #' calculates all requested shares through one shared Parent mapping, and then
 #' removes the metadata before returning the requested column order.
 #'
-#' General dbplyr backends are not executed or probed solely to validate an
-#' arbitrary summary result's type or cardinality. Statically detectable helper
-#' errors remain targeted before execution; an incompatible lazy expression may
-#' instead fail with its database error at [dplyr::collect()]. See
-#' [share_of_parent()] for the complete direct-expression, source, ordering,
-#' value, and `across()` contracts.
+#' Local data frames reject an ineligible source before any Parent share is
+#' calculated. `dtplyr` steps stay lazy and report the same conditions during
+#' explicit execution, before an invalid grouping row is emitted. General
+#' dbplyr backends are not executed or probed solely to validate an arbitrary
+#' summary result's type or cardinality: statically detectable helper errors
+#' remain targeted before execution, while an incompatible lazy expression may
+#' instead fail with its database error at [dplyr::collect()].
 #'
-#' Empty inputs follow this Parent-share contract:
-#'
-#' | Input | Result rows | Parent-share column |
-#' |---|---:|---|
-#' | Empty, without `.by` | One root row | `1.0`, double |
-#' | Empty, with `.by` | Zero rows | Empty double vector |
+#' [share_of_parent()] is the canonical reference for the complete
+#' direct-expression, source, ordering, value, empty-input, and `across()`
+#' contracts.
 #'
 #' @section Display labels and grouping identity:
 #' `.margin_label` is a display value, not the identity of a grouping set. An
@@ -230,8 +218,11 @@
 #' A factor observation that uses an NA level can print as `<NA>` while
 #' `is.na()` is false. A missing factor code has `is.na()` equal to true.
 #' Source missing values and typed-missing Margin values may display
-#' identically, so retain [grouping_bit()] or [grouping_id()] when structural
-#' identity matters. The eager default `.check_margin_label = TRUE` detects
+#' identically, so keep a structural identity column when the difference
+#' matters: `.id` is available from every Margin verb, and
+#' [summarize_with_margins()] can additionally write [grouping_bit()] or
+#' [grouping_id()] as summaries. The eager default
+#' `.check_margin_label = TRUE` detects
 #' collisions for local data. Lazy tables default to `FALSE` because checking
 #' would execute an extra query; opt in when that scan is appropriate.
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -176,6 +176,53 @@ january_sales |>
 removed `store`. This is the role of the SQL `GROUPING()` function; replacing
 every missing value with `"Total"` cannot preserve that distinction.
 
+## Compare each summary with its rollup parent
+
+`share_of_parent()` divides a preceding named summary by the same summary one
+rollup level up. Name the source summary first, then take its share:
+
+```{r}
+parent_report <- january_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    revenue_share = share_of_parent(revenue),
+    .grouping = rollup(region, store)
+  )
+
+parent_report
+```
+
+For several measures, use two ordered `across()` expressions. The second one
+selects the summaries the first one created:
+
+```{r}
+january_sales |>
+  summarize_with_margins(
+    dplyr::across(c(units, revenue), sum),
+    dplyr::across(
+      c(units, revenue),
+      share_of_parent,
+      .names = "{.col}_share"
+    ),
+    .grouping = rollup(region, store)
+  )
+```
+
+Percentages, rounding, and other derived columns belong in a `mutate()` after
+the summary:
+
+```{r}
+parent_report |>
+  dplyr::mutate(revenue_percent = 100 * revenue_share)
+```
+
+The root row's share is one, and a missing or zero denominator gives `NA`.
+Parent matching is structural, so display labels never choose the parent. The
+[`share_of_parent()`
+reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
+documents the eligible sources, value rules, `across()` grammar, and backend
+boundaries in full.
+
 ## Use the same report with a database
 
 The grouping plan becomes part of the lazy query. `show_query()` inspects the

--- a/README.md
+++ b/README.md
@@ -225,6 +225,87 @@ rollup removed `store`. This is the role of the SQL `GROUPING()`
 function; replacing every missing value with `"Total"` cannot preserve
 that distinction.
 
+## Compare each summary with its rollup parent
+
+`share_of_parent()` divides a preceding named summary by the same
+summary one rollup level up. Name the source summary first, then take
+its share:
+
+``` r
+parent_report <- january_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    revenue_share = share_of_parent(revenue),
+    .grouping = rollup(region, store)
+  )
+
+parent_report
+#> # A tibble: 8 × 4
+#>   region store         revenue revenue_share
+#>   <chr>  <chr>           <dbl>         <dbl>
+#> 1 East   Boston           6000         0.536
+#> 2 East   New York         3000         0.268
+#> 3 East   <NA>             2200         0.196
+#> 4 West   San Francisco    7200         0.595
+#> 5 West   Seattle          4900         0.405
+#> 6 East   Total           11200         0.481
+#> 7 West   Total           12100         0.519
+#> 8 Total  Total           23300         1
+```
+
+For several measures, use two ordered `across()` expressions. The second
+one selects the summaries the first one created:
+
+``` r
+january_sales |>
+  summarize_with_margins(
+    dplyr::across(c(units, revenue), sum),
+    dplyr::across(
+      c(units, revenue),
+      share_of_parent,
+      .names = "{.col}_share"
+    ),
+    .grouping = rollup(region, store)
+  )
+#> # A tibble: 8 × 6
+#>   region store         units revenue units_share revenue_share
+#>   <chr>  <chr>         <int>   <dbl>       <dbl>         <dbl>
+#> 1 East   Boston            5    6000       0.135         0.536
+#> 2 East   New York         10    3000       0.270         0.268
+#> 3 East   <NA>             22    2200       0.595         0.196
+#> 4 West   San Francisco     6    7200       0.182         0.595
+#> 5 West   Seattle          27    4900       0.818         0.405
+#> 6 East   Total            37   11200       0.529         0.481
+#> 7 West   Total            33   12100       0.471         0.519
+#> 8 Total  Total            70   23300       1             1
+```
+
+Percentages, rounding, and other derived columns belong in a `mutate()`
+after the summary:
+
+``` r
+parent_report |>
+  dplyr::mutate(revenue_percent = 100 * revenue_share)
+#> # A tibble: 8 × 5
+#>   region store         revenue revenue_share revenue_percent
+#>   <chr>  <chr>           <dbl>         <dbl>           <dbl>
+#> 1 East   Boston           6000         0.536            53.6
+#> 2 East   New York         3000         0.268            26.8
+#> 3 East   <NA>             2200         0.196            19.6
+#> 4 West   San Francisco    7200         0.595            59.5
+#> 5 West   Seattle          4900         0.405            40.5
+#> 6 East   Total           11200         0.481            48.1
+#> 7 West   Total           12100         0.519            51.9
+#> 8 Total  Total           23300         1               100
+```
+
+The root row’s share is one, and a missing or zero denominator gives
+`NA`. Parent matching is structural, so display labels never choose the
+parent. The [`share_of_parent()`
+reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
+documents the eligible sources, value rules, `across()` grammar, and
+backend boundaries in full.
+
 ## Use the same report with a database
 
 The grouping plan becomes part of the lazy query. `show_query()`

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -133,21 +133,61 @@ identifier \code{1L}, and a zero-row result retains an integer \code{.id} column
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then
 ordinary output columns. For \code{\link[=nest_with_margins]{nest_with_margins()}}, \code{.id} is an outer key
 and is not included inside the nested data. For
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.\tabular{lll}{
-   Value \tab Meaning \tab Duplicate occurrences \cr
-   \code{.id} \tab Position in this ordered Grouping plan \tab Distinct with \code{"keep"} \cr
-   \code{\link[=inspect_grouping]{inspect_grouping()}} \code{set_id} \tab The same position before execution \tab Distinct with \code{"keep"} \cr
-   \code{\link[=grouping_bit]{grouping_bit()}} \tab Whether one dimension is omitted (\code{0L} or \code{1L}) \tab Same \cr
-   \code{\link[=grouping_id]{grouping_id()}} \tab Bit mask of omitted dimensions \tab Same \cr
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.
+
+\code{.id} records plan occurrence, not physical result order, and is not a
+durable business key: reordering or deduplicating the Grouping
+specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
+\code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
+\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Display labels and grouping identity}{
+
+\code{.margin_label} is a display value, not the identity of a grouping set. An
+unnamed scalar labels every resolved Margin dimension. A named vector
+provides column-specific labels and must cover the resolved dimensions
+exactly once; missing, unknown, duplicate, and empty names are rejected, as
+are names from \code{.by}.
+
+Non-missing labels convert ordinary grouping dimensions to character. A
+factor or ordered factor is reconstructed after the Margin operation,
+preserving ordered status and placing the synthetic level last by default
+or first when \code{.margin_label_position = "first"}. With collision checking
+enabled, the complete factor domain is checked, including unused levels.
+With checking disabled, an existing level may be reused and is moved to the
+requested position. Reconstruction preserves the distinction between an
+observation that uses a factor NA level and an actually missing factor code.
+
+\code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
+not create a synthetic factor level. Position is therefore a no-op for
+either value. \code{NA_character_} still participates in collision validation;
+\code{NULL} opts out. A factor NA level is a structural conflict for
+\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+
+With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+   Margin label \tab NA level \tab Missing value \tab Result \cr
+   \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
+   \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
+   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
+   \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
+   \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
+   \code{NULL} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
+   \code{NULL} \tab no \tab no \tab Allowed; use typed missing \cr
 }
 
 
-Thus a two-dimension rollup has \code{.id} values \code{1L}, \code{2L}, and \code{3L}, while
-its \code{\link[=grouping_id]{grouping_id()}} values are \code{0L}, \code{1L}, and \code{3L}. \code{.id} is not a
-durable business key and can change when the Grouping plan is reordered or
-deduplicated. It records plan occurrence, not physical result order; use
-\code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for the complete comparison.
+A factor observation that uses an NA level can print as \verb{<NA>} while
+\code{is.na()} is false. A missing factor code has \code{is.na()} equal to true.
+Source missing values and typed-missing Margin values may display
+identically, so keep a structural identity column when the difference
+matters: \code{.id} is available from every Margin verb, and
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
+\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
+\code{.check_margin_label = TRUE} detects
+collisions for local data. Lazy tables default to \code{FALSE} because checking
+would execute an extra query; opt in when that scan is appropriate.
 }
 
 \section{Database backend coverage}{

--- a/man/grouping_bit.Rd
+++ b/man/grouping_bit.Rd
@@ -15,9 +15,16 @@ grouping_id(...)
 \item{...}{Bare grouping columns.}
 }
 \value{
-A numeric grouping flag or identifier when used inside
-\code{\link[=summarize_with_margins]{summarize_with_margins()}}. Local results use integer vectors; database
-result types follow the backend.
+A grouping flag or identifier when used inside
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}. Local data frames and \code{dtplyr} steps return R
+integers, because the value is known for each Grouping-set branch and is
+substituted before execution. Arrow and every backend taking the portable
+\verb{UNION ALL} path receive that same constant as a literal in their own
+query. Only a backend actually running native \verb{GROUP BY GROUPING SETS}
+emits SQL \code{GROUPING()}, so PostgreSQL falls back to the literal whenever
+\code{.duplicates = "keep"} sends it down the portable path. In every remote
+case the collected type comes from the backend, so cast explicitly when a
+downstream calculation depends on it.
 }
 \description{
 \code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}} are contextual summary helpers for
@@ -37,7 +44,14 @@ for placing equal values next to one another.
 
 Columns fixed by \code{.by} may also be passed to these helpers. Because a \code{.by}
 column belongs to every grouping set, \code{\link[=grouping_bit]{grouping_bit()}} is always \code{0L} for it
-and it contributes a zero bit to \code{\link[=grouping_id]{grouping_id()}}.\tabular{lll}{
+and it contributes a zero bit to \code{\link[=grouping_id]{grouping_id()}}.
+}
+\section{Grouping identity values}{
+
+marginplyr exposes four related values. Two describe \emph{where} a Grouping-set
+occurrence sits in one ordered Grouping plan; two describe \emph{which}
+dimensions are absent from a row. Only the first pair can tell repeated
+identical Grouping sets apart:\tabular{lll}{
    Value \tab Meaning \tab Duplicate Grouping-set occurrences \cr
    \code{.id} \tab One-based position in the resolved Grouping plan \tab Distinct with \code{.duplicates = "keep"} \cr
    \code{\link[=inspect_grouping]{inspect_grouping()}} \verb{$set_id} \tab The same position before execution \tab Distinct with \code{.duplicates = "keep"} \cr
@@ -46,10 +60,31 @@ and it contributes a zero bit to \code{\link[=grouping_id]{grouping_id()}}.\tabu
 }
 
 
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for the comparison with \code{.id} and
-\code{\link[=inspect_grouping]{inspect_grouping()}}, rollup and cube masks, physical row order, Margin
-labels, and factor missingness.
+The correspondence between \code{.id} and \code{set_id} holds for one resolved \code{.by},
+\code{.grouping}, and \code{.duplicates}. Reordering or deduplicating a Grouping
+specification changes both, so \code{.id} is not a durable business key.
+
+Grouping identifiers encode absence and need not be consecutive. A
+\code{rollup(region, store)} plan therefore has \code{.id} values \code{1L}, \code{2L}, and
+\code{3L} but \code{\link[=grouping_id]{grouping_id()}} values \code{0L}, \code{1L}, and \code{3L}: identifier \code{2} would
+mean \code{region} absent while \code{store} remains, which the declared hierarchy
+never produces. A \code{cube(region, store)} plan contains every mask, so its
+identifiers are \code{0L}, \code{1L}, \code{2L}, and \code{3L}.
+
+Neither value records physical row order. Call \code{\link[dplyr:arrange]{dplyr::arrange()}} whenever
+presentation order matters.
+
+Displayed Margin labels are not identity. A source value can equal its
+Margin label, and a source missing value can print exactly like a
+typed-missing Margin value, so retain one of these helpers or \code{.id} when
+structural identity matters. See
+\emph{\link[=summarize_with_margins]{Display labels and grouping identity}} for the
+complete label, factor, and missing-value contract.
+
+The \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} works through these values with
+executable examples.
 }
+
 \examples{
 # Online-direct sales have a source NA store. grouping_bit(store) is 0 for
 # that detail row but 1 when ROLLUP removes store to create a subtotal.
@@ -75,3 +110,13 @@ summarize_with_margins(
   .margin_label = NULL
 )
 }
+\seealso{
+Other grouping plans and grouping identity:
+\code{\link[=grouping_set]{grouping_set()}},
+\code{\link[=inspect_grouping]{inspect_grouping()}}
+
+Other contextual summary helpers:
+\code{\link[=share_of_parent]{share_of_parent()}}
+}
+\concept{contextual summary helpers}
+\concept{grouping plans and grouping identity}

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -57,9 +57,10 @@ comma-separated SQL \verb{GROUP BY} items.
 A \code{\link[=grouping_set]{grouping_set()}} nested directly inside \code{\link[=rollup]{rollup()}} or \code{\link[=cube]{cube()}} is a
 composite dimension. Its columns are added or removed together.
 
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for how a resolved Grouping plan
-relates to \code{.id}, \code{\link[=inspect_grouping]{inspect_grouping()}}, \code{\link[=grouping_bit]{grouping_bit()}}, and
-\code{\link[=grouping_id]{grouping_id()}}.
+A resolved Grouping plan can be read back in four ways: \code{.id},
+\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+\code{\link[=grouping_bit]{grouping_bit()}} compares them; the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} works
+through the same values with executable examples.
 }
 \examples{
 # The operations team needs store, region, and company totals for each
@@ -158,3 +159,13 @@ postgres_sales |>
   ) |>
   dplyr::show_query()
 }
+\seealso{
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}},
+\code{\link[=nest_with_margins]{nest_with_margins()}}, and \code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, the Margin verbs
+that consume a grouping specification.
+
+Other grouping plans and grouping identity:
+\code{\link[=grouping_bit]{grouping_bit()}},
+\code{\link[=inspect_grouping]{inspect_grouping()}}
+}
+\concept{grouping plans and grouping identity}

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -47,6 +47,9 @@ same resolved plan. \code{grouping_bits} instead describes whether each variable
 dimension is included (\code{0L}) or omitted (\code{1L}), and \code{grouping_id} encodes
 that absence pattern as a bit mask. \code{grouping_id} is \code{NA_integer_} beyond
 31 variable dimensions, while \code{grouping_bits} remains complete.
+
+\code{\link[=grouping_bit]{grouping_bit()}} is the canonical reference for how these four values
+relate and which of them distinguish duplicate Grouping-set occurrences.
 }
 
 \section{Formats and ordinary tibble behavior}{
@@ -73,7 +76,8 @@ Grouping plan. It is deliberately separate from a SQL execution plan. Use
 \code{\link[dplyr:show_query]{dplyr::show_query()}} for generated SQL and backend-native tools for an
 optimizer plan.
 
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for the full comparison.
+The \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} walks through inspecting a plan and
+reading it back off a Margin result.
 }
 
 \examples{
@@ -130,3 +134,12 @@ inspect_grouping(
   .duplicates = "keep"
 )
 }
+\seealso{
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} to run a Margin operation on the
+inspected plan.
+
+Other grouping plans and grouping identity:
+\code{\link[=grouping_bit]{grouping_bit()}},
+\code{\link[=grouping_set]{grouping_set()}}
+}
+\concept{grouping plans and grouping identity}

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -145,21 +145,61 @@ identifier \code{1L}, and a zero-row result retains an integer \code{.id} column
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then
 ordinary output columns. For \code{\link[=nest_with_margins]{nest_with_margins()}}, \code{.id} is an outer key
 and is not included inside the nested data. For
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.\tabular{lll}{
-   Value \tab Meaning \tab Duplicate occurrences \cr
-   \code{.id} \tab Position in this ordered Grouping plan \tab Distinct with \code{"keep"} \cr
-   \code{\link[=inspect_grouping]{inspect_grouping()}} \code{set_id} \tab The same position before execution \tab Distinct with \code{"keep"} \cr
-   \code{\link[=grouping_bit]{grouping_bit()}} \tab Whether one dimension is omitted (\code{0L} or \code{1L}) \tab Same \cr
-   \code{\link[=grouping_id]{grouping_id()}} \tab Bit mask of omitted dimensions \tab Same \cr
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.
+
+\code{.id} records plan occurrence, not physical result order, and is not a
+durable business key: reordering or deduplicating the Grouping
+specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
+\code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
+\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Display labels and grouping identity}{
+
+\code{.margin_label} is a display value, not the identity of a grouping set. An
+unnamed scalar labels every resolved Margin dimension. A named vector
+provides column-specific labels and must cover the resolved dimensions
+exactly once; missing, unknown, duplicate, and empty names are rejected, as
+are names from \code{.by}.
+
+Non-missing labels convert ordinary grouping dimensions to character. A
+factor or ordered factor is reconstructed after the Margin operation,
+preserving ordered status and placing the synthetic level last by default
+or first when \code{.margin_label_position = "first"}. With collision checking
+enabled, the complete factor domain is checked, including unused levels.
+With checking disabled, an existing level may be reused and is moved to the
+requested position. Reconstruction preserves the distinction between an
+observation that uses a factor NA level and an actually missing factor code.
+
+\code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
+not create a synthetic factor level. Position is therefore a no-op for
+either value. \code{NA_character_} still participates in collision validation;
+\code{NULL} opts out. A factor NA level is a structural conflict for
+\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+
+With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+   Margin label \tab NA level \tab Missing value \tab Result \cr
+   \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
+   \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
+   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
+   \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
+   \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
+   \code{NULL} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
+   \code{NULL} \tab no \tab no \tab Allowed; use typed missing \cr
 }
 
 
-Thus a two-dimension rollup has \code{.id} values \code{1L}, \code{2L}, and \code{3L}, while
-its \code{\link[=grouping_id]{grouping_id()}} values are \code{0L}, \code{1L}, and \code{3L}. \code{.id} is not a
-durable business key and can change when the Grouping plan is reordered or
-deduplicated. It records plan occurrence, not physical result order; use
-\code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for the complete comparison.
+A factor observation that uses an NA level can print as \verb{<NA>} while
+\code{is.na()} is false. A missing factor code has \code{is.na()} equal to true.
+Source missing values and typed-missing Margin values may display
+identically, so keep a structural identity column when the difference
+matters: \code{.id} is available from every Margin verb, and
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
+\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
+\code{.check_margin_label = TRUE} detects
+collisions for local data. Lazy tables default to \code{FALSE} because checking
+would execute an extra query; opt in when that scan is appropriate.
 }
 
 \section{Backend extension design}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -171,21 +171,61 @@ identifier \code{1L}, and a zero-row result retains an integer \code{.id} column
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then
 ordinary output columns. For \code{\link[=nest_with_margins]{nest_with_margins()}}, \code{.id} is an outer key
 and is not included inside the nested data. For
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.\tabular{lll}{
-   Value \tab Meaning \tab Duplicate occurrences \cr
-   \code{.id} \tab Position in this ordered Grouping plan \tab Distinct with \code{"keep"} \cr
-   \code{\link[=inspect_grouping]{inspect_grouping()}} \code{set_id} \tab The same position before execution \tab Distinct with \code{"keep"} \cr
-   \code{\link[=grouping_bit]{grouping_bit()}} \tab Whether one dimension is omitted (\code{0L} or \code{1L}) \tab Same \cr
-   \code{\link[=grouping_id]{grouping_id()}} \tab Bit mask of omitted dimensions \tab Same \cr
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.
+
+\code{.id} records plan occurrence, not physical result order, and is not a
+durable business key: reordering or deduplicating the Grouping
+specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
+\code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
+\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Display labels and grouping identity}{
+
+\code{.margin_label} is a display value, not the identity of a grouping set. An
+unnamed scalar labels every resolved Margin dimension. A named vector
+provides column-specific labels and must cover the resolved dimensions
+exactly once; missing, unknown, duplicate, and empty names are rejected, as
+are names from \code{.by}.
+
+Non-missing labels convert ordinary grouping dimensions to character. A
+factor or ordered factor is reconstructed after the Margin operation,
+preserving ordered status and placing the synthetic level last by default
+or first when \code{.margin_label_position = "first"}. With collision checking
+enabled, the complete factor domain is checked, including unused levels.
+With checking disabled, an existing level may be reused and is moved to the
+requested position. Reconstruction preserves the distinction between an
+observation that uses a factor NA level and an actually missing factor code.
+
+\code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
+not create a synthetic factor level. Position is therefore a no-op for
+either value. \code{NA_character_} still participates in collision validation;
+\code{NULL} opts out. A factor NA level is a structural conflict for
+\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+
+With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+   Margin label \tab NA level \tab Missing value \tab Result \cr
+   \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
+   \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
+   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
+   \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
+   \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
+   \code{NULL} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
+   \code{NULL} \tab no \tab no \tab Allowed; use typed missing \cr
 }
 
 
-Thus a two-dimension rollup has \code{.id} values \code{1L}, \code{2L}, and \code{3L}, while
-its \code{\link[=grouping_id]{grouping_id()}} values are \code{0L}, \code{1L}, and \code{3L}. \code{.id} is not a
-durable business key and can change when the Grouping plan is reordered or
-deduplicated. It records plan occurrence, not physical result order; use
-\code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for the complete comparison.
+A factor observation that uses an NA level can print as \verb{<NA>} while
+\code{is.na()} is false. A missing factor code has \code{is.na()} equal to true.
+Source missing values and typed-missing Margin values may display
+identically, so keep a structural identity column when the difference
+matters: \code{.id} is available from every Margin verb, and
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
+\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
+\code{.check_margin_label = TRUE} detects
+collisions for local data. Lazy tables default to \code{FALSE} because checking
+would execute an extra query; opt in when that scan is appropriate.
 }
 
 \section{Backend extension design}{

--- a/man/retail_sales.Rd
+++ b/man/retail_sales.Rd
@@ -29,4 +29,10 @@ Online-direct records have a missing \code{store}, which makes it possible to
 distinguish a source missing value from a subtotal produced by a grouping
 operation.
 }
+\seealso{
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}},
+\code{\link[=nest_with_margins]{nest_with_margins()}}, and \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} for the Margin verbs
+these columns are used with, and \code{\link[=grouping_bit]{grouping_bit()}} for telling the missing
+\code{store} values apart from a subtotal.
+}
 \keyword{datasets}

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -338,12 +338,29 @@ Missing detail or subtotal combinations are not completed.
 Parent-share execution supports local data frames and lazy dbplyr and dtplyr
 inputs for one pure \code{\link[=rollup]{rollup()}}, including composite dimensions. Lazy results
 remain lazy: ordinary summaries are followed by one Parent-share mapping and
-join shared by every requested measure.
+join shared by every requested measure, however many measures are requested.
+
+Syntax, source-name, written-order, and \code{across()} errors are always
+reported locally, before execution, on every backend. Only the \emph{result}
+rules — eligible numeric type and exactly-one-value cardinality — depend on
+what the backend can prove:\tabular{ll}{
+   Backend \tab Where source type and cardinality are checked \cr
+   Local data frame \tab Before any Parent share is calculated \cr
+   \code{dtplyr} step \tab At explicit execution, before an invalid row is emitted \cr
+   Arrow \tab Not reached; Parent shares are rejected outright \cr
+   General dbplyr \tab Not by marginplyr; the database may error at collection \cr
+}
+
 
 Arrow inputs reject Parent shares after expression planning and common
 Margin-operation validation but before constructing a summary query. Other
 Arrow Margin operations remain supported and lazy. Explicitly collect an
 Arrow input first when local Parent-share execution is appropriate.
+
+A \code{dtplyr} step remains a native lazy query: no validation-only query is
+added and nothing is collected on your behalf. Its execution-time
+diagnostics keep the Parent-share output name, the source summary name, and
+the original public call, so they read like the local ones.
 
 General dbplyr backends are not queried solely to discover an arbitrary
 summary result's type or cardinality. Statically detectable syntax and
@@ -452,3 +469,11 @@ try(summarize_with_margins(
   .grouping = rollup(region, store)
 ))
 }
+\seealso{
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}, the only verb this helper can be used
+in, and \code{\link[=rollup]{rollup()}}, the only Grouping specification it accepts.
+
+Other contextual summary helpers:
+\code{\link[=grouping_bit]{grouping_bit()}}
+}
+\concept{contextual summary helpers}

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -159,21 +159,13 @@ identifier \code{1L}, and a zero-row result retains an integer \code{.id} column
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then
 ordinary output columns. For \code{\link[=nest_with_margins]{nest_with_margins()}}, \code{.id} is an outer key
 and is not included inside the nested data. For
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.\tabular{lll}{
-   Value \tab Meaning \tab Duplicate occurrences \cr
-   \code{.id} \tab Position in this ordered Grouping plan \tab Distinct with \code{"keep"} \cr
-   \code{\link[=inspect_grouping]{inspect_grouping()}} \code{set_id} \tab The same position before execution \tab Distinct with \code{"keep"} \cr
-   \code{\link[=grouping_bit]{grouping_bit()}} \tab Whether one dimension is omitted (\code{0L} or \code{1L}) \tab Same \cr
-   \code{\link[=grouping_id]{grouping_id()}} \tab Bit mask of omitted dimensions \tab Same \cr
-}
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, it is also a row-wise grouping key.
 
-
-Thus a two-dimension rollup has \code{.id} values \code{1L}, \code{2L}, and \code{3L}, while
-its \code{\link[=grouping_id]{grouping_id()}} values are \code{0L}, \code{1L}, and \code{3L}. \code{.id} is not a
-durable business key and can change when the Grouping plan is reordered or
-deduplicated. It records plan occurrence, not physical result order; use
-\code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
-See the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} for the complete comparison.
+\code{.id} records plan occurrence, not physical result order, and is not a
+durable business key: reordering or deduplicating the Grouping
+specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
+\code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
+\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
 }
 
 \section{Relationship to dplyr summaries}{
@@ -225,18 +217,17 @@ preserves collision-safe Grouping set metadata through ordinary aggregation,
 calculates all requested shares through one shared Parent mapping, and then
 removes the metadata before returning the requested column order.
 
-General dbplyr backends are not executed or probed solely to validate an
-arbitrary summary result's type or cardinality. Statically detectable helper
-errors remain targeted before execution; an incompatible lazy expression may
-instead fail with its database error at \code{\link[dplyr:collect]{dplyr::collect()}}. See
-\code{\link[=share_of_parent]{share_of_parent()}} for the complete direct-expression, source, ordering,
-value, and \code{across()} contracts.
+Local data frames reject an ineligible source before any Parent share is
+calculated. \code{dtplyr} steps stay lazy and report the same conditions during
+explicit execution, before an invalid grouping row is emitted. General
+dbplyr backends are not executed or probed solely to validate an arbitrary
+summary result's type or cardinality: statically detectable helper errors
+remain targeted before execution, while an incompatible lazy expression may
+instead fail with its database error at \code{\link[dplyr:collect]{dplyr::collect()}}.
 
-Empty inputs follow this Parent-share contract:\tabular{lrl}{
-   Input \tab Result rows \tab Parent-share column \cr
-   Empty, without \code{.by} \tab One root row \tab \code{1.0}, double \cr
-   Empty, with \code{.by} \tab Zero rows \tab Empty double vector \cr
-}
+\code{\link[=share_of_parent]{share_of_parent()}} is the canonical reference for the complete
+direct-expression, source, ordering, value, empty-input, and \code{across()}
+contracts.
 }
 
 \section{Display labels and grouping identity}{
@@ -278,8 +269,11 @@ With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tab
 A factor observation that uses an NA level can print as \verb{<NA>} while
 \code{is.na()} is false. A missing factor code has \code{is.na()} equal to true.
 Source missing values and typed-missing Margin values may display
-identically, so retain \code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} when structural
-identity matters. The eager default \code{.check_margin_label = TRUE} detects
+identically, so keep a structural identity column when the difference
+matters: \code{.id} is available from every Margin verb, and
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
+\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
+\code{.check_margin_label = TRUE} detects
 collisions for local data. Lazy tables default to \code{FALSE} because checking
 would execute an extra query; opt in when that scan is appropriate.
 }

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -1,0 +1,117 @@
+# The generated function references are the canonical user contract, so the
+# rules they state must be reachable from every topic that points at them.
+# These tests read the Rd sources rather than any private roxygen structure.
+
+rd_topics <- function() {
+  # Prefer the source `man/` directory, because `tools::Rd_db()` reads whatever
+  # marginplyr version happens to be installed and would silently test stale
+  # documentation.
+  man <- testthat::test_path("..", "..", "man")
+  if (dir.exists(man)) {
+    files <- list.files(man, pattern = "[.]Rd$", full.names = TRUE)
+    topics <- lapply(files, function(file) {
+      paste(readLines(file, warn = FALSE), collapse = "\n")
+    })
+    return(stats::setNames(topics, basename(files)))
+  }
+
+  db <- tryCatch(tools::Rd_db("marginplyr"), error = function(cnd) NULL)
+  if (length(db) == 0L) {
+    return(NULL)
+  }
+  lapply(db, function(rd) {
+    paste(utils::capture.output(print(rd)), collapse = "\n")
+  })
+}
+
+rd_section_titles <- function(text) {
+  matches <- regmatches(text, gregexpr("\\\\section\\{[^{}]+\\}", text))[[1]]
+  gsub("^\\\\section\\{|\\}$", "", matches)
+}
+
+# An italicised section reference takes one of two forms. A bare
+# `\emph{Title}` names a section in the same topic, while
+# `\emph{\link[=topic]{Title}}` names one in `topic`. Both are resolved against
+# the topic they actually promise, so a cross-topic reference cannot pass by
+# accident.
+rd_section_references <- function(text, topic) {
+  linked <- "\\\\emph\\{\\\\link\\[=([^][]+)\\]\\{([^{}]+)\\}\\}"
+  linked_matches <- regmatches(text, gregexpr(linked, text))[[1]]
+  linked_refs <- data.frame(
+    # `paste0()` would recycle the suffix into a phantom row when nothing
+    # matched, so build the target from the match itself.
+    target = sub(linked, "\\1.Rd", linked_matches),
+    title = sub(linked, "\\2", linked_matches)
+  )
+
+  without_links <- gsub(linked, "", text)
+  plain_matches <- regmatches(
+    without_links,
+    gregexpr("\\\\emph\\{[^{}]+\\}", without_links)
+  )[[1]]
+  plain_refs <- data.frame(
+    target = rep(topic, length(plain_matches)),
+    title = gsub("^\\\\emph\\{|\\}$", "", plain_matches)
+  )
+
+  rbind(linked_refs, plain_refs)
+}
+
+test_that("italicised section references reach the section they promise", {
+  topics <- rd_topics()
+  skip_if(is.null(topics), "No Rd sources available")
+
+  sections <- lapply(topics, rd_section_titles)
+  # Only phrases that actually name a section somewhere in the package are
+  # treated as cross-references; ordinary emphasis is left alone.
+  known <- unique(unlist(sections, use.names = FALSE))
+
+  unresolved <- unlist(
+    lapply(names(topics), function(topic) {
+      refs <- rd_section_references(topics[[topic]], topic)
+      refs <- refs[refs$title %in% known, , drop = FALSE]
+      reached <- mapply(
+        function(target, title) title %in% sections[[target]],
+        refs$target,
+        refs$title
+      )
+      if (all(reached)) {
+        return(NULL)
+      }
+      broken <- refs[!reached, , drop = FALSE]
+      paste0(topic, " -> ", broken$target, ": ", broken$title)
+    }),
+    use.names = FALSE
+  )
+
+  expect_equal(unresolved, NULL)
+})
+
+test_that("every documented user-facing topic offers related-topic links", {
+  topics <- rd_topics()
+  skip_if(is.null(topics), "No Rd sources available")
+
+  navigable <- vapply(
+    topics,
+    function(text) grepl("\\seealso{", text, fixed = TRUE),
+    logical(1)
+  )
+
+  expect_equal(names(navigable)[!navigable], character())
+})
+
+test_that("the Grouping-identity comparison has exactly one canonical home", {
+  topics <- rd_topics()
+  skip_if(is.null(topics), "No Rd sources available")
+
+  # The table is recognised by its own header cells rather than by a section
+  # title, so a copy pasted into another topic is still detected.
+  header <- "Value \\tab Meaning \\tab Duplicate Grouping-set occurrences"
+  carries_table <- vapply(
+    topics,
+    function(text) grepl(header, text, fixed = TRUE),
+    logical(1)
+  )
+
+  expect_equal(names(topics)[carries_table], "grouping_bit.Rd")
+})

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -325,25 +325,24 @@ states where each backend reports these errors.
 
 ## Backend verification levels
 
-The status describes what the automated test suite actually verifies. SQL
-simulation is useful evidence about rendering, but it is not the same as
-running a query on a live server.
+Support is not one status. SQL simulation is useful evidence about rendering,
+but it is not the same as running a query on a live server, so it is worth
+knowing which claim rests on which.
 
-| Status | Backends | What is verified |
-|---|---|---|
-| Live native execution tested | DuckDB | SQL generation, execution, result values, labels, and grouping identity |
-| Live portable Parent-share execution tested | SQLite | `UNION ALL` execution, Parent-share values, missing-safe matching, and Grouping set identifiers |
-| Native SQL generation tested | PostgreSQL | SQL rendered with dbplyr's PostgreSQL simulator |
-| Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections | Portable branch and `UNION ALL` rendering with dbplyr simulators |
-| Non-SQL lazy backend tested | Arrow, dtplyr | Lazy summary or expansion behavior appropriate to the backend |
+Only DuckDB and SQLite are exercised as live SQL databases. DuckDB covers
+native SQL end to end — generation, execution, result values, labels, and
+grouping identity — while SQLite's live claim is narrower: portable
+`UNION ALL` execution for Parent shares, including missing-safe matching and
+Grouping set identifiers. PostgreSQL and the dozen-plus fallback dialects are
+verified through dbplyr simulators, which prove what SQL is rendered and
+nothing about a running server. Arrow and dtplyr are tested for the lazy
+behavior each supports.
 
-DuckDB and SQLite are exercised as live SQL databases in automated tests;
-SQLite's live claim is limited to portable Parent-share execution. Treat
-simulator-only backends as SQL-generation support, and report server-specific
-behavior with a minimal query and the backend version. *Database backend
-coverage* in the [`summarize_with_margins()`
+Treat a simulator-only backend as SQL-generation support, and report
+server-specific behavior with a minimal query and the backend version.
+*Database backend coverage* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
-carries the same claims for the package documentation.
+names every verified backend.
 
 ## Practical rules for remote analysis
 

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -312,6 +312,17 @@ collect(dt_query)
 SQL database and Arrow tables cannot use the nesting verbs because their
 result contains a list column.
 
+dtplyr also enforces the Parent-share source rules. A valid request stays a
+native lazy query, and an ineligible source type or a non-scalar summary
+raises a Package condition at explicit execution, before an invalid grouping
+row is emitted.
+
+Arrow summaries and expansions are supported and lazy, but a Parent share is
+rejected outright, before any Arrow query is constructed. Collect the Arrow
+table first when you need Parent shares. The
+[`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
+states where each backend reports these errors.
+
 ## Backend verification levels
 
 The status describes what the automated test suite actually verifies. SQL
@@ -329,7 +340,10 @@ running a query on a live server.
 DuckDB and SQLite are exercised as live SQL databases in automated tests;
 SQLite's live claim is limited to portable Parent-share execution. Treat
 simulator-only backends as SQL-generation support, and report server-specific
-behavior with a minimal query and the backend version.
+behavior with a minimal query and the backend version. *Database backend
+coverage* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+carries the same claims for the package documentation.
 
 ## Practical rules for remote analysis
 

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -390,9 +390,12 @@ retail_sales |>
 The source `NA` store has `store_is_total = 0`. The region subtotal has
 `store_is_total = 1`, because `store` was removed by the rollup.
 
-For the complete comparison of `.id`, `inspect_grouping()$set_id`,
-`grouping_bit()`, and `grouping_id()`, continue with the [Grouping identity
-guide](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html).
+The [`grouping_bit()`
+reference](https://sayuks.github.io/marginplyr/man/grouping_bit.html) compares
+`.id`, `inspect_grouping()$set_id`, `grouping_bit()`, and `grouping_id()` in
+full. The [Grouping identity
+guide](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
+works through the same values with executable examples.
 
 `grouping_id()` combines the flags as a bit mask. Its last argument is the
 least-significant bit:
@@ -501,6 +504,11 @@ query. Result row order is unspecified for both local and lazy inputs, so call
 display value; retain `grouping_bit()` or `grouping_id()` whenever source
 values can equal the label.
 
+Naming rules, ordered-factor preservation, level positioning, and the complete
+eight-case `NA_character_`/`NULL` factor contract live in *Display labels and
+grouping identity* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
+
 ## Advanced dplyr behavior
 
 ### Persistent groups as fixed keys
@@ -559,6 +567,11 @@ interpretation:
 | `cur_group*()` and deprecated `cur_data*()` helpers | Describe the current dplyr group or data mask | Rejected because branch-local identifiers, rows, and columns have no global meaning after grouping sets are combined; use `grouping_bit()` or `grouping_id()` for levels |
 | Ordering | `.by` summaries use first-appearance order | Row order is unspecified for local and lazy results; call `arrange()` explicitly |
 | Backend extension | `summarize()` is a public S3 generic | Public margin verbs share one validated plan; a private adapter selects backend execution |
+
+This table exists to contrast the two APIs. *Relationship to dplyr summaries*
+in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+is the authoritative statement of the marginplyr side.
 
 For example, `everything()` below selects measures but not `year`, `region`,
 or `store`:
@@ -829,6 +842,9 @@ The margin-aware verbs deliberately share the main result shapes of
 
 The shared features in this table do not amount to complete upstream
 compatibility; the deliberate differences are part of the margin-aware API.
+*Relationship to tidyr and dplyr* in the [`nest_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/nest_with_margins.html) is
+the authoritative statement of both contracts.
 
 For grouped input, existing grouping columns become fixed keys as though they
 had been supplied through `.by`. Unlike `tidyr::nest()`, `nest_with_margins()`

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -539,39 +539,42 @@ groups created with `.drop = FALSE` are rejected because empty factor groups
 do not have a consistent SQL or lazy-backend equivalent.
 
 Input groups affect the calculation but, except for the explicitly row-wise
-nesting verb, do not persist on the result:
-
-| Function | Output grouping | Difference from the closest official verb |
-|---|---|---|
-| `summarize_with_margins()` | Ungrouped | `dplyr::summarize()` can retain groups; arbitrary grouping sets have no single `drop_last` level |
-| `expand_with_margins()` | Ungrouped | The expanded branches deliberately discard persistent grouping metadata |
-| `nest_with_margins()` | Ungrouped | `tidyr::nest()` preserves grouped input; this function consumes those groups as fixed keys but does not preserve them |
-| `nest_by_with_margins()` | Row-wise by every visible key | Like `dplyr::nest_by()`, but grouping-set dimensions are also outer row-wise keys |
+nesting verb, do not persist on the result. `summarize_with_margins()`,
+`expand_with_margins()`, and `nest_with_margins()` all return ungrouped
+output, because a result spanning several grains has no single grouping
+hierarchy to keep. `nest_by_with_margins()` is row-wise by every visible key,
+grouping-set dimensions included.
 
 This invariant is shared by local data frames and supported lazy backends.
 The nesting functions support local data frames and dtplyr because SQL and
 Arrow tables cannot contain their list-column result.
 
+*Grouped and row-wise inputs* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+states the rule for all four verbs.
+
 ### Intentional differences from `dplyr::summarize()`
 
-Summary expressions use dplyr data masking, but marginplyr narrows a few parts
+Summary expressions use dplyr data masking, but marginplyr narrows the parts
 of the official API where arbitrary grouping sets have no portable
-interpretation:
+interpretation. A summary may not overwrite a fixed key or grouping dimension,
+even where the local dplyr backend would allow it, because that would destroy
+grouping-set identity. `across()` and `pick()` exclude every column in the
+complete grouping plan, not only the ones active in one branch. The
+`cur_group*()` family is rejected outright: a branch-local identifier, row
+position, or column set has no global meaning once several grouping sets are
+combined, so use `grouping_bit()` or `grouping_id()` to identify levels
+instead.
 
-| Feature | Official dplyr behavior | marginplyr behavior and rationale |
-|---|---|---|
-| Spelling | `summarise()` and `summarize()` are synonyms | `summarise_with_margins()` and `summarize_with_margins()` are synonyms |
-| Output grouping | Can retain or create output groups | Always ungrouped; multiple grains have no single grouping hierarchy |
-| Summary name matches a grouping key | The local backend can overwrite the key | Rejected, including data-frame-valued summaries, so grouping-set identity is not destroyed and backend behavior remains portable |
-| `across()` and `pick()` | Exclude the grouping columns active in the verb | Exclude all fixed keys and margin dimensions in the complete plan, even in a branch where a dimension is rolled up |
-| `cur_group*()` and deprecated `cur_data*()` helpers | Describe the current dplyr group or data mask | Rejected because branch-local identifiers, rows, and columns have no global meaning after grouping sets are combined; use `grouping_bit()` or `grouping_id()` for levels |
-| Ordering | `.by` summaries use first-appearance order | Row order is unspecified for local and lazy results; call `arrange()` explicitly |
-| Backend extension | `summarize()` is a public S3 generic | Public margin verbs share one validated plan; a private adapter selects backend execution |
+Two familiar conveniences also behave differently. Row order is unspecified
+for local and lazy results alike, so call `arrange()` when presentation order
+matters. And the Margin verbs are not S3 generics: they share one validated
+plan, and a private adapter chooses the backend. As in dplyr,
+`summarise_with_margins()` and `summarize_with_margins()` are synonyms.
 
-This table exists to contrast the two APIs. *Relationship to dplyr summaries*
-in the [`summarize_with_margins()`
+*Relationship to dplyr summaries* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
-is the authoritative statement of the marginplyr side.
+states each of these rules in full.
 
 For example, `everything()` below selects measures but not `year`, `region`,
 or `store`:
@@ -833,18 +836,18 @@ dtplyr steps rather than SQL database tables.
 #### Relationship to tidyr and dplyr
 
 The margin-aware verbs deliberately share the main result shapes of
-`tidyr::nest()` and `dplyr::nest_by()`, but they are not drop-in replacements:
+`tidyr::nest()` and `dplyr::nest_by()`, but they are not drop-in replacements.
+Both select their keys with `.by` plus `.grouping` rather than data-masking
+`...`, and both take a logical `.keep`. `nest_with_margins()` always nests
+every non-key column and does not implement `...`, multiple list columns, or
+`.names_sep`. `nest_by_with_margins()` collects a dtplyr result before making
+it row-wise, because a row-wise data frame is a local object.
 
-| Function | Official reference | Shared behavior | Deliberate differences |
-|---|---|---|---|
-| `nest_with_margins()` | `tidyr::nest()` | `NULL` `.key` becomes `"data"`; returns one list column; grouping keys can also be retained inside | Uses `.by` plus `.grouping` and a logical `.keep`; always nests all non-key columns; does not implement `...`, multiple list columns, or `.names_sep`; always returns ungrouped output |
-| `nest_by_with_margins()` | `dplyr::nest_by()` | Requires a string `.key`; supports `.keep`; returns a row-wise data frame | Uses `.by` plus `.grouping` instead of data-masking `...`; collects a dtplyr result before making it row-wise |
-
-The shared features in this table do not amount to complete upstream
-compatibility; the deliberate differences are part of the margin-aware API.
-*Relationship to tidyr and dplyr* in the [`nest_with_margins()`
-reference](https://sayuks.github.io/marginplyr/man/nest_with_margins.html) is
-the authoritative statement of both contracts.
+Sharing a result shape is not upstream compatibility; the differences are part
+of the margin-aware API. *Relationship to tidyr and dplyr* in the
+[`nest_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/nest_with_margins.html)
+states both contracts in full.
 
 For grouped input, existing grouping columns become fixed keys as though they
 had been supplied through `.by`. Unlike `tidyr::nest()`, `nest_with_margins()`

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -32,21 +32,18 @@ library(dplyr)
 
 ## Four related values
 
-| Interface | Meaning | Values | Duplicate Grouping sets |
-|---|---|---|---|
-| `.id = "name"` | One-based position of a Grouping-set occurrence in the resolved Grouping plan | `1L`, `2L`, ... | Distinct when `.duplicates = "keep"` |
-| `inspect_grouping()$set_id` | The same occurrence position, inspected before a Margin operation | `1L`, `2L`, ... | Distinct when `.duplicates = "keep"` |
-| `grouping_bit(x)` | Whether one chosen grouping dimension is absent | `0L` when included, `1L` when absent | The same for identical absence patterns |
-| `grouping_id(...)` | Bit mask formed from the chosen Grouping bits | A non-negative integer through 31 chosen dimensions | The same for identical absence patterns |
+Four interfaces answer two different questions. `.id` and
+`inspect_grouping()$set_id` describe *where an occurrence appears in one
+ordered Grouping plan*; `grouping_bit()` and `grouping_id()` describe *which
+dimensions are absent from a row*. A Grouping set identifier can therefore
+distinguish repeated identical sets, and a Grouping identifier deliberately
+cannot.
 
-The first two values describe *where an occurrence appears in one ordered
-Grouping plan*. The last two describe *which dimensions are absent from a
-row*. A Grouping set identifier can therefore distinguish repeated identical
-sets; a Grouping identifier deliberately cannot.
-
-The correspondence between `.id` and `set_id` holds for the same resolved
-`.by`, `.grouping`, and `.duplicates` arguments. Reordering or deduplicating a
-Grouping specification can change both Grouping set identifiers.
+The [`grouping_bit()`
+reference](https://sayuks.github.io/marginplyr/man/grouping_bit.html)
+compares all four values side by side and states their duplicate-occurrence
+rules. The rest of this article works through what that comparison means in
+practice.
 
 ## Why a rollup skips Grouping identifier 2
 


### PR DESCRIPTION
## Summary

- Give every shared contract one canonical home instead of several copies: the Margin-label section is inherited by `expand_with_margins()`, `nest_with_margins()`, and `nest_by_with_margins()` (their `.margin_label` docs pointed at a section they didn't have), and the Grouping-identity comparison table now lives only in `grouping_bit()`, with `summarize_with_margins()`, `inspect_grouping()`, `grouping_set()`, and the `grouping_identity` vignette cross-linking it.
- Correct two backend overclaims found in the process: `grouping_bit()`'s return type ("follows the backend") — native `GROUPING()` is only reached on the native `GROUPING SETS` path, so PostgreSQL falls back to a literal under `.duplicates = "keep"`; and `share_of_parent()`'s backend table conflated always-local syntax/dependency checks with the type/cardinality checks only some backends can prove.
- Add family/seealso navigation to topics that were dead ends: `share_of_parent()`, `grouping_bit()`, the grouping-spec constructors, `inspect_grouping()`, `retail_sales`.
- Add the missing Parent-share discovery examples (direct, `across()`, post-summary `mutate()`) to README, which advertised the feature without demonstrating it.
- Remove every vignette table that duplicated a reference section (Get Started's output-grouping, dplyr-differences, and tidyr/dplyr-nesting tables; the database guide's backend-verification table), replacing each with prose plus a link to the authoritative section. The three remaining vignette tables are worked examples/comparisons no reference documents, not restatements.
- Add `tests/testthat/test-documentation.R`, pinning that italicised section cross-references resolve in the topic they promise, every user-facing topic has related-topic links, and the Grouping-identity comparison has exactly one home.

## Note

While centralizing the Grouping-identity table I found it conflicts with ADR 0009's documentation-placement statement (it says the comparison belongs in the vignette plus a compact per-reference copy). The underlying decision ADR 0009 makes — that Grouping set identifiers and Grouping identifiers are distinct — is unaffected; only its placement text is superseded. Recorded on #39, which owns ADR reconciliation, rather than amending it here.

Closes #36.

## Test plan

- [x] `roxygen2::roxygenise()` — clean regeneration, no drift
- [x] `lintr::lint_package()` (after `pkgload::load_all()`) — no lints
- [x] `spelling::spell_check_package()` — no errors
- [x] Full `testthat` suite — 1492 pass / 0 fail / 0 skip
- [x] `R CMD build` + `R CMD check --no-manual` from the built tarball, vignettes rebuilt — Status: OK, zero errors/warnings/notes