### PR TITLE
State the R-devel CI contract and keep P3M binary rot detectable

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,9 +47,47 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      # P3M does not publish binaries for the development R series. Base R can
-      # install binaries for the compatible release series directly. Preinstall
-      # all check dependencies so pak does not rebuild them for R-devel.
+      # R-devel is covered by two jobs answering different questions, and the
+      # gate is not this one. The R-devel compatibility gate is
+      # `release-matrix.yaml`'s `tarball` job on `ubuntu-latest` / `r: devel`,
+      # which installs hard dependencies plus the test harness and
+      # VignetteBuilder, needs no workaround at all, and checks the artifact a
+      # submission would carry. marginplyr is pure R and
+      # arrow and duckdb are Suggests, so that job settles whether the package
+      # works on R-devel. The question left over -- do the backend paths work
+      # on R-devel? -- is what the steps below add on top of it. A failure
+      # here, in particular a P3M outage, is not by itself an R-devel
+      # compatibility break.
+      #
+      # Source-building the backends is rejected, not merely avoided. A
+      # hosted-runner measurement recorded in
+      # `investigation/github-actions-modernization.md` compiled the full
+      # Suggests set on R-devel for over 55 minutes and was still building
+      # arrow when the job was stopped -- past the `timeout-minutes: 60` set
+      # above. Whether arrow and duckdb build from source under R-devel is
+      # their maintainers' and CRAN's question, not this package's: when a
+      # CRAN r-devel flavor lacks them the tests skip, and
+      # `release-matrix.yaml`'s `depends-only` job already proves skipping is
+      # safe.
+      #
+      # P3M does not publish binaries for the development R series, so base R
+      # installs binaries built for the compatible release series instead.
+      # That they load under R-devel at all rests on one undocumented value.
+      # `R_INTERNALS_UUID`, a compile-time constant in R's private
+      # `src/include/Defn.h`, has been identical across R-4-2 through R-4-6
+      # and trunk; `loadNamespace()` compares it against the installed
+      # package's `Meta/features.rds` and stops when they differ. So the day
+      # R-devel bumps it, this job fails with a clean error naming arrow or
+      # duckdb rather than a crash. That clean failure is a convention R's
+      # developers keep, not a guarantee: an internals change shipped without
+      # a bump passes the guard and has no defined symptom. The bump has no
+      # announcement channel and no deprecation path; see
+      # `investigation/r-devel-binary-compatibility.md` for the evidence, and
+      # #57 for why dropping the backends from this job is the intended
+      # response rather than reverting to source builds.
+      #
+      # Preinstall all check dependencies so pak does not rebuild them for
+      # R-devel.
       - name: Install P3M binary dependencies for R-devel
         if: matrix.config.r == 'devel'
         run: |
@@ -99,6 +137,10 @@ jobs:
           message("Installing P3M binaries: ", paste(dependencies, collapse = ", "))
           install.packages(dependencies, repos = p3m, dependencies = NA)
 
+          # When a binary is unavailable P3M serves source instead, silently
+          # and without an error, so a successful install proves nothing on
+          # its own. `Built` is the only field that separates a served release
+          # binary from a source build that happened to compile.
           packages <- c("arrow", "duckdb")
           built <- vapply(
             packages,
@@ -123,6 +165,15 @@ jobs:
           needs: check
           cache-version: 3
 
+      # Repeats the `Built` assertion after pak has run, because pak resolves
+      # against the running R-devel series and a source build it chose would
+      # replace the binaries installed above. This is a supply-chain check,
+      # and the load check below does not replace it: a source build on
+      # R-devel loads perfectly and passes any load check while being exactly
+      # the hour-long, unexplained timeout this job exists to avoid. It is
+      # also the likelier of the two to fire, since P3M's source fallback is
+      # routine documented behavior whereas the internals UUID has not moved
+      # in four years.
       - name: Verify P3M binary backends on R-devel
         if: matrix.config.r == 'devel'
         run: |
@@ -138,6 +189,23 @@ jobs:
           if (!all(startsWith(built, expected))) {
             stop("Arrow and DuckDB were not installed from P3M release binaries")
           }
+        shell: Rscript {0}
+
+      # This adds no coverage. `R CMD check` below already loads both packages
+      # through the backend tests and would trip the same `loadNamespace()`
+      # guard unaided. The step is here for diagnosis speed: it turns a
+      # binary-incompatibility failure buried in the check log into an
+      # immediate one that names the package and the cause, instead of a test
+      # error that reads like a marginplyr bug.
+      - name: Load the P3M binary backends on R-devel
+        if: matrix.config.r == 'devel'
+        run: |
+          # The internals-UUID comparison lives in `loadNamespace()`, not in
+          # `library()`, so every load path trips it; `library()` is simply
+          # the shortest one to write.
+          library(arrow)
+          library(duckdb)
+          message("Loaded arrow and duckdb under ", R.version.string)
         shell: Rscript {0}
 
       # No `upload-snapshots` here, and no `NOT_CRAN`. This matrix emulates

--- a/investigation/p3m-binary-actions.md
+++ b/investigation/p3m-binary-actions.md
@@ -1,6 +1,8 @@
 # P3M binaries in GitHub Actions
 
-Investigated on 2026-07-19 for `marginplyr`.
+Investigated on 2026-07-19 for `marginplyr`. Revised on 2026-08-04 to record
+what `investigation/r-devel-binary-compatibility.md` established about why
+loading release-series binaries under R-devel works, and what ends it.
 
 ## Findings
 
@@ -18,7 +20,9 @@ Investigated on 2026-07-19 for `marginplyr`.
   Linux runners and exports an `RSPM` URL selected for the runner's
   distribution. Its `http-user-agent: release` input is useful for an R-devel
   job because P3M publishes binaries for release R series, not R-devel. Using
-  this URL avoids hard-coding Ubuntu's release codename or architecture.
+  this URL avoids hard-coding Ubuntu's release codename or architecture. (P3M
+  states that scope by omission rather than positively; see the revisions
+  below.)
 - pak still resolves CRAN packages against the running R-devel series. Setting
   `PKG_R_VERSIONS` or only replacing the repository URL did not stop pak from
   selecting source builds in the observed workflow. Base R's
@@ -28,6 +32,44 @@ Investigated on 2026-07-19 for `marginplyr`.
   current standard r-lib/actions check workflow. It is scaffolding, not a P3M
   binary installer, and rerunning it would overwrite project-specific workflow
   changes. The existing workflow should therefore keep its explicit P3M step.
+
+## Revisions from the compatibility investigation (2026-08-04)
+
+`investigation/r-devel-binary-compatibility.md` reread the primary sources for
+the parts of this note that were inferred rather than quoted. Four corrections
+and additions:
+
+- "P3M publishes binaries for release R series, not R-devel" is right, but P3M
+  states it **by omission**. *Serving Package Binaries* defines its supported
+  set as the current released minor version and the four before it, and never
+  mentions R-devel. Its only compatibility promise is patch-level within one
+  minor series ("binaries for R 4.6 will work with R 4.6.0 through R 4.6.X"),
+  so loading a 4.6 binary under 4.7.0-devel is outside anything Posit asserts.
+  Posit is not the warrant for this arrangement working.
+- What actually makes it work is `R_INTERNALS_UUID`, a compile-time constant in
+  R's private `src/include/Defn.h`. `loadNamespace()` compares it against the
+  installed package's `Meta/features.rds` for any package with compiled code
+  and `stop()`s on a mismatch. The value has been identical across R-4-2
+  through R-4-6 and trunk, unchanged since it appeared between 4.1.3 and 4.2.3.
+  R publishes no binary-compatibility guarantee at any granularity, and ABI
+  breaks have landed at minor versions before (R 3.5.0, R 3.4.0).
+- The arrangement therefore ends with **one commit to `Defn.h`**, on any day,
+  with no announcement channel and no deprecation path. When the bump happens
+  the failure is a clean error naming the package, raised before the shared
+  object loads, so it is diagnosable — but that holds only for internals
+  changes R chose to record with a bump. Whether the maintainers bump it for
+  every such change is unsettled from primary sources; an unrecorded change
+  passes the guard, and R's own position (WRE §5.5) is that calling into
+  changed internals terminates the process rather than erroring. The mechanism
+  is documented nowhere and R-ints §4.1 calls `Meta/*.rds` private to R. Plan
+  for an abrupt break, not a graceful one.
+- The `Built` assertion in step 6 below is worth keeping for a reason this note
+  did not state: P3M's documented behavior when a binary is unavailable is to
+  serve source **silently**, without an error. Such a build compiles, loads
+  perfectly, and passes any load check, while taking the hour that this
+  workflow's 60-minute timeout would cut off with no explanation. The `Built`
+  field is the only thing that tells the two apart, and this failure is likelier
+  than an internals mismatch.
 
 ## Implemented approach
 
@@ -43,7 +85,16 @@ For the Ubuntu R-devel matrix job:
 5. Run `setup-r-dependencies` for system requirements and any missing package.
 6. Before and after pak runs, assert that Arrow and DuckDB have `Built` metadata
    from the release R series. A source build on R-devel therefore fails the job.
-7. Run the full package check, including Arrow and DuckDB backend tests.
+7. Load both packages explicitly once they are installed. This is not coverage
+   — the check in step 8 loads them anyway — but it names binary
+   incompatibility as the cause immediately instead of leaving it buried in the
+   check log.
+8. Run the full package check, including Arrow and DuckDB backend tests.
+
+The job is backend coverage on R-devel, not the R-devel compatibility gate.
+That gate is `release-matrix.yaml`'s `tarball` job on `ubuntu-latest` /
+`r: devel`, which installs hard dependencies plus the test harness and
+VignetteBuilder, and needs none of this.
 
 ## Primary sources
 


### PR DESCRIPTION
Closes #57.

R-devel is covered by two jobs answering different questions, and nothing
recorded which one is the gate. A P3M outage failing the backend job therefore
read as \"R-devel compatibility broke\" and invited reverting to source builds —
measured at over 55 minutes for the full `Suggests` set, against a 60-minute
timeout. This is comments plus one step; no change to which packages the
R-devel job installs, and no source-build fallback.

## `.github/workflows/R-CMD-check.yaml`

- A block next to the R-devel steps, in `release-matrix.yaml`'s
  \"which question does this job answer\" style, recording that the R-devel
  compatibility gate is `release-matrix.yaml`'s `tarball` job on
  `ubuntu-latest` / `r: devel`, and that this job only adds backend coverage on
  top of it.
- Why source-building arrow and duckdb is rejected: the measured >55 minutes
  past `timeout-minutes: 60`, and that their buildability under R-devel is
  their maintainers' and CRAN's question, not this package's — when a CRAN
  r-devel flavor lacks them the tests skip, and `depends-only` already proves
  skipping is safe.
- Why release-series binaries load under R-devel at all: `R_INTERNALS_UUID`
  has been identical across R-4-2 through R-4-6 and trunk, and
  `loadNamespace()` compares it against `Meta/features.rds` and stops cleanly
  when they differ. The comment records that the clean failure is a convention
  R's developers keep rather than a guarantee, and points at
  `investigation/r-devel-binary-compatibility.md`.
- Both `Built` assertions kept, now with their reason recorded: they catch
  P3M's documented **silent** source fallback, a supply-chain property the load
  check cannot see, and the likelier of the two failures to fire.
- New `Load the P3M binary backends on R-devel` step. Its comment opens with
  \"This adds no coverage\" — `R CMD check` loads both packages anyway and would
  trip the same `loadNamespace()` guard unaided. The step exists to turn a
  failure buried in the check log into an immediate one naming the cause.

## `investigation/p3m-binary-actions.md`

A dated revisions section recording what the compatibility investigation
established: P3M states its release-series scope by omission and asserts
nothing about R-devel; `R_INTERNALS_UUID` is what actually makes the
arrangement work; one commit to `Defn.h` ends it, with the clean-error
qualification that it only holds for internals changes R chose to record. The
implemented-approach list gains the load step and the gate attribution.

## Verification

YAML parses and step order is as intended; all three inline `Rscript` blocks
parse; the new load step was run locally against installed arrow and duckdb.
CI on this PR is the real check.

## Follow-ups filed, not done here

- #60 — decide what `investigation/` notes are and how they age. The dated
  revisions section added here was a judgement call with no rule to appeal to.
- #61 — `investigation/github-actions-modernization.md`'s \"R-devel dependency
  scope\" section is stale; blocked by #60, which decides the form of the fix.

The `R_INTERNALS_UUID` argument now appears in three places. \#57's acceptance
criteria 1–3 required the workflow comment to stand on its own at the point of
use, so that is intended; #60 decides which copy is canonical. Until then, the
workflow comment is the one to edit if the UUID ever moves.