### PR TITLE
Correct the placement rationale and the partial-edit count

### DIFF
--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -53,10 +53,10 @@ test_output_path <- function(rcheck, test = "testthat") {
 
 # `optional_suggests()` and `optional_backends()`, the one list of optional
 # backends the release matrix reasons about. It is defined with the guards that
-# consume it rather than here, because `.Rbuildignore` excludes `^\.github$`
-# and does not exclude `tests/`: the tarball ships the helper, so this file can
-# read it and a list kept here could not be read back from the tests. Every job
-# that runs these scripts checks out the repository, so the path resolves.
+# consume it rather than here; the helper's own comment records why that
+# direction is forced. This reads the working tree rather than the built
+# tarball, and every job that runs these scripts checks out the repository, so
+# the path resolves.
 #
 # `source()` evaluates top-level expressions only, and the helper's sole
 # testthat call sits inside `skip_if_backend_absent()`'s body, so this works

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,15 +121,17 @@ run: it fails the job when an optional backend the job did not declare in
 it rather than the workflow calling it as a step, so the assertion cannot be
 dropped from a job that still checks a tarball.
 
-Adding an optional backend means editing three places. Three of the four ways
-to get that wrong fail loudly; the fourth is named at the end:
+Adding an optional backend means editing three places. Every partial edit fails
+loudly except one, which is named at the end:
 
 1. `optional_suggests()` in `tests/testthat/helper-optional-backends.R`, the
    one list every other consumer derives from — `optional_backends()` for the
    subset a job can be asked to withhold, and both `verify-depends-only.R` and
    `verify-library-isolation.R` through it. Doing only this fails
-   `depends-only`, which requires a `{<package>} is not installed` line that no
-   test would produce.
+   `depends-only`: a `TRUE` entry makes `verify-depends-only.R` require a
+   `{<package>} is not installed` line that no test would produce. A `FALSE`
+   entry claims no absence and so is asserted by nothing, which is the DBI case
+   above.
 2. the `skip_if_backend_absent()` or `backend_available()` call in the tests.
    Doing only this errors immediately: those helpers refuse a package
    `optional_suggests()` does not name, since nothing would execute it and
@@ -140,9 +142,10 @@ to get that wrong fail loudly; the fourth is named at the end:
    the new job: a `required` package `optional_suggests()` does not name is
    refused.
 
-Doing 1 and 2 without 3 is the combination that still passes quietly. The
+Doing 1 and 2 without 3 is the one combination that still passes quietly. The
 backend is asserted absent everywhere and executed nowhere, so its tests skip
-in every job. Nothing checks that a tracked backend has a matrix entry.
+in every job. Nothing checks that a tracked backend has a matrix entry; #71
+tracks whether it should, deferred from #69 rather than overlooked.
 
 ## Agent skills
 

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -19,10 +19,12 @@ required_suggests <- function() {
 }
 
 # The optional Suggests these helpers guard on, and the only list the release
-# matrix reads. It lives here rather than in `.github/` because `.Rbuildignore`
-# excludes `^\.github$` and does not exclude `tests/`: the tarball ships this
-# file, so `.github/scripts/ci-helpers.R` can source it, and a list kept there
-# could not be read back from the tests. Adding a backend starts here, because
+# matrix reads. Which side of the repository it lives on is forced, not
+# preferred: `R CMD check` runs these tests from the unpacked tarball, and
+# `.Rbuildignore` excludes `^\.github$` from that tarball, so a list kept in
+# `.github/scripts/` would not exist where the tests execute. The CI scripts run
+# from the checkout instead and can read this file, which makes `tests/` the
+# only placement both sides reach. Adding a backend starts here, because
 # `backend_available()` below refuses a name this list does not carry.
 #
 # The value answers whether the release matrix can assert the package absent by

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -105,9 +105,19 @@ test_that("an untracked package is refused even when it is installed", {
 })
 
 test_that("optional_backends() is the subset a job can be asked to withhold", {
-  tracked <- optional_suggests()
-  expect_identical(optional_backends(), names(tracked)[tracked])
-  expect_true(all(nzchar(names(tracked))))
+  backends <- optional_backends()
+  # `verify-depends-only.R` iterates over this to require one skip line per
+  # backend, and `verify-library-isolation.R` to decide what must be absent. A
+  # derivation that returned nothing would leave both asserting nothing while
+  # still reporting success, so emptiness is the failure worth naming.
+  expect_type(backends, "character")
+  expect_gt(length(backends), 0L)
+  expect_null(names(backends))
+  # Approached from the other side than the derivation, so an inverted or
+  # ignored flag fails here rather than restating the function body.
+  untrackable <- names(optional_suggests())[!optional_suggests()]
+  expect_false(any(untrackable %in% backends))
+  expect_true(all(nzchar(names(optional_suggests()))))
 })
 
 test_that("every tracked Suggest is declared in DESCRIPTION", {


### PR DESCRIPTION
Follow-up to #69 / #70. A two-axis review of that merge found three comment
claims that are not true of what the code does, plus one assertion that cannot
fail. No behaviour changes.

## Standards axis

**The placement rationale credited the wrong fact**, in both
`.github/scripts/ci-helpers.R` and `tests/testthat/helper-optional-backends.R`.
It said the tarball shipping the helper is why `ci-helpers.R` can source it —
but `ci-helpers.R` reads the working tree, not the tarball, so that fact does no
work there.

The direction that is actually forced is the other one: `R CMD check` runs the
tests from the unpacked tarball, `.Rbuildignore` excludes `^\.github$` from it,
so a list kept in `.github/scripts/` would not exist where the tests execute.

Verified against the tarball built from this tree:

```
$ tar -tzf marginplyr_0.1.0.tar.gz | grep -c '\.github'
0
$ tar -tzf marginplyr_0.1.0.tar.gz | grep helper-optional
marginplyr/tests/testthat/helper-optional-backends.R
$ ls -a marginplyr.Rcheck/ | grep github
(absent)
```

The reasoning also existed in two files. It now lives once, with the list.

**`AGENTS.md` miscounted.** "Three of the four ways to get that wrong fail
loudly" — a strict subset of three steps has six ways. The two the sentence
omitted (table + matrix without a guard; guard + matrix without the table) both
fail loudly as well, so five of six do. Reworded to avoid the count.

**A tautological assertion.** `expect_identical(optional_backends(),
names(tracked)[tracked])` restated the function body, so no logic error could
fail it. It now asserts what the consumers actually depend on — a non-empty,
unnamed character vector, because an empty one would leave
`verify-depends-only.R` and `verify-library-isolation.R` asserting nothing while
still reporting success — and checks the flag from the complement side, so an
inverted flag fails.

## Spec axis

#69 asked that the remaining gap be named as **deferred**. `AGENTS.md` named the
gap but not that it was a chosen deferral, so a reader could not tell it from an
oversight. It now points at #71.

Also corrected on the same list: item 1's claim that a lone entry fails
`depends-only` holds for a `TRUE` entry only. A `FALSE` one claims no absence
and is asserted by nothing — the DBI shape.

## Not changed

The `known =` parameter was flagged as Speculative Generality. It is the
injection point that makes the refusal testable at all, chosen in #69's design
session over registering the sentinel in `optional_suggests()`. Kept.

## Checks

- `lintr::lint_package()` and `lintr::lint_dir(".github", …)` → 0 lints
- Full `testthat::test_local()` → 0 failures; `optional-backends` now 22 passes