### PR TITLE
Stop source columns from shadowing internal locals in generated expressions

### DIFF
--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -327,7 +327,9 @@ jobs:
           # installed package says nothing about whether the tests exercising
           # it were renamed, deleted, or skipped for an unrelated reason.
           # Renaming one of these tests deliberately breaks the job that
-          # guards it. Each entry traces to an acceptance criterion of #38.
+          # guards it. Most entries trace to an acceptance criterion of #38;
+          # the factor-restoration shadowing contracts trace to #76, whose
+          # fix is only observable on a live backend.
           - name: RSQLite
             packages: any::DBI, any::RSQLite
             required: RSQLite,DBI
@@ -342,7 +344,8 @@ jobs:
               DuckDB native and UNION adapters agree;
               DuckDB native and portable summaries agree on .id;
               DuckDB Parent shares agree across native, portable, and local
-              paths
+              paths;
+              duckdb factor restoration ignores a column named `sql_query`
           - name: dtplyr
             packages: any::dtplyr
             required: dtplyr
@@ -350,7 +353,8 @@ jobs:
               dtplyr integer and double Parent shares match local results;
               dtplyr rejects every ineligible Parent-share source type;
               dtplyr rejects non-scalar Parent-share sources on collection;
-              dtplyr validates Parent-share source types during collection
+              dtplyr validates Parent-share source types during collection;
+              dtplyr factor restoration ignores columns named like its locals
           - name: Arrow
             packages: any::arrow
             required: arrow

--- a/R/factor.R
+++ b/R/factor.R
@@ -85,13 +85,19 @@ reconstruct_factor.data.frame <- function(data,
   new_levels <- margin_factor_levels(info, .margin_name, position)
   ord <- info$ordered
   missing_sentinel <- factor_missing_sentinel(info, .margin_name)
+  # Every value is injected rather than named. A bare name here resolves
+  # against the data mask first, so a source column called `new_levels`,
+  # `ord`, or `missing_sentinel` would supply the argument instead of the
+  # local, silently rebuilding the factor from the wrong levels.
   dplyr::mutate(
     .data = data,
-    "{col}" := reconstruct_factor_vector(
-      .data[[col]],
-      new_levels = new_levels,
-      ordered = ord,
-      missing_sentinel = missing_sentinel
+    "{col}" := !!rlang::expr(
+      reconstruct_factor_vector(
+        .data[[!!col]],
+        new_levels = !!new_levels,
+        ordered = !!ord,
+        missing_sentinel = !!missing_sentinel
+      )
     )
   )
 }
@@ -117,8 +123,10 @@ reconstruct_factor.tbl_duckdb_connection <- function(data,
     con,
     "CAST({.id col} AS ENUM {new_levels*})"
   )
+  # Injected for the same reason as the data frame method: a source column
+  # named `sql_query` would otherwise replace the cast with that column.
   dplyr::mutate(
     .data = data,
-    "{col}" := sql_query
+    "{col}" := !!sql_query
   )
 }

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -12,9 +12,14 @@ add_grouping_set_id <- function(result, set_id_name, set_id) {
   if (is.null(set_id_name)) {
     return(result)
   }
+  # Injected for the same reason as the factor methods: a bare `set_id` here
+  # resolves against the data mask first, so a grouping column of that name
+  # would number every row from its own values instead of the branch's
+  # grouping-set id. The `{set_id_name}` glue is evaluated in this environment
+  # rather than the mask, so only the value needs injecting.
   dplyr::mutate(
     result,
-    "{set_id_name}" := as.integer(set_id)
+    "{set_id_name}" := !!as.integer(set_id)
   )
 }
 

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -332,8 +332,10 @@ nest_expanded_margins <- function(.data,
     # so their tidyselect resolves `keep_cols` and `group_cols` against the
     # nested rows before the environment. Source columns with those names
     # would select themselves; injecting the character vectors removes the
-    # ambiguity. The `.by` selection above is a plain tidyselect context and
-    # already resolves from the environment.
+    # ambiguity. `inject()` reaches the whole call, so `.by` is injected too
+    # even though a top-level tidyselect context already resolves from the
+    # environment — that is why the `else` branch below can leave its own
+    # `.by` bare and still be correct.
     result <- rlang::inject(dplyr::summarize(
       .data,
       "{.key}" := list({

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -328,17 +328,23 @@ nest_expanded_margins <- function(.data,
                                   .keep,
                                   set_id_name = NULL) {
   if (.keep && length(group_cols) > 0L) {
-    result <- dplyr::summarize(
+    # `rename()` and `relocate()` run inside a data-masked summary expression,
+    # so their tidyselect resolves `keep_cols` and `group_cols` against the
+    # nested rows before the environment. Source columns with those names
+    # would select themselves; injecting the character vectors removes the
+    # ambiguity. The `.by` selection above is a plain tidyselect context and
+    # already resolves from the environment.
+    result <- rlang::inject(dplyr::summarize(
       .data,
       "{.key}" := list({
         nested <- dplyr::rename(
           dplyr::pick(dplyr::everything()),
-          dplyr::all_of(keep_cols)
+          dplyr::all_of(!!keep_cols)
         )
-        dplyr::relocate(nested, dplyr::all_of(group_cols))
+        dplyr::relocate(nested, dplyr::all_of(!!group_cols))
       }),
-      .by = dplyr::all_of(c(group_cols, set_col))
-    )
+      .by = dplyr::all_of(!!c(group_cols, set_col))
+    ))
   } else {
     result <- dplyr::summarize(
       .data,

--- a/tests/testthat/test-internal-name-shadowing.R
+++ b/tests/testthat/test-internal-name-shadowing.R
@@ -118,7 +118,7 @@ test_that("missing factor values survive a column named `missing_sentinel`", {
 test_that("dtplyr factor restoration ignores columns named like its locals", {
   skip_if_backend_absent("dtplyr")
 
-  for (name in c("new_levels", "ord")) {
+  for (name in factor_shadow_names) {
     result <- dplyr::collect(summarize_with_margins(
       dtplyr::lazy_dt(factor_shadow_data(name)),
       s = sum(v),
@@ -144,8 +144,8 @@ test_that("duckdb factor restoration ignores a column named `sql_query`", {
 
   data <- factor_shadow_data("sql_query")
   con <- DBI::dbConnect(duckdb::duckdb())
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
-  duckdb::duckdb_register(con, "shadow", data)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbWriteTable(con, "shadow", data)
 
   result <- dplyr::collect(summarize_with_margins(
     dplyr::tbl(con, "shadow"),
@@ -167,7 +167,7 @@ test_that("duckdb factor restoration ignores a column named `sql_query`", {
   expect_equal(result$s, c(1, 2, 3, 3, 3))
 })
 
-test_that("the grouping-set id ignores a source column named `set_id`", {
+test_that("the Grouping set identifier ignores a column named `set_id`", {
   data <- data.frame(
     g = c("a", "a", "b"),
     set_id = c(10L, 20L, 30L),
@@ -188,7 +188,7 @@ test_that("the grouping-set id ignores a source column named `set_id`", {
   expect_equal(result$set_id, c(10L, 20L, 30L, 10L, 20L, 30L))
 })
 
-test_that("expansion's grouping-set id ignores a column named `set_id`", {
+test_that("expansion's Grouping set identifier ignores a `set_id` column", {
   data <- data.frame(
     g = c("a", "a", "b"),
     set_id = c(10L, 20L, 30L),

--- a/tests/testthat/test-internal-name-shadowing.R
+++ b/tests/testthat/test-internal-name-shadowing.R
@@ -167,6 +167,44 @@ test_that("duckdb factor restoration ignores a column named `sql_query`", {
   expect_equal(result$s, c(1, 2, 3, 3, 3))
 })
 
+test_that("the grouping-set id ignores a source column named `set_id`", {
+  data <- data.frame(
+    g = c("a", "a", "b"),
+    set_id = c(10L, 20L, 30L),
+    v = c(1, 2, 3)
+  )
+
+  # `rollup(g)` has two grouping sets, so the id is 1 on the detail rows and
+  # 2 on the Margin rows regardless of what the colliding column holds.
+  result <- summarize_with_margins(
+    data,
+    s = sum(v),
+    .by = set_id,
+    .grouping = rollup(g),
+    .id = "sid"
+  )
+
+  expect_equal(result$sid, c(1L, 1L, 1L, 2L, 2L, 2L))
+  expect_equal(result$set_id, c(10L, 20L, 30L, 10L, 20L, 30L))
+})
+
+test_that("expansion's grouping-set id ignores a column named `set_id`", {
+  data <- data.frame(
+    g = c("a", "a", "b"),
+    set_id = c(10L, 20L, 30L),
+    v = c(1, 2, 3)
+  )
+
+  result <- expand_with_margins(
+    data,
+    .by = set_id,
+    .grouping = rollup(g),
+    .id = "sid"
+  )
+
+  expect_equal(result$sid, c(1L, 1L, 1L, 2L, 2L, 2L))
+})
+
 test_that("nesting ignores source columns named like its locals", {
   for (name in c("group_cols", "keep_cols", "set_col")) {
     data <- data.frame(

--- a/tests/testthat/test-internal-name-shadowing.R
+++ b/tests/testthat/test-internal-name-shadowing.R
@@ -1,0 +1,210 @@
+# Internal locals are injected into every generated expression, so a source
+# column can never supply one of them. `new_margin_internal_names()` protects
+# generated *column* names; this file protects the *values* the package
+# computes in R and then names inside a data-masked expression, which is the
+# other half of the collision-safety contract.
+#
+# The names below are the locals of `reconstruct_factor.data.frame()`,
+# `reconstruct_factor.tbl_duckdb_connection()`, and
+# `nest_expanded_margins()`. Each one is exercised as an ordinary source
+# column that the Margin operation must carry through untouched.
+
+factor_shadow_names <- c("new_levels", "ord", "missing_sentinel", "col")
+
+factor_shadow_data <- function(name) {
+  data <- data.frame(
+    f = factor(c("a", "b", "a"), levels = c("a", "b")),
+    carrier = c("p", "p", "q"),
+    v = c(1, 2, 3)
+  )
+  names(data)[names(data) == "carrier"] <- name
+  data
+}
+
+# Rows are (f = a, p, 1), (f = b, p, 2), (f = a, q, 3), so partition `p` has
+# both levels and a subtotal of 3, and partition `q` has one level and the
+# same subtotal.
+expected_factor_shadow <- function(name) {
+  data.frame(
+    carrier = c("p", "p", "p", "q", "q"),
+    f = factor(
+      c("a", "b", "Total", "a", "Total"),
+      levels = c("a", "b", "Total")
+    ),
+    s = c(1, 2, 3, 3, 3)
+  ) |>
+    stats::setNames(c(name, "f", "s"))
+}
+
+test_that("factor restoration ignores source columns named like its locals", {
+  for (name in factor_shadow_names) {
+    result <- summarize_with_margins(
+      factor_shadow_data(name),
+      s = sum(v),
+      .by = dplyr::all_of(name),
+      .grouping = rollup(f)
+    )
+    result <- result[order(result[[name]], result$f), ]
+    rownames(result) <- NULL
+
+    expect_equal(result, expected_factor_shadow(name), info = name)
+    expect_s3_class(result$f, "factor")
+    expect_equal(levels(result$f), c("a", "b", "Total"), info = name)
+  }
+})
+
+test_that("ordered status survives a source column named `ord`", {
+  data <- data.frame(
+    size = ordered(c("s", "l", "s"), levels = c("s", "l")),
+    ord = c("p", "p", "q"),
+    v = c(1, 2, 3)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    s = sum(v),
+    .by = ord,
+    .grouping = rollup(size)
+  )
+
+  expect_true(is.ordered(result$size))
+  expect_equal(levels(result$size), c("s", "l", "Total"))
+})
+
+test_that("a factor dimension may itself be named like an internal local", {
+  for (name in factor_shadow_names) {
+    data <- data.frame(
+      x = factor(c("a", "b", "a"), levels = c("a", "b")),
+      v = c(1, 2, 3)
+    )
+    names(data)[1] <- name
+
+    result <- summarize_with_margins(
+      data,
+      s = sum(v),
+      .grouping = rollup(dplyr::all_of(name))
+    )
+
+    expect_equal(
+      as.character(result[[name]]),
+      c("a", "b", "Total"),
+      info = name
+    )
+    expect_equal(levels(result[[name]]), c("a", "b", "Total"), info = name)
+  }
+})
+
+test_that("missing factor values survive a column named `missing_sentinel`", {
+  data <- data.frame(
+    f = addNA(factor(c("a", NA, "a"))),
+    missing_sentinel = c("p", "p", "p"),
+    v = c(1, 2, 3)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    s = sum(v),
+    .by = missing_sentinel,
+    .grouping = rollup(f)
+  )
+
+  # `addNA()` makes the missing value a level of its own, which the Margin
+  # label must not absorb: three rows, one per level plus the total.
+  expect_equal(nrow(result), 3L)
+  expect_equal(levels(result$f), c("a", NA, "Total"), ignore_attr = FALSE)
+  expect_equal(result$s[result$f == "Total" & !is.na(result$f)], 6)
+})
+
+test_that("dtplyr factor restoration ignores columns named like its locals", {
+  skip_if_backend_absent("dtplyr")
+
+  for (name in c("new_levels", "ord")) {
+    result <- dplyr::collect(summarize_with_margins(
+      dtplyr::lazy_dt(factor_shadow_data(name)),
+      s = sum(v),
+      .by = dplyr::all_of(name),
+      .grouping = rollup(f)
+    ))
+    result <- result[order(
+      result[[name]],
+      match(as.character(result$f), c("a", "b", "Total"))
+    ), ]
+
+    expect_equal(
+      as.character(result$f),
+      c("a", "b", "Total", "a", "Total"),
+      info = name
+    )
+    expect_equal(result$s, c(1, 2, 3, 3, 3), info = name)
+  }
+})
+
+test_that("duckdb factor restoration ignores a column named `sql_query`", {
+  skip_if_backend_absent("duckdb", "DBI")
+
+  data <- factor_shadow_data("sql_query")
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  duckdb::duckdb_register(con, "shadow", data)
+
+  result <- dplyr::collect(summarize_with_margins(
+    dplyr::tbl(con, "shadow"),
+    s = sum(v, na.rm = TRUE),
+    .by = sql_query,
+    .grouping = rollup(f)
+  ))
+  # Sort by level position rather than by string, so the assertion does not
+  # depend on the collation the backend or locale happens to use.
+  result <- result[order(
+    result$sql_query,
+    match(as.character(result$f), c("a", "b", "Total"))
+  ), ]
+
+  expect_equal(
+    as.character(result$f),
+    c("a", "b", "Total", "a", "Total")
+  )
+  expect_equal(result$s, c(1, 2, 3, 3, 3))
+})
+
+test_that("nesting ignores source columns named like its locals", {
+  for (name in c("group_cols", "keep_cols", "set_col")) {
+    data <- data.frame(
+      g = c("a", "a", "b"),
+      carrier = c("p", "q", "r"),
+      v = c(1, 2, 3)
+    )
+    names(data)[names(data) == "carrier"] <- name
+
+    nested <- nest_with_margins(data, .grouping = rollup(g), .keep = TRUE)
+
+    expect_equal(nrow(nested), 3L, info = name)
+    expect_equal(as.character(nested$g), c("a", "b", "Total"), info = name)
+    expect_equal(
+      vapply(nested$data, nrow, integer(1)),
+      c(2L, 1L, 3L),
+      info = name
+    )
+    # `.keep = TRUE` retains the pre-margin key, so the nested frames carry
+    # the original `g` values rather than the Margin label.
+    expect_equal(
+      as.character(nested$data[[3L]]$g),
+      c("a", "a", "b"),
+      info = name
+    )
+    expect_true(name %in% names(nested$data[[3L]]), info = name)
+  }
+})
+
+test_that("row-wise nesting ignores source columns named like its locals", {
+  data <- data.frame(
+    g = c("a", "a", "b"),
+    keep_cols = c("p", "q", "r"),
+    v = c(1, 2, 3)
+  )
+
+  nested <- nest_by_with_margins(data, .grouping = rollup(g), .keep = TRUE)
+
+  expect_equal(nrow(nested), 3L)
+  expect_equal(vapply(nested$data, nrow, integer(1)), c(2L, 1L, 3L))
+})


### PR DESCRIPTION
Closes #76. Part of #23, and unblocks #40.

## What changed

`new_margin_internal_names()` makes generated **column names** collision-safe.
It does not cover the other axis #23's user story 5 implies: a **local R value**
named by a bare symbol inside a data-masked expression. Tidy evaluation
resolves that symbol against the data mask before the calling environment, so a
source column of the same name supplies the argument instead of the local — and
the result is silently wrong rather than an error, which is why no CRAN check
and no existing test caught it.

Four sites did this. Each now injects the value instead of naming it, and
carries a comment stating which resolution order the injection defeats, so the
shape is not "simplified" back later.

**`reconstruct_factor.data.frame()`** (`R/factor.R`, also serving the
`dtplyr_step` method) named `new_levels`, `ord`, and `missing_sentinel` into a
`dplyr::mutate()` expression. A column named `new_levels` rebuilt every factor
dimension from that column's values, so the restored factor came back all
`<NA>`.

**`reconstruct_factor.tbl_duckdb_connection()`** named `sql_query`, so a column
of that name replaced the `CAST(... AS ENUM ...)` with its own values.

**`nest_expanded_margins()`** (`R/nest_with_margins.R`) ran `rename()` and
`relocate()` *inside* a data-masked summary expression, where
`dplyr::all_of(keep_cols)` resolves against the nested rows before the
environment. `rlang::inject()` now reaches the whole call. Note this is
specifically the nested case: `all_of()` inside `across()`, `pick()`, or a
top-level `.by` is safe, which is why the sibling `else` branch is untouched.

**`add_grouping_set_id()`** (`R/grouping-adapter-union.R`) was not in the
original ticket — #76's last acceptance criterion asks for a sweep of every
remaining site, and the sweep found it. It wrote
`"{set_id_name}" := as.integer(set_id)` with a bare `set_id`, so a grouping
column of that name numbered every row from its own values instead of the
Grouping set identifier:

```r
d <- data.frame(g = c("a","a","b"), set_id = c(10L,20L,30L), v = c(1,2,3))
summarize_with_margins(d, s = sum(v), .by = set_id,
                       .grouping = rollup(g), .id = "sid")$sid
#> before: 10 20 30 10 20 30      after: 1 1 1 2 2 2
```

This is the widest of the four: it reaches `.id` on both
`summarize_with_margins()` and `expand_with_margins()`, on every backend, since
the union adapter serves them all.

## Sweep result

Nothing else is exposed, recorded in full on #76. Three facts carry it, each
verified rather than assumed:

1. **`.data[[var]]` is safe** — rlang evaluates the subscript in the calling
   environment, not the mask. This covers the seven remaining candidate sites.
2. **The `"{name}" :=` glue left-hand side is safe**, likewise evaluated in the
   calling environment.
3. **Top-level tidyselect is safe** — only the nested case above is not.

That first fact also corrects a premise in #76 itself, which listed the factor
method's `.data[[col]]` read among the broken values. It was never vulnerable.
`.data[[!!col]]` here is therefore a behavioural no-op and `"col"` in
`factor_shadow_names` is defensive coverage rather than a regression test; both
are kept for consistency, and #76's Problem section is corrected so a later
sweep does not inherit the false premise and widen its scope.

## Testing

Coverage sits at the public verb seam, per #23's Testing Decisions ("The
highest and primary test seam is the exported Margin verb interface"):
`tests/testthat/test-internal-name-shadowing.R` exercises every shadowed name
as an ordinary source column, across local, dtplyr, and DuckDB, including
ordered factors, `NA` levels, and a dimension that itself bears a colliding
name. Every new expectation was confirmed to fail without its fix.

The two live-backend contracts are named in `release-matrix.yaml`'s `proves`
lists, since a fix only observable on a live backend is exactly what those
lists exist to keep from being retired by a rename or an unrelated skip.

`lintr::lint_package()` is clean after `pkgload::load_all()`, and the full
suite is `FAIL 0 | WARN 0 | SKIP 0 | PASS 1593` locally with every optional
backend installed.
