### PR TITLE
Stop signaling a lifecycle condition on every generated column reference

### DIFF
--- a/R/factor.R
+++ b/R/factor.R
@@ -93,7 +93,7 @@ reconstruct_factor.data.frame <- function(data,
     .data = data,
     "{col}" := !!rlang::expr(
       reconstruct_factor_vector(
-        .data[[!!col]],
+        !!margin_column_pronoun(col),
         new_levels = !!new_levels,
         ordered = !!ord,
         missing_sentinel = !!missing_sentinel

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -67,9 +67,9 @@ summarize_margin_native <- function(.data,
       function(var, flag, label) {
         rlang::expr(
           dplyr::if_else(
-            .data[[!!flag]] == 1L,
+            (!!margin_column_pronoun(flag)) == 1L,
             !!label,
-            as.character(.data[[!!var]])
+            as.character(!!margin_column_pronoun(var))
           )
         )
       },

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -41,7 +41,7 @@ summarize_margin_union <- function(.data,
   if (length(group_vars) > 0L) {
     key_exprs <- lapply(
       group_vars,
-      function(var) rlang::expr(.data[[!!var]])
+      function(var) margin_column_pronoun(var)
     )
     names(key_exprs) <- unname(key_names)
     .data <- dplyr::mutate(.data, !!!key_exprs)

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -39,10 +39,7 @@ summarize_margin_union <- function(.data,
   names(key_names) <- group_vars
 
   if (length(group_vars) > 0L) {
-    key_exprs <- lapply(
-      group_vars,
-      function(var) margin_column_pronoun(var)
-    )
+    key_exprs <- lapply(group_vars, margin_column_pronoun)
     names(key_exprs) <- unname(key_names)
     .data <- dplyr::mutate(.data, !!!key_exprs)
   }

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -275,7 +275,7 @@ label_margin_branch <- function(.data,
         )
         rlang::expr(
           encode_factor_for_margin(
-            .data[[!!col]],
+            !!margin_column_pronoun(col),
             missing_sentinel = !!missing_sentinel,
             preserve_missing_value = TRUE
           )

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -290,7 +290,7 @@ execute_margin_nest <- function(operation, .key, .keep) {
       if (length(keep_cols) > 0L) {
         keep_exprs <- lapply(
           group_cols,
-          function(var) rlang::expr(.data[[!!var]])
+          function(var) margin_column_pronoun(var)
         )
         names(keep_exprs) <- unname(keep_cols)
         data <- dplyr::mutate(data, !!!keep_exprs)

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -288,10 +288,7 @@ execute_margin_nest <- function(operation, .key, .keep) {
       }
       data <- operation$data
       if (length(keep_cols) > 0L) {
-        keep_exprs <- lapply(
-          group_cols,
-          function(var) margin_column_pronoun(var)
-        )
+        keep_exprs <- lapply(group_cols, margin_column_pronoun)
         names(keep_exprs) <- unname(keep_cols)
         data <- dplyr::mutate(data, !!!keep_exprs)
       }

--- a/R/parent-share.R
+++ b/R/parent-share.R
@@ -1769,10 +1769,7 @@ build_lazy_parent_mapping <- function(result,
                                       plan,
                                       set_id_name) {
   group_vars <- unique(c(plan$by, plan$dimensions))
-  key_exprs <- lapply(
-    group_vars,
-    function(var) margin_column_pronoun(var)
-  )
+  key_exprs <- lapply(group_vars, margin_column_pronoun)
   names(key_exprs) <- group_vars
   denominator_exprs <- lapply(
     sources,

--- a/R/parent-share.R
+++ b/R/parent-share.R
@@ -1683,15 +1683,15 @@ apply_joined_parent_shares <- function(result,
       }
       rlang::expr(
         dplyr::if_else(
-          .data[[!!set_id_name]] %in% !!root_ids,
+          (!!margin_column_pronoun(set_id_name)) %in% !!root_ids,
           1.0,
           dplyr::if_else(
-            is.na(.data[[!!source]]) |
-              is.na(.data[[!!denominator]]) |
-              .data[[!!denominator]] == 0,
+            is.na(!!margin_column_pronoun(source)) |
+              is.na(!!margin_column_pronoun(denominator)) |
+              (!!margin_column_pronoun(denominator)) == 0,
             NA_real_,
-            as.double(.data[[!!source]]) /
-              as.double(.data[[!!denominator]])
+            as.double(!!margin_column_pronoun(source)) /
+              as.double(!!margin_column_pronoun(denominator))
           )
         )
       )
@@ -1771,12 +1771,12 @@ build_lazy_parent_mapping <- function(result,
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_exprs <- lapply(
     group_vars,
-    function(var) rlang::expr(.data[[!!var]])
+    function(var) margin_column_pronoun(var)
   )
   names(key_exprs) <- group_vars
   denominator_exprs <- lapply(
     sources,
-    function(source) rlang::expr(.data[[!!source]])
+    function(source) margin_column_pronoun(source)
   )
   names(denominator_exprs) <- unname(denominator_names[sources])
 
@@ -1821,8 +1821,8 @@ add_lazy_parent_join_keys <- function(result,
       )]
       rlang::expr(
         dplyr::if_else(
-          .data[[!!set_id_name]] %in% !!matching_child_ids,
-          .data[[!!dimension]],
+          (!!margin_column_pronoun(set_id_name)) %in% !!matching_child_ids,
+          !!margin_column_pronoun(dimension),
           NA
         )
       )

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,13 @@
+# rlang soft-deprecated unquoting inside the `.data` pronoun, and signals a
+# lifecycle condition when `expr()` sees it — twice per Margin operation, into
+# whatever condition handler the caller has installed. Building the call
+# directly produces the identical expression, `.data[["name"]]`, without the
+# signal. The name must stay a literal: a bare symbol would be resolved
+# against the data mask when the generated expression runs.
+margin_column_pronoun <- function(name) {
+  rlang::call2("[[", rlang::sym(".data"), name)
+}
+
 assert_logical_scalar <- function(x) {
   nm <- deparse(substitute(x))
   if (!(isTRUE(x) || isFALSE(x))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,6 +5,11 @@
 # signal. The name must stay a literal: a bare symbol would be resolved
 # against the data mask when the generated expression runs.
 margin_column_pronoun <- function(name) {
+  # An invariant, not a Package condition (ADR-0015): every call site passes a
+  # column name it already holds as a string, so no rewrite of a public call
+  # reaches this. A symbol arriving here would build the mask-resolving
+  # reference the comment above warns about, silently.
+  stopifnot(is.character(name), length(name) == 1L, !is.na(name))
   rlang::call2("[[", rlang::sym(".data"), name)
 }
 

--- a/tests/testthat/test-data-pronoun.R
+++ b/tests/testthat/test-data-pronoun.R
@@ -1,0 +1,98 @@
+# Generated expressions reference source columns through `.data[["name"]]`
+# built directly, not through unquoting inside the pronoun. rlang
+# soft-deprecated the latter and signals a lifecycle condition for it, which
+# would otherwise reach every caller handling conditions around a Margin verb
+# — including one catching `marginplyr_error`.
+
+lifecycle_signals <- function(expr) {
+  count <- 0L
+  withCallingHandlers(
+    force(expr),
+    condition = function(cnd) {
+      if (inherits(cnd, "lifecycle_stage")) {
+        count <<- count + 1L
+      }
+    }
+  )
+  count
+}
+
+pronoun_data <- function() {
+  data.frame(
+    g = c("a", "a", "b"),
+    h = c("x", "y", "x"),
+    v = c(1, 2, 3)
+  )
+}
+
+test_that("margin_column_pronoun() builds the pronoun call it replaces", {
+  expect_equal(
+    margin_column_pronoun("region"),
+    quote(.data[["region"]])
+  )
+  expect_equal(lifecycle_signals(margin_column_pronoun("region")), 0L)
+})
+
+test_that("Margin verbs signal no lifecycle condition", {
+  expect_equal(
+    lifecycle_signals(summarize_with_margins(
+      pronoun_data(),
+      s = sum(v),
+      .grouping = rollup(g, h)
+    )),
+    0L
+  )
+  expect_equal(
+    lifecycle_signals(summarize_with_margins(
+      pronoun_data(),
+      s = sum(v),
+      p = share_of_parent(s),
+      .grouping = rollup(g, h)
+    )),
+    0L
+  )
+  expect_equal(
+    lifecycle_signals(expand_with_margins(
+      pronoun_data(),
+      .grouping = rollup(g)
+    )),
+    0L
+  )
+  expect_equal(
+    lifecycle_signals(nest_with_margins(
+      pronoun_data(),
+      .grouping = rollup(g)
+    )),
+    0L
+  )
+})
+
+test_that("results are unchanged by the construction", {
+  result <- summarize_with_margins(
+    pronoun_data(),
+    s = sum(v),
+    p = share_of_parent(s),
+    .grouping = rollup(g, h)
+  )
+
+  expect_equal(result$s, c(1, 2, 3, 3, 3, 6))
+  expect_equal(result$p, c(1 / 3, 2 / 3, 1, 0.5, 0.5, 1))
+})
+
+test_that("a source column named `.data` does not reach the pronoun", {
+  # The pronoun always refers to the mask, so a column of that name is data
+  # like any other. It is exercised here because the replacement builds the
+  # pronoun symbol itself. `all_of()` is required to select it, exactly as in
+  # plain dplyr: a bare `.data` is the pronoun in any tidyselect context.
+  data <- data.frame(g = c("a", "b"), .data = c(1, 2), v = c(1, 2))
+
+  result <- summarize_with_margins(
+    data,
+    s = sum(v),
+    .by = dplyr::all_of(".data"),
+    .grouping = rollup(g)
+  )
+
+  expect_equal(nrow(result), 4L)
+  expect_equal(sum(result$s), 6)
+})

--- a/tests/testthat/test-data-pronoun.R
+++ b/tests/testthat/test-data-pronoun.R
@@ -25,6 +25,18 @@ pronoun_data <- function() {
   )
 }
 
+# A factor dimension routes through the label and factor-reconstruction paths,
+# which a character dimension never reaches. Before the change these signalled
+# 5, 2, and 3 conditions respectively, against 0 for the character fixture —
+# so the character calls below assert nothing on their own.
+pronoun_factor_data <- function() {
+  data.frame(
+    g = factor(c("a", "a", "b")),
+    h = c("x", "y", "x"),
+    v = c(1, 2, 3)
+  )
+}
+
 test_that("margin_column_pronoun() builds the pronoun call it replaces", {
   expect_equal(
     margin_column_pronoun("region"),
@@ -67,6 +79,37 @@ test_that("Margin verbs signal no lifecycle condition", {
   )
 })
 
+test_that("the label, factor, and keep paths signal no lifecycle condition", {
+  expect_equal(
+    lifecycle_signals(summarize_with_margins(
+      pronoun_factor_data(),
+      s = sum(v),
+      .grouping = rollup(g, h)
+    )),
+    0L
+  )
+  expect_equal(
+    lifecycle_signals(expand_with_margins(
+      pronoun_factor_data(),
+      .grouping = rollup(g)
+    )),
+    0L
+  )
+  expect_equal(
+    lifecycle_signals(nest_with_margins(
+      pronoun_factor_data(),
+      .grouping = rollup(g),
+      .keep = TRUE
+    )),
+    0L
+  )
+})
+
+test_that("margin_column_pronoun() rejects a name that is not a literal", {
+  expect_error(margin_column_pronoun(quote(region)))
+  expect_error(margin_column_pronoun(c("a", "b")))
+})
+
 test_that("results are unchanged by the construction", {
   result <- summarize_with_margins(
     pronoun_data(),
@@ -95,4 +138,68 @@ test_that("a source column named `.data` does not reach the pronoun", {
 
   expect_equal(nrow(result), 4L)
   expect_equal(sum(result$s), 6)
+})
+
+# The per-verb assertions above are kept because they record the measured
+# counts this change was made to remove, but they cannot be the whole guard:
+# they only fail when a new site sits on a path one of those six calls
+# executes. That is not a theoretical gap. This branch was written against
+# fifteen sites; while it waited for review, a sixteenth arrived in
+# `R/factor.R` on an unrelated commit, and no call asserted above reaches it.
+# The scan below is coverage-independent — it reads the namespace's own
+# expressions, so a new site fails it wherever it is written, including in
+# code no test executes.
+unquoted_pronoun_sites <- function(ns) {
+  hits <- character()
+  # The empty symbol is held inside a list. Binding it to a variable and
+  # reading that variable back raises "argument is missing", which is what
+  # any argument-less call in a scanned body would otherwise trigger.
+  empty <- list(quote(expr = ))
+
+  is_unquote <- function(x) {
+    is.call(x) && identical(x[[1]], quote(`!`)) && length(x) == 2L &&
+      is.call(x[[2]]) && identical(x[[2]][[1]], quote(`!`))
+  }
+
+  walk <- function(x, where) {
+    if (!is.call(x)) {
+      return(invisible(NULL))
+    }
+    is_pronoun_index <- identical(x[[1]], quote(`[[`)) &&
+      length(x) >= 3L &&
+      identical(x[[2]], quote(.data))
+    if (is_pronoun_index && is_unquote(x[[3]])) {
+      hits <<- c(hits, where)
+    }
+    parts <- as.list(x)
+    for (i in seq_along(parts)) {
+      if (!identical(parts[i], empty)) {
+        walk(parts[[i]], where)
+      }
+    }
+    invisible(NULL)
+  }
+
+  for (nm in ls(ns, all.names = TRUE)) {
+    obj <- tryCatch(get(nm, envir = ns), error = function(e) NULL)
+    if (is.function(obj)) {
+      walk(body(obj), nm)
+    }
+  }
+  sort(unique(hits))
+}
+
+test_that("no function in the package unquotes inside the `.data` pronoun", {
+  # Reads the loaded namespace rather than the sources under `R/`, which are
+  # not installed alongside the tests.
+  expect_equal(unquoted_pronoun_sites(asNamespace("marginplyr")), character())
+})
+
+test_that("the pronoun scan detects the shape it exists to reject", {
+  # Without this, the scan above would keep passing if the matcher broke.
+  ns <- new.env(parent = emptyenv())
+  ns$offender <- function(col) rlang::expr(.data[[!!col]])
+  ns$innocent <- function(col) margin_column_pronoun(col)
+
+  expect_equal(unquoted_pronoun_sites(ns), "offender")
 })


### PR DESCRIPTION
Closes #78. Part of #23; blocks #40.

## Problem

marginplyr built column references as `rlang::expr(.data[[!!var]])`. rlang
soft-deprecated unquoting inside the `.data` pronoun and signals a
`lifecycle_stage` condition each time `expr()` sees that shape. The signal is
not a warning, so nothing surfaces in normal use — but it reaches every
condition handler a caller has installed around a Margin verb, including one
installed to catch `marginplyr_error`. A single
`summarize_with_margins(..., p = share_of_parent(s), ...)` produced nineteen.

That is noise in exactly the channel #23's condition contract depends on: user
story 27 wants backend and user-expression conditions left in their original
classes, and Parent-share execution catches structured package conditions
rather than matching message text. It is also a forward risk — rlang can
escalate a soft-deprecation to a warning in a patch release, at which point a
released marginplyr warns nineteen times with no change on this side.

## Change

`margin_column_pronoun()` in `R/utils.R` builds the call directly with
`rlang::call2("[[", rlang::sym(".data"), name)`, which produces the identical
expression, `.data[["name"]]`, with no signal. All sixteen sites use it.

The name must stay a literal — a bare symbol would resolve against the data
mask when the generated expression runs — so the helper asserts that with
`stopifnot()`. That is an invariant rather than a Package condition
(ADR-0015): every call site passes a column name it already holds as a string,
so no rewrite of a public call reaches it.

## Guarding against the next site

The per-verb zero-signal assertions cannot carry this alone, and the rebase
demonstrated why rather than merely suggesting it. This branch was written
against fifteen sites; while it waited for review, `1e919c1` (the
internal-shadowing fix, #79) added a sixteenth in `R/factor.R`, reached by
none of the asserted calls. Adding more verbs would not have closed that — any
per-verb assertion only fails when a new site sits on a path an asserted call
executes.

`unquoted_pronoun_sites()` in `tests/testthat/test-data-pronoun.R` walks every
function body in the namespace for the `.data[[!!x]]` AST shape instead, so a
new site fails wherever it is written, including in code no test executes. It
finds all seventeen occurrences on `main` (sixteen sites;
`reconstruct_factor.dtplyr_step` shares a body with
`reconstruct_factor.data.frame`) and none here. It reads the loaded namespace
rather than the sources under `R/`, which are not installed alongside the
tests, so it holds under `R CMD check`. A second test feeds it a known
offender so a broken matcher cannot pass quietly.

## Review

`/code-review` against `origin/main` with #78 as the Spec input: no hard
standards violations, no scope creep. Both axes independently found that two
of the four original zero-signal assertions were vacuous — `expand_with_margins()`
and `nest_with_margins()` signal zero on `main` too with a character-only
fixture, leaving the `R/factor.R`, `R/margin-label.R`, and
`R/nest_with_margins.R` edits unexecuted. With a factor dimension `main`
signals 5, 2, and 3; those assertions were added. Findings and the two
declined judgement calls are recorded on #78.

## Verification

- `pkgload::load_all(".", quiet = TRUE); lintr::lint_package()` — clean.
- Full suite — no failures. `test-data-pronoun.R` carries 17 expectations.
- A result-equality test confirms the construction changes no output.
- A source column literally named `.data` is still handled, selected with
  `dplyr::all_of(".data")` exactly as plain dplyr requires.