### PR TITLE
Fail CI when a tracked backend has no release-matrix entry

### DIFF
--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -66,12 +66,24 @@ test_output_path <- function(rcheck, test = "testthat") {
 # purpose is the separation.
 source("tests/testthat/helper-optional-backends.R")
 
-# Reads a delimited list out of the environment, the form the workflow's matrix
-# entries are written in. Package lists are comma-separated; test names are
-# separated by `;`, because a test name may contain a comma.
-env_list <- function(name, sep = ",") {
-  declared <- trimws(strsplit(Sys.getenv(name, ""), sep, fixed = TRUE)[[1]])
+# Splits a delimited list, the form the workflow's matrix entries are written
+# in. Package lists are comma-separated; test names are separated by `;`,
+# because a test name may contain a comma.
+#
+# Separate from `env_list()` because `verify-matrix-coverage.R` reads the same
+# fields out of the workflow file rather than out of the environment, and both
+# readings have to agree on what a list is: a `required` value that this script
+# splits differently from the job that consumes it would compare two different
+# package sets.
+split_list <- function(value, sep = ",") {
+  declared <- trimws(strsplit(value, sep, fixed = TRUE)[[1]])
   declared[nzchar(declared)]
+}
+
+# The same list read out of the environment, which is how a matrix entry reaches
+# the job that acts on it.
+env_list <- function(name, sep = ",") {
+  split_list(Sys.getenv(name, ""), sep)
 }
 
 write_step_summary <- function(lines) {

--- a/.github/scripts/verify-matrix-coverage.R
+++ b/.github/scripts/verify-matrix-coverage.R
@@ -1,0 +1,198 @@
+# Confirms that every optional backend the test suite tracks is executed by a
+# `backend` job.
+#
+# `AGENTS.md`'s "Adding an optional backend" list has three entries, and #69
+# made three of the four ways to get it wrong fail loudly. This is the fourth
+# (#71): a backend added to `optional_suggests()` and guarded in the tests, with
+# no `backend` matrix entry, produces a green workflow. Every job correctly
+# asserts it absent -- that half works -- and no job ever runs it. Its contracts
+# are written and never executed, which is the failure
+# `MARGINPLYR_REQUIRED_SUGGESTS` and `verify-backend.R` exist to rule out,
+# arrived at from the other direction.
+#
+# This has to be a CI job rather than a test in the package's own suite.
+# `.Rbuildignore` excludes `^\.github$`, so the tarball does not ship
+# `release-matrix.yaml` and a test run from the tarball cannot read it -- the
+# direction that made #69 work does not work here. This script runs from the
+# checkout instead, and reads `optional_suggests()` out of
+# `tests/testthat/helper-optional-backends.R` through `ci-helpers.R`, so #69's
+# single source stays single and this file carries no list of its own.
+#
+# The matrix is parsed with the `yaml` package rather than matched with a regex
+# over the `backend:` block. The failure modes decide it: a regex that stops
+# matching -- because an entry gained a comment, changed its quoting, or moved
+# -- finds no entries to complain about and passes, which is the same silent
+# green this script exists to remove. `yaml` has no dependencies and the job
+# installs it directly; DESCRIPTION does not need it, because `.github/scripts/`
+# may use packages installed only for CI.
+#
+# #71 named three candidate assertions. One ships:
+#
+#   Every package `optional_backends()` names has exactly one `backend` matrix
+#   entry naming it in `required`. Nothing covers this today. "Exactly one"
+#   rather than "at least one" because an entry's `proves` list is the only
+#   place a backend's contracts are named and its `cache-version` is derived
+#   from its `name`, so a backend split across two entries has no single answer
+#   to either.
+#
+# Two do not:
+#
+#   Every name in `required` is named by `optional_suggests()`.
+#   `verify-library-isolation.R` already refuses this, at the point the claim is
+#   made and against the library the job actually got. #64's reasoning keeps it
+#   there: `check-tarball.R` sources it, so a job cannot drop the assertion
+#   while still checking anything. A static copy would give one mistake a second
+#   wording to keep in step with the first and would buy only an earlier
+#   failure.
+#
+#   Every job that runs with optional backends withheld runs `check-tarball.R`.
+#   This guards a job that does not exist yet, and it is not the same kind of
+#   static property as the assertion above: withholding is the default, so the
+#   check would first have to decide which jobs make a claim worth asserting,
+#   which is a judgement about a job's shape rather than a fact the file states.
+#   Deferred rather than dismissed -- the case to reopen it is a job that
+#   declares `MARGINPLYR_REQUIRED_SUGGESTS` and checks no tarball.
+
+source(".github/scripts/ci-helpers.R")
+
+# `MARGINPLYR_WORKFLOW` is a knob for this script's own verification, not for
+# the workflow, which never sets it. A gate whose failure path has never been
+# executed is a gate on trust, and the real file is correct by construction, so
+# the only way to see the message this script exists to print is to point it at
+# a fixture. Same reason `backend_available()` takes a `known` argument.
+workflow_path <- Sys.getenv(
+  "MARGINPLYR_WORKFLOW",
+  ".github/workflows/release-matrix.yaml"
+)
+
+if (!file.exists(workflow_path)) {
+  stop(call. = FALSE, sprintf("No workflow file at '%s'.", workflow_path))
+}
+
+workflow <- yaml::read_yaml(workflow_path)
+entries <- workflow$jobs$backend$strategy$matrix$backend
+
+# A missing or empty matrix says the file moved out from under this script,
+# which is a different problem from a backend having no entry and reads better
+# as its own message than as four identical "no entry" lines.
+if (!is.list(entries) || length(entries) == 0L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "`jobs.backend.strategy.matrix.backend` in '%s' is missing or empty, so ",
+      "this check cannot tell which backends the release matrix executes."
+    ),
+    workflow_path
+  ))
+}
+
+entry_name <- function(entry) {
+  if (is.null(entry$name)) "(unnamed entry)" else entry$name
+}
+
+# `required` rather than `packages` is what makes an entry count as executing a
+# backend: it is what the job sets `MARGINPLYR_REQUIRED_SUGGESTS` from, so it is
+# the field that turns a failed install into a failed job instead of a skip. An
+# entry that installed a backend without naming it there would prove nothing.
+entries_naming <- function(package, matrix_entries) {
+  declared <- vapply(
+    matrix_entries,
+    function(entry) {
+      required <- if (is.null(entry$required)) "" else entry$required
+      package %in% split_list(required)
+    },
+    logical(1)
+  )
+  vapply(matrix_entries[declared], entry_name, character(1))
+}
+
+backends <- optional_backends()
+covering <- lapply(backends, entries_naming, matrix_entries = entries)
+names(covering) <- backends
+counts <- lengths(covering)
+
+describe <- function(package) {
+  if (counts[[package]] == 0L) {
+    return("no `backend` entry")
+  }
+  sprintf(
+    "%s %s",
+    if (counts[[package]] == 1L) "entry" else "entries",
+    paste(sprintf("`%s`", covering[[package]]), collapse = ", ")
+  )
+}
+
+verdict <- rep("OK", length(backends))
+verdict[counts == 0L] <- "MISSING"
+verdict[counts > 1L] <- "DUPLICATE"
+
+write_step_summary(c(
+  "## Backend matrix coverage",
+  "",
+  sprintf(
+    "%d of %d tracked backends have exactly one `backend` entry in `%s`.",
+    sum(counts == 1L),
+    length(backends),
+    workflow_path
+  ),
+  "",
+  paste0(
+    "- ", verdict,
+    " **", backends, "** — ",
+    vapply(backends, describe, character(1))
+  )
+))
+
+problems <- character()
+
+uncovered <- backends[counts == 0L]
+if (length(uncovered) > 0L) {
+  problems <- c(problems, sprintf(
+    paste0(
+      "%s named by `optional_suggests()` in ",
+      "`tests/testthat/helper-optional-backends.R` but has no `backend` ",
+      "matrix entry in `%s`, so no job executes it and its contracts skip ",
+      "everywhere. Add an entry naming it in `required` and its contract ",
+      "tests in `proves`."
+    ),
+    if (length(uncovered) == 1L) {
+      sprintf("%s is", uncovered)
+    } else {
+      sprintf("%s are", paste(uncovered, collapse = ", "))
+    },
+    workflow_path
+  ))
+}
+
+duplicated_backends <- backends[counts > 1L]
+if (length(duplicated_backends) > 0L) {
+  problems <- c(problems, sprintf(
+    paste0(
+      "These backends are named in `required` by more than one `backend` ",
+      "matrix entry in `%s`, which leaves their contracts and dependency ",
+      "cache without one entry to read them from: %s."
+    ),
+    workflow_path,
+    paste(
+      sprintf(
+        "%s (%s)",
+        duplicated_backends,
+        vapply(
+          duplicated_backends,
+          function(package) paste(covering[[package]], collapse = ", "),
+          character(1)
+        )
+      ),
+      collapse = "; "
+    )
+  ))
+}
+
+if (length(problems) > 0L) {
+  stop(call. = FALSE, paste(problems, collapse = " "))
+}
+
+message(sprintf(
+  "Verified: %s each have a `backend` matrix entry in %s.",
+  paste(backends, collapse = ", "),
+  workflow_path
+))

--- a/.github/scripts/verify-matrix-coverage.R
+++ b/.github/scripts/verify-matrix-coverage.R
@@ -50,20 +50,26 @@
 #   static property as the assertion above: withholding is the default, so the
 #   check would first have to decide which jobs make a claim worth asserting,
 #   which is a judgement about a job's shape rather than a fact the file states.
-#   Deferred rather than dismissed -- the case to reopen it is a job that
-#   declares `MARGINPLYR_REQUIRED_SUGGESTS` and checks no tarball.
+#   Deferred rather than dismissed, and #73 is where it is recorded -- the case
+#   to act on it is a job that declares `MARGINPLYR_REQUIRED_SUGGESTS` and
+#   checks no tarball.
+#
+# This script runs as a workflow step rather than being sourced by another
+# script, which is the arrangement #64 argued against for
+# `verify-library-isolation.R` on the grounds that a step can be deleted. There
+# is nothing here to source it from: no other job reads a workflow file, and
+# attaching it to `check-tarball.R` would make a claim about this repository
+# depend on a tarball that does not contain the file being read. Deleting the
+# step deletes the only job that has one, which is visible in a way that
+# dropping one assertion from a job that still checks a tarball is not.
 
 source(".github/scripts/ci-helpers.R")
 
-# `MARGINPLYR_WORKFLOW` is a knob for this script's own verification, not for
-# the workflow, which never sets it. A gate whose failure path has never been
-# executed is a gate on trust, and the real file is correct by construction, so
-# the only way to see the message this script exists to print is to point it at
-# a fixture. Same reason `backend_available()` takes a `known` argument.
-workflow_path <- Sys.getenv(
-  "MARGINPLYR_WORKFLOW",
-  ".github/workflows/release-matrix.yaml"
-)
+# Fixed rather than read from the environment, as in the sibling scripts, which
+# name the file they assert against. The failure path is reachable without a
+# knob: adding a name to `optional_suggests()` is the mistake this script exists
+# to catch, and doing it locally prints the message.
+workflow_path <- ".github/workflows/release-matrix.yaml"
 
 if (!file.exists(workflow_path)) {
   stop(call. = FALSE, sprintf("No workflow file at '%s'.", workflow_path))
@@ -93,11 +99,16 @@ entry_name <- function(entry) {
 # backend: it is what the job sets `MARGINPLYR_REQUIRED_SUGGESTS` from, so it is
 # the field that turns a failed install into a failed job instead of a skip. An
 # entry that installed a backend without naming it there would prove nothing.
+# `unlist()` before splitting because YAML gives `required` back as a character
+# vector when it is written as a block sequence and as one string when it is
+# written inline, as every entry is today. Without it the parsed list would keep
+# only its first element, and a backend named second would be reported missing
+# with a message blaming the wrong thing.
 entries_naming <- function(package, matrix_entries) {
   declared <- vapply(
     matrix_entries,
     function(entry) {
-      required <- if (is.null(entry$required)) "" else entry$required
+      required <- paste(unlist(entry$required), collapse = ",")
       package %in% split_list(required)
     },
     logical(1)
@@ -144,22 +155,22 @@ write_step_summary(c(
 
 problems <- character()
 
+# Collective phrasing throughout, as in `verify-library-isolation.R`. A message
+# that reads correctly for one backend and for several needs no branch on the
+# count, and a branch that pluralized only part of a sentence would leave the
+# rest disagreeing.
 uncovered <- backends[counts == 0L]
 if (length(uncovered) > 0L) {
   problems <- c(problems, sprintf(
     paste0(
-      "%s named by `optional_suggests()` in ",
-      "`tests/testthat/helper-optional-backends.R` but has no `backend` ",
-      "matrix entry in `%s`, so no job executes it and its contracts skip ",
-      "everywhere. Add an entry naming it in `required` and its contract ",
-      "tests in `proves`."
+      "These backends are named by `optional_suggests()` in ",
+      "`tests/testthat/helper-optional-backends.R` but have no `backend` ",
+      "matrix entry in `%s`, so no job executes them and their contracts ",
+      "skip everywhere: %s. Add an entry for each, naming it in `required` ",
+      "and its contract tests in `proves`."
     ),
-    if (length(uncovered) == 1L) {
-      sprintf("%s is", uncovered)
-    } else {
-      sprintf("%s are", paste(uncovered, collapse = ", "))
-    },
-    workflow_path
+    workflow_path,
+    paste(uncovered, collapse = ", ")
   ))
 }
 
@@ -173,15 +184,11 @@ if (length(duplicated_backends) > 0L) {
     ),
     workflow_path,
     paste(
-      sprintf(
-        "%s (%s)",
+      sprintf("%s (%s)", duplicated_backends, vapply(
         duplicated_backends,
-        vapply(
-          duplicated_backends,
-          function(package) paste(covering[[package]], collapse = ", "),
-          character(1)
-        )
-      ),
+        function(package) paste(covering[[package]], collapse = ", "),
+        character(1)
+      )),
       collapse = "; "
     )
   ))

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -9,6 +9,8 @@
 #
 # The jobs divide the work:
 #
+#   coverage      reads this file against `optional_suggests()` and fails when
+#                 a tracked backend has no `backend` entry below.
 #   build         produces the single tarball every other job checks.
 #   depends-only  rebuilds examples, tests, and vignettes with Suggested
 #                 packages withheld (`_R_CHECK_DEPENDS_ONLY_=true`).
@@ -72,6 +74,46 @@ env:
   _R_CHECK_CRAN_INCOMING_REMOTE_: false
 
 jobs:
+  # The `backend` matrix below is the only thing that executes an optional
+  # backend, and until now nothing checked that it named all of them: a backend
+  # added to `optional_suggests()` and guarded in the tests, with no entry here,
+  # left a green workflow in which every job correctly asserted it absent and no
+  # job ever ran it (#71). This job reads this file against that list.
+  #
+  # It takes no `needs`, because it asserts a static property of the repository
+  # and nothing it reads comes from the tarball. Failing before `build` finishes
+  # is the point: the answer does not depend on anything the other jobs produce.
+  #
+  # It also installs no dependencies through `setup-r-dependencies`, so it has
+  # no `cache-version` and stands outside the isolation scheme above. That is
+  # consistent rather than an exemption -- the scheme separates jobs by which
+  # optional backends they can see, and this job neither installs nor loads any
+  # package under test.
+  coverage:
+    name: Backend matrix coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      # `yaml` parses this file. It has no dependencies of its own and is not in
+      # DESCRIPTION: `.github/scripts/` may use packages installed only for CI,
+      # and promoting a parser used by one CI script into the package's metadata
+      # would be exactly the false Import `AGENTS.md` warns about. The
+      # alternative, a regex over the `backend:` block, fails open -- a pattern
+      # that stops matching finds nothing to report and passes.
+      - name: Install the YAML parser
+        run: install.packages("yaml")
+        shell: Rscript {0}
+
+      - name: Verify every tracked backend has a matrix entry
+        run: Rscript .github/scripts/verify-matrix-coverage.R
+
   build:
     name: Build source tarball
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,16 +122,17 @@ it rather than the workflow calling it as a step, so the assertion cannot be
 dropped from a job that still checks a tarball.
 
 Adding an optional backend means editing three places. Every partial edit fails
-loudly except one, which is named at the end:
+loudly:
 
 1. `optional_suggests()` in `tests/testthat/helper-optional-backends.R`, the
    one list every other consumer derives from — `optional_backends()` for the
-   subset a job can be asked to withhold, and both `verify-depends-only.R` and
-   `verify-library-isolation.R` through it. Doing only this fails
-   `depends-only`: a `TRUE` entry makes `verify-depends-only.R` require a
-   `{<package>} is not installed` line that no test would produce. A `FALSE`
-   entry claims no absence and so is asserted by nothing, which is the DBI case
-   above.
+   subset a job can be asked to withhold, and `verify-depends-only.R`,
+   `verify-library-isolation.R`, and `verify-matrix-coverage.R` through it.
+   Doing only this fails `coverage`, which reads the list against the `backend`
+   matrix, and `depends-only`, where a `TRUE` entry makes
+   `verify-depends-only.R` require a `{<package>} is not installed` line that no
+   test would produce. A `FALSE` entry claims no absence and so is asserted by
+   nothing, which is the DBI case above.
 2. the `skip_if_backend_absent()` or `backend_available()` call in the tests.
    Doing only this errors immediately: those helpers refuse a package
    `optional_suggests()` does not name, since nothing would execute it and
@@ -142,10 +143,16 @@ loudly except one, which is named at the end:
    the new job: a `required` package `optional_suggests()` does not name is
    refused.
 
-Doing 1 and 2 without 3 is the one combination that still passes quietly. The
-backend is asserted absent everywhere and executed nowhere, so its tests skip
-in every job. Nothing checks that a tracked backend has a matrix entry; #71
-tracks whether it should, deferred from #69 rather than overlooked.
+Doing 1 and 2 without 3 used to pass quietly — the backend was asserted absent
+everywhere and executed nowhere, so its tests skipped in every job.
+`verify-matrix-coverage.R`, run by the `coverage` job, closes that (#71): it
+parses `release-matrix.yaml` and fails when a package `optional_backends()`
+names has no `backend` entry, or has more than one. It is the only job that
+reads a workflow file as data, which is why it is the only one that installs
+`yaml`. Its header records the two further assertions #71 considered and why
+neither ships; the short version is that `verify-library-isolation.R` already
+makes one of them where the claim is made, and the other would guard a job that
+does not exist.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,12 @@ loudly:
    one list every other consumer derives from — `optional_backends()` for the
    subset a job can be asked to withhold, and `verify-depends-only.R`,
    `verify-library-isolation.R`, and `verify-matrix-coverage.R` through it.
-   Doing only this fails `coverage`, which reads the list against the `backend`
-   matrix, and `depends-only`, where a `TRUE` entry makes
-   `verify-depends-only.R` require a `{<package>} is not installed` line that no
-   test would produce. A `FALSE` entry claims no absence and so is asserted by
-   nothing, which is the DBI case above.
+   A `TRUE` entry alone fails `coverage`, which reads the list against the
+   `backend` matrix, and `depends-only`, where it makes `verify-depends-only.R`
+   require a `{<package>} is not installed` line that no test would produce. A
+   `FALSE` entry claims no absence, so `optional_backends()` filters it out
+   before either of those sees it and nothing asserts it — which is the DBI case
+   above, and the reason that value exists.
 2. the `skip_if_backend_absent()` or `backend_available()` call in the tests.
    Doing only this errors immediately: those helpers refuse a package
    `optional_suggests()` does not name, since nothing would execute it and
@@ -150,9 +151,9 @@ parses `release-matrix.yaml` and fails when a package `optional_backends()`
 names has no `backend` entry, or has more than one. It is the only job that
 reads a workflow file as data, which is why it is the only one that installs
 `yaml`. Its header records the two further assertions #71 considered and why
-neither ships; the short version is that `verify-library-isolation.R` already
-makes one of them where the claim is made, and the other would guard a job that
-does not exist.
+neither ships: `verify-library-isolation.R` already makes one of them where the
+claim is made, and the other would guard a job that does not exist, which #73
+holds open.
 
 ## Agent skills
 


### PR DESCRIPTION
Closes #71. Follow-up to #69, which named this as the one remaining gap. Defers
one assertion to #73.

## What changed

`AGENTS.md`'s "Adding an optional backend" list has three entries, and #69 made
three of the four ways to get it wrong fail loudly. This is the fourth: a
backend added to `optional_suggests()` and guarded in the tests, with no
`backend` matrix entry, produced a green workflow. Every job correctly asserted
it absent — that half worked — and no job ever ran it, so its contracts were
written and never executed.

`.github/scripts/verify-matrix-coverage.R` reads `release-matrix.yaml` against
`optional_suggests()` and fails when a package `optional_backends()` names has
no `backend` entry, or has more than one. It carries no list of its own, so
#69's single source stays single. A new `coverage` job runs it.

## Why a job, and why `yaml`

`.Rbuildignore` excludes `^\.github$`, so the tarball does not ship the workflow
and a test run from the tarball cannot read it — the direction that made #69
work does not work here. The script runs from the checkout instead.

The matrix is parsed rather than matched with a regex because the failure modes
differ: a regex that stops matching — an entry gains a comment, changes quoting,
or moves — finds no entries to complain about and passes, which is the same
silent green the script exists to remove. `yaml` has no dependencies, the job
installs it directly, and DESCRIPTION does not gain it; `.github/scripts/` may
use packages installed only for CI.

The `coverage` job takes no `needs`, because it asserts a static property and
nothing it reads comes from the tarball. It installs nothing through
`setup-r-dependencies`, so it has no `cache-version` and stands outside the
library-isolation scheme — consistent rather than exempt, since that scheme
separates jobs by which optional backends they can see and this job loads none.

## Which assertions ship

#71 named three. One ships: every package `optional_backends()` names has
exactly one `backend` entry naming it in `required`. "Exactly one" rather than
"at least one" because an entry's `proves` list is the only place a backend's
contracts are named and its `cache-version` is derived from its `name`, so a
backend split across two entries has no single answer to either.

Two do not, and the script's header records why. `verify-library-isolation.R`
already refuses a `required` package `optional_suggests()` does not name, at the
point the claim is made and against the library the job actually got; a static
copy would give one mistake a second wording to keep in step with the first. The
third guards a job that does not exist yet and is not the same kind of static
property — withholding is the default, so the check would first have to decide
which jobs make a claim worth asserting. #73 holds it open rather than a
paragraph with no tracker.

## Verification

Driven by editing the real files. The script takes no path argument: adding a
name to `optional_suggests()` is the mistake it exists to catch, so doing that
locally prints the message.

| Case | Result |
| --- | --- |
| Real workflow | green, 4 of 4 |
| One tracked backend, no entry | fails, names `polars` and both files |
| Three tracked backends, no entry | fails, message agrees in number |
| Two entries naming `arrow` | fails, names both entries |
| `required:` as a block sequence | green |
| `backend:` matrix removed | fails with its own message |

```
$ Rscript .github/scripts/verify-matrix-coverage.R
Error: These backends are named by `optional_suggests()` in
`tests/testthat/helper-optional-backends.R` but have no `backend` matrix entry
in `.github/workflows/release-matrix.yaml`, so no job executes them and their
contracts skip everywhere: polars. Add an entry for each, naming it in
`required` and its contract tests in `proves`.
```

`lintr::lint_dir(".github", ...)` clean; `devtools::test()` 1523 passing, 0
failures, 0 skipped.

## Review corrections

The second commit applies five findings from the standards and spec reviews.
The two worth naming here: an earlier `MARGINPLYR_WORKFLOW` env var was
justified as the knob that made the failure path reachable, citing
`backend_available()`'s `known` argument as precedent — but `known` has ten call
sites and the knob had none, so it went. And `entries_naming()` now `unlist()`s
`required` before splitting, because `split_list()` keeps only the first element
of a block sequence and a backend named second would have been reported missing
with a message blaming the wrong thing.