### PR TITLE
Reject misspelled options and unsupported input in the caller's terms

### DIFF
--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -73,7 +73,13 @@ expand_with_margins <- function(.data,
                                 .duplicates = c("error", "drop", "keep"),
                                 .id = NULL) {
   call <- rlang::current_call()
-  with_margin_error_call(assert_lazy_table(.data), call = call)
+  with_margin_error_call(
+    {
+      assert_margin_input(.data)
+      assert_lazy_table(.data)
+    },
+    call = call
+  )
   grouping_quo <- rlang::enquo(.grouping)
   by_quo <- rlang::enquo(.by)
 

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -39,6 +39,7 @@ abort_invalid_grouping_spec <- function() {
 
 normalize_grouping_input <- function(.data, by_quo) {
   stopifnot(rlang::is_quosure(by_quo))
+  assert_margin_input(.data)
 
   if (inherits(.data, "rowwise_df")) {
     abort_marginplyr(

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -39,7 +39,6 @@ abort_invalid_grouping_spec <- function() {
 
 normalize_grouping_input <- function(.data, by_quo) {
   stopifnot(rlang::is_quosure(by_quo))
-  assert_margin_input(.data)
 
   if (inherits(.data, "rowwise_df")) {
     abort_marginplyr(

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -127,6 +127,7 @@ inspect_grouping <- function(.data,
 
   with_margin_error_call(
     {
+      assert_margin_input(.data)
       assert_lazy_table(.data)
       .format <- match_margin_choice(
         .format,

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -183,6 +183,10 @@ nest_margin_pipeline <- function(.data,
 
   with_margin_error_call(
     {
+      # General admission first, then the narrower constraint: an input dplyr
+      # cannot group is not a nesting problem, and reporting it as one would
+      # answer a caller who supplied a matrix with the classes that nest.
+      assert_margin_input(.data)
       assert_nest_possible(.data)
       assert_logical_scalar(.keep)
       assert_string_scalar(.key)

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -489,6 +489,7 @@ summarize_with_margins <- function(.data,
         .id = .id
       )
       check_removed_groups_argument(dots)
+      check_option_named_summaries(dots)
       check_summary_context_helpers(dots)
       preflight_parent_shares(dots)
     },

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -480,6 +480,7 @@ summarize_with_margins <- function(.data,
 
   has_parent_shares <- with_margin_error_call(
     {
+      assert_margin_input(.data)
       assert_lazy_table(.data)
       normalize_margin_options(
         .margin_label = .margin_label,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -13,28 +13,45 @@ check_removed_groups_argument <- function(dots) {
 
 # Options the verb once had. A caller following older material writes them as
 # if they were still arguments, and `...` would otherwise accept the value as
-# an ordinary summary and return a constant column.
-removed_summary_options <- c(".sort")
+# an ordinary summary and return a constant column. Each entry carries its own
+# guidance, because what replaces a removed option is specific to that option:
+# a shared sentence parameterized by the name would be confidently wrong for
+# the second entry added here.
+#
+# Naming `grouping_bit()` matters for `.sort`: sorting the result by a
+# dimension's displayed values puts a margin wherever its label falls in the
+# value order, which is not the order the caller writing `.sort` is asking for.
+removed_summary_options <- list(
+  .sort = paste0(
+    "row order is unspecified. Call `dplyr::arrange()` on the result, and ",
+    "add a `grouping_bit()` summary per dimension to sort each margin with ",
+    "the rows it summarizes."
+  )
+)
 
 # Every dot-prefixed name the summary verb answers to. `...` sits before them
 # in the signature, so R matches them exactly and a name that reaches `...`
 # was either misspelled or spliced in.
+#
+# `.data` and `...` are excluded. Neither can reach `...` as a mistaken option
+# name — `.data` matches its own formal exactly, and `...` is not a name a
+# caller can write — so keeping them would only widen the near-miss net over
+# ordinary output names, which is how `.date` came to resemble `.data`.
 summary_option_names <- function() {
-  names(formals(summarize_with_margins))[
-    startsWith(names(formals(summarize_with_margins)), ".")
-  ]
+  formal_names <- names(formals(summarize_with_margins))
+  setdiff(formal_names[startsWith(formal_names, ".")], c(".data", "..."))
 }
 
 # Only dot-prefixed names are examined, and only against an exact match or a
 # one-character difference: that catches the pluralizations real callers
 # write (`.margin_labels`, `.groupings`, `.duplicate`) while leaving ordinary
 # leading-dot output names such as `.n` alone.
-misspelled_summary_option <- function(name, options) {
-  if (name %in% options) {
+nearest_summary_option <- function(name, known_options) {
+  if (name %in% known_options) {
     return(name)
   }
-  distances <- utils::adist(name, options)[1L, ]
-  nearest <- options[distances <= 1L]
+  distances <- utils::adist(name, known_options)[1L, ]
+  nearest <- known_options[distances <= 1L]
   if (length(nearest) == 0L) {
     return(NULL)
   }
@@ -51,23 +68,27 @@ check_option_named_summaries <- function(dots) {
     return(invisible(NULL))
   }
 
-  options <- c(summary_option_names(), removed_summary_options)
+  known_options <- c(summary_option_names(), names(removed_summary_options))
   for (name in candidates) {
-    matched <- misspelled_summary_option(name, options)
+    matched <- nearest_summary_option(name, known_options)
     if (is.null(matched)) {
       next
     }
-    if (matched %in% removed_summary_options) {
-      # Naming `grouping_bit()` matters: sorting the result by its displayed
-      # values puts a margin wherever its label falls in the value order,
-      # which is not the order the caller writing `.sort` is asking for.
-      abort_marginplyr(
+    # Both messages name what the caller wrote, not only what it resembles: a
+    # caller who wrote `.sorts` never wrote `.sort`, and an error naming only
+    # the option they were reaching for leaves them looking for a word that is
+    # not in their code.
+    if (matched %in% names(removed_summary_options)) {
+      opening <- if (identical(name, matched)) {
+        paste0("`summarize_with_margins()` has no `", matched, "` argument")
+      } else {
         paste0(
-          "`summarize_with_margins()` has no `", matched, "` argument; row ",
-          "order is unspecified. Call `dplyr::arrange()` on the result, and ",
-          "add a `grouping_bit()` summary per dimension to sort each margin ",
-          "with the rows it summarizes."
+          "`", name, "` is not an argument of `summarize_with_margins()`, ",
+          "and neither is the `", matched, "` it resembles"
         )
+      }
+      abort_marginplyr(
+        paste0(opening, "; ", removed_summary_options[[matched]])
       )
     }
     abort_marginplyr(

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -11,6 +11,76 @@ check_removed_groups_argument <- function(dots) {
   )
 }
 
+# Options the verb once had. A caller following older material writes them as
+# if they were still arguments, and `...` would otherwise accept the value as
+# an ordinary summary and return a constant column.
+removed_summary_options <- c(".sort")
+
+# Every dot-prefixed name the summary verb answers to. `...` sits before them
+# in the signature, so R matches them exactly and a name that reaches `...`
+# was either misspelled or spliced in.
+summary_option_names <- function() {
+  names(formals(summarize_with_margins))[
+    startsWith(names(formals(summarize_with_margins)), ".")
+  ]
+}
+
+# Only dot-prefixed names are examined, and only against an exact match or a
+# one-character difference: that catches the pluralizations real callers
+# write (`.margin_labels`, `.groupings`, `.duplicate`) while leaving ordinary
+# leading-dot output names such as `.n` alone.
+misspelled_summary_option <- function(name, options) {
+  if (name %in% options) {
+    return(name)
+  }
+  distances <- utils::adist(name, options)[1L, ]
+  nearest <- options[distances <= 1L]
+  if (length(nearest) == 0L) {
+    return(NULL)
+  }
+  nearest[[1L]]
+}
+
+check_option_named_summaries <- function(dots) {
+  dot_names <- names(dots)
+  if (is.null(dot_names)) {
+    return(invisible(NULL))
+  }
+  candidates <- unique(dot_names[startsWith(dot_names, ".")])
+  if (length(candidates) == 0L) {
+    return(invisible(NULL))
+  }
+
+  options <- c(summary_option_names(), removed_summary_options)
+  for (name in candidates) {
+    matched <- misspelled_summary_option(name, options)
+    if (is.null(matched)) {
+      next
+    }
+    if (matched %in% removed_summary_options) {
+      # Naming `grouping_bit()` matters: sorting the result by its displayed
+      # values puts a margin wherever its label falls in the value order,
+      # which is not the order the caller writing `.sort` is asking for.
+      abort_marginplyr(
+        paste0(
+          "`summarize_with_margins()` has no `", matched, "` argument; row ",
+          "order is unspecified. Call `dplyr::arrange()` on the result, and ",
+          "add a `grouping_bit()` summary per dimension to sort each margin ",
+          "with the rows it summarizes."
+        )
+      )
+    }
+    abort_marginplyr(
+      paste0(
+        "`", name, "` is not an argument of `summarize_with_margins()`, so ",
+        "it was captured as a summary named `", name, "`. Did you mean `",
+        matched, "`? Rename the summary if the column is intended."
+      )
+    )
+  }
+  invisible(NULL)
+}
+
 check_summary_context_helpers <- function(dots) {
   unsupported <- unique(unlist(
     lapply(

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,6 +46,38 @@ assert_nest_possible <- function(x) {
   }
 }
 
+# Admission is duck-typed rather than a class whitelist: marginplyr supports
+# any input the dplyr verbs it calls can handle, and a whitelist would reject
+# a backend that works. `group_vars()` is the first dplyr generic every Margin
+# operation reaches, so an input without a method for it cannot proceed, and
+# saying so here keeps the diagnostic in the caller's terms instead of
+# surfacing "no applicable method for 'group_vars'".
+assert_margin_input <- function(x) {
+  nm <- deparse(substitute(x))
+  supported <- tryCatch(
+    {
+      dplyr::group_vars(x)
+      TRUE
+    },
+    error = function(cnd) FALSE
+  )
+  if (supported) {
+    return(invisible(NULL))
+  }
+
+  abort_marginplyr(
+    sprintf(
+      paste0(
+        "`%s` must be a data frame or a lazy table that supports dplyr ",
+        "verbs; %s was supplied. Convert it with `as.data.frame()` or ",
+        "`dplyr::tbl()` first."
+      ),
+      nm,
+      if (is.null(x)) "`NULL`" else sprintf("a <%s>", class(x)[[1L]])
+    )
+  )
+}
+
 assert_lazy_table <- function(x) {
   nm <- deparse(substitute(x))
   invalid_lazy_table_names <- "RecordBatchReader"

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,16 +52,31 @@ assert_nest_possible <- function(x) {
 # operation reaches, so an input without a method for it cannot proceed, and
 # saying so here keeps the diagnostic in the caller's terms instead of
 # surfacing "no applicable method for 'group_vars'".
+#
+# Admissibility is decided by looking for a method rather than by calling the
+# generic and catching whatever comes back. A backend's `group_vars()` can
+# fail for its own reasons, and catching every error would report that failure
+# as the caller having supplied the wrong kind of object. dplyr registers no
+# default method, so an object no registered method matches is exactly the
+# object the generic cannot dispatch on.
 assert_margin_input <- function(x) {
   nm <- deparse(substitute(x))
-  supported <- tryCatch(
-    {
-      dplyr::group_vars(x)
-      TRUE
+  dispatches <- any(vapply(
+    class(x),
+    function(cls) {
+      # `envir` names the namespace that owns the generic. The default is the
+      # caller's frame, where `group_vars` is not visible from inside this
+      # package, so every class would look unsupported.
+      !is.null(utils::getS3method(
+        "group_vars",
+        cls,
+        optional = TRUE,
+        envir = asNamespace("dplyr")
+      ))
     },
-    error = function(cnd) FALSE
-  )
-  if (supported) {
+    logical(1L)
+  ))
+  if (dispatches) {
     return(invisible(NULL))
   }
 

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -17,16 +17,23 @@ test_that("a removed option is reported instead of summarized", {
       .grouping = rollup(g),
       .sort = TRUE
     ),
+    "no `.sort` argument",
     class = "marginplyr_error"
   )
+})
+
+test_that("a near miss on a removed option names what the caller wrote", {
+  # The caller never wrote `.sort`, so an error naming only the option they
+  # were reaching for sends them looking for a word that is not in their code.
   expect_error(
     summarize_with_margins(
       admission_data(),
       s = sum(v),
       .grouping = rollup(g),
-      .sort = TRUE
+      .sorts = TRUE
     ),
-    "no `.sort` argument"
+    "`.sorts` is not an argument.+neither is the `.sort` it resembles",
+    class = "marginplyr_error"
   )
 })
 
@@ -96,17 +103,28 @@ test_that("the check is scoped to names that resemble an option", {
     ),
     c("g", ".set", "s")
   )
+  # `.data` and `...` are formals but not options a caller can misspell into
+  # `...`, so they are kept out of the comparison. Counting `.data` made
+  # `.date` — an ordinary output name — a near miss.
+  expect_named(
+    summarize_with_margins(
+      admission_data(),
+      .date = max(v),
+      .grouping = rollup(g)
+    ),
+    c("g", ".date")
+  )
 })
 
 test_that("the option check survives splicing", {
-  options <- list(.sort = TRUE)
+  spliced <- list(.sort = TRUE)
 
   expect_error(
     summarize_with_margins(
       admission_data(),
       s = sum(v),
       .grouping = rollup(g),
-      !!!options
+      !!!spliced
     ),
     class = "marginplyr_error"
   )
@@ -116,11 +134,8 @@ test_that("input that dplyr cannot group is rejected in the caller's terms", {
   for (input in list(as.matrix(admission_data()), as.list(admission_data()))) {
     expect_error(
       summarize_with_margins(input, s = sum(v), .grouping = rollup(g)),
+      "must be a data frame or a lazy table",
       class = "marginplyr_error"
-    )
-    expect_error(
-      summarize_with_margins(input, s = sum(v), .grouping = rollup(g)),
-      "must be a data frame or a lazy table"
     )
   }
 
@@ -132,21 +147,43 @@ test_that("input that dplyr cannot group is rejected in the caller's terms", {
 
 test_that("every entry point admits input the same way", {
   input <- as.matrix(admission_data())
+  # The same message, not merely the same class: the nesting verbs reject a
+  # matrix on their own narrower whitelist too, which would satisfy a
+  # class-only assertion while answering the caller with the classes that nest.
+  admission_message <- "must be a data frame or a lazy table"
 
   expect_error(
     expand_with_margins(input, .grouping = rollup(g)),
+    admission_message,
     class = "marginplyr_error"
   )
   expect_error(
     nest_with_margins(input, .grouping = rollup(g)),
+    admission_message,
     class = "marginplyr_error"
   )
   expect_error(
     nest_by_with_margins(input, .grouping = rollup(g)),
+    admission_message,
     class = "marginplyr_error"
   )
   expect_error(
     inspect_grouping(input, .grouping = rollup(g)),
+    admission_message,
+    class = "marginplyr_error"
+  )
+})
+
+test_that("admission does not widen what the nesting verbs accept", {
+  skip_if_backend_absent("arrow")
+
+  # Admitted by the shared rule, still refused by nesting's own constraint.
+  expect_error(
+    nest_with_margins(
+      arrow::as_arrow_table(admission_data()),
+      .grouping = rollup(g)
+    ),
+    "which can be nested",
     class = "marginplyr_error"
   )
 })

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -1,0 +1,189 @@
+# Two admission rules that keep a mistake from becoming a plausible result.
+#
+# `...` accepts any named expression, so an argument name the verb does not
+# have becomes a constant summary column instead of an error; and an input
+# without dplyr methods reached `group_vars()` and reported an internal
+# generic rather than the argument the caller supplied.
+
+admission_data <- function() {
+  data.frame(g = c("a", "a", "b"), v = c(1, 2, 3))
+}
+
+test_that("a removed option is reported instead of summarized", {
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .sort = TRUE
+    ),
+    class = "marginplyr_error"
+  )
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .sort = TRUE
+    ),
+    "no `.sort` argument"
+  )
+})
+
+test_that("a misspelled option names the argument it resembles", {
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .margin_labels = "ALL"
+    ),
+    "Did you mean `.margin_label`"
+  )
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .groupings = rollup(g)
+    ),
+    "Did you mean `.grouping`"
+  )
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .duplicate = "drop"
+    ),
+    "Did you mean `.duplicates`"
+  )
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .ids = "set"
+    ),
+    "Did you mean `.id`"
+  )
+})
+
+test_that("the check is scoped to names that resemble an option", {
+  # A leading dot is ordinary in an output name, and only an exact match or a
+  # one-character difference is treated as a mistake.
+  expect_named(
+    summarize_with_margins(
+      admission_data(),
+      .n = dplyr::n(),
+      .grouping = rollup(g)
+    ),
+    c("g", ".n")
+  )
+  expect_named(
+    summarize_with_margins(
+      admission_data(),
+      .total_by_region = sum(v),
+      .grouping = rollup(g)
+    ),
+    c("g", ".total_by_region")
+  )
+  expect_named(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .id = ".set"
+    ),
+    c("g", ".set", "s")
+  )
+})
+
+test_that("the option check survives splicing", {
+  options <- list(.sort = TRUE)
+
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      !!!options
+    ),
+    class = "marginplyr_error"
+  )
+})
+
+test_that("input that dplyr cannot group is rejected in the caller's terms", {
+  for (input in list(as.matrix(admission_data()), as.list(admission_data()))) {
+    expect_error(
+      summarize_with_margins(input, s = sum(v), .grouping = rollup(g)),
+      class = "marginplyr_error"
+    )
+    expect_error(
+      summarize_with_margins(input, s = sum(v), .grouping = rollup(g)),
+      "must be a data frame or a lazy table"
+    )
+  }
+
+  expect_error(
+    summarize_with_margins(NULL, s = sum(v), .grouping = rollup(g)),
+    "`NULL` was supplied"
+  )
+})
+
+test_that("every entry point admits input the same way", {
+  input <- as.matrix(admission_data())
+
+  expect_error(
+    expand_with_margins(input, .grouping = rollup(g)),
+    class = "marginplyr_error"
+  )
+  expect_error(
+    nest_with_margins(input, .grouping = rollup(g)),
+    class = "marginplyr_error"
+  )
+  expect_error(
+    nest_by_with_margins(input, .grouping = rollup(g)),
+    class = "marginplyr_error"
+  )
+  expect_error(
+    inspect_grouping(input, .grouping = rollup(g)),
+    class = "marginplyr_error"
+  )
+})
+
+test_that("supported backends are still admitted", {
+  expect_no_error(
+    summarize_with_margins(
+      tibble::as_tibble(admission_data()),
+      s = sum(v),
+      .grouping = rollup(g)
+    )
+  )
+  expect_no_error(
+    summarize_with_margins(
+      dplyr::group_by(admission_data(), g),
+      s = sum(v)
+    )
+  )
+
+  skip_if_backend_absent("dtplyr")
+  expect_no_error(
+    dplyr::collect(summarize_with_margins(
+      dtplyr::lazy_dt(admission_data()),
+      s = sum(v),
+      .grouping = rollup(g)
+    ))
+  )
+})
+
+test_that("arrow input is still admitted", {
+  skip_if_backend_absent("arrow")
+
+  expect_no_error(
+    dplyr::collect(summarize_with_margins(
+      arrow::as_arrow_table(admission_data()),
+      s = sum(v),
+      .grouping = rollup(g)
+    ))
+  )
+})


### PR DESCRIPTION
Closes #77.

Two admission gaps, both of which turned a caller's mistake into something
other than a clear error.

## A misspelled or removed option became a summary column

`summarize_with_margins()` collects summaries from `...`, so any named
expression was accepted and an argument name the verb does not have became a
constant column rather than a mistake. `.sort = TRUE` — removed in #15 —
returned a `.sort` column of `TRUE`; `.margin_labels`, `.duplicate`, and `.ids`
each did the same, and `.groupings` errored only by accident with a message
that never named `.grouping`.

`check_option_named_summaries()` now rejects a dot-prefixed summary name that
matches a current option exactly or sits within `utils::adist() <= 1` of one,
and names the option it resembles. Removed options carry their own guidance:
`.sort` states the current contract — row order is unspecified — and points at
`dplyr::arrange()` plus a `grouping_bit()` summary per dimension, because
sorting by a dimension's displayed values would put a margin wherever its
label falls in the value order.

Ordinary leading-dot output names are unaffected: `.n`, `.total_by_region`,
`.date`, and a genuine `.id = ".set"` all pass. The check runs on the captured
quosures, so it survives `!!!` splicing of an options list.

## Input dplyr cannot group reported an internal generic

`normalize_grouping_input()` reached `dplyr::group_vars()` before anything
validated the input, so a matrix or `NULL` produced `no applicable method for
'group_vars' applied to an object of class ...` — a `simpleError` naming a
generic the caller never called, which #23's user story 26 cannot catch by
class.

Each verb now calls `assert_margin_input()` beside the admission check it
already had, and aborts with `marginplyr_error` naming the caller's argument.
Admission is duck-typed rather than a class whitelist so a backend dplyr
supports is not rejected: it looks for a registered `group_vars()` method
rather than calling the generic and catching whatever comes back, so a
backend whose method fails for its own reasons reports that failure instead of
being blamed on the caller's input. dplyr registers no default method, so an
object no method matches is exactly the object the generic cannot dispatch on.

All five entry points admit input the same way — `summarize_with_margins()`,
`expand_with_margins()`, `nest_with_margins()`, `nest_by_with_margins()`, and
`inspect_grouping()`. The nesting verbs keep their narrower constraint for
input the shared rule admits.

## Notes for review

The second commit applies the `/code-review` findings; #77 records each one
and what changed. Two are worth flagging here:

- Admission lives with each verb, not in the shared normalizer, per ADR 0001.
  That also makes the message name the caller's argument by construction
  rather than by every verb happening to spell its first formal `.data`.
- The misspelling threshold stays at edit distance 1, and #77 records why.
  Every miss the issue set out to catch is one character of insertion or
  deletion, so 1 is not too narrow; widening to 2 would reject `.n`, which is
  distance 2 from `.by`. The residue is confined to neighbours of the two
  2-character options `.by` and `.id` — `.sd` and `.idx` are the plausible
  ones — and is intrinsic, since `.idx` is the same edit shape as `.ids`,
  which must be caught. The recorded escape hatch, if it is reported in
  practice, is requiring an exact match for the 2-character options.

`.sort` is planned for this release as a structural sort. When it ships,
`.sort` comes out of `removed_summary_options` and the two `.sort`
expectations move to another option — part of that PR, not this one.

## Checks

`pkgload::load_all(".", quiet = TRUE); lintr::lint_package()` is clean, and the
full suite passes: 1633 expectations, 0 failures, 0 skips.
