### PR TITLE
Clear the standards and spec findings from the readiness review

### DIFF
--- a/R/parent-share.R
+++ b/R/parent-share.R
@@ -1036,25 +1036,42 @@ check_parent_scalar <- function(value,
       call = call
     )
   }
-  if (
-    !typeof(value) %in% c("integer", "double") ||
-      is.object(value)
-  ) {
-    detected_type <- if (is.object(value)) class(value) else typeof(value)
-    abort_marginplyr(
-      paste0(
-        "Parent share `", parent_output, "` requires source summary `",
-        source_summary,
-        "` to be a plain integer or double scalar; detected type ",
-        paste(detected_type, collapse = "/"),
-        ". Convert it explicitly in the ordinary summary."
-      ),
+  if (!is_parent_source_type(value)) {
+    abort_parent_source_type(
+      value,
       parent_output = parent_output,
       source_summary = source_summary,
       call = call
     )
   }
   value
+}
+
+# The eligible-type rule and its diagnostic have two raising sites — the check
+# wrapped around each summary expression, and the local backend's re-check of
+# the collected result. They share one definition so the handler-visible fields
+# cannot drift away from the message again.
+is_parent_source_type <- function(value) {
+  typeof(value) %in% c("integer", "double") && !is.object(value)
+}
+
+abort_parent_source_type <- function(value,
+                                     parent_output,
+                                     source_summary,
+                                     call) {
+  detected_type <- if (is.object(value)) class(value) else typeof(value)
+  abort_marginplyr(
+    paste0(
+      "Parent share `", parent_output, "` requires source summary `",
+      source_summary,
+      "` to be a plain integer or double scalar; detected type ",
+      paste(detected_type, collapse = "/"),
+      ". Convert it explicitly in the ordinary summary."
+    ),
+    parent_output = parent_output,
+    source_summary = source_summary,
+    call = call
+  )
 }
 
 parent_call_text <- function(call) {
@@ -1519,7 +1536,7 @@ execute_local_parent_shares <- function(operation,
                                         result,
                                         requests,
                                         set_id_name) {
-  check_local_parent_share_types(result, requests)
+  check_local_parent_share_types(result, requests, call = operation$call)
   apply_joined_parent_shares(
     result,
     requests = requests,
@@ -1571,6 +1588,13 @@ apply_joined_parent_shares <- function(result,
     prefix = "..marginplyr_parent_value_"
   )
   names(denominator_names) <- sources
+
+  # The cleanup at the end of this function drops whatever internal columns
+  # were added, so empty is what it needs when no grouping set has a parent
+  # and no join happens — and for `right_join_names`, also on the non-SQL
+  # path, which joins by name and renames nothing.
+  join_key_names <- character()
+  right_join_names <- character()
 
   child_ids <- plan$set_ids[!is.na(parent_ids)]
   if (length(child_ids) > 0L) {
@@ -1640,7 +1664,6 @@ apply_joined_parent_shares <- function(result,
         y_as = "RHS"
       )
     } else {
-      right_join_names <- character()
       result <- dplyr::left_join(
         result,
         mapping,
@@ -1679,16 +1702,8 @@ apply_joined_parent_shares <- function(result,
 
   internal_names <- c(
     unname(denominator_names),
-    if (exists("right_join_names", inherits = FALSE)) {
-      right_join_names
-    } else {
-      character()
-    },
-    if (exists("join_key_names", inherits = FALSE)) {
-      unname(join_key_names)
-    } else {
-      character()
-    }
+    right_join_names,
+    unname(join_key_names)
   )
   internal_names <- intersect(
     internal_names,
@@ -1817,7 +1832,7 @@ add_lazy_parent_join_keys <- function(result,
   dplyr::mutate(result, !!!join_key_exprs)
 }
 
-check_local_parent_share_types <- function(result, requests) {
+check_local_parent_share_types <- function(result, requests, call) {
   pairs <- parent_share_pairs(requests)
   checked_sources <- character()
 
@@ -1827,18 +1842,12 @@ check_local_parent_share_types <- function(result, requests) {
       next
     }
     values <- result[[source]]
-    if (
-      !typeof(values) %in% c("integer", "double") ||
-        is.object(values)
-    ) {
-      detected_type <- if (is.object(values)) class(values) else typeof(values)
-      abort_marginplyr(
-        paste0(
-          "Parent share `", pair$output, "` requires source summary `", source,
-          "` to be a plain integer or double scalar; detected type ",
-          paste(detected_type, collapse = "/"),
-          ". Convert it explicitly in the ordinary summary."
-        )
+    if (!is_parent_source_type(values)) {
+      abort_parent_source_type(
+        values,
+        parent_output = pair$output,
+        source_summary = source,
+        call = call
       )
     }
     checked_sources <- c(checked_sources, source)

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -79,7 +79,7 @@ types to execution" and "general dbplyr reports static Parent-share errors
 without probing".
 
 **`.grouping` is evaluated through two paths** — #25. `test-parent-share.R`
-"Parent planning evaluates the grouping expression once", "Parent planning
+"Parent planning evaluates the grouping specification once", "Parent planning
 preserves every public-call environment", "Parent planning evaluates across
 arguments once".
 
@@ -560,16 +560,29 @@ for a missing optional package plus 2 for no supported lazy backend and 2 for
 CRAN snapshot semantics.
 
 **`investigation/r-devel-binary-compatibility.md` states live configuration in
-the present tense the notes' own rule forbids** (Standards). **Not fixed —
-split to a new ticket.** `investigation/README.md` lines 41–42: "Do not write
-bare `now`, `currently`, or `today`." The note written by `0a2842c` does so at
-lines 110, 128, 237, 252, and 253 — including the heading "The failure mode is
-a clean error today". This is the failure #61 already corrected once in a
-neighbouring note. *Evidence:* `grep -nE '\b(currently|today)\b'
+the present tense the notes' own rule forbids** (Standards). **Fixed — #66.**
+`investigation/README.md` lines 41–42: "Do not write bare `now`, `currently`,
+or `today`." The note written by `0a2842c` does so at lines 110, 128, 237, 252,
+and 253 — including the heading "The failure mode is a clean error today". This
+is the failure #61 already corrected once in a neighbouring note. *Evidence:*
+`grep -nE '\b(currently|today)\b'
 investigation/r-devel-binary-compatibility.md`.
 
+The five statements were edited in place rather than superseded. #61's
+mechanism does not apply here: a `Revised:` line and a dated revisions section
+record that a finding was **overturned**, and none of these was — the UUID
+readings, the `Defn.h` constant, and the load-time behaviour all still say what
+they said on 2026-08-03. Only the tense was wrong, so each statement now
+carries that date inline, and the paragraph that described the arrangement
+holding hands current state to `R-CMD-check.yaml`'s R-devel comment, which
+`investigation/README.md` makes authoritative for it. *Evidence:* the same grep
+returns nothing. The four artifacts citing this note — `R-CMD-check.yaml`,
+`investigation/github-actions-modernization.md`,
+`investigation/p3m-binary-actions.md`, and this file — cite evidence the edit
+did not touch, so none needed updating alongside it.
+
 **Two new `# nolint` comments carry no expression-specific reason**
-(Standards). **Not fixed — #66.** `AGENTS.md`: "every one in
+(Standards). **Fixed — #66.** `AGENTS.md`: "every one in
 R code sits next to a comment stating the expression-specific reason."
 `tests/testthat/test-nest-operation.R:154` and `:158` suppress
 `line_length_linter` with nothing beside them, and neither needs the
@@ -577,8 +590,15 @@ suppression — the `key_missing` case at `:161` already wraps the same
 `quote()` shape across lines. *Evidence:* the two lines; the wrapped sibling
 seven lines below is the available fix.
 
-**A new test name uses a term the glossary bans** (Standards). **Not fixed —
-split to a new ticket.** `CONTEXT.md:11` lists `_Avoid_: Grouping expression`
+Both `quote()` calls are wrapped across lines like their sibling and both
+suppressions are deleted, so no reason comment is owed. Wrapping was preferred
+to writing the reason down because a reason would have had to say the line was
+long, which the linter can see for itself. *Evidence:* `lintr::lint_package()`
+after `pkgload::load_all(".")` → 0 lints, and `grep -n "nolint"
+tests/testthat/test-nest-operation.R` returns nothing.
+
+**A new test name uses a term the glossary bans** (Standards). **Fixed — #66.**
+`CONTEXT.md:11` lists `_Avoid_: Grouping expression`
 under Grouping specification. `tests/testthat/test-parent-share.R:1389` is
 `test_that("Parent planning evaluates the grouping expression once", ...)`, and
 §1 of this file quotes that name. Renaming the test also breaks nothing in
@@ -586,8 +606,19 @@ under Grouping specification. `tests/testthat/test-parent-share.R:1389` is
 expression" R tests vignettes design CONTEXT.md` — the two hits in
 `vignettes/database_backends.qmd` predate `1c782eb` and are outside this diff.
 
+The test is "Parent planning evaluates the grouping specification once", and §1
+above quotes the new name. The two vignette hits were fixed rather than
+deferred, since both name the user-declared argument the glossary term covers:
+`database_backends.qmd:80` becomes "The grouping specification does not
+change", and `:127` becomes "More complex grouping specifications use the same
+translation". The remaining hit, `R/grouping-context.R:243`'s "A database
+connection is required for SQL grouping expressions", is left alone: it names
+the `GROUPING()` SQL the function builds, not a grouping specification, so the
+glossary entry does not reach it. *Evidence:* `grep -rn "grouping expression" R
+tests vignettes design CONTEXT.md` returns that one line.
+
 **`apply_joined_parent_shares()` discovers local state with `exists()`**
-(Spec). **Not fixed — #66.** #23's Implementation Decisions:
+(Spec). **Fixed — #66.** #23's Implementation Decisions:
 "Fragile local-state patterns are removed: initialize optional locals
 explicitly." `R/parent-share.R:1682` and `:1687` test
 `exists("right_join_names", inherits = FALSE)` and
@@ -599,8 +630,14 @@ assigns `right_join_names <- character()` explicitly in the other branch.
 fix, and `test-parent-share-backends.R` "lazy Parent-share staging avoids
 adversarial user-name collisions" covers the cleanup path either way.
 
+Both are `character()` before the branch, the redundant `else` assignment is
+gone, and the cleanup reads them directly. No new test guards this: the branch
+already has both states covered — a rollup with children and a single-set plan
+with none — and what changed is how the cleanup learns which one ran, not what
+it produces.
+
 **The eligible-type diagnostic exists twice, and one copy drops its structured
-fields** (Spec). **Not fixed — #66.**
+fields** (Spec). **Fixed — #66.**
 `check_parent_scalar()` (`R/parent-share.R:1020`, message at `:1039`) attaches
 `parent_output`, `source_summary`, and `call` to the "requires source summary
 ... to be a plain
@@ -613,8 +650,24 @@ character-identical apart from the operands; `test-parent-share.R`
 "Parent-share sources are numeric" asserts the message, not the fields, which
 is why the drift survived.
 
+`abort_parent_source_type()` is now the only place the message and its fields
+are built, and `is_parent_source_type()` the only place the rule is stated;
+both `check_parent_scalar()` and `check_local_parent_share_types()` call them,
+and the latter takes `operation$call` from `execute_local_parent_shares()`.
+The test change is the part that matters, because a shared constructor can be
+un-shared again: "Parent-share sources are numeric scalar summaries" now
+asserts `parent_output` and `source_summary` on the type error rather than only
+its message, and a new test, "the local eligible-type check raises the shared
+diagnostic", holds the local site's message, class, fields, and call against
+the wrapped site's. That test calls `check_local_parent_share_types()`
+directly, which is deliberate and is the second half of the finding: no public
+call reaches its error, because the check wrapped around each summary
+expression catches every ineligible type first. A raising site no test could
+reach is how two copies of one message stayed different without any run
+disagreeing.
+
 **No test asserts structurally that per-Grouping-set input rescans are gone**
-(Spec). **Not fixed — #66.** #23's Testing Decisions:
+(Spec). **Fixed — #66.** #23's Testing Decisions:
 "Assert the removal of Grouping-set-proportional full input scans
 structurally; do not put wall-clock thresholds in package tests." The
 benchmark half exists (`dev/benchmark-parent-share-local.R` and
@@ -623,6 +676,27 @@ benchmark half exists (`dev/benchmark-parent-share-local.R` and
 set. US42 is currently guarded only by a developer script that CI does not
 run. *Evidence:* `grep -rn "rescan\|single pass"
 tests/testthat/` returns nothing.
+
+`test-parent-share.R` "Parent shares add no input pass per Grouping set"
+supplies the missing half, with no wall-clock threshold. The input carries a
+marker class; every dplyr verb applied to an object still carrying it counts
+one pass, and each such verb drops the marker from what it returns, so a
+derived frame — including the summarized result the Parent-share stage works
+from — is not counted and the input alone is. The test then asserts two
+equalities rather than a number: a five-set plan reads the input as many times
+as a three-set one, and adding Parent shares changes neither count. Fixing a
+number would have made every unrelated refactor of the summarization path a
+failure; the equalities are what US42 actually claims.
+
+`ungroup()` is the one verb left unregistered, and the reason is load-bearing:
+it is applied to the input before the Margin operation stores it, so counting
+it would drop the marker from `operation$data` and hide precisely the rescans
+the test exists to catch. *Evidence for the gate:* reinstating a
+`dplyr::distinct(operation$data, across(all_of(keys)))` loop over
+`plan$set_ids` in `execute_local_parent_shares()` — the shape
+`check_parent_share_cardinality()` had before #27 removed it — fails both
+equalities, at 12 against 10 and 10 against 8. Removing it returns the suite to
+green.
 
 **One `skip_if_backend_absent()` call reverses the argument order a CI gate
 depends on** (Standards). **Fixed — #69, and the finding's premise was wrong.**
@@ -709,12 +783,12 @@ two-axis review and Docs & Tests audit with no unresolved findings, which is
 **The gate is not met as of #40's review.** Local checks, the release matrix,
 and the two-axis review of package behaviour are clean, and no finding above
 changes a result marginplyr returns. What is not clean is the evidence layer
-the gate is written in terms of. Two of its three tickets are still open:
-`cran-comments.md` states counts the tree no longer produces (#65), and six of
-the seven smaller standards and spec findings are #66. The seventh, the
-skip-helper argument order, moved to #69, which took it because the finding as
-written was factually wrong about why the gate passes and correcting it belongs
-with the list it names. The third ticket, #64, is fixed — the release matrix
-now withholds the optional backends it documents withholding, and a gate fails
-the workflow if it stops doing so. #40 stays open until #65, #66, and #69
-close, and no submission is made before then.
+the gate is written in terms of. One of its three tickets is still open:
+`cran-comments.md` states counts the tree no longer produces (#65). Of the
+seven smaller standards and spec findings, six were #66 and are fixed above;
+the seventh, the skip-helper argument order, moved to #69, which took it
+because the finding as written was factually wrong about why the gate passes
+and correcting it belongs with the list it names. The third ticket, #64, is
+fixed — the release matrix now withholds the optional backends it documents
+withholding, and a gate fails the workflow if it stops doing so. #40 stays open
+until #65 closes, and no submission is made before then.

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -576,10 +576,13 @@ they said on 2026-08-03. Only the tense was wrong, so each statement now
 carries that date inline, and the paragraph that described the arrangement
 holding hands current state to `R-CMD-check.yaml`'s R-devel comment, which
 `investigation/README.md` makes authoritative for it. *Evidence:* the same grep
-returns nothing. The four artifacts citing this note — `R-CMD-check.yaml`,
+returns nothing. `investigation/README.md`'s pre-amend grep for the note's path
+names four artifacts — `R-CMD-check.yaml`,
 `investigation/github-actions-modernization.md`,
-`investigation/p3m-binary-actions.md`, and this file — cite evidence the edit
-did not touch, so none needed updating alongside it.
+`investigation/p3m-binary-actions.md`, and this file — and
+`investigation/README.md` itself cites the note twice more by bare filename,
+which that grep does not reach. All six cite evidence the edit did not touch,
+so none needed updating alongside it.
 
 **Two new `# nolint` comments carry no expression-specific reason**
 (Standards). **Fixed — #66.** `AGENTS.md`: "every one in
@@ -615,7 +618,11 @@ translation". The remaining hit, `R/grouping-context.R:243`'s "A database
 connection is required for SQL grouping expressions", is left alone: it names
 the `GROUPING()` SQL the function builds, not a grouping specification, so the
 glossary entry does not reach it. *Evidence:* `grep -rn "grouping expression" R
-tests vignettes design CONTEXT.md` returns that one line.
+tests vignettes CONTEXT.md` returns that one line. The finding's own grep
+included `design`, which this file now answers with three hits of its own —
+the quotation of the old name above, and this paragraph naming what it
+replaced. A disposition has to be able to say what it fixed, so the term
+survives here as a quotation and nowhere as a use.
 
 **`apply_joined_parent_shares()` discovers local state with `exists()`**
 (Spec). **Fixed — #66.** #23's Implementation Decisions:
@@ -691,12 +698,16 @@ failure; the equalities are what US42 actually claims.
 `ungroup()` is the one verb left unregistered, and the reason is load-bearing:
 it is applied to the input before the Margin operation stores it, so counting
 it would drop the marker from `operation$data` and hide precisely the rescans
-the test exists to catch. *Evidence for the gate:* reinstating a
-`dplyr::distinct(operation$data, across(all_of(keys)))` loop over
-`plan$set_ids` in `execute_local_parent_shares()` — the shape
-`check_parent_share_cardinality()` had before #27 removed it — fails both
-equalities, at 12 against 10 and 10 against 8. Removing it returns the suite to
-green.
+the test exists to catch. Its reach is the generic list in
+`register_parent_scan_methods()`: a rescan routed through a verb that list does
+not name would go uncounted, so the list is what to extend when the
+summarization path grows a new one.
+
+*Evidence for the gate:* reinstating in `execute_local_parent_shares()` one
+`dplyr::distinct(operation$data, across(all_of(keys)))` per grouping set with
+at least one key — the shape `check_parent_share_cardinality()` had before #27
+removed it — fails both equalities, at 12 against 10 and 10 against 8.
+Removing it returns the suite to green.
 
 **One `skip_if_backend_absent()` call reverses the argument order a CI gate
 depends on** (Standards). **Fixed — #69, and the finding's premise was wrong.**

--- a/investigation/r-devel-binary-compatibility.md
+++ b/investigation/r-devel-binary-compatibility.md
@@ -107,7 +107,8 @@ correct.
 - The value compared is a compile-time constant in R's **private** header
   `src/include/Defn.h`, with the only statement of its contract being its own
   comment: "UUID identifying the internals version -- packages using compiled
-  code should be re-installed when this changes"; currently
+  code should be re-installed when this changes"; as read on 2026-08-03 the
+  definition was
   `#define R_INTERNALS_UUID "2fdf6c18-697a-4ba7-b8ef-11c0d92f1327"`.
 - **The intended contract is documented nowhere else.** `?library`'s Note
   section documents only that an installed package is detected by a `Built:`
@@ -125,10 +126,11 @@ private. Its behaviour is verifiable only from the R source, and R reserves the
 right to change it. That is the honest status; nothing in the documented API
 underwrites the current arrangement.
 
-### 3. The failure mode is a clean error today — but only because of an undocumented guard
+### 3. The failure mode was a clean error on 2026-08-03 — but only because of an undocumented guard
 
 The working hypothesis (crash or unclear failure) is **refuted for the specific
-case in question, on current R**, and confirmed as the general position.
+case in question, against the R 4.6.1 and trunk sources read for this note**,
+and confirmed as the general position.
 
 - Refuted for this case: when R's internals UUID differs, `loadNamespace()`
   stops with a clear, actionable message naming the package and the required
@@ -234,7 +236,8 @@ Two things follow:
 
 ### How long the arrangement holds, and what ends it
 
-The arrangement rests on one value. Measured against the R source tree today:
+The arrangement rests on one value. Measured against the R source tree on
+2026-08-03:
 
 | Source | `R_INTERNALS_UUID` |
 |---|---|
@@ -246,16 +249,19 @@ The arrangement rests on one value. Measured against the R source tree today:
 | `branches/R-4-6-branch` (4.6.1 Patched) | `2fdf6c18-...` |
 | `trunk` (4.7.0 Under development) | `2fdf6c18-...` |
 
-Local R 4.6.1 reports `.Internal(internalsID())` as
+On the same date, local R 4.6.1 reported `.Internal(internalsID())` as
 `2fdf6c18-697a-4ba7-b8ef-11c0d92f1327`, and the `Meta/features.rds` of every
-locally installed compiled package — including `arrow` — records the same value.
-R-devel's internals UUID is currently **identical** to the release series'.
-That, and nothing else, is why release binaries load under R-devel today.
+locally installed compiled package — including `arrow` — recorded the same
+value. R-devel's internals UUID was therefore **identical** to the release
+series', and that, and nothing else, is why release binaries loaded under
+R-devel. `R-CMD-check.yaml`'s R-devel comment is authoritative for what that
+job relies on; this note is not.
 
-The mechanism was introduced between R 4.1.3 and R 4.2.3 and its value has not
-changed since. The `0310d4b8-ccb1-4bb8-ba94-d36a55f60262` constant in
-`namespace.R` is a sentinel assigned to packages installed before `features.rds`
-existed, not a superseded real value.
+The mechanism was introduced between R 4.1.3 and R 4.2.3, and as of 2026-08-03
+its value had not changed since. The
+`0310d4b8-ccb1-4bb8-ba94-d36a55f60262` constant in `namespace.R` is a sentinel
+assigned to packages installed before `features.rds` existed, not a superseded
+real value.
 
 **The specific event that ends the arrangement is a single commit to R-devel
 changing `R_INTERNALS_UUID` in `src/include/Defn.h`.** It is not tied to a

--- a/investigation/r-devel-binary-compatibility.md
+++ b/investigation/r-devel-binary-compatibility.md
@@ -124,7 +124,7 @@ correct.
 **Conclusion:** the version gate that matters is undocumented and explicitly
 private. Its behaviour is verifiable only from the R source, and R reserves the
 right to change it. That is the honest status; nothing in the documented API
-underwrites the current arrangement.
+underwrites the arrangement `R-CMD-check.yaml`'s R-devel job rests on.
 
 ### 3. The failure mode was a clean error on 2026-08-03 — but only because of an undocumented guard
 

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -151,11 +151,19 @@ test_that("nesting option errors use the package condition seam", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   cases <- list(
     keep = list(
-      expr = quote(nest_with_margins(data, .grouping = rollup(group), .keep = 1)), # nolint: line_length_linter
+      expr = quote(nest_with_margins(
+        data,
+        .grouping = rollup(group),
+        .keep = 1
+      )),
       message = "`\\.keep` must be a logical scalar"
     ),
     key_type = list(
-      expr = quote(nest_with_margins(data, .grouping = rollup(group), .key = 1)), # nolint: line_length_linter
+      expr = quote(nest_with_margins(
+        data,
+        .grouping = rollup(group),
+        .key = 1
+      )),
       message = "`\\.key` must be a character vector of length 1"
     ),
     key_missing = list(

--- a/tests/testthat/test-parent-share.R
+++ b/tests/testthat/test-parent-share.R
@@ -1530,12 +1530,15 @@ test_that("Parent syntax and local execution errors precede typed metadata", {
 
 # US42 is structural, not a timing budget: the local Parent-share stage reads
 # the summarized result, never the input, so no pass over the input may be
-# proportional to the Grouping-set count. Every dplyr verb applied to an object
-# still carrying this class counts as one such pass, and the class is dropped
-# from whatever a verb returns, so a derived frame is not counted and only the
-# input itself is. `ungroup()` is deliberately not registered: it neither scans
-# nor reshapes, and counting it would drop the marker before the Margin
-# operation stores the input, hiding exactly the rescans this asserts against.
+# proportional to the Grouping-set count. Each generic registered below counts
+# one such pass when applied to an object still carrying this class, and drops
+# the class from whatever it returns, so a derived frame is not counted and
+# only the input itself is. The list is the assertion's reach: a rescan routed
+# through a verb it does not name goes uncounted, so extend it when the
+# summarization path grows one. `ungroup()` is deliberately left out — it
+# neither scans nor reshapes, and counting it would drop the marker before the
+# Margin operation stores the input, hiding exactly the rescans asserted
+# against here.
 parent_scan_capture <- new.env(parent = emptyenv())
 
 parent_scan_drop_marker <- function(x) {

--- a/tests/testthat/test-parent-share.R
+++ b/tests/testthat/test-parent-share.R
@@ -683,6 +683,8 @@ test_that("Parent-share sources are numeric scalar summaries", {
     rlang::call_name(conditionCall(type_error)),
     "summarize_with_margins"
   )
+  expect_identical(type_error$parent_output, "share")
+  expect_identical(type_error$source_summary, "total")
   expect_match(conditionMessage(type_error), "Parent share `share`")
   expect_match(conditionMessage(type_error), "source summary `total`")
   expect_error(
@@ -693,6 +695,45 @@ test_that("Parent-share sources are numeric scalar summaries", {
       .grouping = rollup(group)
     ),
     "plain integer or double scalar"
+  )
+})
+
+test_that("the local eligible-type check raises the shared diagnostic", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+
+  wrapped_error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = any(value > 0),
+      share = share_of_parent(total),
+      .grouping = rollup(group)
+    ),
+    "plain integer or double scalar"
+  )
+
+  # The local backend re-checks the collected result, so the same diagnostic
+  # has a second raising site. It is called directly here because the wrapped
+  # summary check reaches every ineligible type first from a public call, and
+  # a second copy of the message is exactly what drifted before.
+  local_error <- expect_error(
+    check_local_parent_share_types(
+      data.frame(group = "x", total = TRUE),
+      requests = list(list(outputs = "share", sources = "total")),
+      call = rlang::call2("summarize_with_margins")
+    ),
+    "plain integer or double scalar"
+  )
+
+  expect_identical(
+    conditionMessage(local_error),
+    conditionMessage(wrapped_error)
+  )
+  expect_s3_class(local_error, "marginplyr_error")
+  expect_identical(local_error$parent_output, "share")
+  expect_identical(local_error$source_summary, "total")
+  expect_identical(
+    rlang::call_name(conditionCall(local_error)),
+    "summarize_with_margins"
   )
 })
 
@@ -1386,7 +1427,7 @@ test_that("Parent planning evaluates across arguments once", {
   expect_identical(parent_names_n, 1L)
 })
 
-test_that("Parent planning evaluates the grouping expression once", {
+test_that("Parent planning evaluates the grouping specification once", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   evaluations <- 0L
   grouping <- function() {
@@ -1485,4 +1526,111 @@ test_that("Parent syntax and local execution errors precede typed metadata", {
   )
   expect_s3_class(error, "marginplyr_parent_cardinality_error")
   expect_identical(parent_preflight_capture$n, 1L)
+})
+
+# US42 is structural, not a timing budget: the local Parent-share stage reads
+# the summarized result, never the input, so no pass over the input may be
+# proportional to the Grouping-set count. Every dplyr verb applied to an object
+# still carrying this class counts as one such pass, and the class is dropped
+# from whatever a verb returns, so a derived frame is not counted and only the
+# input itself is. `ungroup()` is deliberately not registered: it neither scans
+# nor reshapes, and counting it would drop the marker before the Margin
+# operation stores the input, hiding exactly the rescans this asserts against.
+parent_scan_capture <- new.env(parent = emptyenv())
+
+parent_scan_drop_marker <- function(x) {
+  if (is.data.frame(x)) {
+    class(x) <- setdiff(class(x), "parent_scan_counter")
+  }
+  x
+}
+
+parent_scan_dot_data_method <- function(.data, ...) {
+  parent_scan_capture$n <- parent_scan_capture$n + 1L
+  parent_scan_drop_marker(NextMethod())
+}
+
+parent_scan_x_method <- function(x, ...) {
+  parent_scan_capture$n <- parent_scan_capture$n + 1L
+  parent_scan_drop_marker(NextMethod())
+}
+
+register_parent_scan_methods <- function() {
+  dot_data_generics <- c(
+    "arrange", "distinct", "filter", "group_by", "mutate", "pull",
+    "reframe", "rename", "select", "slice", "summarise", "transmute"
+  )
+  x_generics <- c(
+    "anti_join", "collect", "count", "full_join", "inner_join",
+    "left_join", "right_join", "semi_join", "tally"
+  )
+  for (generic in dot_data_generics) {
+    registerS3method(
+      generic,
+      "parent_scan_counter",
+      parent_scan_dot_data_method,
+      envir = asNamespace("dplyr")
+    )
+  }
+  for (generic in x_generics) {
+    registerS3method(
+      generic,
+      "parent_scan_counter",
+      parent_scan_x_method,
+      envir = asNamespace("dplyr")
+    )
+  }
+}
+
+count_parent_input_passes <- function(data, ...) {
+  class(data) <- c("parent_scan_counter", class(data))
+  parent_scan_capture$n <- 0L
+  result <- summarize_with_margins(data, ...)
+  list(passes = parent_scan_capture$n, result = result)
+}
+
+test_that("Parent shares add no input pass per Grouping set", {
+  register_parent_scan_methods()
+  data <- data.frame(
+    a = c("x", "y", "x", "y"),
+    b = c("p", "p", "q", "q"),
+    c = c("m", "m", "n", "n"),
+    d = c("u", "v", "u", "v"),
+    value = 1:4
+  )
+
+  three_sets_plain <- count_parent_input_passes(
+    data,
+    total = sum(value),
+    .grouping = rollup(a, b)
+  )
+  three_sets_share <- count_parent_input_passes(
+    data,
+    total = sum(value),
+    share = share_of_parent(total),
+    .grouping = rollup(a, b)
+  )
+  five_sets_share <- count_parent_input_passes(
+    data,
+    total = sum(value),
+    share = share_of_parent(total),
+    .grouping = rollup(a, b, c, d)
+  )
+
+  # The counter is wired to something: a summarization does read the input.
+  expect_gt(three_sets_plain$passes, 0L)
+  # Adding two Grouping sets adds no pass over the input, so no pass is
+  # proportional to the Grouping-set count.
+  expect_identical(five_sets_share$passes, three_sets_share$passes)
+  # And Parent shares add no pass of their own at either size: they are
+  # calculated from the summarized result, not from a second look at the input.
+  expect_identical(three_sets_share$passes, three_sets_plain$passes)
+
+  # Guard against a vacuous pass: the runs above produced Parent shares.
+  expect_true("share" %in% names(three_sets_share$result))
+  expect_true("share" %in% names(five_sets_share$result))
+  expect_identical(
+    five_sets_share$result$share[[nrow(five_sets_share$result)]],
+    1
+  )
 })

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -77,7 +77,7 @@ local_result <- january_sales |>
 local_result
 ```
 
-The grouping expression does not change when the input becomes a lazy table:
+The grouping specification does not change when the input becomes a lazy table:
 
 ```{r}
 postgres_sales <- dbplyr::tbl_lazy(
@@ -124,7 +124,7 @@ the outer query to label only dimensions removed by aggregation. A source
 `NULL` therefore stays different from a generated subtotal even though SQL
 would otherwise display both as missing.
 
-More complex SQL grouping expressions use the same translation. The two
+More complex grouping specifications use the same translation. The two
 rollups below are combined by Cartesian product, matching comma-separated SQL
 `GROUP BY` items:
 


### PR DESCRIPTION
Closes #66. Part of #23, found by #40's final readiness review. Leaves #65 as
the only ticket #40 still waits on.

## What changed

Six findings, none of which changes a result marginplyr returns and each of
which breaks a rule this repository wrote down. Full evidence and dispositions
are in `design/review-dispositions.md` section 8.

**Tense.** `investigation/r-devel-binary-compatibility.md` stated live
configuration in the present tense at five places. The statements are edited in
place, not superseded: #61's `Revised:` mechanism records an *overturned*
finding, and none of these was — the UUID readings, the `Defn.h` constant, and
the load-time behaviour still say what they said on 2026-08-03. Only the tense
was wrong, so each carries that date inline, and the paragraph describing the
arrangement holding hands current state to `R-CMD-check.yaml`'s R-devel
comment, which `investigation/README.md` makes authoritative for it.

**`# nolint`.** Both suppressions in `test-nest-operation.R` are gone, wrapped
like the `key_missing` sibling below them. Wrapping beat writing the reason
down because the reason would have had to say the line was long, which the
linter can see for itself.

**Banned term.** The test is "Parent planning evaluates the grouping
specification once", and §1 quotes the new name. Both vignette hits are fixed
too, since both name the user-declared argument the glossary term covers.
`R/grouping-context.R:243`'s "SQL grouping expressions" is left alone: it names
the `GROUPING()` SQL the function builds, not a grouping specification.

**`exists()`.** `join_key_names` and `right_join_names` are `character()` above
the branch, the redundant `else` assignment is gone, and the cleanup reads them
directly.

**Duplicated diagnostic.** `abort_parent_source_type()` is the only place the
message and its fields are built, `is_parent_source_type()` the only place the
rule is stated, and `check_local_parent_share_types()` takes `operation$call`.
The tests are the part that matters, since a shared constructor can be
un-shared again: the existing test asserts `parent_output` and
`source_summary` rather than only the message, and a new one holds the local
site's message, class, fields, and call against the wrapped site's. It calls
the local check directly, which is the second half of the finding — no public
call reaches that error, because the check wrapped around each summary
expression catches every ineligible type first. A raising site no test could
reach is how two copies of one message stayed different without any run
disagreeing.

## The structural assertion

`test-parent-share.R` "Parent shares add no input pass per Grouping set"
supplies the missing half of US42, with no wall-clock threshold. A marker class
on the input counts one pass per registered dplyr verb applied to it, and each
such verb drops the marker from what it returns, so a derived frame — including
the summarized result the Parent-share stage works from — is not counted and
the input alone is.

It asserts two equalities rather than a number: a five-set plan reads the input
as many times as a three-set one, and Parent shares change neither count.
Fixing a number would make every unrelated refactor of the summarization path a
failure; the equalities are what US42 actually claims.

`ungroup()` is the one verb left unregistered, and the reason is load-bearing:
it is applied to the input before the Margin operation stores it, so counting
it would drop the marker from `operation$data` and hide precisely the rescans
the test exists to catch. The generic list is the assertion's reach, and both
the test comment and the disposition say so.

*Evidence for the gate:* reinstating in `execute_local_parent_shares()` one
`dplyr::distinct(operation$data, across(all_of(keys)))` per grouping set with
at least one key — the shape `check_parent_share_cardinality()` had before #27
removed it — fails both equalities, at 12 against 10 and 10 against 8.

## Verification

`pkgload::load_all(".")` then `lintr::lint_package()` → 0 lints.
`roxygen2::roxygenise()` → no change to `man/` or `NAMESPACE`.
`testthat::test_local()` under `NOT_CRAN=true` with all four optional backends
installed → all pass, 0 failures, 0 skipped.
`spelling::spell_check_package()` → clean.

## Review corrections

The second commit applies four findings from the standards and spec reviews.
The one worth naming here: the disposition claimed `grep -rn "grouping
expression" R tests vignettes design CONTEXT.md` returns one line, and it
returns four — the finding's own quotation of the old test name, plus two hits
in the prose that names what it replaced. A disposition that states a checkable
command has to state one that checks out, so the command drops `design` and the
paragraph says why the term survives there as a quotation and nowhere as a use.