### PR TITLE
Reconcile architecture, ADRs, and the review disposition ledger

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,7 @@ _Avoid_: Grouping identifier, grouping mask
 A bit mask encoding which chosen grouping dimensions are absent from a
 grouping set. Identical absence patterns have the same identifier regardless
 of their position in a Grouping plan.
-_Avoid_: Grouping set identifier, set number
+_Avoid_: Grouping set identifier, set number, grouping mask
 
 **Grouping bit**:
 A zero-or-one flag indicating whether one chosen grouping dimension is absent

--- a/design/adr/0001-keep-margin-operations-verb-neutral.md
+++ b/design/adr/0001-keep-margin-operations-verb-neutral.md
@@ -1,15 +1,42 @@
-# Keep margin operations verb-neutral
+# Keep Margin operations verb-neutral
 
-A margin operation contains the semantics shared by summarizing, expanding,
+A Margin operation contains the semantics shared by summarizing, expanding,
 and nesting, but does not record which verb requested it. Summary expressions,
 nesting options, and execution remain with their verb-specific implementations;
 this keeps the shared module deep without turning it into a dispatcher whose
 branches grow as the verbs diverge. The shared module interprets persistent
 input groups as fixed keys and normalizes the input to an ungrouped form;
-it also restores margin column types, places grouping columns first, and
+it also restores Margin column types, places grouping columns first, and
 applies the common sorting semantics. Each verb remains responsible for its
 input-class admission checks, verb-specific arguments, execution, and the
 grouping it deliberately adds after finalization. The shared finalizer
 guarantees an ungrouped baseline; `nest_by_with_margins()` alone adds row-wise
 grouping afterward. This avoids passing a verb kind into the shared module
 merely to decide whether a backend or option is admissible.
+
+## Amendment: the finalizer does not order rows
+
+Two clauses of the sentence above are superseded, both narrowing what the
+shared finalizer does rather than changing who owns it.
+
+**"applies the common sorting semantics"** no longer holds. `.sort` was removed
+with the other legacy ordering arguments, and finalization now leaves row
+order unspecified on every backend: a Grouping set identifier records which
+occurrence a row came from but promises nothing about the order the rows
+arrive in. Callers use an explicit `dplyr::arrange()` when presentation order
+matters. ADR 0009 states the same rule from the identifier's side, and
+`inspect_grouping()`'s guaranteed Grouping-plan order under ADR 0013 is an
+inspection guarantee that deliberately does not extend to Margin-operation
+results.
+
+**"restores Margin column types"** is narrower in practice: the finalizer
+restores factor and ordered-factor Margin columns from the metadata captured
+during preparation. Other column types are never lost, so there is nothing
+else to restore.
+
+**"places grouping columns first"** stands, and is now specific: fixed keys,
+then grouping dimensions, then the optional Grouping set identifier.
+
+Nothing else in this decision changes. Verb-neutrality was never what made
+sorting shared, and removing the sort left the finalizer's remaining
+responsibilities in the same place.

--- a/design/adr/0002-acquire-typed-metadata-once.md
+++ b/design/adr/0002-acquire-typed-metadata-once.md
@@ -1,9 +1,9 @@
-# Acquire typed metadata once per margin operation
+# Acquire typed metadata once per Margin operation
 
-Each margin operation acquires typed selection metadata at most once and
-reuses the same snapshot for grouping selections, summary selections, column
+Each Margin operation acquires typed selection metadata at most once and
+reuses the same snapshot for Grouping selections, summary selections, column
 prototypes, and factor metadata. Backend-specific schema reads or zero-row
-collections remain hidden behind the margin-operation seam so later stages
+collections remain hidden behind the Margin operation seam so later stages
 cannot issue duplicate metadata queries or observe a different schema. A
 prepared operation belongs to one public verb call and is not cached, reused,
 or returned to users, which bounds the lifetime of that snapshot.

--- a/design/adr/0003-validate-margin-labels-before-execution.md
+++ b/design/adr/0003-validate-margin-labels-before-execution.md
@@ -1,9 +1,9 @@
-# Validate margin labels before execution
+# Validate Margin labels before execution
 
-Operation preparation normalizes a margin label and constructs its typed
+Operation preparation normalizes a Margin label and constructs its typed
 column metadata, but each verb-specific execution applies all semantic label
 rules after its schema-aware preflight and immediately before low-level
-execution. The margin-operation module still owns backend, factor, and
+execution. The Margin operation module still owns backend, factor, and
 collision validation; delaying them preserves the existing error and query
 order so an invalid summary is rejected before label validation can fail or
 an opt-in collision query contacts a lazy backend.

--- a/design/adr/0004-treat-margin-operations-as-opaque.md
+++ b/design/adr/0004-treat-margin-operations-as-opaque.md
@@ -1,10 +1,10 @@
-# Treat prepared margin operations as opaque values
+# Treat prepared Margin operations as opaque values
 
-Public verb implementations and tests pass a prepared margin operation as a
+Public verb implementations and tests pass a prepared Margin operation as a
 whole rather than reading its fields. Its representation remains a
 package-private implementation detail, with field access localized to the
-margin-operation module and dedicated execution adapters; this prevents the
-new seam from becoming a shallow data bag and allows grouping-plan and backend
+Margin operation module and dedicated execution adapters; this prevents the
+new seam from becoming a shallow data bag and allows Grouping plan and backend
 internals to evolve independently. The value retains only canonical state
 needed for execution and finalization; original quosures, input grouping
 metadata, and options whose validation or compilation has completed are

--- a/design/adr/0005-reject-local-errors-before-backend-reads.md
+++ b/design/adr/0005-reject-local-errors-before-backend-reads.md
@@ -2,7 +2,7 @@
 
 Margin verbs reject invalid arguments, unsupported local contexts, and
 incompatible input grouping before acquiring backend metadata or executing a
-margin-label validation query. Schema-dependent checks follow metadata
+Margin label validation query. Schema-dependent checks follow metadata
 acquisition, but preparation must not contact a backend for an error that can
 already be determined from the call and input metadata available locally.
 

--- a/design/adr/0006-use-an-explicit-margin-operation-lifecycle.md
+++ b/design/adr/0006-use-an-explicit-margin-operation-lifecycle.md
@@ -1,6 +1,6 @@
-# Use an explicit margin-operation lifecycle
+# Use an explicit Margin operation lifecycle
 
-Margin verbs explicitly prepare one opaque margin operation, pass it to their
+Margin verbs explicitly prepare one opaque Margin operation, pass it to their
 verb-specific execution, and finalize the raw result through the shared
 module. We rejected a callback-based runner because the explicit
 prepare–execute–finalize sequence keeps tidy evaluation, call stacks, and

--- a/design/adr/0007-capture-user-expressions-at-public-verbs.md
+++ b/design/adr/0007-capture-user-expressions-at-public-verbs.md
@@ -6,7 +6,7 @@ preparation and verb-specific execution. Internal helpers do not recapture or
 re-inject them through wrapper layers, preserving the caller environment and
 keeping tidy-evaluation and error contexts stable while the lifecycle is
 refactored. The public verb's call context is also propagated explicitly to
-internal helpers that produce user-facing errors so the new seam does not
+internal helpers that raise Package conditions so the new seam does not
 expose lifecycle helper calls. `nest_with_margins()` and
 `nest_by_with_margins()` capture independently at their public boundaries and
 pass those quosures to one private nest pipeline; neither public verb

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -78,7 +78,8 @@ plan and require no rule awareness.
 The implementation must not change:
 
 - exported functions, arguments, syntax, or returned specification classes;
-- grouping-set membership, ordering, duplicate handling, or grouping masks;
+- grouping-set membership, ordering, duplicate handling, or Grouping
+  identifiers;
 - error condition classes, complete messages, public call contexts, or
   detection order;
 - quosure environments or the number and timing of evaluations without a

--- a/design/adr/0009-distinguish-grouping-set-identifiers-from-grouping-identifiers.md
+++ b/design/adr/0009-distinguish-grouping-set-identifiers-from-grouping-identifiers.md
@@ -13,7 +13,7 @@ with `.duplicates = "keep"`, a native summary may use the portable
 
 `inspect_grouping()` always exposes this occurrence number in a column named
 `set_id`. Given the same resolved `.by`, `.grouping`, and `.duplicates`,
-`inspect_grouping()$set_id` is exactly the value produced by a margin verb
+`inspect_grouping()$set_id` is exactly the value produced by a Margin verb
 whose `.id` names an output column. The caller may choose any non-conflicting
 `.id` column name without changing its values.
 
@@ -37,3 +37,22 @@ will compare `.id`, `inspect_grouping()$set_id`, `grouping_bit()`, and
 and distinguish plan identity from Margin labels and physical row order. Each
 function reference will retain a compact comparison and link to the complete
 article rather than relying on the article alone.
+
+## Amendment: the comparison table lives in the reference, not the article
+
+The two sentences above place the single comparison table in the
+`grouping_identity` article and give each function reference a compact copy of
+it. That placement is superseded. Function references are the canonical
+user-facing contract, and a shared reference section is inherited from one
+canonical home rather than copied, so the table now lives only in the
+`grouping_bit()` reference; `summarize_with_margins()`, `inspect_grouping()`,
+`grouping_set()`, and the `grouping_identity` article carry prose plus a
+cross-link to it. `tests/testthat/test-documentation.R` asserts that it has
+exactly one home.
+
+The distinction this ADR decides is unaffected. A Grouping set identifier is
+stable only within one ordered Grouping plan and separates duplicate
+occurrences; a Grouping identifier is stable for one absence pattern and may be
+non-consecutive. Only where that comparison is written down has changed, and
+the article still exists and still explains the concepts — it links to the
+table instead of holding it.

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -9,7 +9,7 @@ Fixed `.by` columns partition the calculation.
 
 Calling `share_of_parent()` directly, from an ordinary `dplyr::summarise()`,
 or from `dplyr::mutate()` is an error. The error will explain that the helper
-requires the grouping plan and staged margin result owned by
+requires the Grouping plan and staged Margin result owned by
 `summarize_with_margins()`, and will point callers to a following
 `dplyr::mutate()` when they intend to derive a value from an existing Parent
 share.
@@ -213,15 +213,15 @@ uses its immediate parent.
 
 Parent shares cannot be evaluated by an ordinary summary expression because
 the denominator belongs to another grouping-set row. The executor will first
-materialize the ordinary margin summaries, then calculate all requested
+materialize the ordinary Margin summaries, then calculate all requested
 Parent shares together using one shared parent mapping. This staging also
 avoids relying on backend-specific support for referring to a summary alias
 from the same `summarise()` call.
 
 The staged calculation must preserve lazy execution and backend-independent
-results. Internal grouping-set metadata, rather than displayed margin labels,
+results. Internal grouping-set metadata, rather than displayed Margin labels,
 will identify levels and parent rows. Genuine missing grouping values and
-margin labels therefore cannot be confused while matching parents.
+Margin labels therefore cannot be confused while matching parents.
 
 Parent lookup uses missing-safe key identity. Missing values in fixed `.by`
 columns belong to one fixed partition, and missing values in included
@@ -383,6 +383,45 @@ schema or cardinality probe, so an incompatible summary-result type or
 non-scalar result may surface as a database error at execution even though all
 statically detectable helper errors are targeted before execution.
 
+## Amendment: where each backend proves the source contract
+
+This decision divides backends into ones whose summary-result type and
+cardinality are available before execution and ones whose are not, and it
+assumed every backend falls on one side or the other of that line. Two do not,
+and the implementation settled both. The value contract above is unchanged;
+only where each backend enforces it is amended.
+
+**Arrow rejects Parent shares entirely.** Arrow's schema seam can reject some
+semantic types but cannot prove scalar cardinality, and the mechanisms that
+would run validation inside the query — native UDFs, batch hooks, query
+wrappers — either erase the Package condition class and the caller's call or
+are not preserved by query-rebuilding verbs. Both alternatives to rejecting
+were therefore unavailable: enforcing the contract weakly would let an
+ineligible source through, and enforcing it by collecting would collect behind
+the caller's back. A Parent-share request on an Arrow backend raises a Package
+condition before ordinary summaries are staged, so no Arrow query is
+constructed. Ordinary Arrow Margin summaries, expansions, and nesting are
+unaffected. ADR 0005 records why that admission point is allowed to run after
+the typed metadata snapshot.
+
+**dtplyr validates at explicit execution.** dtplyr has no materialized result
+to inspect while the query is built, but unlike a general SQL backend it
+translates R expressions, so the check can be placed inside the ordinary
+summary rather than beside it. Each referenced source summary is wrapped in a
+validator that becomes part of the translated data.table expression and runs
+only when the caller collects. It costs no validation-only query, keeps the
+result a native lazy step, and raises the same Package condition — including
+`marginplyr_parent_cardinality_error` for a non-scalar source — naming the
+Parent share, the source summary, and the original public call. An invalid
+source therefore fails at collection rather than emitting a wrong row.
+
+Local execution uses the same wrapper for the same reason: validating inside
+the ordinary summary is what removes the full input rescan per Grouping set
+that a separate cardinality query would need. General dbplyr keeps the
+relaxation this decision already granted it: no extra schema or cardinality
+query, no implicit collection, and an incompatible type or non-scalar result
+surfacing as a database condition at execution.
+
 ## Considered options
 
 `rollup_share()` was rejected because it names the input structure rather than
@@ -391,6 +430,6 @@ subtotal rows to `1` is a presentation rule and obscures the immediate-parent
 definition, especially in rollups with three or more dimensions.
 
 A post-summary `add_rollup_share()` verb was rejected because the grouping
-plan and parent mapping are already available inside the margin operation.
+plan and parent mapping are already available inside the Margin operation.
 Allowing `cube()` or arbitrary grouping sets was deferred until an explicit
 parent-selection model exists.

--- a/design/adr/0011-keep-key-completion-outside-margin-operations.md
+++ b/design/adr/0011-keep-key-completion-outside-margin-operations.md
@@ -12,7 +12,7 @@ mutations.
 Input completion and result completion have different semantics. Completing
 fact rows before summarization makes the inserted values participate in
 detail, subtotal, and grand-total calculations. Completing an already
-summarized margin result can add display rows without changing existing
+summarized Margin result can add display rows without changing existing
 aggregates. One argument cannot hide that distinction without surprising
 either row counts and non-additive summaries or the relationship between
 detail rows and totals.

--- a/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
+++ b/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
@@ -1,0 +1,98 @@
+# Select Parent-share adapters from the prepared backend kind
+
+Parent shares are calculated by one deep private module behind a small
+interface. Its backend behavior lives in explicit adapters, and the adapter is
+chosen by looking up the backend kind that the Margin operation already
+prepared — never by inspecting the class of the staged ordinary-summary
+result, and never by a chain of capability predicates rebuilt at this seam.
+
+## Decision
+
+Parent mapping, ratio calculation, and temporary-name cleanup are shared by
+every backend. There are three adapters, and each carries only what its
+backends do differently:
+
+| Adapter | Backend kinds | What it adds to the shared work |
+|---|---|---|
+| Local | `local` | Checks the materialized source types first |
+| General dbplyr | `duckdb`, `postgres`, `sql` | Missing-safe `sql_on` join |
+| Lazy non-SQL | `dtplyr`, `other` | Nothing |
+
+The third adapter adds nothing, and that is the decision rather than an
+accident of implementation. A lazy non-SQL backend joins exactly as local data
+does, and differs from local only in what it cannot do: there is no
+materialized result to type-check, so its source validation has already
+happened inside the ordinary summary. Naming that as its own adapter keeps
+the difference visible at the seam obliged to honour it, and keeps the branch
+where a future lazy non-SQL divergence belongs. Merging it into the local
+adapter would give `dtplyr` a type check it cannot run; merging it into the
+dbplyr adapter would give it a `sql_on` condition it has no connection for.
+
+Arrow is not in the table. A valid Arrow Parent-share request is rejected at
+the executor boundary immediately before ordinary summaries are staged, so no
+Arrow adapter is ever reached. ADR 0005 records why that rejection is
+admissible after the typed metadata snapshot.
+
+The lookup has no default. An unrecognized backend kind is a marginplyr defect
+rather than something a caller can rewrite their way out of, so it stops with
+a bare `stop()` under ADR 0015 rather than silently falling through to the
+adapter that happens to look plausible.
+
+Every adapter has the same signature: the prepared Margin operation, the
+staged result, the planned requests, and the internal Grouping set identifier
+name. Adapters are dispatch targets rather than independent entry points, so
+they receive the operation whole; they read the Grouping plan from it and
+nothing else. `execute_parent_shares()` reads the backend kind and the
+caller-visible Grouping set identifier name and is the only place the
+operation crosses into the module.
+
+The seam sits after ordinary Margin summaries are staged and before
+Margin-operation finalization. Placing it there is what lets one adapter set
+serve every verb-neutral guarantee: the shared finalizer still restores factor
+Margin columns, orders columns, and leaves row order unspecified, and the
+adapters never see a finalized result.
+
+Adapters are private. They are not a third-party extension interface, and
+adding a backend means naming its kind in the lookup inside marginplyr, as
+described in `design/architecture.md`.
+
+## Why not the staged result's class
+
+The staged result's class is incidental to how the ordinary summaries happened
+to execute, not to what the operation prepared. A DuckDB summary that reached
+the portable `UNION ALL` adapter and a DuckDB summary that used native
+`GROUPING SETS` are the same Parent-share problem and must take the same
+branch; a local tibble collected out of a lazy pipeline by an unrelated step
+would take the local branch and quietly acquire validation the lazy contract
+says it does not have. Reading the prepared kind keeps the branch decision on
+state that was validated once during preparation and cannot drift between the
+two query stages.
+
+It also keeps the Arrow rejection honest. That rejection is decided from the
+prepared kind before any query is constructed; if adapter selection used the
+staged class, the same fact would be established twice from two different
+sources of truth.
+
+## Considered options
+
+**One function with backend branches.** Rejected: the branches would grow with
+every backend and would sit in the middle of the join, mixing the parts that
+differ per backend with the mapping, calculation, and cleanup that do not.
+
+**Capability predicates at the seam** — ask again whether the backend supports
+missing-safe joins or materialized types. Rejected: capability discovery
+belongs to `R/grouping-backend.R` and is already done during preparation.
+Re-deriving it here would make the Parent-share module a second authority on
+backend classification, free to disagree with the first.
+
+**S3 dispatch on a backend class.** Rejected: it would make the adapter set a
+public extension point by construction, which contradicts keeping one Grouping
+plan and one lifecycle for every backend, and it would put the dispatch table
+in the method registry where the three-way grouping is no longer readable in
+one place.
+
+**A separate adapter per backend kind**, mirroring the six kinds one to one.
+Rejected: four of the six would repeat a body that already exists — three SQL
+kinds share one, and `dtplyr` and `other` share another — and the duplication
+would invite them to drift into differences no contract asked for. Backend
+kinds are grouped by what their Parent-share execution actually needs.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -6,7 +6,7 @@ in [`adr/`](adr/) are authoritative.
 
 ## Lifecycle
 
-Every exported margin verb follows the same explicit lifecycle:
+Every exported Margin verb follows the same explicit lifecycle:
 
 1. **Capture and admit.** The public verb captures `.by`, `.grouping`, and,
    for summaries, `...` exactly once. It rejects unsupported input classes and
@@ -16,7 +16,7 @@ Every exported margin verb follows the same explicit lifecycle:
    discovers the backend and column names, validates an optional output
    Grouping set identifier name, acquires one typed metadata snapshot,
    compiles the Grouping specification into a Grouping plan, and derives
-   margin-column metadata. Locally detectable errors are rejected before the
+   Margin-column metadata. Locally detectable errors are rejected before the
    typed metadata read.
 3. **Execute.** The verb passes the prepared Margin operation to exactly one
    of `execute_margin_summary()`, `execute_margin_expand()`, or
@@ -24,7 +24,7 @@ Every exported margin verb follows the same explicit lifecycle:
    calls `validate_margin_operation()` immediately before low-level work, and
    selects or invokes the appropriate adapter.
 4. **Finalize.** `finalize_margin_operation()` starts from an ungrouped
-   result, restores factor margin columns, places fixed keys and grouping
+   result, restores factor Margin columns, places fixed keys and grouping
    dimensions followed by the optional Grouping set identifier first, and
    leaves row ordering unspecified.
 
@@ -52,7 +52,7 @@ on a verb kind.
 
 Owns the shared prepare and finalize lifecycle, common option normalization,
 grouped-input normalization, the package-private Margin operation value, the
-shared semantic margin-label validation entry point, and propagation of the
+shared semantic Margin label validation entry point, and propagation of the
 public call in Package conditions. Preparation stores only canonical derived
 state needed by execution and finalization; a Margin operation is single-use
 state for one public call.
@@ -76,7 +76,7 @@ Owns validation and compilation of a Grouping specification into the
 backend-independent Grouping plan: fixed keys, resolved dimensions, expanded
 grouping sets, their one-based occurrence identifiers, and the duplicate-set
 policy. It resolves selections against the prepared metadata but does not read
-a backend or execute a margin.
+a backend or execute a Margin operation.
 
 Grouping specification kinds are governed by one private strategy registry in
 this module. Each kind rule owns empty-argument validation, validation of
@@ -96,7 +96,7 @@ completed its schema-aware preflight and is about to execute.
 
 ### Factor (`R/factor.R`)
 
-Owns restoration of factor and ordered-factor margin columns from the metadata
+Owns restoration of factor and ordered-factor Margin columns from the metadata
 captured during preparation. Its backend methods preserve levels and ordering
 after labels have been materialized; it does not acquire metadata itself.
 
@@ -111,12 +111,88 @@ opt-in lazy collision query.
 
 ### Parent share (`R/parent-share.R`)
 
-Owns Parent-share request planning, parent mapping, source validation, ratio
-calculation, collision-safe temporary names, and private backend adapter
-dispatch. The adapter interface receives the prepared Margin operation, the
-staged ordinary-summary result, and all planned requests together; selection
-uses the prepared backend kind rather than the staged result's incidental
-class.
+One deep private module owns every Parent-share responsibility: request
+planning, parent mapping, source validation, ratio calculation, collision-safe
+temporary names and their cleanup, and backend adapter dispatch. Its file is
+large because the module is deep, not because it is several modules sharing a
+file; splitting it would move the seam without shrinking the interface.
+
+The exported `share_of_parent()` in this file is only a context guard: reaching
+its body means the helper was called outside a Margin summary, so it always
+raises. The rest of the module is private and is reached through four entry
+points, and no other:
+
+- `preflight_parent_shares()`, called from the public verb's admission block
+  before preparation, which reports whether the call contains any
+  Parent-share request and rejects statically impossible forms;
+- `plan_parent_share_expressions()`, called by `plan_summary_expressions()`
+  in the summary-selection module, which rewrites the captured summary
+  expressions into ordinary summaries plus planned Parent-share requests;
+- `wrap_parent_sources()`, called from the same place immediately afterwards,
+  which wraps each referenced source summary in the validator its backend can
+  execute; and
+- `execute_parent_shares()`, called by `execute_margin_summary()`, which
+  receives the prepared Margin operation, the staged ordinary-summary result,
+  and all planned requests together.
+
+Planning and wrapping are two calls rather than one because the summary
+selections have to be resolved between them: the plan names which summaries a
+Parent share depends on, resolution turns `across()` into the columns it
+expands to, and only then can the validator be wrapped around the right
+expressions.
+
+`check_parent_grouping_spec()` is additionally passed to
+`prepare_margin_operation()` as a validation hook, so the rollup-only
+restriction is checked with the rest of grouping validation instead of after
+it.
+
+The responsibilities divide as follows:
+
+- **Planning** analyzes the ordinary summaries preceding each request,
+  retains candidate-name provenance for duplicate, expanded, ineligible, and
+  unknown sources, validates direct and `across()` grammar, resolves
+  name-based tidyselect against preceding ordinary summaries only, and checks
+  output-name collisions against fixed keys, dimensions, ordinary summaries,
+  the Grouping set identifier, and other Parent shares.
+- **Validation** is placed where each backend can prove it. Local and dtplyr
+  operations wrap the referenced source summaries in a type-and-cardinality
+  validator inside the ordinary summary itself, so validation costs no extra
+  pass over the input and no validation-only query; the local adapter then
+  checks the materialized source types. General dbplyr keeps the documented
+  relaxation and issues no probe. Arrow is rejected before any of this.
+- **Mapping** derives each grouping set's parent from the Grouping plan with
+  `parent_set_ids()`, which skips duplicate occurrences while finding the
+  next strictly less detailed set. Parents are matched on the internal
+  Grouping set identifier, the fixed keys, and one join key per dimension
+  that carries the dimension's value only where the parent set includes it
+  and is missing otherwise — computed by the same expression on both sides,
+  and never from a displayed Margin label or the caller-visible `.id`.
+- **Calculation** builds one shared mapping for all requests, joins it once,
+  and emits each ratio as an explicit double division guarded for a root row,
+  a missing numerator, and a missing or zero denominator.
+- **Cleanup** allocates every temporary — denominators, join keys, and the
+  right-hand match names of the SQL join — through
+  `new_margin_internal_names()` against the names already in the result, and
+  drops all of them before returning.
+
+Adapter selection is a lookup on the prepared backend kind, not on the staged
+result's class, and every adapter takes the same four arguments. See
+[ADR 0014](adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md).
+The mapping, calculation, and cleanup above are shared; there are three
+adapters, and each says only what its backends do differently:
+
+| Adapter | Backend kinds | Difference from the shared work |
+|---|---|---|
+| Local | `local` | Checks materialized source types first |
+| General dbplyr | `duckdb`, `postgres`, `sql` | Missing-safe `sql_on` join |
+| Lazy non-SQL | `dtplyr`, `other` | Nothing |
+
+The lazy non-SQL adapter adding nothing is the point rather than an
+oversight: it names the contract that a lazy non-SQL backend joins exactly as
+local data does but cannot have its source types checked first, because
+nothing is materialized to check. Its validation happens earlier, inside the
+ordinary summary. Collapsing it into the local adapter would make that
+difference invisible at the seam that has to honour it.
 
 Arrow is rejected at the immediately earlier executor boundary because no
 ordinary-summary query may be staged for a valid Arrow Parent-share request.
@@ -124,6 +200,21 @@ The rejection runs after request planning and common Margin-operation
 validation, uses only the operation's prepared backend kind, and adds no
 wrapper, hook, sentinel, or extension seam. Other Arrow Margin operations
 continue through the ordinary summary, expansion, and nesting paths.
+
+### Package conditions (`R/conditions.R`)
+
+`abort_marginplyr()` is the only constructor for a Package condition and the
+whole of this module. A Package condition is raised exactly when the caller
+can avoid it by rewriting the call within the documented public interface;
+unreachable invariants and upstream defects use bare `stop()` or
+`stopifnot()`, and External conditions propagate untouched. `marginplyr_error`
+is the only promised class. See
+[ADR 0015](adr/0015-separate-package-conditions-from-internal-invariants.md).
+
+The rule is not mechanically enforced, so both directions of the boundary are
+review surface: a Package condition demoted to `stop()` silently leaves the
+public contract, and an invariant promoted to `abort_marginplyr()` silently
+enters it.
 
 ### Native adapter (`R/grouping-adapter-native.R`)
 
@@ -150,14 +241,21 @@ or construct it independently.
 
 Direct field reads are confined to:
 
-- the Margin operation module, for validation and finalization; and
+- the Margin operation module, for validation and finalization;
 - the three dedicated verb executors, for their schema-aware preflight and
-  calls into low-level adapters.
+  calls into low-level adapters;
+- `execute_parent_shares()`, which reads the prepared backend kind to select
+  an adapter and the caller-visible Grouping set identifier name to restore
+  it after the join; and
+- the three Parent-share adapters, which read the Grouping plan and nothing
+  else.
 
-The native and portable adapters receive the specific derived values they
-need, not the Margin operation itself. This boundary lets the operation,
-Grouping plan, and backend representations change without spreading field
-access through public verbs or adapters.
+The native and portable Grouping adapters receive the specific derived values
+they need, not the Margin operation itself. The Parent-share adapters take it
+whole because they are dispatch targets of one signature rather than
+independent entry points. This boundary lets the operation, Grouping plan, and
+backend representations change without spreading field access through public
+verbs or adapters.
 
 ## Test seams
 
@@ -171,14 +269,27 @@ constructor shape, or internal helper order.
 The test suite divides supporting contracts as follows:
 
 - `test-grouping-interface.R` covers shared local behavior through the public
-  verbs, including grouping plans, labels, factors, duplicate policies,
-  persistent groups, result grouping, summary selections, and nesting.
+  verbs, including Grouping plans, labels, factors, duplicate policies,
+  persistent groups, result grouping, summary selections, nesting, and the
+  documented `marginplyr_error` handler.
 - `test-margin-id.R` covers Grouping set occurrence identifiers across all
   public verbs, including local, native, portable, duplicate, nesting,
-  collision, missing-value, and laziness semantics.
+  collision, missing-value, zero-row, and laziness semantics.
+- `test-margin-label.R` covers Margin labels through the public verbs: named
+  per-dimension labels, the eight-case factor NA contract of ADR 0012, label
+  placement, collisions including unused factor levels, and typed missing
+  values on dtplyr, Arrow, portable SQL, and DuckDB.
 - `test-summarize-operation.R`, `test-expand-operation.R`, and
   `test-nest-operation.R` cover lifecycle ordering and the single typed
-  metadata snapshot through public calls.
+  metadata snapshot through public calls. `test-nest-operation.R` also covers
+  the nesting duplicate-drop policy and quosure environments of both nesting
+  verbs.
+- `test-parent-share.R` covers Parent-share semantics through
+  `summarize_with_margins()`: rollup levels, typed grouping identity against
+  the default Margin label, missing keys separated from displayed margins,
+  the direct and `across()` grammar, source type and cardinality, output-name
+  collisions, dependency provenance, single evaluation of captured
+  expressions, and error precedence.
 - `test-grouping-backends.R` covers Arrow and dtplyr metadata behavior,
   native and portable SQL strategy, lazy query composition, collision checks,
   internal-name safety, and live DuckDB equivalence.
@@ -186,15 +297,55 @@ The test suite divides supporting contracts as follows:
   including targeted pre-query Arrow rejection, dtplyr execution-time
   validation, lazy SQL composition, live SQLite portable execution, and live
   DuckDB native-versus-portable results.
+- `test-inspect-grouping.R` covers `inspect_grouping()` as an ordinary tibble
+  per ADR 0013, including both formats, plan order, and that a lazy input is
+  inspected without executing a Margin operation.
 - `test-get-col-names.R` and `test-factor.R` cover the focused metadata and
   factor backend contracts.
 - `test-grouping-plan.R` covers the backend-independent Grouping
   specification compiler directly, including the complete kind-nesting
   grammar, phase-sensitive empty rules, error precedence, and expansion order.
+- `test-documentation.R` covers the reference documentation's own contracts:
+  that an italicised section cross-reference resolves in the topic it
+  promises, that every user-facing topic offers related-topic links, and that
+  the Grouping-identity comparison has exactly one canonical home.
+- `test-utils.R` and `test-retail-sales.R` cover the shared assertion helpers
+  and the documented properties of the bundled dataset.
+
+Package conditions are not tested in one file. Each module's tests assert the
+`marginplyr_error` class next to the behavior that raises it — the "use the
+package condition seam" tests in `test-grouping-interface.R`,
+`test-margin-label.R`, `test-summarize-operation.R`, `test-nest-operation.R`,
+`test-inspect-grouping.R`, and `test-utils.R` — while the matching
+"retain their provenance" and "preserve user-expression conditions" tests
+assert that an External condition keeps its original class. Keeping the two
+halves adjacent is what makes the boundary in ADR 0015 reviewable.
 
 Backend tests may instrument a backend seam or inspect semantic query shape,
 but should not couple to the Margin operation representation or require
 byte-for-byte SQL formatting.
+
+### Release gates
+
+One property of this suite is not observable from any single run of it: an
+optional-backend test that skipped and one that passed look the same in a
+green job. A backend contract therefore has a second seam, in
+`.github/workflows/release-matrix.yaml`, where a dedicated job installs that
+backend alone and fails if the contract did not execute.
+
+What this asks of a test is that it never decide on its own whether it may
+skip. Optional-backend tests route through `skip_if_backend_absent()` or
+`backend_available()` in `tests/testthat/helper-optional-backends.R` — never
+`skip_if_not_installed()` or `rlang::is_installed()` — because only the helper
+can be told, through `MARGINPLYR_REQUIRED_SUGGESTS`, that this job promised to
+prove the backend and an absence is a failure. `test-optional-backends.R`
+covers the helper itself. Snapshot expectations belong to the same seam:
+testthat skips them under CRAN semantics, so they run only in those jobs.
+
+A test title is part of that contract, because each job names the titles it
+exists to execute. Renaming a contract test is expected to break its job.
+`AGENTS.md` is the operational reference for the jobs, the verifier scripts,
+and the sites an added backend has to touch.
 
 ## Extending backend support
 
@@ -212,12 +363,18 @@ A backend change should:
    executor;
 3. reuse the existing portable adapter unless native `GROUPING SETS` support
    is confirmed and covered by the native adapter contract;
-4. keep label rules, factor restoration, summary selection, and finalization
-   in their owning modules rather than duplicating them in the adapter; and
-5. add contract coverage for metadata acquisition, observable results,
+4. name the new backend kind in `parent_share_adapter()`, choosing one of the
+   three existing Parent-share adapters or adding a fourth. The lookup has no
+   default: an unnamed kind stops the operation rather than falling through to
+   a plausible-looking join;
+5. keep label rules, factor restoration, summary selection, and finalization
+   in their owning modules rather than duplicating them in the adapter;
+6. add contract coverage for metadata acquisition, observable results,
    laziness, SQL strategy and composition where applicable, identifier and
    label quoting, and native-versus-portable equivalence when both paths
-   exist.
+   exist; and
+7. wire the new coverage into the release gates, per `AGENTS.md`, so its
+   contracts cannot pass by skipping.
 
 The backend capability description selects between already prepared execution
 strategies. It does not replace the Margin operation, specialize the Grouping
@@ -225,8 +382,15 @@ plan, or bypass common finalization.
 
 ## Repository placement
 
-This file, `CONTEXT.md`, and the ADRs are human-maintained contributor
-material. They are separate from the generated package site in `docs/`;
-`^CONTEXT\.md$` and `^design$` in `.Rbuildignore` exclude them from source
-packages. Internal architecture is not duplicated into the README or
+This file, `CONTEXT.md`, the ADRs, and
+[`review-dispositions.md`](review-dispositions.md) are human-maintained
+contributor material. They are separate from the generated package site in
+`docs/`; `^CONTEXT\.md$` and `^design$` in `.Rbuildignore` exclude them from
+source packages. Internal architecture is not duplicated into the README or
 vignettes.
+
+`review-dispositions.md` is the ledger that gives "review complete" an
+auditable meaning: every observation from a recorded review is listed there as
+fixed or rejected, with a test, command, or reproduction behind it. An ADR
+records what was decided; the ledger records what was reviewed and what
+happened to it.

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -1,0 +1,454 @@
+# Review disposition ledger
+
+Every observation from a recorded review of the 0.1.0 stabilization work is
+listed here as **fixed** or **rejected**, with a test name, command, or
+reproduction result behind it. This is what makes "review complete" mean
+something other than "the reviewer stopped talking": a suggestion that was not
+implemented has to say why, in a form the next reader can check.
+
+A recorded review is one whose findings were written down in the issue tracker
+— an issue comment, a pull-request body, or a commit message that names what
+review found. Findings raised and fixed inside one commit before it was pushed
+are not separately listed; they left no trace to reconcile and the commit is
+the record.
+
+Rejecting an observation is a normal outcome. A review suggestion is a
+hypothesis about the code, and several of the ones below were disproved by
+coverage that already existed. Defensible design is not rewritten to make a
+review comment go away.
+
+Adding an entry: give the observation in one sentence, name its axis, state
+the disposition, and point at something executable. "Looks fine" is not
+evidence; a test title, a `git` command, or a reproduced result is.
+
+---
+
+## 1. The pre-release review (produced #23)
+
+A two-axis review plus a Docs & Tests audit of the 0.1.0 tree at
+`1c782eb` produced the 47 user stories of #23. Each cluster of observations
+became a blocker-aware ticket, and the ticket's merged work is its disposition.
+All are **fixed**; each entry names coverage that executes the contract through
+the public interface, or the command that reproduces the result.
+
+**Displayed Margin labels corrupt local cardinality matching for
+non-character dimensions** — #27. `test-parent-share.R` "default Margin labels
+preserve typed grouping identity" and "Parent identity separates missing keys
+from displayed margins".
+
+**Parent shares must hold for every documented dimension storage type** —
+#27. `test-parent-share.R` "direct Parent shares use the immediate rollup
+parent" and "three-dimension Parent shares advance one rollup level".
+
+**Genuine missing grouping values must stay distinct from omitted
+dimensions** — #27. `test-margin-id.R` ".id distinguishes source missing
+values from margins".
+
+**Adversarial column names can collide with implementation temporaries** —
+#27. `test-parent-share-backends.R` "lazy Parent-share staging avoids
+adversarial user-name collisions".
+
+**Duplicate occurrences must be retained while parent lookup skips them** —
+#27. `test-parent-share-backends.R` "lazy Parent shares skip duplicate
+grouping-set occurrences".
+
+**Fixed `.by` partitions must not share denominators, including on empty
+input** — #27. `test-parent-share-backends.R` "lazy Parent shares preserve
+empty-input root and partition behavior".
+
+**Ineligible source types and non-scalar sources must raise a targeted
+error** — #24, #27. `test-parent-share.R` "Parent-share sources are numeric
+scalar summaries", "semantic and nonnumeric classes are not Parent-share
+sources", "cardinality errors identify the affected Parent-share request".
+
+**dtplyr silently coerces an ineligible source or emits Cartesian rows** —
+#28. `test-parent-share-backends.R` "dtplyr validates Parent-share source
+types during collection", "dtplyr rejects every ineligible Parent-share source
+type", "dtplyr rejects non-scalar Parent-share sources on collection", "dtplyr
+integer and double Parent shares match local results".
+
+**Arrow cannot preserve the condition contract through its execution
+bridge** — #29. `test-parent-share-backends.R` "Arrow rejects Parent shares
+before constructing a query", "Arrow ordinary Margin summaries remain lazy and
+available", "Arrow Parent-share planning errors precede backend rejection";
+the reasoning is recorded in ADR 0010's amendment.
+
+**General dbplyr must stay lazy with no validation-only probe** — #30.
+`test-parent-share-backends.R` "general dbplyr leaves incompatible summary
+types to execution" and "general dbplyr reports static Parent-share errors
+without probing".
+
+**`.grouping` is evaluated through two paths** — #25. `test-parent-share.R`
+"Parent planning evaluates the grouping expression once", "Parent planning
+preserves every public-call environment", "Parent planning evaluates across
+arguments once".
+
+**`across()` diagnostics conflate duplicate, unknown, and predicate cases** —
+#25. `test-parent-share.R` "Parent-share across classifies source-name
+failures", "Parent-share across rejects non-name contracts", "Parent-share
+across does not infer bare predicate symbols", "caller function symbols are
+not inferred to be predicates".
+
+**Package errors are inferred from third-party message text** — #24, #31,
+#32. `test-parent-share.R` "Parent-share execution preserves user-expression
+conditions".
+
+**Package-created errors need a stable base class, external ones their
+provenance** — #31, #32, #33. `test-grouping-interface.R` "the documented
+`marginplyr_error` handler catches conditions" and "Grouping tidyselect
+conditions retain their provenance", plus the "use the package condition seam"
+tests in six files.
+
+**Local cardinality validation rescans the input once per Grouping set** —
+#27. Validation is wrapped into the ordinary summary by
+`wrap_parent_sources()`, so no separate pass exists to scale;
+`dev/benchmark-parent-share-local.R` and
+`investigation/parent-share-local-benchmark.md` carry the measurement.
+
+**Suggested packages are used without complete guards; a dependency-only
+check fails** — #34. `_R_CHECK_DEPENDS_ONLY_=true R CMD check` on the built
+tarball went from 3 ERRORs to status OK, and `release-matrix.yaml`'s
+`depends-only` job runs it on every push.
+
+**Unused Suggests inflate installation cost** — #34. `data.table`, `ggplot2`,
+`purrr`, `sessioninfo`, and `stringr` removed after a repository-wide usage
+audit; nothing promoted to Imports.
+
+**Supported-backend claims are not backed by live execution** — #35, #38.
+`test-parent-share-backends.R` "RSQLite executes portable Parent shares end to
+end" and "DuckDB Parent shares agree across native, portable, and local
+paths", executed by the four `backend` jobs.
+
+**Reference documentation duplicates contracts that can drift** — #36. All
+three tests in `test-documentation.R`.
+
+**Citation, NEWS, Quarto requirement, and CRAN comments disagree with the
+release** — #37. `inst/CITATION`, `NEWS.md`, `DESCRIPTION`'s
+`SystemRequirements`, and `cran-comments.md` as of 9874313.
+
+**A green fully provisioned check is not a release gate on its own** — #38.
+`.github/workflows/release-matrix.yaml` checks one built tarball through a
+`depends-only` job, five `tarball` jobs, and four `backend` jobs.
+
+**Architecture, ADRs, and the disposition record lag the implementation** —
+#39. `design/architecture.md`, ADR 0014, the ADR 0001, 0009, and 0010
+amendments, and this file.
+
+The same review's remaining requirement — a fresh two-axis review with no
+unresolved findings — is #40 and is deliberately not answered here. This
+ledger records dispositions; it does not certify the next review.
+
+## 2. Disproved claims from the pre-release review
+
+These were reported as gaps and are **rejected**: the coverage already existed.
+#23 puts them out of scope explicitly so they cannot return as busywork, and
+#35 re-verified each one rather than taking the earlier judgement on trust.
+
+**Contextual Grouping helpers have no outside-context tests** (Docs & Tests).
+**Rejected — disproved.** `test-grouping-interface.R` "grouping helpers
+validate their context and columns" calls `grouping_bit()` and `grouping_id()`
+at top level and asserts both the message and the `marginplyr_error` class;
+`test-parent-share.R` "share_of_parent reports its required context" does the
+same for the third helper and additionally asserts that `conditionCall()` names
+`share_of_parent`. All three contextual helpers are covered.
+
+**Zero-row results have no integer `.id` test** (Docs & Tests).
+**Rejected — disproved.** `test-margin-id.R` "zero-row results retain an
+integer .id column" runs all four Margin verbs over a zero-row input and
+asserts `nrow() == 0L` and `identical(result$set, integer())` for each, so the
+column is proved present *and* integer-typed. "empty ungrouped nest_by retains
+its sole occurrence identifier" covers the `nest_by` one-row empty case.
+
+**Factor returns are defective** (Spec).
+**Rejected — no observable gap.** No factor-return defect reproduces at the
+public interface. `test-margin-label.R` "factor NA levels and missing values
+follow the eight-case contract" walks the whole ADR 0012 table; "NA factor
+levels stay structural when collision checks are disabled" covers the
+`.check_margin_label = FALSE` clause; "dtplyr applies mixed named labels
+lazily and restores factors" and "DuckDB uses typed missing for a missing
+factor Margin label" cover factor returns from lazy backends. Returned columns
+are factors with the documented levels on every backend tested.
+
+**A custom printer must be removed** (Standards).
+**Rejected.** The package's one custom printer is
+`print.margin_grouping_spec`, which prints a Grouping specification — an input
+value the caller constructed — and nothing else carries one. The related
+question about *results* was decided in the opposite direction and separately:
+ADR 0013 requires `inspect_grouping()` to return a plain tibble with no custom
+class or printer, and `test-inspect-grouping.R` covers it.
+
+## 3. `/code-review` of the #32 condition migration (9644e0b)
+
+Recorded on #39 and #33.
+
+**Summary tidyselect conditions no longer carry a marginplyr prefix** (Spec).
+**Rejected.** #32 removed a `tryCatch` that re-signalled tidyselect failures
+with a marginplyr message. The criterion the reviewer applied governs
+package-created errors; a propagated tidyselect failure is an External
+condition, which #23 user story 27 and ADR 0015 both require to keep its
+original class. *Evidence:* `test-summarize-operation.R` "summary tidyselect
+conditions retain their provenance" and `test-grouping-interface.R` "Grouping
+tidyselect conditions retain their provenance" assert
+`expect_identical(class(error), class(baseline))`.
+
+**`abort_dbplyr_representation()` should have stayed an internal assertion**
+(Spec). **Fixed in #33.** Initially rejected on the grounds that the message
+was written for a user — which describes message style, not a rule. ADR 0015
+supplied the rule: a Package condition is raised exactly when the caller can
+avoid it by rewriting the call, and no rewrite of a
+`summarize_with_margins()` call avoids a change in dbplyr's internal
+`lazy_query` structure. The guard reverted to bare `stop()`, and the
+`expect_s3_class(error, "marginplyr_error")` assertion #32 had added was
+removed; the message assertion stays. *Evidence:*
+`abort_dbplyr_representation()` in `R/grouping-adapter-native.R` is a bare
+`stop()` carrying a comment that names ADR 0015;
+`test-grouping-backends.R` "native SQL reports incompatible dbplyr query
+representations".
+
+The second half of the same observation — that the guard carries no public
+Margin call — stands as **rejected, inherent**. `dbplyr::sql_build()` runs at
+print or collect time, after the Margin verb has returned and its call frame is
+gone. It is also moot: a bare `stop()` makes no public-class promise.
+
+**Snapshot files gained a trailing blank line** (both axes).
+**Rejected, no action.** This is the current testthat's canonical snapshot
+format, not an edit. *Reproduction:* `git checkout tests/testthat/_snaps/`
+followed by `testthat::test_local(filter = "parent-share")` reproduces the
+identical trailing newline, so any subsequent commit that runs the suite
+carries it instead.
+
+**`abort_marginplyr()` class arguments are inconsistent across migration
+batches** (Standards). **Fixed in #33.** 45 sites passed
+`class = "simpleError"` and 34 omitted it, tracking which ticket migrated the
+site rather than any semantic difference. ADR 0015 settled it: `simpleError`
+was a transitional shim from f7ac9e7, the resulting object claimed to be both
+`simpleError` and `rlang_error`, and 0.1.0 has no released handlers to keep
+compatible. *Evidence:* `grep -rn simpleError R/` returns nothing;
+`test-grouping-interface.R:940` asserts `expect_false(inherits(caught,
+"simpleError"))`.
+
+**The `abort_marginplyr()` / `stop()` boundary is documented nowhere**
+(both axes). **Fixed in #33.** Both review axes flagged independently that no
+ADR, comment, or contributor doc recorded the rule separating the migrated
+sites from the four surviving bare `stop()` calls. *Evidence:* ADR 0015 states
+the avoidability predicate; `R/conditions.R` carries it at the only
+constructor; `?marginplyr` documents the `marginplyr_error` contract for
+users; `design/architecture.md` has a Package conditions section.
+
+**`match_margin_choice()` duplicates each option vocabulary** (Standards).
+**Fixed in #33.** `match.arg(x)` derived choices from the formal default;
+the explicit-choices helper wrote each vocabulary twice, and the two copies
+could drift with no test failing. *Evidence:*
+`margin_duplicates_choices` and `margin_label_position_choices` in
+`R/margin-operation.R` are the single vocabularies, and
+`test-grouping-interface.R` "documented option formals match the shared choice
+vocabularies" holds every public formal to the constant it mirrors.
+
+**ADR 0009's documentation-placement statement conflicts with #36**
+(Docs & Tests). **Fixed in #39.** #36 centralized the Grouping-identity
+comparison table in the `grouping_bit()` reference, which contradicts ADR
+0009's statement that the article holds the table and each reference keeps a
+compact copy. *Evidence:* the amendment section in ADR 0009;
+`test-documentation.R` "the Grouping-identity comparison has exactly one
+canonical home".
+
+## 4. Reviews during the documentation and release tickets
+
+**A broad mid-test `skip_if_not_installed()` silently swallowed coverage for
+the backends listed after it** (Docs & Tests, found during #34).
+**Fixed in #34.** The skip masked one ungated SQLite render that a
+dependency-only check would otherwise have caught, so the test file looked
+green while proving less than it claimed. *Evidence:* the guards were narrowed
+to the branch that needs them; running the suite against a library with only
+RSQLite removed produced 0 failures and explicit skips, and the ungated render
+became visible.
+
+**`attachment::att_amend_desc()` cannot express conditionally used Suggests**
+(Standards, raised during #34, tracked as #44). **Fixed in #44.** The tool
+statically scans `R/` and promotes anything it finds to Imports — including
+`arrow::schema()` sitting behind a backend-kind guard in
+`R/backend-metadata.R` — which would violate #23's "no optional package is
+promoted to Imports solely to make checks pass". *Evidence:* no
+`pkg_ignore`/`extra.suggests` setting fixes it, because the false positive is
+inherent to static scanning; `dev/config_attachment.yaml` was deleted and
+`AGENTS.md`'s "Dependency metadata" section documents the manual audit that
+replaces it, naming `_R_CHECK_DEPENDS_ONLY_` as the authority on optionality.
+Nothing outside this ledger names the deleted config, and `DESCRIPTION` was
+unchanged by its removal.
+
+**`_R_CHECK_DEPENDS_ONLY_` described as already wired into CI** (Spec, PR #47).
+**Fixed before merge.** The new `AGENTS.md` section claimed a CI gate that #38
+had not yet built. *Evidence:* the merged text named it as not yet wired and
+pointed at #38; it now describes `release-matrix.yaml`'s `depends-only` job,
+which exists.
+
+**A two-line comment duplicated at three sites explained the linter rather
+than the code** (both axes, PR #49). **Fixed before merge.** Extracting
+`dtplyr_lambda_pronoun()` put the reason on one definition and let each call
+site say what the pronoun is. *Evidence:* `R/parent-share.R:909`; three
+`# nolint: object_usage_linter` comments deleted; `R CMD check` reports no
+`.x` NOTE in either check mode.
+
+**`AGENTS.md` describes a `.lintr` file this repo does not have** (Standards,
+PR #49 review). **Fixed in #48** (commit f98abdb), spun out rather than
+widening that PR.
+
+**Site-verification markers pinned phrases the rewritten prose no longer
+renders** (Docs & Tests, PR #51). **Fixed before merge.**
+`.github/scripts/verify-site.R` still checked for the removed Database-backends
+table and for an empty-input table that had moved to `share_of_parent()`.
+*Evidence:* commit 8670ad4, verified against a full local
+`altdoc::render_docs()` build and then running the script against it, matching
+what the altdoc CI job does.
+
+**`grouping_bit()` claimed its return type "follows the backend"** (Spec, found
+during #36). **Fixed.** Native `GROUPING()` is reached only when the plan runs
+as native `GROUPING SETS`, so PostgreSQL falls back to the portable literal
+under `.duplicates = "keep"`. *Evidence:* `man/grouping_bit.Rd`;
+`test-grouping-backends.R` "PostgreSQL duplicate keep falls back
+conservatively".
+
+**`share_of_parent()`'s backend table conflated always-local checks with
+type and cardinality checks** (Spec, found during #36). **Fixed.** The
+reference now separates the syntax, source, dependency, and naming rules
+validated locally on every backend from the type and cardinality rules only
+some backends can prove — the distinction ADR 0010 already made. *Evidence:*
+`man/share_of_parent.Rd`; ADR 0010's amendment section.
+
+**`MARGINPLYR_REQUIRED_SUGGESTS` proves installation, not execution**
+(Spec, PR #53). **Fixed before merge.** A contract test that was renamed,
+deleted, or skipped for an unrelated reason still left a `backend` job green.
+*Evidence:* each `backend` matrix entry names the tests it proves, and
+`.github/scripts/verify-backend.R` fails the job unless every one ran and
+passed. It immediately caught a real gap — `expect_snapshot()` skips under
+CRAN semantics, so "Arrow rejects Parent shares before constructing a query"
+had never executed inside `R CMD check`. The `backend` jobs now set `NOT_CRAN`;
+the CRAN-emulating jobs deliberately do not.
+
+**`R-CMD-check.yaml` asked for snapshot artifacts it can never produce**
+(Docs & Tests, PR #53). **Fixed.** `upload-snapshots: true` implied coverage
+that matrix does not have. *Evidence:* commit cb450a7 removes the request and
+records where snapshots actually run.
+
+Five further findings from the same review, all **fixed before merge** in
+commit 7c5e38f: remote CRAN incoming checks turned off, because their NOTEs
+depend on the network and the clock and each would have been annotated as
+unexpected; the "checking CRAN incoming feasibility" header no longer treated
+as an understood NOTE, which would have classified every future incoming
+finding as understood; `<test>.Rout.fail` read alongside `<test>.Rout`, so a
+failing suite is not reported as a suite that never ran; both verifier steps
+run on failure, where their diagnosis is worth most; and `ci-helpers.R`
+extracted for the summary writing and check-directory handling all three
+scripts had grown a copy of.
+
+**`AGENTS.md`'s release-matrix claim was false once the workflow existed**
+(Standards, PR #53). **Fixed in the same PR.** *Evidence:* the "Release
+matrix" section describes the merged workflow and names the three edit sites
+an added backend needs.
+
+## 5. Lint-environment findings (#41, #45)
+
+**149 of 161 `object_usage_linter` suppressions existed only because the
+linter ran without the package loaded** (Standards). **Fixed in #41.**
+*Reproduction:* `lintr::lint_package()` reported 158 `object_usage_linter`
+lints; `pkgload::load_all(".")` first reduced that to 12. Installing the
+package was not sufficient — it must be loaded. *Evidence:* `AGENTS.md`
+records the requirement, `lint.yaml` loads before linting, and the
+suppressions are gone.
+
+**A `# nolint` on a roxygen line leaks into user-facing `.Rd` help text**
+(Docs & Tests). **Fixed in #41.** *Evidence:* the surviving roxygen `# nolint`
+comments are markdown table rows only, where roxygen discards whatever follows
+the row's final `|`; `document.yaml` fails CI on any leak into `man/`.
+
+**Three surviving suppressions are genuine NSE artifacts** (Standards).
+**Rejected for `grouping_sets_sql` and `new_levels`; amended and fixed for
+`.x`.** The first two are values read only from a glue string or an NSE
+pronoun that `codetools` cannot follow, which is the correct use of an inline
+suppression. The `.x` disposition was **amended by #45**: that expression also
+produced an `R CMD check` NOTE, which a `# nolint` cannot suppress, so the
+suppression never settled the finding — and `rlang::sym(".x")` returns an
+`identical()` symbol while showing static analysis only a string, making it a
+spelling choice rather than an irreducible artifact. *Evidence:*
+`codetools::checkUsage()` silent on all three rewritten functions;
+`R CMD check` `Status: OK` from the tarball in both normal and
+`_R_CHECK_DEPENDS_ONLY_=true` modes.
+
+## 6. CRAN observations
+
+**Dependency-only check fails in examples, tests, and vignettes.**
+**Fixed in #34.** *Command:* `_R_CHECK_DEPENDS_ONLY_=true R CMD check` on the
+built tarball, 3 ERRORs → status OK. Re-verified against a library with only
+RSQLite removed. Now a gate rather than a manual step.
+
+**`no visible binding for global variable '.x'` NOTE in every check mode.**
+**Fixed in #45.** *Command:* `R CMD check` from the tarball reports
+`checking R code for possible problems ... OK` in both modes.
+
+**New-submission NOTE.** **Accepted and recorded.** It is expected for a first
+submission and is the only NOTE the fully provisioned run reports.
+*Evidence:* `cran-comments.md`, which records both gates with their actual
+results — `_R_CHECK_DEPENDS_ONLY_=true` status OK, 1083 pass / 68 skip, and
+fully provisioned `--as-cran` 1 NOTE, 1487 pass / 3 skip.
+
+**Snapshot skips inside `R CMD check`.** **Accepted and explained.** testthat
+skips `expect_snapshot()` under CRAN semantics; the three skips in the
+provisioned run are exactly those. They are not lost coverage, because the
+`backend` jobs run them with `NOT_CRAN` set. *Evidence:* `cran-comments.md`
+names the skips; `release-matrix.yaml` explains the split.
+
+**Quarto vignette engine behavior without the Quarto binary.**
+**Accepted and documented.** The engine writes a placeholder rather than
+failing, so a check run without Quarto has no vignette coverage.
+*Evidence:* verified empirically by rebuilding the vignettes with Quarto off
+the `PATH`; recorded in `cran-comments.md` so a reviewer is not misled by a
+pass.
+
+## 7. Review of this ticket's own changes (#39)
+
+The two-axis review of the reconciliation commit found several places where
+the new prose misdescribed the code — an entry-point list that omitted
+`wrap_parent_sources()`, an adapter table that credited the lazy non-SQL
+adapter with a join the local adapter takes too, a test-seam list missing
+`test-documentation.R`, and two recorded observations with no ledger row. All
+were fixed before the commit was pushed, so they are the commit rather than
+entries here. One finding was rejected, and it is the kind most likely to be
+raised again.
+
+**The lazy non-SQL Parent-share adapter is a Middle Man** (Standards).
+`execute_non_sql_parent_shares()` is a strict subset of
+`execute_local_parent_shares()`: both call `apply_joined_parent_shares()` with
+`sql_join = FALSE`, and local merely runs `check_local_parent_share_types()`
+first. Two of the three adapters therefore have near-identical bodies, which
+the reviewer read as undercutting ADR 0014's own rejection of one adapter per
+backend kind.
+
+**Rejected.** The three-adapter split is a decision of the parent spec, not an
+artifact: #23 states "There are three genuine Parent-share adapters: local,
+general dbplyr, and lazy non-SQL", and pre-empts collapsing them on size —
+"New pass-through helpers are not introduced merely to reduce line count" and
+"File count and line count are not design goals". Merging is also not
+behaviour-preserving in either direction: folding the lazy non-SQL kinds into
+the local adapter would run `check_local_parent_share_types()` against a
+result dtplyr has not materialized, and folding them into the dbplyr adapter
+would build a `sql_on` condition with no connection to build it from. The
+emptiness of the third adapter is the contract — a lazy non-SQL backend joins
+as local data does but cannot have its sources type-checked here, because its
+validation already happened inside the ordinary summary.
+
+*Evidence:* `R/parent-share.R` `parent_share_adapter()` and the three adapter
+bodies; ADR 0014's Decision section states the same reasoning as a decision
+rather than a defence, so a future reader meets it before the code. The
+contracts that would break under either merge are
+`test-parent-share-backends.R` "dtplyr validates Parent-share source types
+during collection" and "dtplyr integer and double Parent shares match local
+results".
+
+---
+
+## Status
+
+Every observation from every recorded review is dispositioned above. The
+release gate #23 sets is not met by this file alone: it also requires a fresh
+two-axis review and Docs & Tests audit with no unresolved findings, which is
+#40. New findings from that review are dispositioned here as they arrive.


### PR DESCRIPTION
Closes #39.

## Summary

Contributor-facing design material only — no R sources, `man/`, or `NAMESPACE`
changes. `^design$` and `^CONTEXT\.md$` keep all of it out of the tarball and
the package site.

**`design/architecture.md`.** The Parent-share section described a module with
a sentence's worth of responsibilities. It now describes the one that exists:
four private entry points, the planning / validation / mapping / calculation /
cleanup split, and why planning and wrapping are two calls rather than one
(summary selections have to be resolved between them). Adapter selection is a
lookup on the prepared backend kind, and the table says what each of the three
adapters adds to the shared work. The opaque-seam section now records the
field reads that actually cross into the module instead of claiming a boundary
the code does not have. Adds the Package conditions module, undocumented since
ADR 0015.

The test-seam list covers every file in `tests/testthat/`, plus a Release
gates section for the one property a single suite run cannot show — a skipped
optional-backend test and a proved one look identical in a green job. It
defers to `AGENTS.md` for the operational detail rather than copying it.

**ADR 0014.** #23 reserved the number for the explicit-adapter decision and it
was never written. It records why the branch reads prepared state rather than
the staged result's incidental class, and why three adapters rather than six
or one.

**Amendments, keeping the superseded text visible.** ADR 0001 promised the
finalizer "the common sorting semantics"; `.sort` is gone and row order is
unspecified. ADR 0009 placed the Grouping-identity table in the article with a
compact copy per reference; #36 gave it one canonical home in `grouping_bit()`.
ADR 0010 assumed every backend either can or cannot prove a source contract
before execution — Arrow and dtplyr fall between, and the amendment says where
each ended up.

**`design/review-dispositions.md`.** The ledger that makes "review complete"
auditable: every observation from a recorded review, fixed or rejected, with a
test title, command, or reproduction behind it. Rejections include the three
claims #23 put out of scope as already disproved.

## The second commit

`CONTEXT.md` listed "grouping mask" as an avoided synonym for Grouping set
identifier only, while Grouping identifier's own definition opens "A bit mask".
The omission read as permission for the one phrase the other entry bans. Both
entries now avoid it. Found while normalizing ADR 0008, where the same sentence
needed "Grouping identifiers" and the glossary offered no basis for the choice.

Separate commit so it can be split off — it is a glossary fix, not #39's scope.

## Notable rejection

`/code-review` flagged the lazy non-SQL Parent-share adapter as a Middle Man:
`execute_non_sql_parent_shares()` is a strict subset of
`execute_local_parent_shares()`. Rejected and recorded in the ledger's section
7. #23 decides the three-adapter split directly, and merging is not
behaviour-preserving in either direction — folding into the local adapter would
type-check a result dtplyr has not materialized; folding into the dbplyr
adapter would build a `sql_on` condition with no connection. The third
adapter's emptiness is the contract.

The review's other findings were factual errors in my prose about the code (an
entry-point list omitting `wrap_parent_sources()`, an adapter table crediting
the lazy non-SQL adapter with a join the local adapter also takes, a missing
`test-documentation.R` row, two undispositioned observations). All fixed before
the commit, so the commit is their record.

## Test plan

- [x] `pkgload::load_all(".")` + `lintr::lint_package()` — no lints
- [x] Full `testthat` suite — green, 0 failures
- [x] `spelling::spell_check_package()` — no errors
- [x] Every relative link in `design/**` and `CONTEXT.md` resolves
- [x] `git status` confirms no `R/`, `man/`, `NAMESPACE`, or `DESCRIPTION` change, so `roxygen2::roxygenise()` output is unaffected
- [x] Every test title, commit SHA, file path, and job count quoted in the ledger verified against the tree
- [x] Two-axis `/code-review` (Standards + Spec) run; findings applied or dispositioned