### PR TITLE
Decide and document how Margin verbs treat result class and attributes

### DIFF
--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -15,11 +15,14 @@
 #' @inheritParams summarize_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
+#' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Database backend coverage
 #' @inheritSection summarize_with_margins Backend extension design
-#' @return An ungrouped data frame, or a lazy table when `.data` is lazy.
+#' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its
+#'   class and attributes follow [dplyr::mutate()] combined with
+#'   [dplyr::union_all()]; see *Result class and attributes*.
 #'   Result row order is unspecified; use [dplyr::arrange()] when presentation
 #'   order matters.
 #' @family summarize and expand data with margins

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -5,6 +5,7 @@
 #' @inheritParams nest_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
+#' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Backend extension design
@@ -22,7 +23,9 @@
 #' margin-operation pipeline, so they share one grouping plan and nesting
 #' contract without invoking each other.
 #' @return A row-wise data frame grouped by the visible grouping columns and
-#'   `.id` when supplied.
+#'   `.id` when supplied. This is the return shape whatever the class of
+#'   `.data`, because a row-wise data frame is always a tibble subclass; see
+#'   *Result class and attributes*.
 #'   Result row order is unspecified; use [dplyr::arrange()] when presentation
 #'   order matters.
 #' @family summarize and expand data with margins

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -6,6 +6,7 @@
 #' @inheritParams summarize_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
+#' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Backend extension design
@@ -46,7 +47,12 @@
 #' that `.keep` retains grouping columns.
 #'
 #' The list column is a regular list of data frames; its exact `vctrs_list_of`
-#' subclass is not part of the API. [nest_with_margins()] follows
+#' subclass is not part of the API. Neither is the class of its elements,
+#' which follows whichever backend produced them: tibbles for a local input,
+#' because that is what [dplyr::pick()] returns, and data tables under
+#' `dtplyr`. Only their being data frames holding the input's non-key columns
+#' is promised. Call `lapply(result$data, tibble::as_tibble)` when one element
+#' class is needed across backends. [nest_with_margins()] follows
 #' [tidyr::nest()] for an empty ungrouped input and returns zero outer rows.
 #' [nest_by_with_margins()] follows [dplyr::nest_by()] and returns one row
 #' containing the empty input when there are no grouping keys.
@@ -55,8 +61,10 @@
 #' grouping-set and `.keep` columns are generated collision-free and removed
 #' before the result is returned.
 #'
-#' @return For a local input, an ungrouped data frame with one list column. A
-#'   `dtplyr` input returns a lazy `dtplyr` step until collected. Result row
+#' @return For a local input, an ungrouped data frame with one list column,
+#'   whose class and attributes follow [dplyr::summarize()]; see *Result class
+#'   and attributes*. A `dtplyr` input returns a lazy `dtplyr` step until
+#'   collected. Result row
 #'   order is unspecified; use [dplyr::arrange()] when presentation order
 #'   matters.
 #' @family summarize and expand data with margins
@@ -73,9 +81,9 @@
 #'   .data = january_sales,
 #'   .grouping = rollup(region, store)
 #' )
-#' # `january_sales` is a plain data frame and the outer class is preserved,
-#' # so `nested` prints its list column as flattened values. A tibble prints
-#' # each nested table as its dimensions instead.
+#' # `january_sales` is a plain data frame, so nesting it returns one too, and
+#' # `nested` prints its list column as flattened values. A tibble prints each
+#' # nested table as its dimensions instead.
 #' nested |>
 #'   dplyr::as_tibble() |>
 #'   head()

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -43,7 +43,9 @@
 #'   collide with source columns, grouping keys, summary outputs, or a nesting
 #'   `.key`.
 #'
-#' @return An ungrouped data frame, or a lazy table when `.data` is lazy.
+#' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its
+#'   class and attributes follow [dplyr::summarize()]; see *Result class and
+#'   attributes*.
 #'   Result row order is unspecified; use [dplyr::arrange()] when presentation
 #'   order matters.
 #'
@@ -103,6 +105,30 @@
 #' [nest_by_with_margins()] instead returns a row-wise data frame grouped by
 #' all visible fixed keys, grouping dimensions, and `.id` when supplied.
 #' Row-wise input is rejected; call [dplyr::ungroup()] first.
+#'
+#' @section Result class and attributes:
+#' Each Margin verb follows the same class and attribute rules as the dplyr
+#' verb it is built from: [summarize_with_margins()] those of
+#' [dplyr::summarize()], and [expand_with_margins()] and the nesting verbs
+#' those of [dplyr::mutate()] combined with [dplyr::union_all()]. Passing a
+#' plain data frame therefore returns a plain data frame and passing a tibble
+#' returns a tibble.
+#'
+#' The input class is not guaranteed to be preserved, and neither are
+#' object-level attributes of the input or attributes of columns marginplyr
+#' does not rewrite. A data frame subclass survives only where dplyr can
+#' reconstruct it, so a subclass with no [dplyr::dplyr_reconstruct()] method
+#' is lost by [dplyr::summarize()] itself. Attributes on a column that carries
+#' no class are dropped wherever branches are combined, because that is what
+#' the vctrs rules for combining bare vectors do with them. Attach the
+#' attributes a result must carry after the Margin operation, as with any
+#' dplyr pipeline.
+#'
+#' Factor and ordered-factor columns are the one exception, because
+#' marginplyr decomposes them to insert `.margin_label` and rebuilds them
+#' itself. Their levels and ordering are preserved; see *Display labels and
+#' grouping identity*. Classed columns such as [Date] and [POSIXct], including
+#' its `tzone`, are carried through by dplyr and vctrs unchanged.
 #'
 #' @section Grouping set identifiers:
 #' When `.id` names an output column, each result row receives the one-based

--- a/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
+++ b/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
@@ -1,0 +1,216 @@
+# Delegate result class and attributes to dplyr
+
+marginplyr promises exactly what marginplyr constructs. The class and the
+attributes of a Margin operation's result are whatever the dplyr and vctrs
+operations that the verb is composed from produce, and marginplyr writes no
+attribute-restoration logic of its own. Factor restoration in `R/factor.R` is
+the single exception, because marginplyr is what decomposed the factors it
+rebuilds. The reference will state that results follow the same class and
+attribute rules as the corresponding dplyr verb, and will not promise that the
+input class, its object-level attributes, or its column attributes are
+preserved.
+
+## Decision
+
+### The promise boundary
+
+The rule that decides every case below is whether marginplyr constructed the
+property or merely passed it through.
+
+marginplyr constructs, and therefore promises:
+
+- the ungrouped result of `summarize_with_margins()`,
+  `expand_with_margins()`, and `nest_with_margins()`, and the row-wise result
+  of `nest_by_with_margins()`, both applied unconditionally in
+  `finalize_margin_operation()` and at the end of `nest_by_with_margins()`;
+- Margin columns first, in Grouping-plan order, followed by the remaining
+  columns;
+- factor and ordered-factor levels, ordering, and Margin-label placement, per
+  ADR 0012.
+
+marginplyr passes through, and therefore describes but does not promise:
+
+- the class of the result relative to the class of the input;
+- object-level attributes of the input;
+- attributes and classes of columns marginplyr does not rewrite.
+
+Nothing else in the package needs a reconstruction rule, because every Margin
+verb ends in a dplyr verb applied to a data frame that dplyr itself produced.
+
+### Measured behavior
+
+Measured against marginplyr at this commit with R 4.6.1, dplyr 1.2.1,
+vctrs 0.7.3, tibble 3.3.1, and dtplyr 1.3.3. The issue's table recorded
+"preserved" for two rows that are preserved only under conditions the table
+did not vary, so those rows are restated here with the condition attached.
+
+| Subject | `summarize` | `expand` | `nest` outer | `nest` inner |
+|---|---|---|---|---|
+| Result class from a plain `data.frame` | `data.frame` | `data.frame` | `data.frame` | `tbl_df` |
+| Result class from a tibble | `tbl_df` | `tbl_df` | `tbl_df` | `tbl_df` |
+| `data.frame` subclass (`mytbl`) | dropped | kept | — | — |
+| Object-level attribute, plain input | dropped | kept | dropped | dropped |
+| Object-level attribute, subclassed input | dropped | **dropped** | — | — |
+| Bare column attribute, one grouping set | — | kept | — | — |
+| Bare column attribute, many grouping sets | — | **dropped** | — | — |
+| Classed column (`Date`, `POSIXct`, custom) | kept | kept | kept | kept |
+| Factor levels and `.margin_label` | kept | kept | kept | — |
+
+The two bolded rows are the corrections. Both are decisive for this decision,
+because both show the same verb answering the same question differently
+depending on an input or plan property the caller did not think they were
+choosing:
+
+- Object-level attributes survive `expand_with_margins()` for a plain
+  `data.frame` and are lost for a subclass of one. The step responsible is
+  `dplyr::mutate()`, which restores object-level attributes for a bare
+  `data.frame` and drops them for a subclass with no `dplyr_reconstruct()`
+  method. Plain `dplyr::bind_rows()` keeps them in both cases, so this is not
+  the union.
+- A `label` attribute on a bare double survives a one-set plan and is lost
+  from a plan with two or more sets, because a multi-set plan combines
+  branches with `dplyr::union_all()` and `vctrs::vec_c()` drops attributes of
+  bare vectors. A column that also carries a class keeps both class and
+  attribute, which is why the issue's `value` column — classed `myunit` and
+  labelled at once — read as preserved.
+
+The subclass drop under `summarize_with_margins()` is likewise not
+marginplyr's: `dplyr::summarise()` alone returns a bare `data.frame` from the
+same subclassed input, because no `dplyr_reconstruct()` method exists for it.
+
+### Verb-to-verb asymmetry is dplyr's composition, not marginplyr's
+
+`expand_with_margins()` keeping an object-level attribute that
+`summarize_with_margins()` drops is not an inconsistency between two
+marginplyr verbs that marginplyr should resolve. It is the difference between
+`dplyr::mutate()` and `dplyr::summarise()`, measured directly on a plain
+`data.frame`: mutate, filter, and bind_rows keep object-level attributes and
+summarise does not. Each Margin verb inherits the rule of the dplyr verb it
+ends in, and a caller who knows dplyr already knows which one that is.
+
+Aligning the verbs was considered in both directions and rejected.
+
+Aligning downward — having `expand_with_margins()` strip what dplyr would
+have kept — destroys information for symmetry alone, and makes marginplyr
+worse than the dplyr pipeline it replaces.
+
+Aligning upward — restoring attributes onto the result of
+`summarize_with_margins()` — is worse than it looks. For a subclassed input,
+whether an attribute survives is decided by that class's
+`dplyr_reconstruct()` method, which is the class author's declaration about
+which properties an aggregation invalidates. marginplyr reattaching an
+attribute after the fact overrides a decision that is not marginplyr's to
+make, and it would do so silently, on classes that did not exist when the
+restoration was written. A `provenance` attribute naming the source rows is a
+concrete case where surviving aggregation is the wrong answer, and marginplyr
+cannot tell that attribute apart from one that should survive.
+
+Neither alignment is available in full anyway. The bare-column-attribute row
+above shows that marginplyr could not make attribute preservation
+plan-independent without reimplementing vctrs' combining rules for arbitrary
+user vectors — which is the guarantee this ADR exists to refuse.
+
+### `nest_by_with_margins()` returns a row-wise data frame, by contract
+
+`nest_by_with_margins()` calls `dplyr::rowwise()` unconditionally, so a plain
+`data.frame` input returns a `rowwise_df`. This is not a class-preservation
+failure and it is not changed. There is no row-wise plain `data.frame` in
+dplyr: `rowwise_df` is a `tbl_df` subclass, and `dplyr::nest_by()` returns
+one from a plain `data.frame` for the same reason. The row-wise shape is the
+verb's deliverable, exactly as a grouped result is `dplyr::group_by()`'s.
+marginplyr constructs it, so marginplyr promises it.
+
+The element class inside the list column is the opposite case. Elements are
+tibbles for a local input because `dplyr::pick()` returns a tibble, and data
+tables under dtplyr because that is what the data.table translation produces.
+marginplyr chooses neither. The asymmetry is therefore documented as observed
+backend behavior and not promised: what is promised is that each element is a
+data frame holding the input's non-key columns, alongside the existing
+statement that the list column's `vctrs_list_of` subclass is not part of the
+API.
+
+Normalizing the element class was rejected. Locally it would mean coercing
+away from the tibble that dplyr chose; under dtplyr it would mean mapping a
+conversion over every element after collection, an allocation per group to
+satisfy an aesthetic, and for `nest_with_margins()` — which returns a lazy
+dtplyr step — it would mean collecting a result the caller asked to keep
+lazy. A caller who needs uniform elements writes
+`lapply(result$data, tibble::as_tibble)`, which costs the same and is opt-in.
+
+## Implementation consequences
+
+No source change is required; this ADR ratifies existing behavior and forbids
+a class of future change.
+
+`finalize_margin_operation()` stays as it is: ungroup, restore factors,
+reorder Margin columns. It gains no attribute-capture step, no
+`dplyr_reconstruct()` call, and no template argument. Backend adapters
+likewise gain none. A future reconstruction hook is a change to this decision
+and needs a superseding ADR, not a patch.
+
+`restore_margin_factors()` remains the only place marginplyr rebuilds a
+column's type, and its justification is narrow and stated: marginplyr
+decomposed those factors during preparation and inserts the Margin label as a
+level, so nothing else can rebuild them. That justification does not extend
+to any other attribute, because marginplyr removes no other attribute.
+
+## Documentation consequences
+
+The `@return` text of the Margin verbs must state the rule without promising
+class preservation:
+
+- `summarize_with_margins()` and `expand_with_margins()`: an ungrouped data
+  frame, or a lazy table for a lazy input, whose class and attributes follow
+  the same rules as `dplyr::summarise()` and `dplyr::mutate()` respectively;
+  the input's class and object-level attributes are not guaranteed to be
+  preserved.
+- `nest_with_margins()`: unchanged in shape, with the same class and
+  attribute caveat.
+- `nest_by_with_margins()`: always a row-wise data frame grouped by the
+  visible grouping columns and `.id`, whatever the input class.
+
+The nesting verbs' shared "Relationship to tidyr and dplyr" section gains the
+element-class note: tibbles for a local input, data tables under dtplyr, with
+the `lapply()` coercion for callers who need one class.
+
+The example comment in `R/nest_with_margins.R` that says the outer class "is
+preserved" for a plain `data.frame` input is accurate for that example and
+misleading as a general statement. It is rewritten to say that a plain
+`data.frame` input produced a plain `data.frame` here, which is why the list
+column prints flattened.
+
+`design/architecture.md` gains a line at the `R/factor.R` module description
+recording that factor restoration is the only type or attribute restoration
+in the package, with a pointer to this ADR.
+
+## Test consequences
+
+Tests pin what this ADR promises and nothing else. The measured table above
+is evidence for the decision, not a specification: a test asserting a row of
+it would convert a described behavior into a guarantee by the back door, and
+would fail as an unexplained marginplyr failure the day dplyr or vctrs
+changed a rule marginplyr does not own. No test therefore asserts
+object-level attributes, `data.frame` subclasses, or bare column attributes
+through any verb.
+
+Two tests in `test-grouping-interface.R` cover the promise:
+
+- "Margin results take their class from the underlying dplyr verb" asserts
+  that a plain `data.frame` stays a plain `data.frame` through
+  `summarize_with_margins()`, `expand_with_margins()`, and
+  `nest_with_margins()`. For the first two it asserts the literal class and
+  the class of the corresponding bare dplyr expression side by side. The
+  pair is the point: the literal assertion is what a reader checks, and the
+  delegation assertion is what stays true if dplyr's own rule changes, so a
+  future failure says which of the two happened.
+- "`nest_by_with_margins()` is row-wise whatever the input class" asserts
+  `rowwise_df`, the visible grouping columns, and that a list-column element
+  is a data frame — the whole of what the element contract promises.
+
+Both were confirmed to fail before passing, by injecting the regression each
+exists to catch: an `as_tibble()` in `finalize_margin_operation()` for the
+first, and `group_by()` in place of `rowwise()` for the second.
+
+Classed-column round-tripping — `Date`, `POSIXct` with `tzone`, ordered and
+unordered factors — is already covered by `test-grouping-interface.R` and
+`test-factor.R` under ADR 0012, and needs nothing further here.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -100,6 +100,12 @@ Owns restoration of factor and ordered-factor Margin columns from the metadata
 captured during preparation. Its backend methods preserve levels and ordering
 after labels have been materialized; it does not acquire metadata itself.
 
+This is the only type or attribute restoration in the package, and it exists
+because marginplyr is what decomposed those factors. Every other class and
+attribute of a result is whatever the underlying dplyr and vctrs operations
+produced, and no verb restores one. See
+[ADR 0016](adr/0016-delegate-result-class-and-attributes-to-dplyr.md).
+
 ### Summary selection (`R/summary-selections.R`)
 
 Owns summary-only semantics: rejecting the removed `.groups` argument and

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -31,4 +31,5 @@ tidyr
 tidyselect
 unclamped
 ungrouped
+vctrs
 yaml

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -56,7 +56,9 @@ collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 }
 \value{
-An ungrouped data frame, or a lazy table when \code{.data} is lazy.
+An ungrouped data frame, or a lazy table when \code{.data} is lazy. Its
+class and attributes follow \code{\link[dplyr:mutate]{dplyr::mutate()}} combined with
+\code{\link[dplyr:union_all]{dplyr::union_all()}}; see \emph{Result class and attributes}.
 Result row order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation
 order matters.
 }
@@ -120,6 +122,32 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Result class and attributes}{
+
+Each Margin verb follows the same class and attribute rules as the dplyr
+verb it is built from: \code{\link[=summarize_with_margins]{summarize_with_margins()}} those of
+\code{\link[dplyr:summarize]{dplyr::summarize()}}, and \code{\link[=expand_with_margins]{expand_with_margins()}} and the nesting verbs
+those of \code{\link[dplyr:mutate]{dplyr::mutate()}} combined with \code{\link[dplyr:union_all]{dplyr::union_all()}}. Passing a
+plain data frame therefore returns a plain data frame and passing a tibble
+returns a tibble.
+
+The input class is not guaranteed to be preserved, and neither are
+object-level attributes of the input or attributes of columns marginplyr
+does not rewrite. A data frame subclass survives only where dplyr can
+reconstruct it, so a subclass with no \code{\link[dplyr:dplyr_reconstruct]{dplyr::dplyr_reconstruct()}} method
+is lost by \code{\link[dplyr:summarize]{dplyr::summarize()}} itself. Attributes on a column that carries
+no class are dropped wherever branches are combined, because that is what
+the vctrs rules for combining bare vectors do with them. Attach the
+attributes a result must carry after the Margin operation, as with any
+dplyr pipeline.
+
+Factor and ordered-factor columns are the one exception, because
+marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
+itself. Their levels and ordering are preserved; see \emph{Display labels and
+grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
+its \code{tzone}, are carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -69,7 +69,9 @@ original, pre-margin values rather than \code{.margin_label}.}
 }
 \value{
 A row-wise data frame grouped by the visible grouping columns and
-\code{.id} when supplied.
+\code{.id} when supplied. This is the return shape whatever the class of
+\code{.data}, because a row-wise data frame is always a tibble subclass; see
+\emph{Result class and attributes}.
 Result row order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation
 order matters.
 }
@@ -132,6 +134,32 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Result class and attributes}{
+
+Each Margin verb follows the same class and attribute rules as the dplyr
+verb it is built from: \code{\link[=summarize_with_margins]{summarize_with_margins()}} those of
+\code{\link[dplyr:summarize]{dplyr::summarize()}}, and \code{\link[=expand_with_margins]{expand_with_margins()}} and the nesting verbs
+those of \code{\link[dplyr:mutate]{dplyr::mutate()}} combined with \code{\link[dplyr:union_all]{dplyr::union_all()}}. Passing a
+plain data frame therefore returns a plain data frame and passing a tibble
+returns a tibble.
+
+The input class is not guaranteed to be preserved, and neither are
+object-level attributes of the input or attributes of columns marginplyr
+does not rewrite. A data frame subclass survives only where dplyr can
+reconstruct it, so a subclass with no \code{\link[dplyr:dplyr_reconstruct]{dplyr::dplyr_reconstruct()}} method
+is lost by \code{\link[dplyr:summarize]{dplyr::summarize()}} itself. Attributes on a column that carries
+no class are dropped wherever branches are combined, because that is what
+the vctrs rules for combining bare vectors do with them. Attach the
+attributes a result must carry after the Margin operation, as with any
+dplyr pipeline.
+
+Factor and ordered-factor columns are the one exception, because
+marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
+itself. Their levels and ordering are preserved; see \emph{Display labels and
+grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
+its \code{tzone}, are carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{
@@ -242,7 +270,12 @@ with \code{"Total"}. This is the closest margin-aware analogue of dplyr's rule
 that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
-subclass is not part of the API. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+subclass is not part of the API. Neither is the class of its elements,
+which follows whichever backend produced them: tibbles for a local input,
+because that is what \code{\link[dplyr:pick]{dplyr::pick()}} returns, and data tables under
+\code{dtplyr}. Only their being data frames holding the input's non-key columns
+is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
+class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -67,8 +67,10 @@ inside each nested data frame? If \code{TRUE}, the nested columns contain their
 original, pre-margin values rather than \code{.margin_label}.}
 }
 \value{
-For a local input, an ungrouped data frame with one list column. A
-\code{dtplyr} input returns a lazy \code{dtplyr} step until collected. Result row
+For a local input, an ungrouped data frame with one list column,
+whose class and attributes follow \code{\link[dplyr:summarize]{dplyr::summarize()}}; see \emph{Result class
+and attributes}. A \code{dtplyr} input returns a lazy \code{dtplyr} step until
+collected. Result row
 order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation order
 matters.
 }
@@ -103,7 +105,12 @@ with \code{"Total"}. This is the closest margin-aware analogue of dplyr's rule
 that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
-subclass is not part of the API. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+subclass is not part of the API. Neither is the class of its elements,
+which follows whichever backend produced them: tibbles for a local input,
+because that is what \code{\link[dplyr:pick]{dplyr::pick()}} returns, and data tables under
+\code{dtplyr}. Only their being data frames holding the input's non-key columns
+is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
+class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.
@@ -158,6 +165,32 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Result class and attributes}{
+
+Each Margin verb follows the same class and attribute rules as the dplyr
+verb it is built from: \code{\link[=summarize_with_margins]{summarize_with_margins()}} those of
+\code{\link[dplyr:summarize]{dplyr::summarize()}}, and \code{\link[=expand_with_margins]{expand_with_margins()}} and the nesting verbs
+those of \code{\link[dplyr:mutate]{dplyr::mutate()}} combined with \code{\link[dplyr:union_all]{dplyr::union_all()}}. Passing a
+plain data frame therefore returns a plain data frame and passing a tibble
+returns a tibble.
+
+The input class is not guaranteed to be preserved, and neither are
+object-level attributes of the input or attributes of columns marginplyr
+does not rewrite. A data frame subclass survives only where dplyr can
+reconstruct it, so a subclass with no \code{\link[dplyr:dplyr_reconstruct]{dplyr::dplyr_reconstruct()}} method
+is lost by \code{\link[dplyr:summarize]{dplyr::summarize()}} itself. Attributes on a column that carries
+no class are dropped wherever branches are combined, because that is what
+the vctrs rules for combining bare vectors do with them. Attach the
+attributes a result must carry after the Margin operation, as with any
+dplyr pipeline.
+
+Factor and ordered-factor columns are the one exception, because
+marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
+itself. Their levels and ordering are preserved; see \emph{Display labels and
+grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
+its \code{tzone}, are carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{
@@ -253,9 +286,9 @@ nested <- nest_with_margins(
   .data = january_sales,
   .grouping = rollup(region, store)
 )
-# `january_sales` is a plain data frame and the outer class is preserved,
-# so `nested` prints its list column as flattened values. A tibble prints
-# each nested table as its dimensions instead.
+# `january_sales` is a plain data frame, so nesting it returns one too, and
+# `nested` prints its list column as flattened values. A tibble prints each
+# nested table as its dimensions instead.
 nested |>
   dplyr::as_tibble() |>
   head()

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -74,7 +74,9 @@ collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 }
 \value{
-An ungrouped data frame, or a lazy table when \code{.data} is lazy.
+An ungrouped data frame, or a lazy table when \code{.data} is lazy. Its
+class and attributes follow \code{\link[dplyr:summarize]{dplyr::summarize()}}; see \emph{Result class and
+attributes}.
 Result row order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation
 order matters.
 }
@@ -146,6 +148,32 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Result class and attributes}{
+
+Each Margin verb follows the same class and attribute rules as the dplyr
+verb it is built from: \code{\link[=summarize_with_margins]{summarize_with_margins()}} those of
+\code{\link[dplyr:summarize]{dplyr::summarize()}}, and \code{\link[=expand_with_margins]{expand_with_margins()}} and the nesting verbs
+those of \code{\link[dplyr:mutate]{dplyr::mutate()}} combined with \code{\link[dplyr:union_all]{dplyr::union_all()}}. Passing a
+plain data frame therefore returns a plain data frame and passing a tibble
+returns a tibble.
+
+The input class is not guaranteed to be preserved, and neither are
+object-level attributes of the input or attributes of columns marginplyr
+does not rewrite. A data frame subclass survives only where dplyr can
+reconstruct it, so a subclass with no \code{\link[dplyr:dplyr_reconstruct]{dplyr::dplyr_reconstruct()}} method
+is lost by \code{\link[dplyr:summarize]{dplyr::summarize()}} itself. Attributes on a column that carries
+no class are dropped wherever branches are combined, because that is what
+the vctrs rules for combining bare vectors do with them. Attach the
+attributes a result must carry after the Margin operation, as with any
+dplyr pipeline.
+
+Factor and ordered-factor columns are the one exception, because
+marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
+itself. Their levels and ordering are preserved; see \emph{Display labels and
+grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
+its \code{tzone}, are carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -609,6 +609,60 @@ test_that("existing groups become implicit fixed keys", {
   expect_equal(dplyr::group_vars(implicit_nest_by), c("year", "region"))
 })
 
+test_that("Margin results take their class from the underlying dplyr verb", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 2, 3)
+  )
+
+  summary <- summarize_with_margins(
+    data,
+    value = sum(value),
+    .grouping = rollup(region)
+  )
+
+  expect_identical(class(summary), "data.frame")
+  # ADR 0016 promises delegation rather than the literal class above:
+  # marginplyr adds no class of its own to what the corresponding dplyr verb
+  # returned. Were dplyr to change what `summarise()` gives a plain data
+  # frame, this expectation would keep passing while the previous one failed,
+  # which is the reading that says marginplyr still honours the promise.
+  expect_identical(
+    class(summary),
+    class(dplyr::summarise(data, value = sum(value), .by = region))
+  )
+
+  expansion <- expand_with_margins(data, .grouping = rollup(region))
+
+  expect_identical(class(expansion), "data.frame")
+  expect_identical(
+    class(expansion),
+    class(dplyr::union_all(data, dplyr::mutate(data, region = "Total")))
+  )
+
+  nested <- nest_with_margins(data, .grouping = rollup(region))
+
+  expect_identical(class(nested), "data.frame")
+})
+
+test_that("nest_by_with_margins() is row-wise whatever the input class", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 2, 3)
+  )
+
+  nested_by <- nest_by_with_margins(data, .grouping = rollup(region))
+
+  # Unlike the verbs above, the row-wise shape is marginplyr's own
+  # construction, so ADR 0016 promises it for every input class. There is no
+  # row-wise plain data frame in dplyr to delegate to.
+  expect_s3_class(nested_by, "rowwise_df")
+  expect_identical(dplyr::group_vars(nested_by), "region")
+  # The promise about list-column elements is only that each is a data frame.
+  # Their exact class follows the backend and is documented, not guaranteed.
+  expect_s3_class(nested_by$data[[1L]], "data.frame")
+})
+
 test_that("grouped inputs reject conflicting grouping instructions", {
   data <- data.frame(
     year = c(2025L, 2026L),


### PR DESCRIPTION
Closes #56

## What changed

ADR 0016 records the rule that marginplyr promises exactly what marginplyr
constructs, and the reference now states it where users meet it. Two contract
tests pin the promise. No source behaviour changed — this decides, documents,
and tests what the package already does, and forbids a class of future change.

- `design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md`
- A shared `@section Result class and attributes:` on
  `summarize_with_margins()`, inherited by the other three verbs; each
  `@return` names the dplyr verb its class follows.
- The nesting verbs' shared section gains the list-column element rule.
- Two tests in `test-grouping-interface.R`.
- `design/architecture.md` records at `R/factor.R` that factor restoration is
  the only type or attribute restoration in the package.

## Two corrections to the measured table in #56

Re-measuring for the ADR found two rows that hold only under conditions the
original table did not vary. Both are why no attribute promise is defensible.

- An object-level attribute survives `expand_with_margins()` for a plain data
  frame and is **lost for a subclass of one**. `dplyr::mutate()` restores
  attributes for a bare data frame and drops them for a subclass with no
  `dplyr_reconstruct()` method. Plain `dplyr::bind_rows()` keeps them in both
  cases, so this is not the union step.
- A `label` on a **bare** double survives a one-set plan and is **lost from a
  multi-set plan**, because the multi-set path combines branches with
  `union_all()` and `vctrs::vec_c()` drops attributes of bare vectors. The
  issue's `value` column read as preserved because it was classed `myunit`
  *and* labelled at once; detach the class and the label is gone.

The same verb answers the same question differently depending on a property
the caller did not think they were choosing.

## The two questions, settled as delegation

**`expand` keeps an object-level attribute that `summarize` drops.** This is
not an inconsistency between two marginplyr verbs. It is the difference
between `dplyr::mutate()` and `dplyr::summarise()`, measured directly on a
plain data frame. Aligning downward destroys information dplyr keeps.
Aligning upward means marginplyr reattaching an attribute that a class
author's `dplyr_reconstruct()` deliberately dropped — silently, on classes
that did not exist when the restoration was written.

**`nest_by_with_margins()` returns a `rowwise_df` with tibble elements.** The
row-wise shape is promised: marginplyr calls `dplyr::rowwise()` itself and
there is no row-wise plain data frame in dplyr to delegate to. The element
class is not: it follows `dplyr::pick()` locally and dtplyr's translation
otherwise. Documented, with `lapply(result$data, tibble::as_tibble)` for
callers who need one class. Normalizing it would mean collecting a result
`nest_with_margins()` returns lazy.

## What the tests deliberately do not pin

No test asserts object-level attributes, data frame subclasses, or bare
column attributes through any verb. Those rows are evidence for the decision,
not a specification: a test would convert a described behaviour into a
guarantee by the back door, and would fail as an unexplained marginplyr
failure the day dplyr or vctrs changed a rule marginplyr does not own.

The class test asserts the literal class and the equivalent bare-dplyr
expression side by side. If dplyr's own rule ever changes, the literal fails
and the delegation assertion passes, which tells the next reader which of the
two happened.

Both tests were confirmed to fail before passing, by injecting the regression
each exists to catch: an `as_tibble()` in `finalize_margin_operation()`, and
`group_by()` in place of `rowwise()`.

## A claim in #58 this qualifies

That PR opened with "The Margin verbs hand their input's class through
dplyr". True for a plain data frame and a tibble; false for a subclass, since
`dplyr::summarise()` alone returns a bare data frame from a subclassed input.
`retail_sales` ships as a plain data frame, so that work is unaffected and
nothing needs redoing — the qualification is recorded so the next reader on
that thread lands on ADR 0016 rather than the broader claim.

## Verification

`roxygen2::roxygenise()`, `lintr::lint_package()` clean,
`spelling::spell_check_package()` clean, the full suite passing, and the Rd
examples of all four changed pages executed.

`vctrs` is added to `inst/WORDLIST` for one prose mention, named without a
`[vctrs::vec_c()]` link on purpose: marginplyr does not depend on vctrs, and
a cross-package link would either add a dependency for a documentation
reference or rely on dplyr's transitive one.