### PR TITLE
Stop the release matrix restoring a fully provisioned package cache

### DIFF
--- a/.github/scripts/check-tarball.R
+++ b/.github/scripts/check-tarball.R
@@ -17,6 +17,13 @@
 
 source(".github/scripts/ci-helpers.R")
 
+# Asserts that this job's library holds the optional backends it declared and
+# no others, and stops before the check when it does not. It runs here rather
+# than as its own workflow step so that it cannot be dropped from a job while
+# the job goes on claiming to check a tarball; see the script's own header. A
+# separate environment keeps its working names off this one.
+source(".github/scripts/verify-library-isolation.R", local = new.env())
+
 tarball_dir <- Sys.getenv("MARGINPLYR_TARBALL_DIR", "tarball")
 check_dir <- check_directory()
 label <- check_label()

--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -65,10 +65,11 @@ optional_backends <- function() {
   c("arrow", "duckdb", "dtplyr", "RSQLite")
 }
 
-# Reads a comma-separated package list from the environment, the form the
-# workflow's matrix entries are written in.
-env_packages <- function(name) {
-  declared <- trimws(strsplit(Sys.getenv(name, ""), ",", fixed = TRUE)[[1]])
+# Reads a delimited list out of the environment, the form the workflow's matrix
+# entries are written in. Package lists are comma-separated; test names are
+# separated by `;`, because a test name may contain a comma.
+env_list <- function(name, sep = ",") {
+  declared <- trimws(strsplit(Sys.getenv(name, ""), sep, fixed = TRUE)[[1]])
   declared[nzchar(declared)]
 }
 

--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -51,6 +51,27 @@ test_output_path <- function(rcheck, test = "testthat") {
   if (length(found) == 0L) NA_character_ else found[1]
 }
 
+# The optional backends the release matrix reasons about, named once so that
+# the job asserting they are absent and the job asserting one of them is
+# present cannot drift apart. Adding a backend to
+# `tests/testthat/helper-optional-backends.R` means adding it here too.
+#
+# `DBI` is deliberately not here. It is a driver interface rather than a
+# backend, and `verify-depends-only.R` reads skip lines:
+# `skip_if_backend_absent("duckdb", "DBI")` skips on the first missing package,
+# so a `{DBI} is not installed` line never appears and requiring one would fail
+# every run.
+optional_backends <- function() {
+  c("arrow", "duckdb", "dtplyr", "RSQLite")
+}
+
+# Reads a comma-separated package list from the environment, the form the
+# workflow's matrix entries are written in.
+env_packages <- function(name) {
+  declared <- trimws(strsplit(Sys.getenv(name, ""), ",", fixed = TRUE)[[1]])
+  declared[nzchar(declared)]
+}
+
 write_step_summary <- function(lines) {
   summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", "")
   if (nzchar(summary_path)) {

--- a/.github/scripts/verify-backend.R
+++ b/.github/scripts/verify-backend.R
@@ -14,12 +14,7 @@
 
 source(".github/scripts/ci-helpers.R")
 
-required_tests <- trimws(strsplit(
-  Sys.getenv("MARGINPLYR_BACKEND_TESTS", ""),
-  ";",
-  fixed = TRUE
-)[[1]])
-required_tests <- required_tests[nzchar(required_tests)]
+required_tests <- env_list("MARGINPLYR_BACKEND_TESTS", ";")
 if (length(required_tests) == 0L) {
   stop("MARGINPLYR_BACKEND_TESTS is empty, so this job asserts nothing.")
 }

--- a/.github/scripts/verify-depends-only.R
+++ b/.github/scripts/verify-depends-only.R
@@ -12,12 +12,16 @@
 
 source(".github/scripts/ci-helpers.R")
 
-# The backends whose absence this job depends on. `DBI` is deliberately not
-# here: `skip_if_backend_absent("duckdb", "DBI")` skips on the first missing
-# package, so a `{DBI} is not installed` line never appears and requiring one
-# would fail every run. Adding a backend to
-# `tests/testthat/helper-optional-backends.R` means adding it here too.
-optional_backends <- c("arrow", "duckdb", "dtplyr", "RSQLite")
+# The backends whose absence this job depends on, and the reason `DBI` is not
+# among them, are recorded with `optional_backends()` in `ci-helpers.R`.
+#
+# This script asserts absence at check time, from the tests' own skip lines.
+# `verify-library-isolation.R` asserts it earlier and from the library itself,
+# which is the half that catches a poisoned dependency cache before the check
+# runs. Neither replaces the other: a library can be clean while the suite
+# never starts, and the suite can skip a backend for a reason unrelated to
+# `_R_CHECK_DEPENDS_ONLY_`.
+withheld <- optional_backends()
 
 log_path <- test_output_path(rcheck_directory())
 if (is.na(log_path)) {
@@ -48,8 +52,8 @@ if (counts[["pass"]] == 0L) {
 
 # Every optional backend must have skipped. A backend that ran here was visible
 # to the check, which means Suggested packages were not actually withheld.
-visible <- optional_backends[!vapply(
-  optional_backends,
+visible <- withheld[!vapply(
+  withheld,
   function(package) {
     skipped <- sprintf("{%s} is not installed", package)
     any(grepl(skipped, test_log, fixed = TRUE))
@@ -70,5 +74,5 @@ message(sprintf(
   "Verified: %d tests passed with %d skipped, and %s were all withheld.",
   counts[["pass"]],
   counts[["skip"]],
-  paste(optional_backends, collapse = ", ")
+  paste(withheld, collapse = ", ")
 ))

--- a/.github/scripts/verify-library-isolation.R
+++ b/.github/scripts/verify-library-isolation.R
@@ -1,0 +1,115 @@
+# Confirms that a job whose signal depends on which optional backends are
+# installed really ran with that library.
+#
+# `r-lib/actions/setup-r-dependencies@v2` restores a cache by prefix --
+# `<os>-<R version>-<arch>-<cache-version>-` -- whenever the exact key misses,
+# so a job that asks for hard dependencies only still starts from whatever
+# library the last cache under that prefix saved, and pak then installs only
+# what is still missing on top of it. Every job in this workflow and in
+# `R-CMD-check.yaml` once shared `cache-version: 3`, which restored the fully
+# provisioned library into the jobs documented as running without it (#64). The
+# per-job `cache-version` values keep the prefixes apart; this script is what
+# stops that separation from decaying silently, because a cache-key mistake
+# produces a green run that looks exactly like a correct one unless somebody
+# reads a `Session info` step.
+#
+# `MARGINPLYR_REQUIRED_SUGGESTS` is the job's declaration of which optional
+# packages it asked for. Every one of them must be installed, and every other
+# optional backend must be absent. A job that names none, such as `tarball`, is
+# declaring that all of them are absent.
+#
+# This runs before `R CMD check` rather than after it. A leaked backend
+# invalidates the run's whole claim, so there is nothing to learn from spending
+# another 45 minutes on the check, and the failure names the cause instead of
+# the symptom.
+
+source(".github/scripts/ci-helpers.R")
+
+label <- check_label()
+backends <- optional_backends()
+
+# The declaration also names `DBI`, which is a driver interface rather than a
+# backend and is not tracked by `optional_backends()`. Intersecting keeps the
+# two lists independent of each other.
+expected <- intersect(env_packages("MARGINPLYR_REQUIRED_SUGGESTS"), backends)
+withheld <- setdiff(backends, expected)
+
+# Searches every library on the path, which is the same set `requireNamespace()`
+# consults from the tests, so "visible to this job" means the same thing here as
+# it does there.
+location <- function(package) {
+  found <- find.package(package, quiet = TRUE)
+  if (length(found) == 0L) NA_character_ else normalizePath(found[1])
+}
+
+found <- vapply(backends, location, character(1))
+installed <- !is.na(found)
+
+missing <- expected[!installed[expected]]
+leaked <- withheld[installed[withheld]]
+
+describe <- function(package) {
+  if (is.na(found[[package]])) {
+    return("absent")
+  }
+  sprintf(
+    "%s at `%s`",
+    as.character(packageVersion(package)),
+    found[[package]]
+  )
+}
+
+verdict <- ifelse(
+  backends %in% c(missing, leaked),
+  ifelse(backends %in% missing, "MISSING", "LEAKED"),
+  "OK"
+)
+
+summary_lines <- c(
+  sprintf("## %s library isolation", label),
+  "",
+  sprintf(
+    "Requested: %s. Withheld: %s.",
+    if (length(expected) == 0L) "none" else paste(expected, collapse = ", "),
+    if (length(withheld) == 0L) "none" else paste(withheld, collapse = ", ")
+  ),
+  "",
+  paste0(
+    "- ", verdict,
+    " **", backends, "** — ",
+    vapply(backends, describe, character(1))
+  ),
+  "",
+  "Libraries searched:",
+  "",
+  paste0("- `", .libPaths(), "`")
+)
+write_step_summary(summary_lines)
+
+problems <- character()
+if (length(leaked) > 0L) {
+  problems <- c(problems, sprintf(
+    paste0(
+      "these optional backends are installed but were not requested: %s, so ",
+      "this job did not run with them withheld"
+    ),
+    paste(leaked, collapse = ", ")
+  ))
+}
+if (length(missing) > 0L) {
+  problems <- c(problems, sprintf(
+    "these requested optional backends are not installed: %s",
+    paste(missing, collapse = ", ")
+  ))
+}
+if (length(problems) > 0L) {
+  stop(sprintf("%s: %s.", label, paste(problems, collapse = "; ")))
+}
+
+message(sprintf(
+  "Verified: %s runs with %s installed and %s withheld.",
+  label,
+  if (length(expected) == 0L) "no optional backend" else
+    paste(expected, collapse = ", "),
+  paste(withheld, collapse = ", ")
+))

--- a/.github/scripts/verify-library-isolation.R
+++ b/.github/scripts/verify-library-isolation.R
@@ -1,37 +1,53 @@
-# Confirms that a job whose signal depends on which optional backends are
-# installed really ran with that library.
+# Confirms that a job got the library it declared, before it checks anything.
 #
-# `r-lib/actions/setup-r-dependencies@v2` restores a cache by prefix --
-# `<os>-<R version>-<arch>-<cache-version>-` -- whenever the exact key misses,
-# so a job that asks for hard dependencies only still starts from whatever
-# library the last cache under that prefix saved, and pak then installs only
-# what is still missing on top of it. Every job in this workflow and in
-# `R-CMD-check.yaml` once shared `cache-version: 3`, which restored the fully
-# provisioned library into the jobs documented as running without it (#64). The
-# per-job `cache-version` values keep the prefixes apart; this script is what
-# stops that separation from decaying silently, because a cache-key mistake
-# produces a green run that looks exactly like a correct one unless somebody
-# reads a `Session info` step.
+# Which optional backends a job installs is the whole signal of `depends-only`,
+# `tarball`, and the four `backend` jobs, and the dependency cache is what
+# nearly took it away: `setup-r-dependencies@v2` falls back to a `restore-keys`
+# prefix, so jobs sharing a `cache-version` share a library (#64). The
+# `cache-version` scheme that separates them is recorded in
+# `release-matrix.yaml`'s header. A cache key is not self-checking, though --
+# a wrong one produces a green run that reads like a correct one -- which is
+# what this script is for.
+#
+# `check-tarball.R` sources it rather than the workflow calling it as its own
+# step. A step can be deleted, and deleting it would restore exactly the silent
+# regression #64 found; sourcing it here means a job can only skip the
+# assertion by no longer checking the tarball at all. Every job that checks one
+# is a job that makes a claim about which backends it had.
 #
 # `MARGINPLYR_REQUIRED_SUGGESTS` is the job's declaration of which optional
-# packages it asked for. Every one of them must be installed, and every other
-# optional backend must be absent. A job that names none, such as `tarball`, is
-# declaring that all of them are absent.
-#
-# This runs before `R CMD check` rather than after it. A leaked backend
-# invalidates the run's whole claim, so there is nothing to learn from spending
-# another 45 minutes on the check, and the failure names the cause instead of
-# the symptom.
+# packages it asked for -- the same one `helper-optional-backends.R` reads to
+# turn an absent backend into a failure -- so the assertion needs no second
+# list to keep in step with the matrix. Every package named there must be
+# installed, and every other optional backend must be absent. A job that names
+# none, such as `tarball`, is declaring that all of them are absent.
 
 source(".github/scripts/ci-helpers.R")
 
 label <- check_label()
 backends <- optional_backends()
+declared <- env_list("MARGINPLYR_REQUIRED_SUGGESTS")
 
-# The declaration also names `DBI`, which is a driver interface rather than a
-# backend and is not tracked by `optional_backends()`. Intersecting keeps the
-# two lists independent of each other.
-expected <- intersect(env_packages("MARGINPLYR_REQUIRED_SUGGESTS"), backends)
+# `DBI` is a driver interface rather than a backend, so it is not tracked by
+# `optional_backends()` and the jobs that name it are not making a claim about
+# it. Anything else unrecognized is a backend that was added to the matrix
+# without being added to `optional_backends()`, which would leave it unchecked
+# in every other job -- silently, since an untracked name simply drops out of
+# the intersection below. Failing here is what makes that omission visible.
+untracked <- setdiff(declared, c(backends, "DBI"))
+if (length(untracked) > 0L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "%s declares %s in MARGINPLYR_REQUIRED_SUGGESTS, which ",
+      "`optional_backends()` in `ci-helpers.R` does not track, so no job ",
+      "asserts it is absent."
+    ),
+    label,
+    paste(untracked, collapse = ", ")
+  ))
+}
+
+expected <- intersect(declared, backends)
 withheld <- setdiff(backends, expected)
 
 # Searches every library on the path, which is the same set `requireNamespace()`
@@ -59,11 +75,9 @@ describe <- function(package) {
   )
 }
 
-verdict <- ifelse(
-  backends %in% c(missing, leaked),
-  ifelse(backends %in% missing, "MISSING", "LEAKED"),
-  "OK"
-)
+verdict <- rep("OK", length(backends))
+verdict[backends %in% missing] <- "MISSING"
+verdict[backends %in% leaked] <- "LEAKED"
 
 summary_lines <- c(
   sprintf("## %s library isolation", label),
@@ -90,26 +104,32 @@ problems <- character()
 if (length(leaked) > 0L) {
   problems <- c(problems, sprintf(
     paste0(
-      "these optional backends are installed but were not requested: %s, so ",
-      "this job did not run with them withheld"
+      "These optional backends are installed but were not requested: %s. ",
+      "This job did not run with them withheld."
     ),
     paste(leaked, collapse = ", ")
   ))
 }
 if (length(missing) > 0L) {
   problems <- c(problems, sprintf(
-    "these requested optional backends are not installed: %s",
+    "These requested optional backends are not installed: %s.",
     paste(missing, collapse = ", ")
   ))
 }
 if (length(problems) > 0L) {
-  stop(sprintf("%s: %s.", label, paste(problems, collapse = "; ")))
+  # `call. = FALSE` because `check-tarball.R` sources this file: without it the
+  # message arrives wrapped in `Error in eval(ei, envir)` and a `source ->
+  # withVisible` traceback, which buries the one line that names the cause.
+  stop(call. = FALSE, sprintf("%s: %s", label, paste(problems, collapse = " ")))
 }
 
 message(sprintf(
   "Verified: %s runs with %s installed and %s withheld.",
   label,
-  if (length(expected) == 0L) "no optional backend" else
-    paste(expected, collapse = ", "),
+  if (length(expected) == 0L) {
+    "no optional backend"
+  } else {
+    paste(expected, collapse = ", ")
+  },
   paste(withheld, collapse = ", ")
 ))

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,14 +50,17 @@ jobs:
       # R-devel is covered by two jobs answering different questions, and the
       # gate is not this one. The R-devel compatibility gate is
       # `release-matrix.yaml`'s `tarball` job on `ubuntu-latest` / `r: devel`,
-      # which installs hard dependencies plus the test harness and
-      # VignetteBuilder, needs no workaround at all, and checks the artifact a
-      # submission would carry. marginplyr is pure R and
-      # arrow and duckdb are Suggests, so that job settles whether the package
-      # works on R-devel. The question left over -- do the backend paths work
-      # on R-devel? -- is what the steps below add on top of it. A failure
-      # here, in particular a P3M outage, is not by itself an R-devel
-      # compatibility break.
+      # which installs hard dependencies plus rcmdcheck, testthat, and quarto
+      # and checks the artifact a submission would carry. That set is pure R,
+      # so pak has nothing to build from source and needs no workaround; arrow
+      # and duckdb are Suggests and stay out of it, which that job's own
+      # `verify-library-isolation.R` step asserts rather than assumes. Until
+      # #64 gave the two workflows separate `cache-version` values it did not
+      # hold: the tarball job restored this matrix's provisioned library by
+      # `restore-keys` prefix and installed arrow and duckdb along with it. The
+      # question left over -- do the backend paths work on R-devel? -- is what
+      # the steps below add on top of it. A failure here, in particular a P3M
+      # outage, is not by itself an R-devel compatibility break.
       #
       # Source-building the backends is rejected, not merely avoided. A
       # hosted-runner measurement recorded in
@@ -163,7 +166,11 @@ jobs:
           # so install the package itself first, as quarto-r's CI does.
           extra-packages: any::rcmdcheck, local::.
           needs: check
-          cache-version: 3
+          # This matrix is the provisioned one, so it shares the `full-1` cache
+          # with `release-matrix.yaml`'s `build` job and with nothing else. The
+          # naming scheme, and why a shared `cache-version` broke the release
+          # matrix, are recorded in that workflow's header.
+          cache-version: full-1
 
       # Repeats the `Built` assertion after pak has run, because pak resolves
       # against the running R-devel series and a source build it chose would

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,13 +51,14 @@ jobs:
       # gate is not this one. The R-devel compatibility gate is
       # `release-matrix.yaml`'s `tarball` job on `ubuntu-latest` / `r: devel`,
       # which installs hard dependencies plus rcmdcheck, testthat, and quarto
-      # and checks the artifact a submission would carry. That set is pure R,
-      # so pak has nothing to build from source and needs no workaround; arrow
-      # and duckdb are Suggests and stay out of it, which that job's own
+      # and checks the artifact a submission would carry. That job builds all
+      # of that from source on R-devel and needs no workaround, because the two
+      # packages whose source builds are prohibitive are arrow and duckdb, and
+      # they are Suggests it never requests -- which its own
       # `verify-library-isolation.R` step asserts rather than assumes. Until
-      # #64 gave the two workflows separate `cache-version` values it did not
+      # #64 gave the two workflows separate `cache-version` values that did not
       # hold: the tarball job restored this matrix's provisioned library by
-      # `restore-keys` prefix and installed arrow and duckdb along with it. The
+      # `restore-keys` prefix and received arrow and duckdb along with it. The
       # question left over -- do the backend paths work on R-devel? -- is what
       # the steps below add on top of it. A failure here, in particular a P3M
       # outage, is not by itself an R-devel compatibility break.

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,11 +54,11 @@ jobs:
       # and checks the artifact a submission would carry. That job builds all
       # of that from source on R-devel and needs no workaround, because the two
       # packages whose source builds are prohibitive are arrow and duckdb, and
-      # they are Suggests it never requests -- which its own
-      # `verify-library-isolation.R` step asserts rather than assumes. Until
-      # #64 gave the two workflows separate `cache-version` values that did not
-      # hold: the tarball job restored this matrix's provisioned library by
-      # `restore-keys` prefix and received arrow and duckdb along with it. The
+      # they are Suggests it never requests -- which its `check-tarball.R` run
+      # asserts rather than assumes. Until #64 moved that job off the
+      # `cache-version` this matrix uses, it did not hold: the tarball job
+      # restored this matrix's provisioned library by `restore-keys` prefix and
+      # received arrow and duckdb along with it. The
       # question left over -- do the backend paths work on R-devel? -- is what
       # the steps below add on top of it. A failure here, in particular a P3M
       # outage, is not by itself an R-devel compatibility break.
@@ -168,9 +168,11 @@ jobs:
           extra-packages: any::rcmdcheck, local::.
           needs: check
           # This matrix is the provisioned one, so it shares the `full-1` cache
-          # with `release-matrix.yaml`'s `build` job and with nothing else. The
-          # naming scheme, and why a shared `cache-version` broke the release
-          # matrix, are recorded in that workflow's header.
+          # with `release-matrix.yaml`'s `build` job and with nothing else.
+          # Neither of those two claims a package is absent, which is what
+          # makes sharing safe; the release matrix's isolation-critical jobs
+          # each have their own value. The naming scheme, and why one shared
+          # `cache-version` broke them, are recorded in that workflow's header.
           cache-version: full-1
 
       # Repeats the `Built` assertion after pak has run, because pak resolves

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -20,6 +20,31 @@
 # prove the same contracts, and those jobs set `MARGINPLYR_REQUIRED_SUGGESTS`
 # so that a backend which failed to install fails the job instead of skipping
 # into a false green. See `tests/testthat/helper-optional-backends.R`.
+#
+# Which packages a job installs is therefore the whole signal, and the
+# dependency cache is what nearly took it away. `setup-r-dependencies@v2` falls
+# back to a `restore-keys` prefix of `<os>-<R version>-<arch>-<cache-version>-`
+# when its exact key misses, so every job sharing a `cache-version` also shares
+# a library: while all five jobs here and `R-CMD-check.yaml` used
+# `cache-version: 3`, the fully provisioned library was restored into the jobs
+# documented as running without it, and pak installed only the remainder on top
+# (#64). The fix is a `cache-version` per dependency request rather than
+# `cache: false`, because these jobs still want a warm cache and losing it
+# would cost every run an install of the hard dependency closure; what they
+# cannot tolerate is sharing one with a differently provisioned job. The names
+# say which request they stand for:
+#
+#   full-1              hard dependencies plus every Suggest (`build`, and
+#                       `R-CMD-check.yaml`, whose matrix wants the same set).
+#   hard-1              hard dependencies plus rcmdcheck, testthat, and the
+#                       VignetteBuilder (`depends-only` and `tarball`).
+#   backend-<name>-1    that, plus exactly one optional backend.
+#
+# A cache key is not self-checking -- a mistake in one produces a green run
+# that reads like a correct one -- so `verify-library-isolation.R` asserts the
+# library each job actually got, before its check runs. Renaming a
+# `cache-version` is safe; dropping the isolation step is what would let this
+# regress.
 on:
   push:
     branches: [main, master]
@@ -71,7 +96,10 @@ jobs:
           # itself as well.
           extra-packages: local::.
           needs: check
-          cache-version: 3
+          # Provisioned on purpose: this job builds the tarball, and vignette
+          # sources exercise the optional backends. Shared with
+          # `R-CMD-check.yaml`, which asks for the same set.
+          cache-version: full-1
 
       - name: Build source tarball
         run: |
@@ -130,7 +158,14 @@ jobs:
         with:
           dependencies: '"hard"'
           extra-packages: any::rcmdcheck, any::testthat, any::quarto
-          cache-version: 3
+          cache-version: hard-1
+
+      # Fails before the check when the restored cache carried an optional
+      # backend in. `verify-depends-only.R` below proves the same thing from
+      # the tests' skip lines; this proves it from the library, which is where
+      # a cache mistake shows up first.
+      - name: Verify no optional backend is installed
+        run: Rscript .github/scripts/verify-library-isolation.R
 
       - uses: actions/download-artifact@v4
         with:
@@ -171,9 +206,10 @@ jobs:
           - {os: windows-latest, r: 'release'}
 
     env:
-      # Optional backends are deliberately absent from this matrix; the
-      # dedicated `backend` jobs execute them. Without this, `--as-cran` would
-      # fail the job for the missing Suggests rather than let the tests skip.
+      # Optional backends are deliberately absent from this matrix -- asserted
+      # by the isolation step below, not merely intended -- and the dedicated
+      # `backend` jobs execute them. Without this, `--as-cran` would fail the
+      # job for the missing Suggests rather than let the tests skip.
       _R_CHECK_FORCE_SUGGESTS_: false
       MARGINPLYR_CHECK_LABEL: >-
         Tarball ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -194,12 +230,20 @@ jobs:
       # Keeping this to hard dependencies plus the test harness and
       # VignetteBuilder is what lets R-devel join the matrix without the
       # binary-repository workaround `R-CMD-check.yaml` needs for arrow and
-      # duckdb: those packages are simply not part of this job.
+      # duckdb. The hard dependency closure is pure R, so pak has nothing to
+      # build from source and nothing to resolve against a series P3M ships no
+      # binaries for. That is a claim about which packages this job installs,
+      # and the isolation step below is what checks it: while this job shared a
+      # `cache-version` with the provisioned matrix it was in fact installing
+      # arrow and duckdb from the restored cache (#64).
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: '"hard"'
           extra-packages: any::rcmdcheck, any::testthat, any::quarto
-          cache-version: 3
+          cache-version: hard-1
+
+      - name: Verify no optional backend is installed
+        run: Rscript .github/scripts/verify-library-isolation.R
 
       - uses: actions/download-artifact@v4
         with:
@@ -279,7 +323,10 @@ jobs:
       # The `depends-only` and `tarball` jobs deliberately do not.
       NOT_CRAN: true
       # Every other optional backend is absent on purpose: proving one backend
-      # in isolation also proves it does not depend on the others.
+      # in isolation also proves it does not depend on the others. That second
+      # half is only worth stating because the isolation step below enforces
+      # it; a `backend` job that could see the other three would still prove
+      # its own contracts and prove nothing about independence.
       _R_CHECK_FORCE_SUGGESTS_: false
       # Vignette rebuilding is covered by `depends-only` and `tarball`. Leaving
       # it out here keeps the job's toolchain to what the backend contract
@@ -299,7 +346,19 @@ jobs:
           dependencies: '"hard"'
           extra-packages: >-
             any::rcmdcheck, any::testthat, ${{ matrix.backend.packages }}
-          cache-version: 3
+          # One cache per backend. These four jobs share an operating system,
+          # R version, and architecture, so a single `cache-version` would put
+          # all four libraries behind one `restore-keys` prefix and every job
+          # would start from whichever ran last.
+          cache-version: backend-${{ matrix.backend.name }}-1
+
+      # Asserts that this job installed its own backend and none of the other
+      # three, which is what makes the isolation claim above a result rather
+      # than an intention. `MARGINPLYR_REQUIRED_SUGGESTS` is already the job's
+      # declaration of what it asked for, so the gate needs no second list to
+      # keep in step with the matrix.
+      - name: Verify only ${{ matrix.backend.name }} is installed
+        run: Rscript .github/scripts/verify-library-isolation.R
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -25,7 +25,7 @@
 # dependency cache is what nearly took it away. `setup-r-dependencies@v2` falls
 # back to a `restore-keys` prefix of `<os>-<R version>-<arch>-<cache-version>-`
 # when its exact key misses, so every job sharing a `cache-version` also shares
-# a library: while all five jobs here and `R-CMD-check.yaml` used
+# a library: while all four jobs here and `R-CMD-check.yaml` used
 # `cache-version: 3`, the fully provisioned library was restored into the jobs
 # documented as running without it, and pak installed only the remainder on top
 # (#64). The fix is a `cache-version` per dependency request rather than
@@ -34,17 +34,19 @@
 # cannot tolerate is sharing one with a differently provisioned job. The names
 # say which request they stand for:
 #
-#   full-1              hard dependencies plus every Suggest (`build`, and
-#                       `R-CMD-check.yaml`, whose matrix wants the same set).
-#   hard-1              hard dependencies plus rcmdcheck, testthat, and the
-#                       VignetteBuilder (`depends-only` and `tarball`).
-#   backend-<name>-1    that, plus exactly one optional backend.
+#   full-1              hard dependencies plus every Suggest, and the package
+#                       itself (`build`, and `R-CMD-check.yaml`).
+#   hard-1              hard dependencies plus rcmdcheck, testthat, and quarto
+#                       (`depends-only` and `tarball`).
+#   backend-<name>-1    hard dependencies plus rcmdcheck and testthat, and
+#                       exactly one optional backend (`backend`). No quarto:
+#                       these jobs run `--ignore-vignettes`.
 #
 # A cache key is not self-checking -- a mistake in one produces a green run
 # that reads like a correct one -- so `verify-library-isolation.R` asserts the
-# library each job actually got, before its check runs. Renaming a
-# `cache-version` is safe; dropping the isolation step is what would let this
-# regress.
+# library each job got before its check runs. `check-tarball.R` sources it, so
+# every job that checks the tarball makes that assertion and no job can drop it
+# while still claiming to check anything. Renaming a `cache-version` is safe.
 on:
   push:
     branches: [main, master]
@@ -98,7 +100,10 @@ jobs:
           needs: check
           # Provisioned on purpose: this job builds the tarball, and vignette
           # sources exercise the optional backends. Shared with
-          # `R-CMD-check.yaml`, which asks for the same set.
+          # `R-CMD-check.yaml`, which asks for the same set plus rcmdcheck.
+          # Sharing a prefix with a superset is safe here because neither job
+          # claims any package is absent; that claim is what the other
+          # `cache-version` values protect.
           cache-version: full-1
 
       - name: Build source tarball
@@ -160,18 +165,16 @@ jobs:
           extra-packages: any::rcmdcheck, any::testthat, any::quarto
           cache-version: hard-1
 
-      # Fails before the check when the restored cache carried an optional
-      # backend in. `verify-depends-only.R` below proves the same thing from
-      # the tests' skip lines; this proves it from the library, which is where
-      # a cache mistake shows up first.
-      - name: Verify no optional backend is installed
-        run: Rscript .github/scripts/verify-library-isolation.R
-
       - uses: actions/download-artifact@v4
         with:
           name: source-tarball
           path: tarball
 
+      # Stops before checking anything if the restored cache carried an
+      # optional backend in; see `verify-library-isolation.R`.
+      # `verify-depends-only.R` below proves the same absence from the tests'
+      # own skip lines, which is a different question: a library can be clean
+      # while the suite never starts.
       - name: Check the tarball without Suggested packages
         run: Rscript .github/scripts/check-tarball.R
 
@@ -207,7 +210,7 @@ jobs:
 
     env:
       # Optional backends are deliberately absent from this matrix -- asserted
-      # by the isolation step below, not merely intended -- and the dedicated
+      # by `check-tarball.R`, not merely intended -- and the dedicated
       # `backend` jobs execute them. Without this, `--as-cran` would fail the
       # job for the missing Suggests rather than let the tests skip.
       _R_CHECK_FORCE_SUGGESTS_: false
@@ -236,8 +239,8 @@ jobs:
       # and so are never requested here. The measurement is in
       # `investigation/github-actions-modernization.md`.
       #
-      # That is a claim about which packages this job installs, and the
-      # isolation step below is what checks it: while this job shared a
+      # That is a claim about which packages this job installs, and
+      # `check-tarball.R` is what checks it: while this job shared a
       # `cache-version` with the provisioned matrix it was in fact receiving
       # arrow and duckdb from the restored cache (#64).
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -245,9 +248,6 @@ jobs:
           dependencies: '"hard"'
           extra-packages: any::rcmdcheck, any::testthat, any::quarto
           cache-version: hard-1
-
-      - name: Verify no optional backend is installed
-        run: Rscript .github/scripts/verify-library-isolation.R
 
       - uses: actions/download-artifact@v4
         with:
@@ -328,9 +328,9 @@ jobs:
       NOT_CRAN: true
       # Every other optional backend is absent on purpose: proving one backend
       # in isolation also proves it does not depend on the others. That second
-      # half is only worth stating because the isolation step below enforces
-      # it; a `backend` job that could see the other three would still prove
-      # its own contracts and prove nothing about independence.
+      # half is only worth stating because `check-tarball.R` enforces it; a
+      # `backend` job that could see the other three would still prove its own
+      # contracts and prove nothing about independence.
       _R_CHECK_FORCE_SUGGESTS_: false
       # Vignette rebuilding is covered by `depends-only` and `tarball`. Leaving
       # it out here keeps the job's toolchain to what the backend contract
@@ -355,14 +355,6 @@ jobs:
           # all four libraries behind one `restore-keys` prefix and every job
           # would start from whichever ran last.
           cache-version: backend-${{ matrix.backend.name }}-1
-
-      # Asserts that this job installed its own backend and none of the other
-      # three, which is what makes the isolation claim above a result rather
-      # than an intention. `MARGINPLYR_REQUIRED_SUGGESTS` is already the job's
-      # declaration of what it asked for, so the gate needs no second list to
-      # keep in step with the matrix.
-      - name: Verify only ${{ matrix.backend.name }} is installed
-        run: Rscript .github/scripts/verify-library-isolation.R
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -229,12 +229,16 @@ jobs:
 
       # Keeping this to hard dependencies plus the test harness and
       # VignetteBuilder is what lets R-devel join the matrix without the
-      # binary-repository workaround `R-CMD-check.yaml` needs for arrow and
-      # duckdb. The hard dependency closure is pure R, so pak has nothing to
-      # build from source and nothing to resolve against a series P3M ships no
-      # binaries for. That is a claim about which packages this job installs,
-      # and the isolation step below is what checks it: while this job shared a
-      # `cache-version` with the provisioned matrix it was in fact installing
+      # binary-repository workaround `R-CMD-check.yaml` needs. P3M publishes no
+      # binaries for the development series, so on R-devel pak builds this
+      # whole set from source; that is affordable because the two packages
+      # whose source builds are not are arrow and duckdb, which are Suggests
+      # and so are never requested here. The measurement is in
+      # `investigation/github-actions-modernization.md`.
+      #
+      # That is a claim about which packages this job installs, and the
+      # isolation step below is what checks it: while this job shared a
+      # `cache-version` with the provisioned matrix it was in fact receiving
       # arrow and duckdb from the restored cache (#64).
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,13 +95,26 @@ also lists the test names it exists to execute in its `proves` field, and
 Renaming a contract test is therefore expected to break its job — that is the
 gate working, and the fix is to update the `proves` list, not to relax it.
 
+Which packages a job installs is the whole signal of that design, so the
+dependency cache is part of it. `setup-r-dependencies@v2` falls back to a
+`restore-keys` prefix of `<os>-<R version>-<arch>-<cache-version>-`, which
+means every job sharing a `cache-version` shares a library. Each dependency
+request therefore gets its own value — `full-1`, `hard-1`,
+`backend-<name>-1`, named in `release-matrix.yaml`'s header — and a new job
+that copies an existing `cache-version` inherits that job's library rather than
+installing its own. `verify-library-isolation.R` runs before each check and
+fails the job when an optional backend it did not request is on `.libPaths()`,
+which is what keeps the scheme honest; a wrong cache key is otherwise
+indistinguishable from a correct run.
+
 Adding an optional backend means editing three places, and doing only the first
 leaves a contract nothing executes:
 
 1. the `skip_if_backend_absent()` call in the tests,
-2. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts,
-3. `optional_backends` in `.github/scripts/verify-depends-only.R`, which
-   asserts the backend really was withheld from the minimal-dependency job.
+2. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts and
+   carrying its own `cache-version`,
+3. `optional_backends()` in `.github/scripts/ci-helpers.R`, which is the one
+   list both `verify-depends-only.R` and `verify-library-isolation.R` read.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,19 +102,25 @@ means every job sharing a `cache-version` shares a library. Each dependency
 request therefore gets its own value — `full-1`, `hard-1`,
 `backend-<name>-1`, named in `release-matrix.yaml`'s header — and a new job
 that copies an existing `cache-version` inherits that job's library rather than
-installing its own. `verify-library-isolation.R` runs before each check and
-fails the job when an optional backend it did not request is on `.libPaths()`,
-which is what keeps the scheme honest; a wrong cache key is otherwise
-indistinguishable from a correct run.
+installing its own. `verify-library-isolation.R` is what keeps the scheme
+honest, since a wrong cache key is otherwise indistinguishable from a correct
+run: it fails the job when an optional backend the job did not declare in
+`MARGINPLYR_REQUIRED_SUGGESTS` is on `.libPaths()`. `check-tarball.R` sources
+it rather than the workflow calling it as a step, so the assertion cannot be
+dropped from a job that still checks a tarball.
 
 Adding an optional backend means editing three places, and doing only the first
 leaves a contract nothing executes:
 
 1. the `skip_if_backend_absent()` call in the tests,
-2. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts and
-   carrying its own `cache-version`,
+2. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts in
+   `proves` and its packages in `required` — `required` is also what the
+   isolation assertion reads as the job's declaration,
 3. `optional_backends()` in `.github/scripts/ci-helpers.R`, which is the one
    list both `verify-depends-only.R` and `verify-library-isolation.R` read.
+   Skipping this one fails the new job rather than passing quietly: a
+   `required` package that `optional_backends()` does not track is refused,
+   because nothing would assert it absent elsewhere.
 
 ## Agent skills
 

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -506,17 +506,23 @@ reinstalling the hard dependency closure. A cache key is not self-checking, so
 the disposition is not the key change but the gate beside it:
 `.github/scripts/verify-library-isolation.R` reads the job's own
 `MARGINPLYR_REQUIRED_SUGGESTS` declaration and fails before the check when a
-requested backend is absent or an unrequested one is on `.libPaths()`. It runs
-in `depends-only`, all five `tarball` jobs, and all four `backend` jobs. The
-two isolation claims and both copies of the R-devel rationale are rewritten to
-what the jobs install.
+requested backend is absent or an unrequested one is on `.libPaths()`.
+`check-tarball.R` sources it rather than the workflow calling it as a step,
+which is what makes the criterion's "cannot regress silently" hold: a step can
+be deleted, and deleting it would restore exactly this finding, whereas every
+job that checks the tarball necessarily makes the assertion. That covers
+`depends-only`, all five `tarball` jobs, and all four `backend` jobs — the ten
+that claim a backend is absent — and it also refuses a `required` package that
+`optional_backends()` does not track, so adding a fifth backend without
+registering it fails rather than going unchecked. The two isolation claims and
+both copies of the R-devel rationale are rewritten to what the jobs install.
 
 *Evidence for the fix:* release-matrix run
 [30907216394](https://github.com/sayuks/marginplyr/actions/runs/30907216394) on
 `0a6363e`, all 11 jobs green. `Tarball ubuntu-latest (release)` now logs `Cache
 not found for input keys: ...-hard-1-2f5979dd..., ...-hard-1-` — the same
 primary key as before, with a restore-key prefix that no longer reaches the
-provisioned library — and its isolation step reports all four backends absent,
+provisioned library — and its isolation report lists all four backends absent,
 as do `depends-only` and the macOS and Windows tarball jobs. Each `backend` job
 reports its own backend and the other three absent: `Live Arrow` arrow 25.0.0,
 `Live DuckDB` duckdb 1.5.5, `Live dtplyr` dtplyr 1.3.3, `Live RSQLite` RSQLite
@@ -528,9 +534,10 @@ provisioned cache: it missed both keys, built the whole set from source under
 R 4.7.0, and reported `Status: OK` in 10m12s against a `timeout-minutes: 60` —
 against the over-55-minute arrow build that `R-CMD-check.yaml` avoids. The
 gate's
-four states — nothing requested and nothing installed, a requested backend
-absent, an unrequested one present, and the mixed case — were exercised
-locally against a controlled `R_LIBS_USER` before the run.
+states — nothing requested and nothing installed, a requested backend absent,
+an unrequested one present, the mixed case, and an untracked `required`
+package — were exercised locally against a controlled `R_LIBS_USER`, as was the
+ordering that stops the job before `check-tarball.R` looks for a tarball.
 
 **`cran-comments.md` reports test counts the current tree does not produce**
 (Docs & Tests). **Not fixed — blocking, #65.** The file

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -473,27 +473,64 @@ The four `backend` jobs each report one NOTE, dispositioned below, and each
 
 **Every ubuntu release-matrix job restores a fully provisioned package library
 from a shared cache, so no job in the workflow runs with the optional backends
-actually withheld** (Docs & Tests). **Not fixed — blocking, #64.**
+actually withheld** (Docs & Tests). **Fixed — #64, PR #68.**
 `setup-r-dependencies@v2` sets `restore-keys` to the prefix
 `<os>-<R version>-<arch>-<cache-version>-`, and `R-CMD-check.yaml` and all four
-`release-matrix.yaml` jobs share `cache-version: 3`, so the fully provisioned
-library that `R-CMD-check.yaml` saves is restored into jobs that ask for hard
-dependencies only. *Evidence:* in run 30889837726, job `Tarball ubuntu-latest
-(release)` logs `Cache hit for restore-key: ...-3-bb148ad6...` after missing its
-own primary key `2f5979dd...`; the `Session info` step of every ubuntu job
-lists `arrow 25.0.0`, `dtplyr 1.3.3`, `duckdb 1.5.5`, and `RSQLite` among
-122–124 packages in `/home/runner/work/_temp/Library`; and `Live RSQLite`
-newly installs only `rcmdcheck`, `RSQLite`, `sessioninfo`, and `testthat` on
-top of what the cache supplied. Three documented claims are therefore false of
-what ran: `release-matrix.yaml`'s "Optional backends are deliberately absent
-from this matrix", its "Every other optional backend is absent on purpose:
-proving one backend in isolation also proves it does not depend on the others",
-and the R-devel rationale in both that file and `R-CMD-check.yaml` that arrow
-and duckdb "are simply not part of this job". No contract is unproven —
-`verify-backend.R` passed in all four jobs — but backend independence is, and
-the #57 R-devel separation is not what the runs demonstrate. `depends-only` is
-unaffected, because `_R_CHECK_DEPENDS_ONLY_=true` restricts the library at
-check time and `verify-depends-only.R` confirmed all four backends skipped.
+`release-matrix.yaml` jobs shared `cache-version: 3`, so the fully provisioned
+library that `R-CMD-check.yaml` saves was restored into jobs that ask for hard
+dependencies only. *Evidence for the finding:* in run 30889837726, job `Tarball
+ubuntu-latest (release)` logs `Cache hit for restore-key: ...-3-bb148ad6...`
+after missing its own primary key `2f5979dd...`; the `Session info` step of
+every ubuntu job lists `arrow 25.0.0`, `dtplyr 1.3.3`, `duckdb 1.5.5`, and
+`RSQLite` among 122–124 packages in `/home/runner/work/_temp/Library`; and
+`Live RSQLite` newly installs only `rcmdcheck`, `RSQLite`, `sessioninfo`, and
+`testthat` on top of what the cache supplied. Three documented claims were
+therefore false of what ran: `release-matrix.yaml`'s "Optional backends are
+deliberately absent from this matrix", its "Every other optional backend is
+absent on purpose: proving one backend in isolation also proves it does not
+depend on the others", and the R-devel rationale in both that file and
+`R-CMD-check.yaml` that arrow and duckdb "are simply not part of this job". No
+contract was unproven — `verify-backend.R` passed in all four jobs — but
+backend independence was, and the #57 R-devel separation was not what those
+runs demonstrated. `depends-only` was unaffected, because
+`_R_CHECK_DEPENDS_ONLY_=true` restricts the library at check time and
+`verify-depends-only.R` confirmed all four backends skipped.
+
+The fix gives each dependency request its own `cache-version` — `full-1` for
+the provisioned jobs, `hard-1` for `depends-only` and `tarball`,
+`backend-<name>-1` for each of the four `backend` jobs, which had shared one
+prefix with each other as well as with the provisioned matrix. Disabling the
+cache on the isolation-critical jobs was the alternative and was not taken:
+separate prefixes cost nothing and `cache: false` would spend every run
+reinstalling the hard dependency closure. A cache key is not self-checking, so
+the disposition is not the key change but the gate beside it:
+`.github/scripts/verify-library-isolation.R` reads the job's own
+`MARGINPLYR_REQUIRED_SUGGESTS` declaration and fails before the check when a
+requested backend is absent or an unrequested one is on `.libPaths()`. It runs
+in `depends-only`, all five `tarball` jobs, and all four `backend` jobs. The
+two isolation claims and both copies of the R-devel rationale are rewritten to
+what the jobs install.
+
+*Evidence for the fix:* release-matrix run
+[30907216394](https://github.com/sayuks/marginplyr/actions/runs/30907216394) on
+`0a6363e`, all 11 jobs green. `Tarball ubuntu-latest (release)` now logs `Cache
+not found for input keys: ...-hard-1-2f5979dd..., ...-hard-1-` — the same
+primary key as before, with a restore-key prefix that no longer reaches the
+provisioned library — and its isolation step reports all four backends absent,
+as do `depends-only` and the macOS and Windows tarball jobs. Each `backend` job
+reports its own backend and the other three absent: `Live Arrow` arrow 25.0.0,
+`Live DuckDB` duckdb 1.5.5, `Live dtplyr` dtplyr 1.3.3, `Live RSQLite` RSQLite
+3.53.3, each at `/home/runner/work/_temp/Library`. All twelve named contracts
+still ran, and `depends-only` reports 1107 passed with 66 skipped.
+`Tarball ubuntu-latest (devel)` is the case the rewritten R-devel rationale
+turns on, and this is the first run where it was actually withheld from the
+provisioned cache: it missed both keys, built the whole set from source under
+R 4.7.0, and reported `Status: OK` in 10m12s against a `timeout-minutes: 60` —
+against the over-55-minute arrow build that `R-CMD-check.yaml` avoids. The
+gate's
+four states — nothing requested and nothing installed, a requested backend
+absent, an unrequested one present, and the mixed case — were exercised
+locally against a controlled `R_LIBS_USER` before the run.
 
 **`cran-comments.md` reports test counts the current tree does not produce**
 (Docs & Tests). **Not fixed — blocking, #65.** The file
@@ -572,8 +609,9 @@ tests/testthat/` returns nothing.
 
 **One `skip_if_backend_absent()` call reverses the argument order a CI gate
 depends on** (Standards). **Not fixed — #66.**
-`.github/scripts/verify-depends-only.R:15-18` excludes DBI from
-`optional_backends` because `skip_if_backend_absent("duckdb", "DBI")` "skips on
+`optional_backends()` in `.github/scripts/ci-helpers.R`, which #64 moved there
+from `verify-depends-only.R`, excludes DBI
+because `skip_if_backend_absent("duckdb", "DBI")` "skips on
 the first missing package, so a `{DBI} is not installed` line never appears".
 `tests/testthat/test-margin-label.R:295` calls it as `("DBI", "duckdb")`. The
 gate still passes, because `test-margin-id.R` and `test-expand-operation.R`
@@ -639,8 +677,9 @@ two-axis review and Docs & Tests audit with no unresolved findings, which is
 **The gate is not met as of #40's review.** Local checks, the release matrix,
 and the two-axis review of package behaviour are clean, and no finding above
 changes a result marginplyr returns. What is not clean is the evidence layer
-the gate is written in terms of: the release matrix does not withhold the
-optional backends it documents withholding (#64), and `cran-comments.md`
-states counts the tree no longer produces (#65). The seven smaller
-standards and spec findings are #66. #40 stays open until all three close,
-and no submission is made before then.
+the gate is written in terms of. Two of its three tickets are still open:
+`cran-comments.md` states counts the tree no longer produces (#65), and the
+seven smaller standards and spec findings are #66. The third, #64, is fixed —
+the release matrix now withholds the optional backends it documents
+withholding, and a gate fails the workflow if it stops doing so. #40 stays open
+until #65 and #66 close, and no submission is made before then.

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -518,26 +518,33 @@ registering it fails rather than going unchecked. The two isolation claims and
 both copies of the R-devel rationale are rewritten to what the jobs install.
 
 *Evidence for the fix:* release-matrix run
+[30909320124](https://github.com/sayuks/marginplyr/actions/runs/30909320124) on
+`dc37234`, all 11 jobs green, is the run of the mechanism as it stands. Each
+`backend` job reports its own backend and the other three absent: `Live Arrow`
+arrow 25.0.0, `Live DuckDB` duckdb 1.5.5, `Live dtplyr` dtplyr 1.3.3, `Live
+RSQLite` RSQLite 3.53.3, each at `/home/runner/work/_temp/Library`. All twelve
+named contracts still ran. `depends-only`, all five `tarball` jobs, and both
+non-Linux platforms report all four backends absent, and `depends-only` reports
+1107 passed with 66 skipped.
+
+Two measurements come from the preceding run
 [30907216394](https://github.com/sayuks/marginplyr/actions/runs/30907216394) on
-`0a6363e`, all 11 jobs green. `Tarball ubuntu-latest (release)` now logs `Cache
+`0a6363e`, which was the first under the new `cache-version` values and so the
+only one whose caches were cold. `Tarball ubuntu-latest (release)` logs `Cache
 not found for input keys: ...-hard-1-2f5979dd..., ...-hard-1-` — the same
-primary key as before, with a restore-key prefix that no longer reaches the
-provisioned library — and its isolation report lists all four backends absent,
-as do `depends-only` and the macOS and Windows tarball jobs. Each `backend` job
-reports its own backend and the other three absent: `Live Arrow` arrow 25.0.0,
-`Live DuckDB` duckdb 1.5.5, `Live dtplyr` dtplyr 1.3.3, `Live RSQLite` RSQLite
-3.53.3, each at `/home/runner/work/_temp/Library`. All twelve named contracts
-still ran, and `depends-only` reports 1107 passed with 66 skipped.
-`Tarball ubuntu-latest (devel)` is the case the rewritten R-devel rationale
-turns on, and this is the first run where it was actually withheld from the
-provisioned cache: it missed both keys, built the whole set from source under
-R 4.7.0, and reported `Status: OK` in 10m12s against a `timeout-minutes: 60` —
-against the over-55-minute arrow build that `R-CMD-check.yaml` avoids. The
-gate's
-states — nothing requested and nothing installed, a requested backend absent,
-an unrequested one present, the mixed case, and an untracked `required`
-package — were exercised locally against a controlled `R_LIBS_USER`, as was the
-ordering that stops the job before `check-tarball.R` looks for a tarball.
+primary key it missed before, now with a restore-key prefix that no longer
+reaches the provisioned library. And `Tarball ubuntu-latest (devel)`, the case
+the rewritten R-devel rationale turns on, built the whole set from source under
+R 4.7.0 and reported `Status: OK` in 10m12s against a `timeout-minutes: 60` —
+against the over-55-minute arrow build `R-CMD-check.yaml` avoids. The same job
+takes 3m00s in run 30909320124 on a warm `hard-1` cache, which is why the cold
+figure is the one recorded here.
+
+The assertion's states — nothing requested and nothing installed, a requested
+backend absent, an unrequested one present, the mixed case, and an untracked
+`required` package — were exercised locally against a controlled `R_LIBS_USER`,
+as was the ordering that stops the job before `check-tarball.R` looks for a
+tarball.
 
 **`cran-comments.md` reports test counts the current tree does not produce**
 (Docs & Tests). **Not fixed — blocking, #65.** The file


### PR DESCRIPTION
Closes #64.

## What was wrong

`r-lib/actions/setup-r-dependencies@v2` falls back to a `restore-keys` prefix
of `<os>-<R version>-<arch>-<cache-version>-` when its exact key misses. All
four `release-matrix.yaml` jobs and `R-CMD-check.yaml` used `cache-version: 3`,
so the fully provisioned library `R-CMD-check.yaml` saves was restored into the
jobs documented as running with the optional backends withheld, and pak
installed only the few remaining packages on top.

No contract was unproven — `verify-backend.R` passed in all four `backend` jobs
— but backend *independence* was, and three documented claims were false of
what actually ran.

## What this does

- **Per-request `cache-version` values**, not `cache: false`: `full-1` for the
  provisioned jobs (`R-CMD-check.yaml`, `build`), `hard-1` for `depends-only`
  and `tarball`, `backend-<name>-1` for each of the four `backend` jobs. Those
  four share an OS, R version, and architecture, so one value put all four
  libraries behind a single prefix. Keeping the cache costs nothing now that
  the prefixes are separate, and losing it would cost every run an install of
  the hard dependency closure. The scheme is recorded in `release-matrix.yaml`'s
  header.
- **An assertion that cannot be dropped.** A cache key is not self-checking: a
  wrong one produces a green run that reads like a correct one.
  `.github/scripts/verify-library-isolation.R` reads the job's own
  `MARGINPLYR_REQUIRED_SUGGESTS` declaration — no second list to keep in step
  with the matrix — and fails when a requested backend is absent or an
  unrequested one is on `.libPaths()`. `check-tarball.R` **sources** it rather
  than the workflow calling it as a step: a step can be deleted, and deleting it
  would reinstate exactly the silent regression this ticket is about, so the ten
  jobs that claim a backend is absent can only skip the assertion by no longer
  checking a tarball. It still runs before anything else, so a leak fails in
  seconds rather than after a 45-minute check.
- **Fails closed.** An unset or misspelled `MARGINPLYR_REQUIRED_SUGGESTS` makes
  every backend "withheld", so a `backend` job reports its own backend leaked
  and stops. A `required` package that `optional_backends()` does not track is
  refused outright — otherwise a fifth backend added to the matrix but never
  registered would have been asserted absent nowhere.
- **One backend list.** `optional_backends()` moves to `ci-helpers.R`, read by
  both `verify-depends-only.R` and the new script.
- **Prose.** Both isolation claims and both copies of the R-devel rationale now
  describe what the jobs install, and name what holds them to it.

`verify-depends-only.R` is unchanged in substance: it still asserts absence at
check time from the tests' skip lines. The new script asserts it earlier and
from the library. Neither replaces the other — a library can be clean while the
suite never starts.

## Evidence

Release-matrix run
[30909320124](https://github.com/sayuks/marginplyr/actions/runs/30909320124) on
`dc37234`, all 11 jobs green, is the run of the mechanism as it stands. Each
`backend` job reports its own backend and the other three absent — `Live Arrow`
arrow 25.0.0, `Live DuckDB` duckdb 1.5.5, `Live dtplyr` dtplyr 1.3.3, `Live
RSQLite` RSQLite 3.53.3 — and `depends-only` plus all five `tarball` jobs report
all four absent. All twelve named contracts still ran.

Two cold-cache measurements come from the preceding run
[30907216394](https://github.com/sayuks/marginplyr/actions/runs/30907216394),
the first under the new `cache-version` values and so the only one whose caches
were empty: `Tarball ubuntu-latest (release)` logs `Cache not found for input
keys: ...-hard-1-2f5979dd..., ...-hard-1-` — the same primary key it missed
before, now with a prefix that no longer reaches the provisioned library — and
the R-devel tarball job built its whole set from source in 10m12s with
`Status: OK`, which is what the rewritten R-devel rationale turns on.

The assertion's states — nothing requested and nothing installed, a requested
backend absent, an unrequested one present, the mixed case, and an untracked
`required` package — were exercised locally against a controlled `R_LIBS_USER`,
as was the ordering that stops the job before `check-tarball.R` looks for a
tarball.

## Review

`/code-review` against #64 found that the gate, as first written, sat in a
deletable step and so did not yet meet the criterion's "cannot regress
silently"; that is what the sourcing change above answers. It also found six
inaccurate claims in the new comments — the same failure mode this ticket
exists to fix — including "all five jobs here" when the workflow defines four,
and `backend-<name>-1` described as including a VignetteBuilder those jobs do
not install. All are corrected in `dc37234`.