### PR TITLE
Collapse the optional-backend list to a single source of truth

### DIFF
--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -51,19 +51,20 @@ test_output_path <- function(rcheck, test = "testthat") {
   if (length(found) == 0L) NA_character_ else found[1]
 }
 
-# The optional backends the release matrix reasons about, named once so that
-# the job asserting they are absent and the job asserting one of them is
-# present cannot drift apart. Adding a backend to
-# `tests/testthat/helper-optional-backends.R` means adding it here too.
+# `optional_suggests()` and `optional_backends()`, the one list of optional
+# backends the release matrix reasons about. It is defined with the guards that
+# consume it rather than here, because `.Rbuildignore` excludes `^\.github$`
+# and does not exclude `tests/`: the tarball ships the helper, so this file can
+# read it and a list kept here could not be read back from the tests. Every job
+# that runs these scripts checks out the repository, so the path resolves.
 #
-# `DBI` is deliberately not here. It is a driver interface rather than a
-# backend, and `verify-depends-only.R` reads skip lines:
-# `skip_if_backend_absent("duckdb", "DBI")` skips on the first missing package,
-# so a `{DBI} is not installed` line never appears and requiring one would fail
-# every run.
-optional_backends <- function() {
-  c("arrow", "duckdb", "dtplyr", "RSQLite")
-}
+# `source()` evaluates top-level expressions only, and the helper's sole
+# testthat call sits inside `skip_if_backend_absent()`'s body, so this works
+# from a bare `Rscript` with testthat unattached. It also brings in
+# `backend_available()` and `required_suggests()`; nothing here calls them, and
+# separating the list into its own file would trade that for a file whose only
+# purpose is the separation.
+source("tests/testthat/helper-optional-backends.R")
 
 # Reads a delimited list out of the environment, the form the workflow's matrix
 # entries are written in. Package lists are comma-separated; test names are

--- a/.github/scripts/verify-depends-only.R
+++ b/.github/scripts/verify-depends-only.R
@@ -13,7 +13,8 @@
 source(".github/scripts/ci-helpers.R")
 
 # The backends whose absence this job depends on, and the reason `DBI` is not
-# among them, are recorded with `optional_backends()` in `ci-helpers.R`.
+# among them, are recorded with `optional_suggests()` in
+# `tests/testthat/helper-optional-backends.R`.
 #
 # This script asserts absence at check time, from the tests' own skip lines.
 # `verify-library-isolation.R` asserts it earlier and from the library itself,

--- a/.github/scripts/verify-library-isolation.R
+++ b/.github/scripts/verify-library-isolation.R
@@ -28,19 +28,21 @@ label <- check_label()
 backends <- optional_backends()
 declared <- env_list("MARGINPLYR_REQUIRED_SUGGESTS")
 
-# `DBI` is a driver interface rather than a backend, so it is not tracked by
-# `optional_backends()` and the jobs that name it are not making a claim about
-# it. Anything else unrecognized is a backend that was added to the matrix
-# without being added to `optional_backends()`, which would leave it unchecked
-# in every other job -- silently, since an untracked name simply drops out of
-# the intersection below. Failing here is what makes that omission visible.
-untracked <- setdiff(declared, c(backends, "DBI"))
+# `optional_suggests()` names every package a guard may be written against;
+# `optional_backends()` is the subset whose absence a job can claim, and is
+# what this script iterates over. A job may declare `DBI`, which is in the
+# first and not the second, and makes no absence claim by doing so. Anything in
+# neither is a backend added to the matrix without being added to the list,
+# which would leave it unchecked in every other job -- silently, since an
+# untracked name simply drops out of the intersection below. Failing here is
+# what makes that omission visible.
+untracked <- setdiff(declared, names(optional_suggests()))
 if (length(untracked) > 0L) {
   stop(call. = FALSE, sprintf(
     paste0(
       "%s declares %s in MARGINPLYR_REQUIRED_SUGGESTS, which ",
-      "`optional_backends()` in `ci-helpers.R` does not track, so no job ",
-      "asserts it is absent."
+      "`optional_suggests()` in `tests/testthat/helper-optional-backends.R` ",
+      "does not name, so no job asserts it is absent."
     ),
     label,
     paste(untracked, collapse = ", ")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,18 @@ same mode in `release-matrix.yaml`'s `depends-only` job, so this is a gate
 rather than a manual step, but running it locally is still the fastest way to
 find out which guard is missing.
 
+A Suggest can also be non-optional without being an Import, because an Import
+already requires it. `dbplyr` declares `Imports: DBI`, so DBI sits in the hard
+dependency closure and is installed under `_R_CHECK_DEPENDS_ONLY_=true` like
+any Import; tibble reaches the same place through dplyr. Such a package is
+never absent, so a guard written against it never fires and
+`optional_suggests()` cannot claim it absent — that is why `DBI = FALSE`
+there. Check with `packageDescription("<import>")$Imports`, not by reading this
+package's DESCRIPTION: the closure is a property of another package's metadata,
+so it can change without a commit here. Keeping the Suggests entry is still
+right, because it records a direct use that would need declaring if the closure
+stopped supplying it.
+
 ### Release matrix
 
 `.github/workflows/release-matrix.yaml` checks one built tarball rather than
@@ -109,18 +121,28 @@ run: it fails the job when an optional backend the job did not declare in
 it rather than the workflow calling it as a step, so the assertion cannot be
 dropped from a job that still checks a tarball.
 
-Adding an optional backend means editing three places, and doing only the first
-leaves a contract nothing executes:
+Adding an optional backend means editing three places. Three of the four ways
+to get that wrong fail loudly; the fourth is named at the end:
 
-1. the `skip_if_backend_absent()` call in the tests,
-2. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts in
+1. `optional_suggests()` in `tests/testthat/helper-optional-backends.R`, the
+   one list every other consumer derives from — `optional_backends()` for the
+   subset a job can be asked to withhold, and both `verify-depends-only.R` and
+   `verify-library-isolation.R` through it. Doing only this fails
+   `depends-only`, which requires a `{<package>} is not installed` line that no
+   test would produce.
+2. the `skip_if_backend_absent()` or `backend_available()` call in the tests.
+   Doing only this errors immediately: those helpers refuse a package
+   `optional_suggests()` does not name, since nothing would execute it and
+   nothing would assert it absent.
+3. a `backend` matrix entry in `release-matrix.yaml`, naming its contracts in
    `proves` and its packages in `required` — `required` is also what the
-   isolation assertion reads as the job's declaration,
-3. `optional_backends()` in `.github/scripts/ci-helpers.R`, which is the one
-   list both `verify-depends-only.R` and `verify-library-isolation.R` read.
-   Skipping this one fails the new job rather than passing quietly: a
-   `required` package that `optional_backends()` does not track is refused,
-   because nothing would assert it absent elsewhere.
+   isolation assertion reads as the job's declaration. Doing only this fails
+   the new job: a `required` package `optional_suggests()` does not name is
+   refused.
+
+Doing 1 and 2 without 3 is the combination that still passes quietly. The
+backend is asserted absent everywhere and executed nowhere, so its tests skip
+in every job. Nothing checks that a tracked backend has a matrix entry.
 
 ## Agent skills
 

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -512,9 +512,12 @@ which is what makes the criterion's "cannot regress silently" hold: a step can
 be deleted, and deleting it would restore exactly this finding, whereas every
 job that checks the tarball necessarily makes the assertion. That covers
 `depends-only`, all five `tarball` jobs, and all four `backend` jobs — the ten
-that claim a backend is absent — and it also refuses a `required` package that
-`optional_backends()` does not track, so adding a fifth backend without
-registering it fails rather than going unchecked. The two isolation claims and
+that claim a backend is absent — and it also refuses a `required` package the
+tracked list does not name, so adding a fifth backend without registering it
+fails rather than going unchecked. That list was `optional_backends()` in
+`.github/scripts/ci-helpers.R` as #64 shipped it; #69 collapsed it into
+`optional_suggests()` in `tests/testthat/helper-optional-backends.R`, which is
+where to look now. The two isolation claims and
 both copies of the R-devel rationale are rewritten to what the jobs install.
 
 *Evidence for the fix:* release-matrix run
@@ -622,16 +625,31 @@ run. *Evidence:* `grep -rn "rescan\|single pass"
 tests/testthat/` returns nothing.
 
 **One `skip_if_backend_absent()` call reverses the argument order a CI gate
-depends on** (Standards). **Not fixed — #66.**
-`optional_backends()` in `.github/scripts/ci-helpers.R`, which #64 moved there
-from `verify-depends-only.R`, excludes DBI
-because `skip_if_backend_absent("duckdb", "DBI")` "skips on
-the first missing package, so a `{DBI} is not installed` line never appears".
-`tests/testthat/test-margin-label.R:295` calls it as `("DBI", "duckdb")`. The
-gate still passes, because `test-margin-id.R` and `test-expand-operation.R`
-call it duckdb-first and supply the required `{duckdb} is not installed`
-line — so the convention the script documents is unenforced, not broken.
-*Evidence:* the dependency-only run above skips 14 tests for `{duckdb}`.
+depends on** (Standards). **Fixed — #69, and the finding's premise was wrong.**
+As recorded, the finding read the reason `optional_backends()` in
+`.github/scripts/ci-helpers.R` gave for excluding DBI —
+`skip_if_backend_absent("duckdb", "DBI")` "skips on the first missing package,
+so a `{DBI} is not installed` line never appears" — observed that
+`tests/testthat/test-margin-label.R:295` calls it as `("DBI", "duckdb")`, and
+concluded that the gate passes only because other files call it duckdb-first,
+leaving the convention unenforced rather than broken.
+
+That is not why it passes. `dbplyr` is an Import and declares
+`Imports: DBI (>= 1.1.3)`, so DBI is inside the hard dependency closure and is
+installed in every release-matrix job, `depends-only` included. The reversed
+calls therefore reach `"duckdb"` and emit its skip line like every other call
+site, and no run can produce a `{DBI} is not installed` line at all. The
+closure is the reason DBI is untrackable; the skip order is a consequence of
+it, not the cause. *Evidence:* the dependency-only run above skips 14 tests for
+`{duckdb}` against 13 duckdb-first call sites, so at least one reversed site
+supplied a `{duckdb}` line; and `packageDescription("dbplyr")$Imports` names
+DBI.
+
+The finding also missed the second reversed site,
+`tests/testthat/test-factor.R:63`. #69 reorders both for consistency, records
+the closure reason where the list now lives, and asserts it in
+`test-optional-backends.R`, so a future dbplyr that drops DBI fails a test
+rather than silently making the exclusion wrong.
 
 ### Rejected
 
@@ -692,8 +710,11 @@ two-axis review and Docs & Tests audit with no unresolved findings, which is
 and the two-axis review of package behaviour are clean, and no finding above
 changes a result marginplyr returns. What is not clean is the evidence layer
 the gate is written in terms of. Two of its three tickets are still open:
-`cran-comments.md` states counts the tree no longer produces (#65), and the
-seven smaller standards and spec findings are #66. The third, #64, is fixed —
-the release matrix now withholds the optional backends it documents
-withholding, and a gate fails the workflow if it stops doing so. #40 stays open
-until #65 and #66 close, and no submission is made before then.
+`cran-comments.md` states counts the tree no longer produces (#65), and six of
+the seven smaller standards and spec findings are #66. The seventh, the
+skip-helper argument order, moved to #69, which took it because the finding as
+written was factually wrong about why the gate passes and correcting it belongs
+with the list it names. The third ticket, #64, is fixed — the release matrix
+now withholds the optional backends it documents withholding, and a gate fails
+the workflow if it stops doing so. #40 stays open until #65, #66, and #69
+close, and no submission is made before then.

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -18,11 +18,67 @@ required_suggests <- function() {
   declared[nzchar(declared)]
 }
 
+# The optional Suggests these helpers guard on, and the only list the release
+# matrix reads. It lives here rather than in `.github/` because `.Rbuildignore`
+# excludes `^\.github$` and does not exclude `tests/`: the tarball ships this
+# file, so `.github/scripts/ci-helpers.R` can source it, and a list kept there
+# could not be read back from the tests. Adding a backend starts here, because
+# `backend_available()` below refuses a name this list does not carry.
+#
+# The value answers whether the release matrix can assert the package absent by
+# name. `DBI` cannot. `dbplyr` is an Import and declares `Imports: DBI`, so DBI
+# is inside the hard dependency closure and is installed in every job,
+# `_R_CHECK_DEPENDS_ONLY_=true` included. `verify-depends-only.R` would then
+# require a `{DBI} is not installed` line that no run can produce, and
+# `verify-library-isolation.R` would find DBI on `.libPaths()` in every job that
+# withheld it.
+optional_suggests <- function() {
+  c(
+    arrow = TRUE,
+    duckdb = TRUE,
+    dtplyr = TRUE,
+    RSQLite = TRUE,
+    DBI = FALSE
+  )
+}
+
+# The subset a job can be asked to withhold, which is what the release matrix's
+# absence assertions iterate over. Keeps the name it had while it lived in
+# `ci-helpers.R`, so `verify-depends-only.R` and `verify-library-isolation.R`
+# call it unchanged.
+optional_backends <- function() {
+  asserted <- optional_suggests()
+  names(asserted)[asserted]
+}
+
 # Reports whether an optional backend can be used, and refuses to report FALSE
 # for a backend the running job promised to exercise. Callers that select among
 # several backends use this directly, because dropping one from a list records
 # no skip at all and would otherwise be invisible.
-backend_available <- function(package) {
+#
+# A package `known` does not name is an error rather than FALSE. Nothing in the
+# release matrix executes such a package and nothing asserts it absent, so a
+# guard on it would do nothing while reading as protection; erroring is what
+# makes this test suite the place a backend gets registered. The check runs
+# before `requireNamespace()` so that it fires the same way on a fully
+# provisioned developer machine, where the package is installed and a check
+# placed after it would never be reached.
+#
+# `known` is a parameter only so that this helper's own tests can drive both
+# outcomes. They need a sentinel name no CRAN package uses and a base package
+# that is always installed, and neither belongs in `optional_suggests()`. Every
+# other call site takes the default.
+backend_available <- function(package, known = optional_suggests()) {
+  if (!package %in% names(known)) {
+    stop(sprintf(
+      paste0(
+        "{%s} is not named in `optional_suggests()`, so no release-matrix job ",
+        "executes it and no job asserts it is absent. Add it there, and add a ",
+        "`backend` entry in `release-matrix.yaml`."
+      ),
+      package
+    ))
+  }
   if (requireNamespace(package, quietly = TRUE)) {
     return(TRUE)
   }
@@ -40,9 +96,12 @@ backend_available <- function(package) {
 
 # Skips unless every named backend is installed, keeping testthat's own wording
 # so the skip summary reads the same as it did under `skip_if_not_installed()`.
-skip_if_backend_absent <- function(...) {
+#
+# `known` sits after `...` and so can only be supplied by full name, which keeps
+# it from ever swallowing a backend argument.
+skip_if_backend_absent <- function(..., known = optional_suggests()) {
   for (package in c(...)) {
-    if (!backend_available(package)) {
+    if (!backend_available(package, known = known)) {
       skip(sprintf("{%s} is not installed", package))
     }
   }

--- a/tests/testthat/test-factor.R
+++ b/tests/testthat/test-factor.R
@@ -60,7 +60,7 @@ test_that("reconstruct_factor() works with data.frame", {
 })
 
 test_that("reconstruct_factor() works with duckdb", {
-  skip_if_backend_absent("DBI", "duckdb")
+  skip_if_backend_absent("duckdb", "DBI")
 
   x <- c("a", "b", "c", NA_character_)
   data <- data.frame(

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -292,7 +292,7 @@ test_that("portable SQL consumes named per-column labels lazily", {
 })
 
 test_that("DuckDB uses typed missing for a missing factor Margin label", {
-  skip_if_backend_absent("DBI", "duckdb")
+  skip_if_backend_absent("duckdb", "DBI")
   con <- DBI::dbConnect(duckdb::duckdb())
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -23,6 +23,14 @@ with_required_suggests <- function(value, code) {
 # environment.
 absent_package <- "marginplyrNoSuchBackend"
 
+# The `known` tables the tests below inject. Neither name belongs in
+# `optional_suggests()` -- the sentinel is not a package, and `stats` is a base
+# package rather than an optional backend -- but between them they make both
+# sides of `backend_available()` reachable without depending on which optional
+# backends the checking environment happens to have.
+known_absent <- stats::setNames(TRUE, absent_package)
+known_installed <- c(stats = TRUE)
+
 test_that("required suggests are parsed from the environment variable", {
   with_required_suggests("", expect_identical(required_suggests(), character()))
   with_required_suggests(
@@ -33,12 +41,12 @@ test_that("required suggests are parsed from the environment variable", {
 
 test_that("an absent backend is skippable when no job promised it", {
   with_required_suggests("", {
-    expect_false(backend_available(absent_package))
+    expect_false(backend_available(absent_package, known = known_absent))
     # Caught rather than asserted with `expect_error()`, because testthat lets
     # a skip condition escape an expectation and skip the whole test instead.
     skipped <- tryCatch(
       {
-        skip_if_backend_absent(absent_package)
+        skip_if_backend_absent(absent_package, known = known_absent)
         NULL
       },
       skip = function(condition) condition
@@ -51,11 +59,11 @@ test_that("an absent backend is skippable when no job promised it", {
 test_that("an absent backend fails when the job promised to prove it", {
   with_required_suggests(absent_package, {
     expect_error(
-      backend_available(absent_package),
+      backend_available(absent_package, known = known_absent),
       "MARGINPLYR_REQUIRED_SUGGESTS"
     )
     expect_error(
-      skip_if_backend_absent(absent_package),
+      skip_if_backend_absent(absent_package, known = known_absent),
       "MARGINPLYR_REQUIRED_SUGGESTS"
     )
   })
@@ -63,14 +71,59 @@ test_that("an absent backend fails when the job promised to prove it", {
 
 test_that("promising one backend does not make an unrelated one required", {
   with_required_suggests("duckdb", expect_false(backend_available(
-    absent_package
+    absent_package,
+    known = known_absent
   )))
 })
 
 test_that("an installed backend is available whether or not it is required", {
-  with_required_suggests("", expect_true(backend_available("stats")))
+  with_required_suggests(
+    "",
+    expect_true(backend_available("stats", known = known_installed))
+  )
   with_required_suggests("stats", {
-    expect_true(backend_available("stats"))
-    expect_no_error(skip_if_backend_absent("stats"))
+    expect_true(backend_available("stats", known = known_installed))
+    expect_no_error(skip_if_backend_absent("stats", known = known_installed))
   })
+})
+
+test_that("a package outside the tracked list is refused rather than skipped", {
+  with_required_suggests("", {
+    expect_error(backend_available(absent_package), "optional_suggests")
+    expect_error(skip_if_backend_absent(absent_package), "optional_suggests")
+  })
+})
+
+test_that("an untracked package is refused even when it is installed", {
+  # The refusal runs before `requireNamespace()`. Placed after it, this call
+  # would return TRUE, and a guard on an unregistered backend would go
+  # unnoticed on every provisioned machine and in `R-CMD-check.yaml`.
+  with_required_suggests(
+    "",
+    expect_error(backend_available("stats"), "optional_suggests")
+  )
+})
+
+test_that("optional_backends() is the subset a job can be asked to withhold", {
+  tracked <- optional_suggests()
+  expect_identical(optional_backends(), names(tracked)[tracked])
+  expect_true(all(nzchar(names(tracked))))
+})
+
+test_that("every tracked Suggest is declared in DESCRIPTION", {
+  # A typo in `optional_suggests()` would make `backend_available()` refuse the
+  # real backend at every guard, which reads as a registration error rather
+  # than as the typo it is.
+  declared <- strsplit(packageDescription("marginplyr")$Suggests, ",")[[1]]
+  declared <- trimws(sub("\\(.*", "", declared))
+  expect_true(all(names(optional_suggests()) %in% declared))
+})
+
+test_that("DBI is untrackable because dbplyr puts it in the hard closure", {
+  # The reason `optional_suggests()` records for `DBI = FALSE`, asserted rather
+  # than only written down. If dbplyr ever drops DBI, DBI becomes genuinely
+  # absent under `_R_CHECK_DEPENDS_ONLY_=true` and belongs in the withheld
+  # subset, and this test is what says so.
+  expect_match(packageDescription("dbplyr")$Imports, "\\bDBI\\b")
+  expect_false(optional_suggests()[["DBI"]])
 })


### PR DESCRIPTION
Closes #69. Follow-up to #64; takes one acceptance criterion from #66.

## What changed

The optional-backend list now exists once, in `optional_suggests()` in
`tests/testthat/helper-optional-backends.R`. `.github/scripts/ci-helpers.R`
sources it instead of keeping its own copy.

`.Rbuildignore` excludes `^\.github$` and not `tests/`, so the tarball ships the
helper and not the CI scripts — this is the only direction that can work.
Sourcing from a bare `Rscript` works because the helper's `skip()` call sits
inside a function body and is never evaluated at source time:

```
$ Rscript -e 'source("tests/testthat/helper-optional-backends.R"); print(backend_available("stats"))'
[1] TRUE
```

`backend_available()` refuses a package the list does not name, before
`requireNamespace()` so it fires the same way on a provisioned developer machine
as in a minimal CI job. That closes the direction #64's gate left open: a
backend the tests guard on with no entry in the list.

## The DBI reason was wrong

`ci-helpers.R` recorded DBI's exclusion as a consequence of
`skip_if_backend_absent("duckdb", "DBI")` skipping on the first missing package.
The cause is upstream: `dbplyr` is an Import and declares `Imports: DBI`, so DBI
is inside the hard dependency closure and is installed in every job. No run can
produce a `{DBI} is not installed` line at all.

Local depends-only check on the built tarball:

```
36:• {RSQLite} is not installed (5)
39:• {arrow} is not installed (12)
46:• {dtplyr} is not installed (33)
63:• {duckdb} is not installed (14)
```

Zero `{DBI}` lines, and 14 `{duckdb}` skips — which is what
`design/review-dispositions.md` §8 already recorded, against 13 duckdb-first
call sites at the time. At least one of the two reversed sites therefore emitted
a `{duckdb}` line, which it could only do with DBI present.

`test-optional-backends.R` now asserts the dbplyr metadata the exclusion rests
on, so a future dbplyr that drops DBI fails a test rather than silently making
the exclusion wrong.

## #66's argument-order criterion

That finding's premise — the gate passes only because other files call it
duckdb-first — is false for the reason above. Both reversed call sites are
reordered for consistency (`test-factor.R:63` is the one #66 missed), the
finding is dispositioned Fixed in §8 with the correction, and #66's checklist
points here.

## Out of scope

Statically checking that every tracked backend has exactly one `backend` matrix
entry. That is the one omission still passing quietly, named as such in
`AGENTS.md`, and whether it earns a job is decided after this lands.

## Checks

- `pkgload::load_all()` + `lintr::lint_package()` → 0 lints
- `lintr::lint_dir(".github", object_usage_linter = NULL)` → 0 lints
- `R CMD check --as-cran` on the built tarball → **Status: OK**
- `_R_CHECK_DEPENDS_ONLY_=true R CMD check --as-cran` on the same tarball →
  **Status: OK**, 1110 pass / 68 skip
- `verify-depends-only.R` against that check → `Verified: 1110 tests passed with
  68 skipped, and arrow, duckdb, dtplyr, RSQLite were all withheld`
- `verify-library-isolation.R` with an untracked declaration → refused, naming
  the list's new location; with `DBI` alone → accepted as a non-claim

No `R/`, `man/`, `NAMESPACE`, or vignette changes, so no roxygen regeneration.