### PR TITLE
Establish the source-tarball release matrix

### DIFF
--- a/.github/scripts/check-tarball.R
+++ b/.github/scripts/check-tarball.R
@@ -15,23 +15,28 @@
 # a gate that cries wolf gets ignored. Judging the recorded NOTEs is part of
 # the release review.
 
+source(".github/scripts/ci-helpers.R")
+
 tarball_dir <- Sys.getenv("MARGINPLYR_TARBALL_DIR", "tarball")
-check_dir <- Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
-label <- Sys.getenv("MARGINPLYR_CHECK_LABEL", "R CMD check")
+check_dir <- check_directory()
+label <- check_label()
 
 split_words <- function(value) {
   words <- trimws(strsplit(value, "[[:space:]]+")[[1]])
   words[nzchar(words)]
 }
 
-# NOTEs this package has already accounted for. Each entry pairs a regular
-# expression with the reason the NOTE is expected, so the job summary explains
-# itself without a reviewer having to reconstruct the history.
+# NOTEs this package has already accounted for. Each entry pairs a literal
+# fragment of the NOTE's text with the reason it is expected, so the job
+# summary explains itself without a reviewer reconstructing the history.
+#
+# Fragments are matched literally and kept narrow on purpose. Matching the
+# "checking CRAN incoming feasibility" header instead would classify every
+# future incoming finding -- misspellings, unreachable URLs -- as understood,
+# which is the opposite of what this list is for.
 understood_notes <- c(
   "New submission" =
     "marginplyr 0.1.0 is a first CRAN release, so incoming checks say so.",
-  "checking CRAN incoming feasibility" =
-    "Header of the first-release incoming NOTE above.",
   "Days since last update" =
     "Only meaningful for resubmissions during a review cycle."
 )
@@ -39,7 +44,7 @@ understood_notes <- c(
 describe_note <- function(note) {
   matched <- vapply(
     names(understood_notes),
-    function(pattern) grepl(pattern, note, fixed = TRUE),
+    function(fragment) grepl(fragment, note, fixed = TRUE),
     logical(1)
   )
   if (!any(matched)) {
@@ -90,9 +95,7 @@ append_section <- function(lines, heading, entries) {
     lines,
     sprintf("### %s", heading),
     "",
-    unlist(lapply(entries, function(entry) {
-      c("```", strsplit(entry, "\n", fixed = TRUE)[[1]], "```", "")
-    })),
+    unlist(lapply(entries, as_summary_block)),
     ""
   )
 }
@@ -110,21 +113,14 @@ for (note in result$notes) {
     "",
     if (is.na(reason)) "No recorded explanation for this NOTE." else reason,
     "",
-    "```",
-    strsplit(note, "\n", fixed = TRUE)[[1]],
-    "```",
-    ""
+    as_summary_block(note)
   )
   if (is.na(reason)) {
     unexpected <- c(unexpected, note)
   }
 }
 
-summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", "")
-if (nzchar(summary_path)) {
-  write(summary_lines, file = summary_path, append = TRUE)
-}
-cat(summary_lines, sep = "\n")
+write_step_summary(summary_lines)
 
 for (note in unexpected) {
   # `::warning::` surfaces the NOTE in the Actions run header, where a release

--- a/.github/scripts/check-tarball.R
+++ b/.github/scripts/check-tarball.R
@@ -1,0 +1,146 @@
+# Checks a built source tarball and records the outcome where a release
+# reviewer can audit it.
+#
+# Every release-matrix job runs this script rather than
+# `r-lib/actions/check-r-package`, for three reasons. The jobs must check the
+# tarball the `build` job produced instead of rebuilding one from the working
+# tree, so that what passes is the artifact a submission would carry. They must
+# agree on which NOTEs are understood, which is a policy that belongs in one
+# reviewed place rather than in six copies of an inline step. And a matrix job
+# cannot pass R arguments, so configuration arrives through the environment.
+#
+# Exits non-zero on any ERROR or WARNING. An unexpected NOTE is annotated and
+# written to the job summary but does not fail the job: R-devel and CRAN
+# incoming checks introduce NOTEs that are outside this package's control, and
+# a gate that cries wolf gets ignored. Judging the recorded NOTEs is part of
+# the release review.
+
+tarball_dir <- Sys.getenv("MARGINPLYR_TARBALL_DIR", "tarball")
+check_dir <- Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
+label <- Sys.getenv("MARGINPLYR_CHECK_LABEL", "R CMD check")
+
+split_words <- function(value) {
+  words <- trimws(strsplit(value, "[[:space:]]+")[[1]])
+  words[nzchar(words)]
+}
+
+# NOTEs this package has already accounted for. Each entry pairs a regular
+# expression with the reason the NOTE is expected, so the job summary explains
+# itself without a reviewer having to reconstruct the history.
+understood_notes <- c(
+  "New submission" =
+    "marginplyr 0.1.0 is a first CRAN release, so incoming checks say so.",
+  "checking CRAN incoming feasibility" =
+    "Header of the first-release incoming NOTE above.",
+  "Days since last update" =
+    "Only meaningful for resubmissions during a review cycle."
+)
+
+describe_note <- function(note) {
+  matched <- vapply(
+    names(understood_notes),
+    function(pattern) grepl(pattern, note, fixed = TRUE),
+    logical(1)
+  )
+  if (!any(matched)) {
+    return(NA_character_)
+  }
+  understood_notes[[which(matched)[1]]]
+}
+
+tarballs <- list.files(tarball_dir, pattern = "[.]tar[.]gz$", full.names = TRUE)
+if (length(tarballs) != 1L) {
+  stop(sprintf(
+    "Expected exactly one source tarball in '%s', found %d.",
+    tarball_dir,
+    length(tarballs)
+  ))
+}
+message("Checking source tarball: ", tarballs)
+
+result <- rcmdcheck::rcmdcheck(
+  tarballs,
+  args = unique(c("--no-manual", split_words(
+    Sys.getenv("MARGINPLYR_CHECK_ARGS", "--as-cran")
+  ))),
+  # The tarball is already built; rebuilding it here would reintroduce exactly
+  # the working-tree dependency this workflow exists to remove.
+  build_args = NULL,
+  check_dir = check_dir,
+  error_on = "never"
+)
+
+summary_lines <- c(
+  sprintf("## %s", label),
+  "",
+  sprintf(
+    "%d ERROR(s), %d WARNING(s), %d NOTE(s).",
+    length(result$errors),
+    length(result$warnings),
+    length(result$notes)
+  ),
+  ""
+)
+
+append_section <- function(lines, heading, entries) {
+  if (length(entries) == 0L) {
+    return(lines)
+  }
+  c(
+    lines,
+    sprintf("### %s", heading),
+    "",
+    unlist(lapply(entries, function(entry) {
+      c("```", strsplit(entry, "\n", fixed = TRUE)[[1]], "```", "")
+    })),
+    ""
+  )
+}
+
+summary_lines <- append_section(summary_lines, "Errors", result$errors)
+summary_lines <- append_section(summary_lines, "Warnings", result$warnings)
+
+unexpected <- character()
+for (note in result$notes) {
+  reason <- describe_note(note)
+  heading <- if (is.na(reason)) "Unexpected NOTE" else "Understood NOTE"
+  summary_lines <- c(
+    summary_lines,
+    sprintf("### %s", heading),
+    "",
+    if (is.na(reason)) "No recorded explanation for this NOTE." else reason,
+    "",
+    "```",
+    strsplit(note, "\n", fixed = TRUE)[[1]],
+    "```",
+    ""
+  )
+  if (is.na(reason)) {
+    unexpected <- c(unexpected, note)
+  }
+}
+
+summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", "")
+if (nzchar(summary_path)) {
+  write(summary_lines, file = summary_path, append = TRUE)
+}
+cat(summary_lines, sep = "\n")
+
+for (note in unexpected) {
+  # `::warning::` surfaces the NOTE in the Actions run header, where a release
+  # reviewer sees it without opening the uploaded check directory.
+  cat(sprintf(
+    "::warning title=Unexpected NOTE in %s::%s\n",
+    label,
+    gsub("\n", " ", trimws(note))
+  ))
+}
+
+if (length(result$errors) > 0L || length(result$warnings) > 0L) {
+  stop(sprintf(
+    "%s failed with %d ERROR(s) and %d WARNING(s).",
+    label,
+    length(result$errors),
+    length(result$warnings)
+  ))
+}

--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -1,0 +1,67 @@
+# Shared by the check helper scripts in this directory, which all read the same
+# two environment variables and write to the same job summary. Sourced by path
+# because every workflow step runs from the repository root.
+#
+# These scripts are excluded from the built package by `.Rbuildignore`, so
+# `lintr::lint_package()` does not see them, but the repository's style still
+# applies. Lint them by calling `lintr::lint_dir()` on ".github", passing
+# `lintr::linters_with_defaults()` with `object_usage_linter` set to NULL.
+#
+# `object_usage_linter()` cannot follow `source()`, so it reports every helper
+# defined here as an undefined global at each call site. Disabling that one
+# linter is the accurate fix: there is no namespace for it to resolve against,
+# unlike the package itself, where `pkgload::load_all()` supplies one.
+
+# Where `rcmdcheck` was told to put its output.
+check_directory <- function() {
+  Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
+}
+
+# Names the job in the summary, so a run page with several checks stays
+# readable.
+check_label <- function() {
+  Sys.getenv("MARGINPLYR_CHECK_LABEL", "R CMD check")
+}
+
+# The `<package>.Rcheck` directory the check produced. Found by globbing rather
+# than by assuming the package name, so a rename cannot leave a script silently
+# looking at nothing.
+rcheck_directory <- function(required = TRUE) {
+  found <- Sys.glob(file.path(check_directory(), "*.Rcheck"))
+  if (length(found) == 1L) {
+    return(found)
+  }
+  if (!required) {
+    return(NA_character_)
+  }
+  stop(sprintf(
+    "Expected exactly one *.Rcheck directory under '%s', found %d.",
+    check_directory(),
+    length(found)
+  ))
+}
+
+# R CMD check keeps a test's output in `<test>.Rout`, but renames it to
+# `<test>.Rout.fail` when the test exits non-zero. Reading only the first name
+# would report a failing suite as a suite that never ran.
+test_output_path <- function(rcheck, test = "testthat") {
+  names <- paste0(test, c(".Rout", ".Rout.fail"))
+  candidates <- file.path(rcheck, "tests", names)
+  found <- candidates[file.exists(candidates)]
+  if (length(found) == 0L) NA_character_ else found[1]
+}
+
+write_step_summary <- function(lines) {
+  summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", "")
+  if (nzchar(summary_path)) {
+    write(lines, file = summary_path, append = TRUE)
+  }
+  cat(lines, sep = "\n")
+  cat("\n")
+  invisible(lines)
+}
+
+# Wraps text as a fenced block for the job summary.
+as_summary_block <- function(text) {
+  c("```", unlist(strsplit(text, "\n", fixed = TRUE)), "```", "")
+}

--- a/.github/scripts/summarize-check-log.R
+++ b/.github/scripts/summarize-check-log.R
@@ -1,0 +1,50 @@
+# Copies a finished check's status and every ERROR, WARNING, and NOTE into the
+# GitHub job summary.
+#
+# `check-r-package` uploads the check directory as an artifact, but reading a
+# NOTE then costs a download and an unzip, which is enough friction that NOTEs
+# go unread between releases. This puts the same information on the run page.
+# Unlike `check-tarball.R`, which drives rcmdcheck itself, this reads the log
+# an already-completed check left behind, so it can be bolted onto a workflow
+# that uses the standard action.
+
+check_dir <- Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
+label <- Sys.getenv("MARGINPLYR_CHECK_LABEL", "R CMD check")
+
+log_paths <- Sys.glob(file.path(check_dir, "*.Rcheck", "00check.log"))
+if (length(log_paths) == 0L) {
+  message("No check log under '", check_dir, "'; nothing to summarize.")
+  quit(save = "no")
+}
+
+check_log <- readLines(log_paths[1], warn = FALSE)
+
+# Check results are one line per test, so a result and its detail lines run
+# from a line ending in ERROR/WARNING/NOTE up to the next line starting a new
+# test. Keeping the detail is the point: "1 NOTE" alone is not auditable.
+starts <- grep("^[*] .*(ERROR|WARNING|NOTE)$", check_log)
+boundaries <- grep("^[*] ", check_log)
+findings <- unlist(lapply(starts, function(start) {
+  next_boundary <- boundaries[boundaries > start]
+  end <- if (length(next_boundary) == 0L) {
+    length(check_log)
+  } else {
+    next_boundary[1] - 1L
+  }
+  c("```", check_log[start:end], "```", "")
+}))
+
+status <- grep("^Status:", check_log, value = TRUE)
+summary_lines <- c(
+  sprintf("## %s", label),
+  "",
+  if (length(status) == 0L) "No status line in the check log." else status,
+  "",
+  findings
+)
+
+summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", "")
+if (nzchar(summary_path)) {
+  write(summary_lines, file = summary_path, append = TRUE)
+}
+cat(summary_lines, sep = "\n")

--- a/.github/scripts/summarize-check-log.R
+++ b/.github/scripts/summarize-check-log.R
@@ -8,16 +8,16 @@
 # an already-completed check left behind, so it can be bolted onto a workflow
 # that uses the standard action.
 
-check_dir <- Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
-label <- Sys.getenv("MARGINPLYR_CHECK_LABEL", "R CMD check")
+source(".github/scripts/ci-helpers.R")
 
-log_paths <- Sys.glob(file.path(check_dir, "*.Rcheck", "00check.log"))
-if (length(log_paths) == 0L) {
-  message("No check log under '", check_dir, "'; nothing to summarize.")
+rcheck <- rcheck_directory(required = FALSE)
+log_path <- file.path(rcheck, "00check.log")
+if (is.na(rcheck) || !file.exists(log_path)) {
+  message("No check log under '", check_directory(), "'; nothing to summarize.")
   quit(save = "no")
 }
 
-check_log <- readLines(log_paths[1], warn = FALSE)
+check_log <- readLines(log_path, warn = FALSE)
 
 # Check results are one line per test, so a result and its detail lines run
 # from a line ending in ERROR/WARNING/NOTE up to the next line starting a new
@@ -31,20 +31,16 @@ findings <- unlist(lapply(starts, function(start) {
   } else {
     next_boundary[1] - 1L
   }
-  c("```", check_log[start:end], "```", "")
+  as_summary_block(paste(check_log[start:end], collapse = "\n"))
 }))
 
 status <- grep("^Status:", check_log, value = TRUE)
 summary_lines <- c(
-  sprintf("## %s", label),
+  sprintf("## %s", check_label()),
   "",
   if (length(status) == 0L) "No status line in the check log." else status,
   "",
   findings
 )
 
-summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", "")
-if (nzchar(summary_path)) {
-  write(summary_lines, file = summary_path, append = TRUE)
-}
-cat(summary_lines, sep = "\n")
+write_step_summary(summary_lines)

--- a/.github/scripts/verify-backend.R
+++ b/.github/scripts/verify-backend.R
@@ -1,0 +1,91 @@
+# Confirms that a dedicated backend job executed the contracts it exists for.
+#
+# `MARGINPLYR_REQUIRED_SUGGESTS` proves only that the backend package is
+# installed. It says nothing about whether the tests that exercise the backend
+# actually ran: a test that is renamed, deleted, or skipped for some unrelated
+# reason leaves the job green and the contract unproven, which is the exact
+# failure the dedicated jobs exist to rule out.
+#
+# So the workflow names each contract as a test name, and this script re-runs
+# the checked tarball's suite against the package the check installed, then
+# asserts that every named test ran, passed, and did not skip. Naming them in
+# the workflow is deliberate: renaming a contract test now forces an edit to
+# the gate that guards it, instead of silently retiring the gate.
+
+source(".github/scripts/ci-helpers.R")
+
+required_tests <- trimws(strsplit(
+  Sys.getenv("MARGINPLYR_BACKEND_TESTS", ""),
+  ";",
+  fixed = TRUE
+)[[1]])
+required_tests <- required_tests[nzchar(required_tests)]
+if (length(required_tests) == 0L) {
+  stop("MARGINPLYR_BACKEND_TESTS is empty, so this job asserts nothing.")
+}
+
+backend <- Sys.getenv("MARGINPLYR_BACKEND_NAME", "backend")
+rcheck <- rcheck_directory()
+
+# R CMD check installs the package under the .Rcheck directory and copies the
+# tarball's tests beside it, so both come from the tarball rather than the
+# working tree.
+library_path <- normalizePath(rcheck)
+test_path <- file.path(rcheck, "tests", "testthat")
+if (!dir.exists(test_path)) {
+  stop(sprintf("No tests directory at '%s'.", test_path))
+}
+.libPaths(c(library_path, .libPaths()))
+
+results <- testthat::test_dir(
+  test_path,
+  package = "marginplyr",
+  load_package = "installed",
+  reporter = "silent",
+  stop_on_failure = FALSE
+)
+outcomes <- as.data.frame(results)
+
+report <- function(test) {
+  row <- outcomes[outcomes$test == test, , drop = FALSE]
+  if (nrow(row) == 0L) {
+    return("did not run")
+  }
+  if (sum(row$skipped) > 0L) {
+    return("skipped")
+  }
+  if (sum(row$failed) > 0L || any(row$error)) {
+    return("failed")
+  }
+  if (sum(row$passed) == 0L) {
+    return("asserted nothing")
+  }
+  sprintf("%d assertion(s) passed", sum(row$passed))
+}
+
+statuses <- vapply(required_tests, report, character(1))
+proved <- grepl("passed$", statuses)
+
+summary_lines <- c(
+  sprintf("## Live %s contracts", backend),
+  "",
+  sprintf(
+    "%d of %d named contracts executed.",
+    sum(proved),
+    length(required_tests)
+  ),
+  "",
+  paste0(
+    "- ", ifelse(proved, "OK", "MISSING"),
+    " **", names(statuses), "** — ", statuses
+  )
+)
+write_step_summary(summary_lines)
+
+if (!all(proved)) {
+  stop(sprintf(
+    "These %s contracts were not executed: %s.",
+    backend,
+    paste(names(statuses)[!proved], collapse = "; ")
+  ))
+}

--- a/.github/scripts/verify-depends-only.R
+++ b/.github/scripts/verify-depends-only.R
@@ -10,18 +10,21 @@
 # backend jobs: there an optional backend must be present, here it must be
 # absent.
 
-check_dir <- Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
+source(".github/scripts/ci-helpers.R")
+
+# The backends whose absence this job depends on. `DBI` is deliberately not
+# here: `skip_if_backend_absent("duckdb", "DBI")` skips on the first missing
+# package, so a `{DBI} is not installed` line never appears and requiring one
+# would fail every run. Adding a backend to
+# `tests/testthat/helper-optional-backends.R` means adding it here too.
 optional_backends <- c("arrow", "duckdb", "dtplyr", "RSQLite")
 
-log_path <- file.path(check_dir, "marginplyr.Rcheck", "tests", "testthat.Rout")
-if (!file.exists(log_path)) {
-  stop(sprintf(
-    paste0(
-      "No testthat log at '%s'. The minimal-dependency check did not run ",
-      "the tests."
-    ),
-    log_path
-  ))
+log_path <- test_output_path(rcheck_directory())
+if (is.na(log_path)) {
+  stop(
+    "No testthat output under the .Rcheck directory, so the ",
+    "minimal-dependency check never ran the tests."
+  )
 }
 test_log <- readLines(log_path, warn = FALSE)
 

--- a/.github/scripts/verify-depends-only.R
+++ b/.github/scripts/verify-depends-only.R
@@ -1,0 +1,71 @@
+# Confirms that the minimal-dependency job tested what it claims to test.
+#
+# `_R_CHECK_DEPENDS_ONLY_=true` passing is not by itself evidence: a check whose
+# test suite failed to start, or one where a Suggested package leaked into the
+# library, reports the same green status. This script reads the check's own test
+# log and asserts both halves of the claim, so the job cannot quietly stop being
+# a minimal-dependency gate.
+#
+# It is the mirror image of `MARGINPLYR_REQUIRED_SUGGESTS` in the dedicated
+# backend jobs: there an optional backend must be present, here it must be
+# absent.
+
+check_dir <- Sys.getenv("MARGINPLYR_CHECK_DIR", "check")
+optional_backends <- c("arrow", "duckdb", "dtplyr", "RSQLite")
+
+log_path <- file.path(check_dir, "marginplyr.Rcheck", "tests", "testthat.Rout")
+if (!file.exists(log_path)) {
+  stop(sprintf(
+    paste0(
+      "No testthat log at '%s'. The minimal-dependency check did not run ",
+      "the tests."
+    ),
+    log_path
+  ))
+}
+test_log <- readLines(log_path, warn = FALSE)
+
+# testthat's final tally, for example
+# "[ FAIL 0 | WARN 0 | SKIP 68 | PASS 1083 ]".
+tally <- grep("\\[ FAIL [0-9]+ \\|", test_log, value = TRUE)
+if (length(tally) == 0L) {
+  stop("The testthat log has no result tally, so the suite did not complete.")
+}
+tally <- tally[length(tally)]
+counts <- as.integer(regmatches(tally, gregexpr("[0-9]+", tally))[[1]])
+names(counts) <- c("fail", "warn", "skip", "pass")
+message("Minimal-dependency test tally: ", tally)
+
+if (counts[["fail"]] > 0L) {
+  stop("The minimal-dependency run has failing tests.")
+}
+if (counts[["pass"]] == 0L) {
+  stop("The minimal-dependency run passed no tests, so it proved nothing.")
+}
+
+# Every optional backend must have skipped. A backend that ran here was visible
+# to the check, which means Suggested packages were not actually withheld.
+visible <- optional_backends[!vapply(
+  optional_backends,
+  function(package) {
+    skipped <- sprintf("{%s} is not installed", package)
+    any(grepl(skipped, test_log, fixed = TRUE))
+  },
+  logical(1)
+)]
+if (length(visible) > 0L) {
+  stop(sprintf(
+    paste0(
+      "These optional backends did not skip: %s. Suggested packages were ",
+      "visible, so this run is not a minimal-dependency gate."
+    ),
+    paste(visible, collapse = ", ")
+  ))
+}
+
+message(sprintf(
+  "Verified: %d tests passed with %d skipped, and %s were all withheld.",
+  counts[["pass"]],
+  counts[["skip"]],
+  paste(optional_backends, collapse = ", ")
+))

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -145,3 +145,17 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+          # Uploaded for successful runs too, not just failures. A NOTE that
+          # only appears on a green run is exactly the one nobody reads, and
+          # the release review has to account for every NOTE.
+          upload-results: true
+
+      # Puts the status line and the full text of every ERROR, WARNING, and
+      # NOTE on the run page, so auditing them does not require downloading
+      # and unzipping the check directory.
+      - name: Summarize the check log
+        if: always()
+        run: Rscript .github/scripts/summarize-check-log.R
+        env:
+          MARGINPLYR_CHECK_LABEL: >-
+            ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -140,10 +140,20 @@ jobs:
           }
         shell: Rscript {0}
 
+      # No `upload-snapshots` here, and no `NOT_CRAN`. This matrix emulates
+      # CRAN, and testthat skips snapshot expectations under CRAN semantics, so
+      # all three snapshot-bearing tests skip and there is never a snapshot to
+      # upload. Asking for one implied a coverage this job does not have.
+      #
+      # Snapshots run in `release-matrix.yaml`'s `backend` jobs, which set
+      # `NOT_CRAN` because they prove behavior rather than emulate CRAN, and
+      # whose uploaded check directory carries any `.new.md` diff. Keeping them
+      # to those jobs is deliberate: #23 holds snapshots to diagnostic meaning
+      # rather than byte-for-byte wording, and comparing five platforms' error
+      # text would fail on formatting that was never a promise.
       - name: Check package
         uses: r-lib/actions/check-r-package@v2
         with:
-          upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
           # Uploaded for successful runs too, not just failures. A NOTE that
           # only appears on a green run is exactly the one nobody reads, and

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -37,6 +37,12 @@ concurrency:
 
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  # `--as-cran` otherwise queries CRAN on every run. That adds network
+  # flakiness and NOTEs about clock skew or momentarily unreachable URLs which
+  # say nothing about the change under test, and each one would be annotated as
+  # unexpected. Local incoming checks still run; the remote ones belong to the
+  # pre-submission `rhub.yaml` run, where a human is reading the result.
+  _R_CHECK_CRAN_INCOMING_REMOTE_: false
 
 jobs:
   build:
@@ -134,7 +140,11 @@ jobs:
       - name: Check the tarball without Suggested packages
         run: Rscript .github/scripts/check-tarball.R
 
+      # Runs even when the check failed: if a Suggested package leaked into the
+      # library, that leak is the most useful thing to report, and skipping the
+      # step would leave only the downstream symptom.
       - name: Verify the minimal-dependency run proved something
+        if: always()
         run: Rscript .github/scripts/verify-depends-only.R
 
       - uses: actions/upload-artifact@v4
@@ -206,6 +216,11 @@ jobs:
           path: check
           retention-days: 7
 
+  # Ubuntu at R release only. Each job's value is isolation -- one backend
+  # installed, everything else absent -- not platform breadth, and multiplying
+  # that by three operating systems would quadruple the cost of the workflow
+  # for a weaker signal. macOS and Windows still exercise every backend
+  # together in the fully provisioned `R-CMD-check.yaml` matrix.
   backend:
     name: Live ${{ matrix.backend.name }}
     needs: build
@@ -217,30 +232,52 @@ jobs:
       matrix:
         backend:
           # `required` names the packages whose absence must fail this job
-          # instead of skipping its tests. `proves` is the contract the job
-          # exists to execute, recorded here so a reader knows what removing
-          # the job would cost.
+          # instead of skipping its tests. `proves` names the tests that must
+          # actually have run and passed, which is a stronger claim: an
+          # installed package says nothing about whether the tests exercising
+          # it were renamed, deleted, or skipped for an unrelated reason.
+          # Renaming one of these tests deliberately breaks the job that
+          # guards it. Each entry traces to an acceptance criterion of #38.
           - name: RSQLite
             packages: any::DBI, any::RSQLite
             required: RSQLite,DBI
-            proves: portable UNION ALL fallback executed end to end
+            proves: >-
+              RSQLite executes portable Parent shares end to end;
+              RSQLite Parent shares preserve runtime backend conditions
           - name: DuckDB
             packages: any::DBI, any::duckdb
             required: duckdb,DBI
-            proves: native grouping sets and forced-portable agreement
+            proves: >-
+              DuckDB executes native grouping sets with unambiguous bits;
+              DuckDB native and UNION adapters agree;
+              DuckDB native and portable summaries agree on .id;
+              DuckDB Parent shares agree across native, portable, and local
+              paths
           - name: dtplyr
             packages: any::dtplyr
             required: dtplyr
-            proves: valid and invalid Parent shares during collection
+            proves: >-
+              dtplyr integer and double Parent shares match local results;
+              dtplyr rejects every ineligible Parent-share source type;
+              dtplyr rejects non-scalar Parent-share sources on collection;
+              dtplyr validates Parent-share source types during collection
           - name: Arrow
             packages: any::arrow
             required: arrow
-            proves: rejected Parent shares and ordinary Margin summaries
+            proves: >-
+              Arrow rejects Parent shares before constructing a query;
+              Arrow ordinary Margin summaries remain lazy and available
 
     env:
       # Turns an absent backend into a failure, so this job cannot pass while
       # skipping the very tests it exists to run.
       MARGINPLYR_REQUIRED_SUGGESTS: ${{ matrix.backend.required }}
+      # testthat skips snapshot expectations under CRAN semantics, which marks
+      # the whole test skipped -- including "Arrow rejects Parent shares before
+      # constructing a query", whose diagnostic this job is meant to execute.
+      # These jobs prove behavior rather than emulate CRAN, so they opt out.
+      # The `depends-only` and `tarball` jobs deliberately do not.
+      NOT_CRAN: true
       # Every other optional backend is absent on purpose: proving one backend
       # in isolation also proves it does not depend on the others.
       _R_CHECK_FORCE_SUGGESTS_: false
@@ -272,10 +309,15 @@ jobs:
       - name: Check the tarball with ${{ matrix.backend.name }} installed
         run: Rscript .github/scripts/check-tarball.R
 
-      - name: Record what this job proved
+      # Reports which named contracts executed, and fails if any of them did
+      # not. Runs even after a failed check, because "which contract broke" is
+      # the answer this job exists to give.
+      - name: Verify the live ${{ matrix.backend.name }} contracts executed
         if: always()
-        run: |
-          echo "Proves: ${{ matrix.backend.proves }}" >> "$GITHUB_STEP_SUMMARY"
+        run: Rscript .github/scripts/verify-backend.R
+        env:
+          MARGINPLYR_BACKEND_NAME: ${{ matrix.backend.name }}
+          MARGINPLYR_BACKEND_TESTS: ${{ matrix.backend.proves }}
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -1,0 +1,285 @@
+# Release gates for the source tarball.
+#
+# `R-CMD-check.yaml` checks a fully provisioned working tree, which is the
+# right signal while developing but cannot answer two release questions: are
+# the Suggested packages genuinely optional, and does each supported backend
+# actually execute? This workflow answers both against one built tarball --
+# the artifact a submission would carry -- so that nothing here can pass
+# because of a file that exists only in the development tree.
+#
+# The jobs divide the work:
+#
+#   build         produces the single tarball every other job checks.
+#   depends-only  rebuilds examples, tests, and vignettes with Suggested
+#                 packages withheld (`_R_CHECK_DEPENDS_ONLY_=true`).
+#   tarball       checks that tarball on R release, devel, and oldrel.
+#   backend       four jobs that each execute one backend's live behavior.
+#
+# Optional backends skip in `depends-only` and `tarball`, which is what a
+# minimal CRAN flavor does. That is only acceptable because the `backend` jobs
+# prove the same contracts, and those jobs set `MARGINPLYR_REQUIRED_SUGGESTS`
+# so that a backend which failed to install fails the job instead of skipping
+# into a false green. See `tests/testthat/helper-optional-backends.R`.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+name: release-matrix.yaml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Build source tarball
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      # The vignette engine is the quarto R package, which shells out to the
+      # Quarto CLI named in DESCRIPTION's SystemRequirements. Install it here
+      # rather than assuming the runner image ships one.
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # Quarto renders vignettes in a child R process that cannot see the
+          # temporary installation R CMD build makes, so install the package
+          # itself as well.
+          extra-packages: local::.
+          needs: check
+          cache-version: 3
+
+      - name: Build source tarball
+        run: |
+          mkdir tarball
+          R CMD build .
+          mv marginplyr_*.tar.gz tarball/
+
+      - name: Record the tarball contents
+        run: |
+          tarball=$(ls tarball/marginplyr_*.tar.gz)
+          echo "## Source tarball" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          ls -l "$tarball" >> "$GITHUB_STEP_SUMMARY"
+          tar -tzf "$tarball" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: source-tarball
+          path: tarball/marginplyr_*.tar.gz
+          retention-days: 7
+          if-no-files-found: error
+
+  depends-only:
+    name: Minimal dependencies (depends-only)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      # Withholds Suggested packages from examples, tests, and vignettes.
+      _R_CHECK_DEPENDS_ONLY_: true
+      # Without this, `--as-cran` treats the deliberately absent Suggests as a
+      # check failure, which would make the job impossible to run.
+      _R_CHECK_FORCE_SUGGESTS_: false
+      MARGINPLYR_CHECK_LABEL: Minimal dependencies (depends-only)
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      # Installs only what DESCRIPTION declares as a hard dependency, plus the
+      # test harness and the declared VignetteBuilder. R CMD check makes the
+      # VignetteBuilder visible while rebuilding vignettes even in
+      # depends-only mode, so quarto here does not weaken the gate; every
+      # optional backend stays absent, and `verify-depends-only.R` fails the
+      # job if one turns out not to be.
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          extra-packages: any::rcmdcheck, any::testthat, any::quarto
+          cache-version: 3
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-tarball
+          path: tarball
+
+      - name: Check the tarball without Suggested packages
+        run: Rscript .github/scripts/check-tarball.R
+
+      - name: Verify the minimal-dependency run proved something
+        run: Rscript .github/scripts/verify-depends-only.R
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: check-depends-only
+          path: check
+          retention-days: 7
+
+  tarball:
+    name: Tarball ${{ matrix.config.os }} (${{ matrix.config.r }})
+    needs: build
+    runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+
+    env:
+      # Optional backends are deliberately absent from this matrix; the
+      # dedicated `backend` jobs execute them. Without this, `--as-cran` would
+      # fail the job for the missing Suggests rather than let the tests skip.
+      _R_CHECK_FORCE_SUGGESTS_: false
+      MARGINPLYR_CHECK_LABEL: >-
+        Tarball ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      # Keeping this to hard dependencies plus the test harness and
+      # VignetteBuilder is what lets R-devel join the matrix without the
+      # binary-repository workaround `R-CMD-check.yaml` needs for arrow and
+      # duckdb: those packages are simply not part of this job.
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          extra-packages: any::rcmdcheck, any::testthat, any::quarto
+          cache-version: 3
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-tarball
+          path: tarball
+
+      - name: Check the tarball
+        run: Rscript .github/scripts/check-tarball.R
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: check-tarball-${{ matrix.config.os }}-${{ matrix.config.r }}
+          path: check
+          retention-days: 7
+
+  backend:
+    name: Live ${{ matrix.backend.name }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+          # `required` names the packages whose absence must fail this job
+          # instead of skipping its tests. `proves` is the contract the job
+          # exists to execute, recorded here so a reader knows what removing
+          # the job would cost.
+          - name: RSQLite
+            packages: any::DBI, any::RSQLite
+            required: RSQLite,DBI
+            proves: portable UNION ALL fallback executed end to end
+          - name: DuckDB
+            packages: any::DBI, any::duckdb
+            required: duckdb,DBI
+            proves: native grouping sets and forced-portable agreement
+          - name: dtplyr
+            packages: any::dtplyr
+            required: dtplyr
+            proves: valid and invalid Parent shares during collection
+          - name: Arrow
+            packages: any::arrow
+            required: arrow
+            proves: rejected Parent shares and ordinary Margin summaries
+
+    env:
+      # Turns an absent backend into a failure, so this job cannot pass while
+      # skipping the very tests it exists to run.
+      MARGINPLYR_REQUIRED_SUGGESTS: ${{ matrix.backend.required }}
+      # Every other optional backend is absent on purpose: proving one backend
+      # in isolation also proves it does not depend on the others.
+      _R_CHECK_FORCE_SUGGESTS_: false
+      # Vignette rebuilding is covered by `depends-only` and `tarball`. Leaving
+      # it out here keeps the job's toolchain to what the backend contract
+      # needs, and keeps what a failure means unambiguous.
+      MARGINPLYR_CHECK_ARGS: --as-cran --ignore-vignettes
+      MARGINPLYR_CHECK_LABEL: Live ${{ matrix.backend.name }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          extra-packages: >-
+            any::rcmdcheck, any::testthat, ${{ matrix.backend.packages }}
+          cache-version: 3
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-tarball
+          path: tarball
+
+      - name: Check the tarball with ${{ matrix.backend.name }} installed
+        run: Rscript .github/scripts/check-tarball.R
+
+      - name: Record what this job proved
+        if: always()
+        run: |
+          echo "Proves: ${{ matrix.backend.proves }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: check-backend-${{ matrix.backend.name }}
+          path: check
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,27 @@ cannot tell whether a Suggest is genuinely optional at runtime. The
 the manual scan: it rebuilds examples, tests, and vignettes with Suggested
 packages absent, which is the only way to confirm code guarded behind a
 Suggest actually degrades correctly instead of erroring. Run it locally with
-`_R_CHECK_DEPENDS_ONLY_=true R CMD check` against a source tarball; a
-dedicated CI job for it is not wired in yet (tracked in #38), so until then
-this is a manual step, same as the grep audit above.
+`_R_CHECK_DEPENDS_ONLY_=true R CMD check` against a source tarball. CI runs the
+same mode in `release-matrix.yaml`'s `depends-only` job, so this is a gate
+rather than a manual step, but running it locally is still the fastest way to
+find out which guard is missing.
+
+### Release matrix
+
+`.github/workflows/release-matrix.yaml` checks one built tarball rather than
+the working tree, because a check that passes on the development tree can be
+passing on a file the tarball does not ship. Its `backend` jobs each install a
+single optional backend and set `MARGINPLYR_REQUIRED_SUGGESTS`, which turns
+that backend's absence into a test failure instead of a skip.
+
+That variable is what makes skipping safe everywhere else. Optional-backend
+tests skip when their package is missing, which is correct for CRAN's minimal
+flavors but means a green job proves nothing about the backend. Every such
+test therefore goes through `skip_if_backend_absent()` or `backend_available()`
+from `tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
+or `rlang::is_installed()` directly, since those cannot be told to fail. A new
+optional backend needs both a `skip_if_backend_absent()` call and a `backend`
+matrix entry; adding only the first produces a contract nothing executes.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ or `rlang::is_installed()` directly, since those cannot be told to fail.
 (`skip_if_not_installed("dbplyr")` is not an exception: dbplyr is an Import, so
 it is never absent.)
 
+The `backend` jobs are also the only place snapshot expectations run: testthat
+skips them under CRAN semantics, so a snapshot never fails in a job that
+emulates CRAN. If a snapshot needs updating, it is a `backend` job that will
+say so.
+
 An installed package still does not prove its tests ran, so each `backend` job
 also lists the test names it exists to execute in its `proves` field, and
 `verify-backend.R` fails the job unless every one of them ran and passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,23 @@ tests skip when their package is missing, which is correct for CRAN's minimal
 flavors but means a green job proves nothing about the backend. Every such
 test therefore goes through `skip_if_backend_absent()` or `backend_available()`
 from `tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
-or `rlang::is_installed()` directly, since those cannot be told to fail. A new
-optional backend needs both a `skip_if_backend_absent()` call and a `backend`
-matrix entry; adding only the first produces a contract nothing executes.
+or `rlang::is_installed()` directly, since those cannot be told to fail.
+(`skip_if_not_installed("dbplyr")` is not an exception: dbplyr is an Import, so
+it is never absent.)
+
+An installed package still does not prove its tests ran, so each `backend` job
+also lists the test names it exists to execute in its `proves` field, and
+`verify-backend.R` fails the job unless every one of them ran and passed.
+Renaming a contract test is therefore expected to break its job — that is the
+gate working, and the fix is to update the `proves` list, not to relax it.
+
+Adding an optional backend means editing three places, and doing only the first
+leaves a contract nothing executes:
+
+1. the `skip_if_backend_absent()` call in the tests,
+2. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts,
+3. `optional_backends` in `.github/scripts/verify-depends-only.R`, which
+   asserts the backend really was withheld from the minimal-dependency job.
 
 ## Agent skills
 

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -1,0 +1,50 @@
+# Every backend behind these helpers is a Suggested package, so a check run
+# without it must skip rather than fail. That is right for CRAN's minimal
+# flavors, but it makes a skip indistinguishable from a proof: a release job
+# whose whole purpose is to execute DuckDB would pass green with fourteen
+# silently skipped tests if duckdb failed to install.
+#
+# `MARGINPLYR_REQUIRED_SUGGESTS` is how a job states which backends it exists
+# to prove. A package named there must be installed, and its absence fails the
+# test instead of skipping it. Generic jobs leave the variable unset and keep
+# skipping. `.github/workflows/release-matrix.yaml` sets it per dedicated job.
+required_suggests <- function() {
+  declared <- strsplit(
+    Sys.getenv("MARGINPLYR_REQUIRED_SUGGESTS", ""),
+    ",",
+    fixed = TRUE
+  )[[1]]
+  declared <- trimws(declared)
+  declared[nzchar(declared)]
+}
+
+# Reports whether an optional backend can be used, and refuses to report FALSE
+# for a backend the running job promised to exercise. Callers that select among
+# several backends use this directly, because dropping one from a list records
+# no skip at all and would otherwise be invisible.
+backend_available <- function(package) {
+  if (requireNamespace(package, quietly = TRUE)) {
+    return(TRUE)
+  }
+  if (package %in% required_suggests()) {
+    stop(sprintf(
+      paste0(
+        "{%s} is named in MARGINPLYR_REQUIRED_SUGGESTS but is not installed, ",
+        "so this job cannot prove its backend contract."
+      ),
+      package
+    ))
+  }
+  FALSE
+}
+
+# Skips unless every named backend is installed, keeping testthat's own wording
+# so the skip summary reads the same as it did under `skip_if_not_installed()`.
+skip_if_backend_absent <- function(...) {
+  for (package in c(...)) {
+    if (!backend_available(package)) {
+      skip(sprintf("{%s} is not installed", package))
+    }
+  }
+  invisible(NULL)
+}

--- a/tests/testthat/helper-sqlite-simulation.R
+++ b/tests/testthat/helper-sqlite-simulation.R
@@ -3,13 +3,11 @@
 # Simulated SQLite queries therefore need the optional RSQLite package even
 # though nothing is executed.
 sqlite_simulation_available <- function() {
-  requireNamespace("RSQLite", quietly = TRUE)
+  backend_available("RSQLite")
 }
 
 skip_if_no_sqlite_simulation <- function() {
-  if (!sqlite_simulation_available()) {
-    skip("RSQLite is not installed")
-  }
+  skip_if_backend_absent("RSQLite")
 }
 
 # Drops the dialects whose SQL cannot be rendered without an optional driver

--- a/tests/testthat/test-expand-operation.R
+++ b/tests/testthat/test-expand-operation.R
@@ -51,7 +51,7 @@ register_expand_proxy_methods <- function() {
 }
 
 test_that("expand rejects invalid grouping before typed metadata acquisition", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_expand_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_expand_proxy_counter", class(source))
@@ -132,7 +132,7 @@ test_that("expand rejects invalid grouping before typed metadata acquisition", {
 })
 
 test_that("dtplyr expansion acquires typed metadata once and stays lazy", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_expand_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),
@@ -156,7 +156,7 @@ test_that("dtplyr expansion acquires typed metadata once and stays lazy", {
 })
 
 test_that("Arrow expansion uses schema metadata without collecting", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   register_expand_proxy_methods()
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
@@ -180,8 +180,7 @@ test_that("Arrow expansion uses schema metadata without collecting", {
 })
 
 test_that("DuckDB expansion acquires one typed selection proxy", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
   register_expand_proxy_methods()
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -270,7 +269,7 @@ test_that("expand preserves duplicate grouping-set policies", {
 })
 
 test_that("expand rejects unsupported sources with a package condition", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
 
   error <- expect_error(
     expand_with_margins(

--- a/tests/testthat/test-factor.R
+++ b/tests/testthat/test-factor.R
@@ -60,8 +60,7 @@ test_that("reconstruct_factor() works with data.frame", {
 })
 
 test_that("reconstruct_factor() works with duckdb", {
-  skip_if_not_installed("DBI")
-  skip_if_not_installed("duckdb")
+  skip_if_backend_absent("DBI", "duckdb")
 
   x <- c("a", "b", "c", NA_character_)
   data <- data.frame(
@@ -122,7 +121,7 @@ test_that("reconstruct_factor() works with duckdb", {
 })
 
 test_that("reconstruct_factor() works with dtplyr_step", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
 
   x <- c("a", "b", "c", NA_character_)
   data <- data.frame(

--- a/tests/testthat/test-get-col-names.R
+++ b/tests/testthat/test-get-col-names.R
@@ -37,7 +37,7 @@ test_that("get_col_names reads dbplyr query metadata", {
 })
 
 test_that("get_col_names reads dtplyr step metadata", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
 
   data <- data.frame(
     first = 1:2,
@@ -53,7 +53,7 @@ test_that("get_col_names reads dtplyr step metadata", {
 })
 
 test_that("get_col_names reads Arrow metadata", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
 
   data <- data.frame(
     first = 1:2,

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -66,7 +66,7 @@ test_that("dtplyr and Arrow use the normalized grouping contract", {
     value = 1:3
   )
 
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   expect_no_message(
     dt_result <- summarize_with_margins(
       dtplyr::lazy_dt(data),
@@ -86,7 +86,7 @@ test_that("dtplyr and Arrow use the normalized grouping contract", {
   expect_s3_class(dt_rowwise, "rowwise_df")
   expect_equal(names(dt_rowwise), c("a", "b", "data"))
 
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   arrow_result <- summarize_with_margins(
     arrow::Table$create(data),
     n = dplyr::n(),
@@ -108,7 +108,7 @@ test_that("dtplyr and Arrow use the normalized grouping contract", {
 })
 
 test_that("Arrow schema metadata supports predicates and computed queries", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
 
   data <- data.frame(
     group = c("x", "x", "y"),
@@ -158,7 +158,7 @@ test_that("Arrow schema metadata supports predicates and computed queries", {
 })
 
 test_that("Arrow metadata preserves ordered dictionaries without collecting", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   registerS3method(
     "head",
     "margin_selection_proxy_counter",
@@ -200,7 +200,7 @@ test_that("Arrow metadata preserves ordered dictionaries without collecting", {
 })
 
 test_that("dtplyr constructs one typed selection proxy for predicates", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   registerS3method(
     "head",
     "margin_selection_proxy_counter",
@@ -250,8 +250,7 @@ test_that("dtplyr constructs one typed selection proxy for predicates", {
 })
 
 test_that("DuckDB constructs one typed selection proxy for predicates", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
   registerS3method(
     "head",
     "margin_selection_proxy_counter",
@@ -309,7 +308,7 @@ test_that("DuckDB constructs one typed selection proxy for predicates", {
 })
 
 test_that("public Arrow table classes are supported", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
 
   data <- data.frame(group = c("x", "y"), value = 1:2)
   table <- arrow::Table$create(data)
@@ -349,7 +348,7 @@ test_that("lazy backends check margin labels across all dimensions", {
     value = 1:2
   )
 
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   expect_error(
     summarize_with_margins(
       dtplyr::lazy_dt(data),
@@ -360,7 +359,7 @@ test_that("lazy backends check margin labels across all dimensions", {
     "grouping columns `first`, `second`"
   )
 
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   expect_error(
     summarize_with_margins(
       arrow::Table$create(data),
@@ -371,8 +370,7 @@ test_that("lazy backends check margin labels across all dimensions", {
     "grouping columns `first`, `second`"
   )
 
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
@@ -518,7 +516,7 @@ test_that("union adapters reserve user columns that look internal", {
   )
   expect_equal(dplyr::arrange(local, group), expected)
 
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   dt_result <- summarize_with_margins(
     dtplyr::lazy_dt(data),
     total = sum(value),
@@ -528,7 +526,7 @@ test_that("union adapters reserve user columns that look internal", {
     dplyr::arrange(group)
   expect_equal(as.data.frame(dt_result), expected)
 
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   arrow_result <- summarize_with_margins(
     arrow::Table$create(data),
     total = sum(value),
@@ -564,7 +562,7 @@ test_that("union adapters reserve generated summary names", {
   )
   expect_equal(dplyr::arrange(local, group), expected)
 
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   dt_result <- summarize_with_margins(
     dtplyr::lazy_dt(data),
     dplyr::across(
@@ -578,7 +576,7 @@ test_that("union adapters reserve generated summary names", {
     dplyr::arrange(group)
   expect_equal(as.data.frame(dt_result), expected)
 
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   arrow_result <- summarize_with_margins(
     arrow::Table$create(data),
     dplyr::across(
@@ -666,8 +664,7 @@ test_that("native adapters reserve generated summary names", {
   expect_match(sql, "\"..marginplyr_grouping_1\"", fixed = TRUE)
   expect_match(sql, "\"..marginplyr_grouping_1__\"", fixed = TRUE)
 
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
@@ -700,7 +697,7 @@ test_that("column-wise summaries share one lazy-backend selection", {
     value = c(1, 2, 3)
   )
 
-  if (rlang::is_installed("dtplyr")) {
+  if (backend_available("dtplyr")) {
     dt_result <- summarize_with_margins(
       dtplyr::lazy_dt(data),
       dplyr::across(
@@ -715,7 +712,7 @@ test_that("column-wise summaries share one lazy-backend selection", {
     expect_setequal(dt_result$n_value, c(2L, 1L, 3L))
   }
 
-  if (rlang::is_installed("arrow")) {
+  if (backend_available("arrow")) {
     arrow_result <- summarize_with_margins(
       arrow::Table$create(data),
       dplyr::across(
@@ -774,7 +771,7 @@ test_that("union backends preserve margin values without implicit ordering", {
   )
   expect_setequal(local$group, expected)
 
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   dt_result <- summarize_with_margins(
     dtplyr::lazy_dt(data),
     total = sum(value),
@@ -783,7 +780,7 @@ test_that("union backends preserve margin values without implicit ordering", {
     dplyr::collect()
   expect_setequal(dt_result$group, expected)
 
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   arrow_result <- summarize_with_margins(
     arrow::Table$create(data),
     total = sum(value),
@@ -794,7 +791,7 @@ test_that("union backends preserve margin values without implicit ordering", {
 })
 
 test_that("dtplyr nesting retains original keys and empty rowwise behavior", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("a", "a", "b"),
     item = c("x", "y", "z"),
@@ -832,7 +829,7 @@ test_that("grouped lazy inputs use their groups as fixed keys", {
     value = c(1, 10, 100, 1000)
   )
 
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   grouped_dt <- dtplyr::lazy_dt(data) |>
     dplyr::group_by(year)
 
@@ -867,7 +864,7 @@ test_that("grouped lazy inputs use their groups as fixed keys", {
   expect_s3_class(dt_nest_by, "rowwise_df")
   expect_equal(dplyr::group_vars(dt_nest_by), c("year", "region"))
 
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   grouped_arrow <- arrow::Table$create(data) |>
     dplyr::group_by(year)
   arrow_summary <- summarize_with_margins(
@@ -910,8 +907,7 @@ test_that("grouped lazy inputs use their groups as fixed keys", {
 })
 
 test_that("DuckDB executes grouped lazy input as fixed keys", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1132,8 +1128,7 @@ test_that("PostgreSQL duplicate keep falls back conservatively", {
 })
 
 test_that("DuckDB executes native grouping sets with unambiguous bits", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1163,8 +1158,7 @@ test_that("DuckDB executes native grouping sets with unambiguous bits", {
 })
 
 test_that("DuckDB keeps input types available to summary expressions", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1188,8 +1182,7 @@ test_that("DuckDB keeps input types available to summary expressions", {
 })
 
 test_that("DuckDB native and UNION adapters agree", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1231,8 +1224,7 @@ test_that("DuckDB native and UNION adapters agree", {
 })
 
 test_that("DuckDB duplicate keep and downstream verbs remain lazy", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1270,8 +1262,7 @@ test_that("DuckDB duplicate keep and downstream verbs remain lazy", {
 })
 
 test_that("DuckDB safely quotes factor identifiers and labels", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -292,7 +292,7 @@ test_that("all Margin verbs eagerly check local margin-label collisions", {
 })
 
 test_that("Margin verbs skip label checks for lazy inputs by default", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(group = c("Total", "x"), value = 1:2)
   source <- dtplyr::lazy_dt(data)
 

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -253,7 +253,7 @@ register_inspect_proxy_methods <- function() {
 }
 
 test_that("lazy inspection reads typed metadata once without executing margins", { # nolint: line_length_linter
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_inspect_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("Total", "x"),

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -288,8 +288,7 @@ test_that("non-syntactic .id names work across Margin verbs", {
 })
 
 test_that("DuckDB native and portable summaries agree on .id", {
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
 
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -225,7 +225,7 @@ test_that("factor collisions include unused levels and remain column-specific", 
 })
 
 test_that("dtplyr applies mixed named labels lazily and restores factors", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     first = factor(c("a", "b")),
     second = ordered(c("x", "y")),
@@ -250,7 +250,7 @@ test_that("dtplyr applies mixed named labels lazily and restores factors", {
 })
 
 test_that("Arrow applies mixed named labels lazily with typed missing values", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   data <- data.frame(
     first = c("a", "b"),
     second = c(1L, 2L),
@@ -292,8 +292,7 @@ test_that("portable SQL consumes named per-column labels lazily", {
 })
 
 test_that("DuckDB uses typed missing for a missing factor Margin label", {
-  skip_if_not_installed("DBI")
-  skip_if_not_installed("duckdb")
+  skip_if_backend_absent("DBI", "duckdb")
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -27,7 +27,7 @@ register_nest_proxy_methods <- function() {
 }
 
 test_that("nest rejects grouping before typed metadata acquisition", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_nest_proxy_counter", class(source))
@@ -65,7 +65,7 @@ test_that("nest rejects grouping before typed metadata acquisition", {
 })
 
 test_that("dtplyr nesting reuses one typed snapshot and stays lazy", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),
@@ -128,7 +128,7 @@ test_that("nest verbs preserve their own quosure environments", {
 })
 
 test_that("nest preflight precedes semantic margin-label validation", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("Total", "x"), value = 1:2))
   class(source) <- c("margin_nest_proxy_counter", class(source))

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -1,0 +1,76 @@
+# The release matrix relies on these helpers to tell a proved backend contract
+# apart from a silently skipped one, so the helpers themselves need coverage:
+# a regression here would be invisible in every other test file.
+
+# Runs `code` with `MARGINPLYR_REQUIRED_SUGGESTS` set, restoring whatever the
+# checking environment had before. Written with `on.exit()` rather than withr
+# so the tests add no dependency beyond the ones DESCRIPTION declares.
+with_required_suggests <- function(value, code) {
+  previous <- Sys.getenv("MARGINPLYR_REQUIRED_SUGGESTS", unset = NA)
+  on.exit(
+    if (is.na(previous)) {
+      Sys.unsetenv("MARGINPLYR_REQUIRED_SUGGESTS")
+    } else {
+      Sys.setenv(MARGINPLYR_REQUIRED_SUGGESTS = previous)
+    },
+    add = TRUE
+  )
+  Sys.setenv(MARGINPLYR_REQUIRED_SUGGESTS = value)
+  force(code)
+}
+
+# A name no CRAN package uses, so it is reliably absent from every checking
+# environment.
+absent_package <- "marginplyrNoSuchBackend"
+
+test_that("required suggests are parsed from the environment variable", {
+  with_required_suggests("", expect_identical(required_suggests(), character()))
+  with_required_suggests(
+    " duckdb , DBI ,,",
+    expect_identical(required_suggests(), c("duckdb", "DBI"))
+  )
+})
+
+test_that("an absent backend is skippable when no job promised it", {
+  with_required_suggests("", {
+    expect_false(backend_available(absent_package))
+    # Caught rather than asserted with `expect_error()`, because testthat lets
+    # a skip condition escape an expectation and skip the whole test instead.
+    skipped <- tryCatch(
+      {
+        skip_if_backend_absent(absent_package)
+        NULL
+      },
+      skip = function(condition) condition
+    )
+    expect_s3_class(skipped, "skip")
+    expect_match(conditionMessage(skipped), "is not installed")
+  })
+})
+
+test_that("an absent backend fails when the job promised to prove it", {
+  with_required_suggests(absent_package, {
+    expect_error(
+      backend_available(absent_package),
+      "MARGINPLYR_REQUIRED_SUGGESTS"
+    )
+    expect_error(
+      skip_if_backend_absent(absent_package),
+      "MARGINPLYR_REQUIRED_SUGGESTS"
+    )
+  })
+})
+
+test_that("promising one backend does not make an unrelated one required", {
+  with_required_suggests("duckdb", expect_false(backend_available(
+    absent_package
+  )))
+})
+
+test_that("an installed backend is available whether or not it is required", {
+  with_required_suggests("", expect_true(backend_available("stats")))
+  with_required_suggests("stats", {
+    expect_true(backend_available("stats"))
+    expect_no_error(skip_if_backend_absent("stats"))
+  })
+})

--- a/tests/testthat/test-parent-share-backends.R
+++ b/tests/testthat/test-parent-share-backends.R
@@ -34,7 +34,7 @@ test_that("Parent shares preserve columns, grouping, and laziness", {
     expect_no_error(dbplyr::sql_render(sql))
   }
 
-  if (rlang::is_installed("dtplyr")) {
+  if (backend_available("dtplyr")) {
     lazy <- summarize(dtplyr::lazy_dt(data))
     expect_s3_class(lazy, "dtplyr_step")
     expect_identical(as.character(dplyr::tbl_vars(lazy)), expected_names)
@@ -50,7 +50,7 @@ test_that("Parent shares preserve columns, grouping, and laziness", {
 })
 
 test_that("dtplyr validates Parent-share source types during collection", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -79,7 +79,7 @@ test_that("dtplyr validates Parent-share source types during collection", {
 })
 
 test_that("dtplyr rejects every ineligible Parent-share source type", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     value = 1:2,
@@ -121,7 +121,7 @@ test_that("dtplyr rejects every ineligible Parent-share source type", {
 })
 
 test_that("dtplyr rejects non-scalar Parent-share sources on collection", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = 1:3
@@ -162,7 +162,7 @@ test_that("dtplyr rejects non-scalar Parent-share sources on collection", {
 })
 
 test_that("dtplyr integer and double Parent shares match local results", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     integer_value = 1:3,
@@ -194,7 +194,7 @@ test_that("dtplyr integer and double Parent shares match local results", {
 })
 
 test_that("dtplyr validates each referenced source expanded by across", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = 1:3
@@ -223,7 +223,7 @@ test_that("dtplyr validates each referenced source expanded by across", {
 })
 
 test_that("dtplyr validates constant summaries expanded by across", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -257,7 +257,7 @@ test_that("dtplyr validates constant summaries expanded by across", {
 })
 
 test_that("dtplyr Parent validation preserves ordinary across arguments", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = c(1, NA, 3)
@@ -283,7 +283,7 @@ test_that("dtplyr Parent validation preserves ordinary across arguments", {
 })
 
 test_that("dtplyr preserves across arguments for unreferenced functions", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = c(1, NA, 3)
@@ -313,7 +313,7 @@ test_that("dtplyr preserves across arguments for unreferenced functions", {
 })
 
 test_that("Arrow rejects Parent shares before constructing a query", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -371,7 +371,7 @@ test_that("Arrow rejects Parent shares before constructing a query", {
 })
 
 test_that("Arrow ordinary Margin summaries remain lazy and available", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   query <- summarize_with_margins(
     arrow::Table$create(data.frame(
       group = c("x", "x", "y"),
@@ -390,7 +390,7 @@ test_that("Arrow ordinary Margin summaries remain lazy and available", {
 })
 
 test_that("Arrow Parent-share planning errors precede backend rejection", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -465,7 +465,7 @@ test_that("Arrow Parent-share planning errors precede backend rejection", {
 })
 
 test_that("dtplyr batches Parent shares with missing-safe matching", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     fixed = c(NA_character_, NA_character_, "a", "a"),
     group = c(NA_character_, "x", NA_character_, "x"),
@@ -504,7 +504,7 @@ parent_sql_count <- function(sql, pattern) {
 }
 
 test_that("dtplyr batches validated summaries and parent mapping", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     revenue = c(1, 3),
@@ -767,8 +767,7 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
 })
 
 test_that("RSQLite executes portable Parent shares end to end", {
-  skip_if_not_installed("RSQLite")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   data <- data.frame(
@@ -850,8 +849,7 @@ test_that("RSQLite executes portable Parent shares end to end", {
 })
 
 test_that("RSQLite Parent shares preserve runtime backend conditions", {
-  skip_if_not_installed("RSQLite")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   remote <- dplyr::copy_to(
@@ -883,8 +881,7 @@ test_that("RSQLite Parent shares preserve runtime backend conditions", {
 })
 
 test_that("DuckDB Parent shares agree across native, portable, and local paths", { # nolint: line_length_linter
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
@@ -988,10 +985,10 @@ test_that("lazy Parent shares preserve empty-input root and partition behavior",
   empty <- data.frame(group = character(), value = double())
   sources <- list()
 
-  if (rlang::is_installed("dtplyr")) {
+  if (backend_available("dtplyr")) {
     sources$dtplyr <- dtplyr::lazy_dt(empty)
   }
-  if (rlang::is_installed("duckdb") && rlang::is_installed("DBI")) {
+  if (backend_available("duckdb") && backend_available("DBI")) {
     con <- DBI::dbConnect(duckdb::duckdb())
     on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
     sources$duckdb <- dplyr::copy_to(
@@ -1052,10 +1049,10 @@ test_that("lazy Parent shares skip duplicate grouping-set occurrences", {
   expected <- summarize(data, include_id = TRUE)
   expected_without_id <- summarize(data, include_id = FALSE)
   sources <- list()
-  if (rlang::is_installed("dtplyr")) {
+  if (backend_available("dtplyr")) {
     sources$dtplyr <- dtplyr::lazy_dt(data)
   }
-  if (rlang::is_installed("duckdb") && rlang::is_installed("DBI")) {
+  if (backend_available("duckdb") && backend_available("DBI")) {
     con <- DBI::dbConnect(duckdb::duckdb())
     on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
     sources$duckdb <- dplyr::copy_to(
@@ -1139,8 +1136,7 @@ test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
     expect_no_error(dbplyr::sql_render(simulated))
   }
 
-  skip_if_not_installed("duckdb")
-  skip_if_not_installed("DBI")
+  skip_if_backend_absent("duckdb", "DBI")
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(

--- a/tests/testthat/test-parent-share.R
+++ b/tests/testthat/test-parent-share.R
@@ -1418,7 +1418,7 @@ parent_preflight_collect <- function(x, ...) {
 }
 
 test_that("Parent syntax and local execution errors precede typed metadata", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   registerS3method(
     "head",
     "parent_preflight_counter",

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -147,7 +147,7 @@ test_that("shared lifecycle options preserve user-expression conditions", {
 })
 
 test_that("summary rejects grouping before typed metadata acquisition", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_summary_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_summary_proxy_counter", class(source))
@@ -168,7 +168,7 @@ test_that("summary rejects grouping before typed metadata acquisition", {
 })
 
 test_that("removed .groups is rejected before typed metadata acquisition", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_summary_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_summary_proxy_counter", class(source))
@@ -189,7 +189,7 @@ test_that("removed .groups is rejected before typed metadata acquisition", {
 })
 
 test_that("dtplyr summary reuses one typed snapshot across selections", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
   register_summary_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -26,7 +26,7 @@ test_that("assert_sring_scalar() works", {
 })
 
 test_that("assert_nest_possible() works", {
-  skip_if_not_installed("dtplyr")
+  skip_if_backend_absent("dtplyr")
 
   expect_no_error(assert_nest_possible(data.frame()))
   expect_no_error(assert_nest_possible(dtplyr::lazy_dt(data.frame())))
@@ -40,7 +40,7 @@ test_that("assert_nest_possible() works", {
 })
 
 test_that("assert_lazy_table() works", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
 
   expect_error(
     assert_lazy_table(
@@ -90,7 +90,7 @@ test_that("shared argument assertions use the package condition seam", {
 })
 
 test_that("lazy-table assertions use the package condition seam", {
-  skip_if_not_installed("arrow")
+  skip_if_backend_absent("arrow")
 
   error <- expect_error(
     assert_lazy_table(arrow::as_record_batch_reader(data.frame())),


### PR DESCRIPTION
Closes #38.

## What this adds

`.github/workflows/release-matrix.yaml` builds one source tarball and checks
that tarball four ways, so that nothing passes because of a file that exists
only in the development tree:

| Job | Proves |
|---|---|
| `build` | Produces the single tarball every other job checks |
| `depends-only` | `_R_CHECK_DEPENDS_ONLY_=true` — examples, tests, and vignettes rebuild with Suggests withheld |
| `tarball` (5) | R release, devel, and oldrel on Linux, plus macOS and Windows at release |
| `backend` (4) | RSQLite, DuckDB, dtplyr, and Arrow each installed alone, live behavior executed |

## Telling a skip apart from a proof

A skipped test and a proved one look identical in a green job, which is the
whole risk in criterion 7 ("optional backends may skip in generic matrix jobs
only when a dedicated job proves their contract"). Three mechanisms close it:

- Optional-backend tests now route through `skip_if_backend_absent()` /
  `backend_available()` (`tests/testthat/helper-optional-backends.R`). The
  `rlang::is_installed()` call sites are included because dropping a backend
  from a list records no skip at all. Both honour
  `MARGINPLYR_REQUIRED_SUGGESTS`, which the dedicated jobs set so a backend
  that failed to install fails the job.
- Each `backend` job names the test titles it exists to run, and
  `verify-backend.R` fails unless every one ran and passed. Renaming a
  contract test deliberately breaks the job guarding it.
- `verify-depends-only.R` asserts the mirror image — that the minimal job ran
  its tests and that all four backends really were withheld.

## Verified locally

Every gate was run against real output, not just written:

- `depends-only`: `Status: OK`, 1094 passed / 68 skipped, all four backends provably withheld.
- All 12 named backend contracts execute across the four jobs.
- Both verifiers exercised on their failure paths.
- The required-Suggests gate proved end to end by running `depends-only` with `MARGINPLYR_REQUIRED_SUGGESTS=duckdb` — 16 failures, exit 1.
- Package and script lint clean; `man/` and `NAMESPACE` unchanged.

## A gap the new gate caught

`expect_snapshot()` skips under CRAN semantics, which marks the whole test
skipped — so "Arrow rejects Parent shares before constructing a query" never
executed inside `R CMD check`, leaving that acceptance criterion silently
unmet. The `backend` jobs now set `NOT_CRAN`, since they prove behavior rather
than emulate CRAN; the CRAN-emulating jobs deliberately do not.

The third commit follows from the same finding: `R-CMD-check.yaml` asked for
snapshot artifacts it can never produce, so that request is removed and the
comment records where snapshots actually run.

## Notes for review

- `AGENTS.md` gains a "Release matrix" section; its claim that this CI job "is not wired in yet (tracked in #38)" is now false and updated.
- Remote CRAN incoming checks are off in this workflow. Their NOTEs depend on the network and the clock, and each would have been annotated as unexpected. `rhub.yaml` remains the pre-submission run where a human reads them.
- `backend` jobs are Ubuntu/R-release only: their value is isolation (one backend installed, everything else absent), not platform breadth. macOS and Windows still exercise every backend together in `R-CMD-check.yaml`.