### PR TITLE
Move .groups into the removed-option mechanism

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,4 +55,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -500,7 +500,6 @@ summarize_with_margins <- function(.data,
         .duplicates = .duplicates,
         .id = .id
       )
-      check_removed_groups_argument(dots)
       check_option_named_summaries(dots)
       check_summary_context_helpers(dots)
       preflight_shares(dots)

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -1,22 +1,10 @@
-check_removed_groups_argument <- function(dots) {
-  if (!".groups" %in% names(dots)) {
-    return(invisible(NULL))
-  }
-
-  abort_marginplyr(
-    paste0(
-      "`summarize_with_margins()` does not support `.groups`; ",
-      "Margin-summary results are always ungrouped."
-    )
-  )
-}
-
 # Options the verb once had. A caller following older material writes them as
 # if they were still arguments, and `...` would otherwise accept the value as
 # an ordinary summary and return a constant column. Each entry carries its own
 # guidance, because what replaces a removed option is specific to that option:
-# a shared sentence parameterized by the name would be confidently wrong for
-# the second entry added here.
+# `.sort` is answered by a call the caller adds, `.groups` by a property the
+# result already has, and a shared sentence parameterized by the name could
+# say neither.
 #
 # Naming `grouping_bit()` matters for `.sort`: sorting the result by a
 # dimension's displayed values puts a margin wherever its label falls in the
@@ -26,7 +14,8 @@ removed_summary_options <- list(
     "row order is unspecified. Call `dplyr::arrange()` on the result, and ",
     "add a `grouping_bit()` summary per dimension to sort each margin with ",
     "the rows it summarizes."
-  )
+  ),
+  .groups = "Margin-summary results are always ungrouped."
 )
 
 # Every dot-prefixed name the summary verb answers to. `...` sits before them
@@ -46,6 +35,12 @@ summary_option_names <- function() {
 # one-character difference: that catches the pluralizations real callers
 # write (`.margin_labels`, `.groupings`, `.duplicate`) while leaving ordinary
 # leading-dot output names such as `.n` alone.
+#
+# The net is not free of ordinary names: `.groups` puts `.group` inside it, and
+# `.group` is a plausible column to want. That is the trade the removed options
+# are worth — a caller who meant the column renames it, while a caller
+# following older material gets told what replaced the option instead of a
+# constant column named after it.
 nearest_summary_option <- function(name, known_options) {
   if (name %in% known_options) {
     return(name)
@@ -68,6 +63,15 @@ check_option_named_summaries <- function(dots) {
     return(invisible(NULL))
   }
 
+  # A call can carry more than one option-shaped name, and this loop answers
+  # the first one the caller wrote. `.groups` used to be checked ahead of every
+  # name by its own function, so it won regardless of where it appeared; inside
+  # the shared loop it has no such standing.
+  #
+  # Written order is the rule rather than an ordering over the kinds of match,
+  # because a caller who wrote two of these has to fix both, and the only thing
+  # an ordering would change is which one they are sent to first. Reading in
+  # written order keeps that walk down the call instead of jumping around it.
   known_options <- c(summary_option_names(), names(removed_summary_options))
   for (name in candidates) {
     matched <- nearest_summary_option(name, known_options)

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -31,19 +31,31 @@ summary_option_names <- function() {
   setdiff(formal_names[startsWith(formal_names, ".")], c(".data", "..."))
 }
 
+# Leading-dot names a caller writes on purpose, exempt from the net below even
+# though each sits one character from an option. `.group` is one deletion from
+# the removed `.groups`, and a group label column is the likelier reading of it.
+#
+# The exemption is by name because no rule over the distance separates these
+# from the mistakes: `.duplicate` is the same one-character deletion from
+# `.duplicates` and is worth catching. What differs is whether callers write
+# the name deliberately, which only a list can record. The cost is that a
+# caller who typed `.group` meaning `.groups` gets a column instead of the
+# guidance — accepted, because the name is common enough that the net cost
+# landed on people who meant it.
+summary_output_name_exemptions <- c(".group")
+
 # Only dot-prefixed names are examined, and only against an exact match or a
 # one-character difference: that catches the pluralizations real callers
 # write (`.margin_labels`, `.groupings`, `.duplicate`) while leaving ordinary
 # leading-dot output names such as `.n` alone.
-#
-# The net is not free of ordinary names: `.groups` puts `.group` inside it, and
-# `.group` is a plausible column to want. That is the trade the removed options
-# are worth — a caller who meant the column renames it, while a caller
-# following older material gets told what replaced the option instead of a
-# constant column named after it.
 nearest_summary_option <- function(name, known_options) {
   if (name %in% known_options) {
     return(name)
+  }
+  # After the exact match, so a name here would still be answered if it ever
+  # became an option — the exemption covers resemblance, not the option itself.
+  if (name %in% summary_output_name_exemptions) {
+    return(NULL)
   }
   distances <- utils::adist(name, known_options)[1L, ]
   nearest <- known_options[distances <= 1L]

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -108,12 +108,13 @@ produced, and no verb restores one. See
 
 ### Summary selection (`R/summary-selections.R`)
 
-Owns summary-only semantics: rejecting the removed `.groups` argument and
-branch-local grouping-context helpers, resolving `across()` and `pick()`
-selections while excluding every fixed key and grouping dimension, predicting
-known output names, and preventing summary outputs from overwriting grouping
-columns. These checks occur before semantic label validation, including any
-opt-in lazy collision query.
+Owns summary-only semantics: rejecting the removed `.sort` and `.groups`
+options — along with the near misses that resemble them — and branch-local
+grouping-context helpers, resolving `across()` and `pick()` selections while
+excluding every fixed key and grouping dimension, predicting known output
+names, and preventing summary outputs from overwriting grouping columns. These
+checks occur before semantic label validation, including any opt-in lazy
+collision query.
 
 ### Contextual shares (`R/share.R`)
 

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -765,7 +765,11 @@ test_that("summary expressions reject the removed .groups argument", {
       .by = group,
       .groups = "drop"
     ),
-    "`summarize_with_margins\\(\\)` does not support `.groups`"
+    paste0(
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument; ",
+      "Margin-summary results are always ungrouped\\."
+    ),
+    class = "marginplyr_error"
   )
 
   summary_options <- list(.groups = "drop")
@@ -776,7 +780,8 @@ test_that("summary expressions reject the removed .groups argument", {
       .by = group,
       !!!summary_options
     ),
-    "`summarize_with_margins\\(\\)` does not support `.groups`"
+    "`summarize_with_margins\\(\\)` has no `\\.groups` argument",
+    class = "marginplyr_error"
   )
 })
 

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -182,7 +182,7 @@ test_that("removed .groups is rejected before typed metadata acquisition", {
       .grouping = rollup(group),
       !!!summary_options
     ),
-    "`summarize_with_margins\\(\\)` does not support `.groups`"
+    "`summarize_with_margins\\(\\)` has no `\\.groups` argument"
   )
 
   expect_identical(summary_proxy_capture$n, 0L)
@@ -231,7 +231,7 @@ test_that("summary selection errors use the package condition seam", {
         .grouping = rollup(group),
         !!!summary_options
       )),
-      message = "`summarize_with_margins\\(\\)` does not support `\\.groups`"
+      message = "`summarize_with_margins\\(\\)` has no `\\.groups` argument"
     ),
     context_helper = list(
       expr = rlang::expr(summarize_with_margins(

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -57,22 +57,19 @@ test_that("every removed option answers its near misses the same way", {
     class = "marginplyr_error"
   )
 
-  for (misspelling in c(".group", ".groupss")) {
-    spliced <- stats::setNames(list("drop"), misspelling)
-    expect_error(
-      summarize_with_margins(
-        admission_data(),
-        s = sum(v),
-        .grouping = rollup(g),
-        !!!spliced
-      ),
-      paste0(
-        "`\\", misspelling, "` is not an argument.+neither is the `\\.groups` ",
-        "it resembles; ", guidance
-      ),
-      class = "marginplyr_error"
-    )
-  }
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .groupss = "drop"
+    ),
+    paste0(
+      "`\\.groupss` is not an argument.+neither is the `\\.groups` it ",
+      "resembles; ", guidance
+    ),
+    class = "marginplyr_error"
+  )
 })
 
 test_that("the synonym answers removed options identically", {
@@ -89,7 +86,7 @@ test_that("the synonym answers removed options identically", {
     conditionMessage(condition)
   }
 
-  for (option in c(".groups", ".group", ".sort", ".sorts")) {
+  for (option in c(".groups", ".groupss", ".sort", ".sorts")) {
     expect_identical(
       removed_option_message(summarise_with_margins, option),
       removed_option_message(summarize_with_margins, option)
@@ -161,6 +158,36 @@ test_that("a misspelled option names the argument it resembles", {
     ),
     "Did you mean `.id`"
   )
+})
+
+test_that("a name callers write on purpose is left alone", {
+  # `.group` is one character from the removed `.groups`, so the net would read
+  # it as a misspelling. It is a column callers produce deliberately, and it is
+  # exempt for that reason — not because of anything about the distance, which
+  # is the same one-character deletion that makes `.duplicate` worth catching.
+  expect_named(
+    summarize_with_margins(
+      admission_data(),
+      .group = max(v),
+      .grouping = rollup(g)
+    ),
+    c("g", ".group")
+  )
+  # The exemption is the name, not a prefix of it: the option itself and its
+  # other near misses are still answered.
+  for (misspelling in c(".groups", ".groupss")) {
+    spliced <- stats::setNames(list("drop"), misspelling)
+    expect_error(
+      summarize_with_margins(
+        admission_data(),
+        s = sum(v),
+        .grouping = rollup(g),
+        !!!spliced
+      ),
+      "Margin-summary results are always ungrouped",
+      class = "marginplyr_error"
+    )
+  }
 })
 
 test_that("the check is scoped to names that resemble an option", {

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -37,6 +37,94 @@ test_that("a near miss on a removed option names what the caller wrote", {
   )
 })
 
+test_that("every removed option answers its near misses the same way", {
+  # `.groups` reached the table by way of a bespoke check that matched the name
+  # exactly, so its misspellings used to fall through to the generic "captured
+  # as a summary" message. The guidance is a property of the option, not of how
+  # the caller spelled it.
+  guidance <- "Margin-summary results are always ungrouped\\."
+
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      s = sum(v),
+      .grouping = rollup(g),
+      .groups = "drop"
+    ),
+    paste0(
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument; ", guidance
+    ),
+    class = "marginplyr_error"
+  )
+
+  for (misspelling in c(".group", ".groupss")) {
+    spliced <- stats::setNames(list("drop"), misspelling)
+    expect_error(
+      summarize_with_margins(
+        admission_data(),
+        s = sum(v),
+        .grouping = rollup(g),
+        !!!spliced
+      ),
+      paste0(
+        "`\\", misspelling, "` is not an argument.+neither is the `\\.groups` ",
+        "it resembles; ", guidance
+      ),
+      class = "marginplyr_error"
+    )
+  }
+})
+
+test_that("the synonym answers removed options identically", {
+  # `summarise_with_margins()` is the same object, but the option names are read
+  # from formals and the messages name one spelling, so the synonym is where a
+  # divergence would show first. Comparing the messages asserts that directly;
+  # a pattern per spelling would pass while the two drifted apart.
+  removed_option_message <- function(verb, option) {
+    spliced <- stats::setNames(list(TRUE), option)
+    condition <- rlang::catch_cnd(
+      verb(admission_data(), s = sum(v), .grouping = rollup(g), !!!spliced),
+      classes = "marginplyr_error"
+    )
+    conditionMessage(condition)
+  }
+
+  for (option in c(".groups", ".group", ".sort", ".sorts")) {
+    expect_identical(
+      removed_option_message(summarise_with_margins, option),
+      removed_option_message(summarize_with_margins, option)
+    )
+  }
+})
+
+test_that("the first option-shaped name written is the one reported", {
+  # `.groups` had its own check ahead of this loop, so it won wherever it
+  # appeared in the call. It has no such standing now, and both orders are
+  # asserted because either one alone would also pass under a rule that ranked
+  # removed options above near misses.
+  reported <- function(...) {
+    spliced <- list(...)
+    conditionMessage(rlang::catch_cnd(
+      summarize_with_margins(
+        admission_data(),
+        s = sum(v),
+        .grouping = rollup(g),
+        !!!spliced
+      ),
+      classes = "marginplyr_error"
+    ))
+  }
+
+  expect_match(
+    reported(.margin_labels = "ALL", .groups = "drop"),
+    "Did you mean `\\.margin_label`"
+  )
+  expect_match(
+    reported(.groups = "drop", .margin_labels = "ALL"),
+    "has no `\\.groups` argument"
+  )
+})
+
 test_that("a misspelled option names the argument it resembles", {
   expect_error(
     summarize_with_margins(


### PR DESCRIPTION
Closes #86. Prefactor for #85; unblocks #87.

## What changed

`.groups` was rejected by `check_removed_groups_argument()`, which matched the
name exactly. `.groupss` therefore missed it and fell through to the generic
"captured as a summary named ..." message, which says nothing about what
replaced the option.

`.groups` is now an entry in `removed_summary_options` carrying its own
guidance sentence, and the bespoke check is deleted:

```
.groups   -> `summarize_with_margins()` has no `.groups` argument; Margin-summary results are always ungrouped.
.groupss  -> `.groupss` is not an argument of `summarize_with_margins()`, and neither is the `.groups` it resembles; Margin-summary results are always ungrouped.
```

`.sort` is untouched, and the table keeps a live entry once #85 removes it.

## `.group` stays an output name

The ticket asked for `.group` to get the same guidance, but the move puts it in
the net only because it is one deletion from `.groups` — and `.group` is a
column callers produce deliberately. Taking a working output name away to catch
a misspelling is the worse trade, so it is exempt by name (`f4b2b70`).

By name rather than by a rule over the distance, because no such rule exists:
`.duplicate` is the same one-character deletion from `.duplicates` and is worth
catching. What separates them is whether callers write the name on purpose.

The cost is accepted deliberately: `.group` typed for `.groups` now yields a
column rather than the guidance.

## Precedence

Deleting the bespoke check changed something the ticket did not name. `.groups`
used to be checked ahead of every other name, so it won wherever it appeared in
the call; inside the shared loop the first option-shaped name the caller wrote
is the one reported.

Written order is kept rather than restoring `.groups`'s priority. A caller who
wrote two of these has to fix both, so an ordering over kinds of match only
decides which one they are sent to first, and written order keeps that a walk
down the call instead of a jump around it. The old priority was an artifact of
where the check sat, not a decision. Both orders are asserted — either alone
would still pass under a rule ranking removed options above near misses.

## On the ticket's snapshot criterion

> The existing `.groups` message snapshot is updated, and no other snapshot changes.

There is no `.groups` testthat snapshot and there never has been —
`tests/testthat/_snaps/` holds only `share.md` and `share-backends.md`, and
every `expect_snapshot()` in the repo is in the share tests. The actual
assertions are regex `expect_error()` calls; both are updated. No `_snaps/`
file is touched. Worth correcting on #86 so #87 does not inherit the premise.

## Unrelated commit

`Record roxygen2 8.1.0 in DESCRIPTION` (`1e1a9e5`) is not part of #86. fe10686
regenerated NAMESPACE under roxygen2 8.1.0 but carried only that hunk, leaving
`Config/roxygen2/version` at 8.0.0; `document.yaml` never caught it because the
gate diffs `man/` and `NAMESPACE` only. No `.Rd` or NAMESPACE change
accompanies it.

## Checks

- `pkgload::load_all()` then `lintr::lint_package()`: no lints.
- `roxygen2::roxygenise()` (8.1.0): no `man/`, `NAMESPACE`, or `DESCRIPTION` diff.
- Full suite green, with every optional backend installed locally — zero skips,
  so the arrow/duckdb/dtplyr paths actually executed.