### PR TITLE
Add .sort for a Margin order on every backend

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,8 +53,9 @@ _Avoid_: Total value, missing-value replacement
 The row order a Margin operation produces when it is asked to order its
 result. Within each fixed key, every grouping dimension contributes its
 Grouping bit before its own value, so a margin row sits with the rows it
-summarizes rather than wherever its Margin label falls among the values.
-Missing values come last within a Grouping bit group. It is a property of the
+summarizes rather than wherever its Margin label falls among the values. Every
+column in the key carries a missingness term, fixed keys included, so missing
+values come last wherever they appear. It is a property of the
 result a Margin verb returns, not of any table derived from it, and it is
 distinct from Grouping-plan order, which numbers grouping-set occurrences.
 _Avoid_: Report order, result order, row order, sort order

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,8 +28,8 @@
   its missingness before its own value, so a subtotal sits with the rows it
   summarizes whatever the Margin label sorts as, and the grand total comes
   last. Factor dimensions follow their restored levels, missing values come
-  last within each Grouping bit group on every backend, `"first"` reverses the
-  Grouping bits alone, and lazy inputs stay lazy on a native `GROUPING SETS`
+  last wherever they appear on every backend, `"first"` reverses the Grouping
+  bits alone, and lazy inputs stay lazy on a native `GROUPING SETS`
   plan as well as the portable one. As with `dplyr::arrange()`, the order is a
   property of the returned object and may not survive further verbs applied to
   a lazy result.

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,18 @@
 * Added `.id` to every Margin verb for one-based Grouping set occurrence
   identifiers, including duplicate-aware local, lazy, expansion, and nesting
   paths.
+* Added `.sort` to every Margin verb for an opt-in Margin order, taking
+  `"none"` (the default), `"last"`, or `"first"`. It orders a result by the
+  structure of its Grouping plan rather than by displayed values: within each
+  fixed `.by` key, every grouping dimension contributes its Grouping bit and
+  its missingness before its own value, so a subtotal sits with the rows it
+  summarizes whatever the Margin label sorts as, and the grand total comes
+  last. Factor dimensions follow their restored levels, missing values come
+  last within each Grouping bit group on every backend, `"first"` reverses the
+  Grouping bits alone, and lazy inputs stay lazy on a native `GROUPING SETS`
+  plan as well as the portable one. As with `dplyr::arrange()`, the order is a
+  property of the returned object and may not survive further verbs applied to
+  a lazy result.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -17,14 +17,16 @@
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
 #' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
+#' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Database backend coverage
 #' @inheritSection summarize_with_margins Backend extension design
 #' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its
 #'   class and attributes follow [dplyr::mutate()] combined with
 #'   [dplyr::union_all()]; see *Result class and attributes*.
-#'   Result row order is unspecified; use [dplyr::arrange()] when presentation
-#'   order matters.
+#'   Result row order is unspecified unless `.sort` asks for a Margin order;
+#'   see *Margin order*, or use [dplyr::arrange()] for any other presentation
+#'   order.
 #' @family summarize and expand data with margins
 #' @export
 #' @examples
@@ -71,7 +73,8 @@ expand_with_margins <- function(.data,
                                 .margin_label_position = c("last", "first"),
                                 .check_margin_label = is.data.frame(.data),
                                 .duplicates = c("error", "drop", "keep"),
-                                .id = NULL) {
+                                .id = NULL,
+                                .sort = c("none", "last", "first")) {
   call <- rlang::current_call()
   with_margin_error_call(
     {
@@ -91,21 +94,34 @@ expand_with_margins <- function(.data,
     .margin_label_position = .margin_label_position,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
+    .sort = .sort,
     .id = .id,
     call = call
   )
-  result <- execute_margin_expand(operation)
-  finalize_margin_operation(operation, result)
+  execution <- execute_margin_expand(operation)
+  finalize_margin_operation(operation, execution)
 }
 
 execute_margin_expand <- function(operation) {
   check_margin_operation(operation)
   validate_margin_operation(operation)
-  expand_margin_union(
-    operation$data,
-    plan = operation$plan,
-    margin_labels = operation$margin_labels,
-    column_info = operation$column_info,
-    set_id_name = operation$set_id_name
+  # Expansion always uses the portable adapter, so a Margin order always reads
+  # its Grouping bits from a per-branch identifier literal.
+  sort_id <- margin_sort_identifier(
+    operation,
+    set_id_name = operation$set_id_name,
+    used_names = operation$data_vars
+  )
+  set_id_name <- if (is.null(sort_id)) operation$set_id_name else sort_id
+
+  new_margin_execution(
+    expand_margin_union(
+      operation$data,
+      plan = operation$plan,
+      margin_labels = operation$margin_labels,
+      column_info = operation$column_info,
+      set_id_name = set_id_name
+    ),
+    sort_id = sort_id
   )
 }

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -333,17 +333,27 @@ order_margin_result <- function(operation, result, execution) {
 
 # The key of ADR 0018, built from the Grouping plan alone:
 #
-#   by1 … byN, bit(d1), is.na(d1), d1, …, [set_id]
+#   is.na(by1), by1, …, bit(d1), is.na(d1), d1, …, [set_id]
 #
 # Fixed-key priority and the Grouping set identifier tiebreak are consequences
 # of following the result's own leading grouping columns, not separate rules,
 # and a composite dimension needs no special case because its columns share a
 # Grouping bit.
 #
+# Every column in the key carries a missingness term, fixed keys included, so
+# that missing values come last wherever they appear rather than wherever the
+# dialect puts them. A fixed key takes no Grouping bit, because it is in every
+# grouping set and never holds a Margin label.
+#
 # `"first"` reverses the Grouping bits alone. Missingness and values stay
 # ascending, because first and last position margins and not missing values.
 margin_order_terms <- function(plan, sort, sort_id) {
-  terms <- lapply(plan$by, margin_column_pronoun)
+  terms <- unlist(
+    lapply(plan$by, function(key) {
+      list(margin_missing_last_expr(key), margin_column_pronoun(key))
+    }),
+    recursive = FALSE
+  )
 
   for (dimension in plan$dimensions) {
     bit <- margin_grouping_bit_expr(plan, dimension, sort_id)
@@ -356,13 +366,12 @@ margin_order_terms <- function(plan, sort, sort_id) {
         }
       ))
     }
-    column <- margin_column_pronoun(dimension)
-    # Written as a comparison rather than as the bare `is.na()` predicate,
-    # because ordering by a boolean is not accepted by every dialect the
-    # portable adapter renders for.
     terms <- c(
       terms,
-      list(rlang::expr(dplyr::if_else(is.na(!!column), 1L, 0L)), column)
+      list(
+        margin_missing_last_expr(dimension),
+        margin_column_pronoun(dimension)
+      )
     )
   }
 
@@ -370,6 +379,17 @@ margin_order_terms <- function(plan, sort, sort_id) {
     terms <- c(terms, list(margin_column_pronoun(sort_id)))
   }
   terms
+}
+
+# One column's missingness term. Written as a comparison rather than as the
+# bare `is.na()` predicate, because ordering by a boolean is not accepted by
+# every dialect the portable adapter renders for.
+margin_missing_last_expr <- function(column) {
+  rlang::expr(dplyr::if_else(
+    is.na(!!margin_column_pronoun(column)),
+    1L,
+    0L
+  ))
 }
 
 # One dimension's Grouping bit, read from the Grouping set identifier the

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -9,6 +9,7 @@ new_margin_operation <- function(data,
                                  margin_labels,
                                  margin_label_position,
                                  check_margin_label,
+                                 sort,
                                  call) {
   structure(
     list(
@@ -23,9 +24,51 @@ new_margin_operation <- function(data,
       margin_labels = margin_labels,
       margin_label_position = margin_label_position,
       check_margin_label = check_margin_label,
+      sort = sort,
       call = call
     ),
     class = "marginplyr_margin_operation"
+  )
+}
+
+# What an executor leaves the finalizer to work with. A Margin order is a
+# property of the Grouping plan, so the key itself is built by the finalizer;
+# all an executor reports is `sort_id`, the Grouping set identifier column its
+# query left behind for the key's Grouping bits to be read from. The finalizer
+# drops that column again unless the caller asked for it with `.id`.
+#
+# One identifier serves every adapter because it is the only form of the key
+# that stays resolvable in the `FROM` clause of the query carrying the
+# `ORDER BY`. A Grouping bit is nameable in SQL only as `GROUPING(d)`, which
+# resolves in the aggregate query alone, and dbplyr discards the ordering of
+# any query it goes on to wrap in a subquery — which labelling the omitted
+# dimensions and placing the grouping columns both do.
+new_margin_execution <- function(result, sort_id = NULL) {
+  structure(
+    list(result = result, sort_id = sort_id),
+    class = "marginplyr_margin_execution"
+  )
+}
+
+margin_sorting <- function(operation) {
+  !identical(operation$sort, "none")
+}
+
+# The Grouping set identifier a Margin order reads its Grouping bits from: the
+# caller's `.id` when there is one, and otherwise an internal column the
+# finalizer drops again. Every executor allocates it only after it has chosen
+# an adapter, so that asking for an order never changes which one runs.
+margin_sort_identifier <- function(operation, set_id_name, used_names) {
+  if (!margin_sorting(operation)) {
+    return(NULL)
+  }
+  if (!is.null(set_id_name)) {
+    return(set_id_name)
+  }
+  new_margin_internal_names(
+    1L,
+    used_names = used_names,
+    prefix = "..marginplyr_sort_"
   )
 }
 
@@ -57,6 +100,8 @@ margin_duplicates_choices <- c("error", "drop", "keep")
 
 margin_label_position_choices <- c("last", "first")
 
+margin_sort_choices <- c("none", "last", "first")
+
 match_margin_choice <- function(value, choices, arg_name) {
   call <- rlang::caller_call()
   force(value)
@@ -79,6 +124,7 @@ normalize_margin_options <- function(.margin_label,
                                      .margin_label_position,
                                      .check_margin_label,
                                      .duplicates,
+                                     .sort,
                                      .id = NULL) {
   assert_logical_scalar(.check_margin_label)
   .id <- normalize_margin_id(.id)
@@ -96,6 +142,11 @@ normalize_margin_options <- function(.margin_label,
       .duplicates,
       choices = margin_duplicates_choices,
       arg_name = ".duplicates"
+    ),
+    sort = match_margin_choice(
+      .sort,
+      choices = margin_sort_choices,
+      arg_name = ".sort"
     )
   )
 }
@@ -133,6 +184,7 @@ prepare_margin_operation <- function(.data,
                                      .margin_label_position,
                                      .check_margin_label,
                                      .duplicates,
+                                     .sort,
                                      .id = NULL,
                                      validate_grouping = NULL,
                                      call = rlang::caller_call()) {
@@ -146,6 +198,7 @@ prepare_margin_operation <- function(.data,
         .margin_label_position = .margin_label_position,
         .check_margin_label = .check_margin_label,
         .duplicates = .duplicates,
+        .sort = .sort,
         .id = .id
       )
       set_id_name <- options$set_id_name
@@ -153,6 +206,7 @@ prepare_margin_operation <- function(.data,
       .margin_label_position <- options$margin_label_position
       .check_margin_label <- options$check_margin_label
       .duplicates <- options$duplicates
+      .sort <- options$sort
 
       grouping <- prepare_grouping_plan(
         .data,
@@ -196,6 +250,7 @@ prepare_margin_operation <- function(.data,
         margin_labels = margin_labels,
         margin_label_position = .margin_label_position,
         check_margin_label = .check_margin_label,
+        sort = .sort,
         call = call
       )
     },
@@ -219,9 +274,10 @@ validate_margin_operation <- function(operation) {
   )
 }
 
-finalize_margin_operation <- function(operation, result) {
+finalize_margin_operation <- function(operation, execution) {
   check_margin_operation(operation)
-  result <- dplyr::ungroup(result)
+  stopifnot(inherits(execution, "marginplyr_margin_execution"))
+  result <- dplyr::ungroup(execution$result)
   result <- restore_margin_factors(
     result,
     factor_info = operation$column_info$factors,
@@ -239,5 +295,103 @@ finalize_margin_operation <- function(operation, result) {
     dplyr::everything()
   )
 
+  order_margin_result(operation, result, execution)
+}
+
+# Ordering comes last so that the `ORDER BY` is the outermost one, and after
+# factor restoration so that a factor dimension sorts by its restored levels
+# rather than by the character values the branches carried.
+order_margin_result <- function(operation, result, execution) {
+  if (!margin_sorting(operation)) {
+    return(result)
+  }
+
+  sort_id <- execution$sort_id
+  # An invariant, not a Package condition (ADR-0015): an executor that reports
+  # no identifier to derive the Grouping bits from would return the rows in an
+  # order that only looks sorted.
+  stopifnot(
+    length(operation$plan$dimensions) == 0L || !is.null(sort_id)
+  )
+
+  terms <- margin_order_terms(
+    plan = operation$plan,
+    sort = operation$sort,
+    sort_id = sort_id
+  )
+  if (length(terms) > 0L) {
+    result <- dplyr::arrange(result, !!!terms)
+  }
+  if (
+    !is.null(sort_id) &&
+      !identical(sort_id, operation$set_id_name)
+  ) {
+    result <- dplyr::select(result, -dplyr::all_of(sort_id))
+  }
   result
+}
+
+# The key of ADR 0018, built from the Grouping plan alone:
+#
+#   by1 … byN, bit(d1), is.na(d1), d1, …, [set_id]
+#
+# Fixed-key priority and the Grouping set identifier tiebreak are consequences
+# of following the result's own leading grouping columns, not separate rules,
+# and a composite dimension needs no special case because its columns share a
+# Grouping bit.
+#
+# `"first"` reverses the Grouping bits alone. Missingness and values stay
+# ascending, because first and last position margins and not missing values.
+margin_order_terms <- function(plan, sort, sort_id) {
+  terms <- lapply(plan$by, margin_column_pronoun)
+
+  for (dimension in plan$dimensions) {
+    bit <- margin_grouping_bit_expr(plan, dimension, sort_id)
+    if (!is.null(bit)) {
+      terms <- c(terms, list(
+        if (identical(sort, "first")) {
+          rlang::expr(dplyr::desc(!!bit))
+        } else {
+          bit
+        }
+      ))
+    }
+    column <- margin_column_pronoun(dimension)
+    # Written as a comparison rather than as the bare `is.na()` predicate,
+    # because ordering by a boolean is not accepted by every dialect the
+    # portable adapter renders for.
+    terms <- c(
+      terms,
+      list(rlang::expr(dplyr::if_else(is.na(!!column), 1L, 0L)), column)
+    )
+  }
+
+  if (!is.null(sort_id)) {
+    terms <- c(terms, list(margin_column_pronoun(sort_id)))
+  }
+  terms
+}
+
+# One dimension's Grouping bit, read from the Grouping set identifier the
+# adapter left in the result. `NULL` when the plan makes the bit constant, so
+# that a term with nothing to order by is not emitted.
+margin_grouping_bit_expr <- function(plan, dimension, sort_id) {
+  if (is.null(sort_id)) {
+    return(NULL)
+  }
+  margin_ids <- as.integer(
+    plan$set_ids[plan$grouping_masks[, dimension] == 1L]
+  )
+  if (
+    length(margin_ids) == 0L ||
+      length(margin_ids) == length(plan$set_ids)
+  ) {
+    return(NULL)
+  }
+
+  rlang::expr(dplyr::if_else(
+    (!!margin_column_pronoun(sort_id)) %in% !!margin_ids,
+    1L,
+    0L
+  ))
 }

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -7,6 +7,7 @@
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
 #' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
+#' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Backend extension design
 #' @inheritSection nest_with_margins Relationship to tidyr and dplyr
@@ -26,8 +27,9 @@
 #'   `.id` when supplied. This is the return shape whatever the class of
 #'   `.data`, because a row-wise data frame is always a tibble subclass; see
 #'   *Result class and attributes*.
-#'   Result row order is unspecified; use [dplyr::arrange()] when presentation
-#'   order matters.
+#'   Result row order is unspecified unless `.sort` asks for a Margin order;
+#'   see *Margin order*, or use [dplyr::arrange()] for any other presentation
+#'   order.
 #' @family summarize and expand data with margins
 #' @export
 #' @examples
@@ -108,6 +110,7 @@ nest_by_with_margins <- function(.data,
                                  .check_margin_label = is.data.frame(.data),
                                  .duplicates = c("error", "drop"),
                                  .id = NULL,
+                                 .sort = c("none", "last", "first"),
                                  .key = "data",
                                  .keep = FALSE) {
   call <- rlang::current_call()
@@ -122,6 +125,7 @@ nest_by_with_margins <- function(.data,
     .margin_label_position = .margin_label_position,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
+    .sort = .sort,
     .id = .id,
     .key = .key,
     .keep = .keep,

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -8,6 +8,7 @@
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
 #' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
+#' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Backend extension design
 #' @param .data A local data frame or a `dtplyr` step. Other lazy tables are
@@ -64,9 +65,9 @@
 #' @return For a local input, an ungrouped data frame with one list column,
 #'   whose class and attributes follow [dplyr::summarize()]; see *Result class
 #'   and attributes*. A `dtplyr` input returns a lazy `dtplyr` step until
-#'   collected. Result row
-#'   order is unspecified; use [dplyr::arrange()] when presentation order
-#'   matters.
+#'   collected. Result row order is unspecified unless `.sort` asks for a
+#'   Margin order; see *Margin order*, or use [dplyr::arrange()] for any other
+#'   presentation order.
 #' @family summarize and expand data with margins
 #' @export
 #' @examples
@@ -138,6 +139,7 @@ nest_with_margins <- function(.data,
                               .check_margin_label = is.data.frame(.data),
                               .duplicates = c("error", "drop"),
                               .id = NULL,
+                              .sort = c("none", "last", "first"),
                               .key = "data",
                               .keep = FALSE) {
   call <- rlang::current_call()
@@ -155,6 +157,7 @@ nest_with_margins <- function(.data,
     .margin_label_position = .margin_label_position,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
+    .sort = .sort,
     .id = .id,
     .key = .key,
     .keep = .keep,
@@ -175,6 +178,7 @@ nest_margin_pipeline <- function(.data,
                                  .margin_label_position,
                                  .check_margin_label,
                                  .duplicates,
+                                 .sort,
                                  .id,
                                  .key,
                                  .keep,
@@ -216,6 +220,7 @@ nest_margin_pipeline <- function(.data,
         .margin_label_position = .margin_label_position,
         .check_margin_label = .check_margin_label,
         .duplicates = .duplicates,
+        .sort = .sort,
         .id = .id
       )
       set_id_name <- options$set_id_name
@@ -223,6 +228,7 @@ nest_margin_pipeline <- function(.data,
       .margin_label_position <- options$margin_label_position
       .check_margin_label <- options$check_margin_label
       .duplicates <- options$duplicates
+      .sort <- options$sort
       check_margin_id_collision(set_id_name, .key, "nesting `.key`")
       if (identical(.duplicates, "keep")) {
         abort_marginplyr(
@@ -244,15 +250,16 @@ nest_margin_pipeline <- function(.data,
     .margin_label_position = .margin_label_position,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
+    .sort = .sort,
     .id = .id,
     call = call
   )
-  result <- execute_margin_nest(
+  execution <- execute_margin_nest(
     operation,
     .key = .key,
     .keep = .keep
   )
-  finalize_margin_operation(operation, result)
+  finalize_margin_operation(operation, execution)
 }
 
 execute_margin_nest <- function(operation, .key, .keep) {
@@ -307,14 +314,22 @@ execute_margin_nest <- function(operation, .key, .keep) {
         set_id_name = set_col
       )
 
-      nest_expanded_margins(
-        expanded,
-        group_cols = group_cols,
-        set_col = set_col,
-        keep_cols = keep_cols,
-        .key = .key,
-        .keep = .keep,
-        set_id_name = operation$set_id_name
+      # Nesting always expands through the portable adapter and already carries
+      # a Grouping set identifier, so a Margin order costs it no column of its
+      # own; the identifier is retained past the nest and dropped once the
+      # finalizer has ordered by it.
+      sorting <- margin_sorting(operation)
+      new_margin_execution(
+        nest_expanded_margins(
+          expanded,
+          group_cols = group_cols,
+          set_col = set_col,
+          keep_cols = keep_cols,
+          .key = .key,
+          .keep = .keep,
+          drop_set_col = is.null(operation$set_id_name) && !sorting
+        ),
+        sort_id = if (sorting) set_col else NULL
       )
     },
     call = operation$call
@@ -327,7 +342,7 @@ nest_expanded_margins <- function(.data,
                                   keep_cols,
                                   .key,
                                   .keep,
-                                  set_id_name = NULL) {
+                                  drop_set_col = TRUE) {
   if (.keep && length(group_cols) > 0L) {
     # `rename()` and `relocate()` run inside a data-masked summary expression,
     # so their tidyselect resolves `keep_cols` and `group_cols` against the
@@ -356,7 +371,7 @@ nest_expanded_margins <- function(.data,
     )
   }
 
-  if (is.null(set_id_name)) {
+  if (drop_set_col) {
     result <- dplyr::select(result, -dplyr::all_of(set_col))
   }
   result

--- a/R/share.R
+++ b/R/share.R
@@ -1741,6 +1741,14 @@ execute_shares <- function(operation,
       "{operation$set_id_name}" := .data[[staged_set_id_name]]
     )
   }
+  # A Margin order reads its Grouping bits from the same staged identifier, so
+  # it is the finalizer that drops it on that path, after the `ORDER BY`.
+  if (identical(
+    margin_summary_stage_sort_id(staged_result),
+    staged_set_id_name
+  )) {
+    return(result)
+  }
   dplyr::select(
     result,
     -dplyr::all_of(staged_set_id_name)

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -42,7 +42,8 @@
 #'   structure of its Grouping plan: within each fixed `.by` key, every grouping
 #'   dimension contributes its Grouping bit and its missingness before its own
 #'   value, so a margin row sits with the rows it summarizes rather than
-#'   wherever `.margin_label` falls among that dimension's values. `"last"`
+#'   wherever `.margin_label` falls among that dimension's values, and missing
+#'   values come last wherever they appear. `"last"`
 #'   places margins after the rows they summarize and `"first"` before them.
 #'   The order is a property of the returned object, as with
 #'   [dplyr::arrange()], and may not survive further verbs applied to a lazy
@@ -166,7 +167,7 @@
 #' whether its value is missing:
 #'
 #' ```
-#' by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+#' is.na(by1), by1, ..., bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
 #' ```
 #'
 #' A margin row therefore sits with the rows it summarizes instead of wherever
@@ -181,8 +182,9 @@
 #'
 #' `"first"` reverses the Grouping bits alone. Missing values and ordinary
 #' values stay ascending, because the choice positions margins and not missing
-#' values. Missing values come last within each Grouping bit group on every
-#' backend, including those whose own default is the opposite. Under
+#' values. Every column in the key carries a missingness term, fixed `.by` keys
+#' included, so missing values come last wherever they appear on every backend,
+#' including those whose own default is the opposite. Under
 #' `.margin_label = NULL` a source missing value and a margin still display
 #' alike, but they are separated by position, because their Grouping bits
 #' differ.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -37,6 +37,16 @@
 #'   lazy inputs, where checking would require an additional query.
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
 #'   duplicate grouping sets after expansion.
+#' @param .sort One of `"none"` (the default), `"last"`, or `"first"`. `"none"`
+#'   leaves row order unspecified. The other two order the result by the
+#'   structure of its Grouping plan: within each fixed `.by` key, every grouping
+#'   dimension contributes its Grouping bit and its missingness before its own
+#'   value, so a margin row sits with the rows it summarizes rather than
+#'   wherever `.margin_label` falls among that dimension's values. `"last"`
+#'   places margins after the rows they summarize and `"first"` before them.
+#'   The order is a property of the returned object, as with
+#'   [dplyr::arrange()], and may not survive further verbs applied to a lazy
+#'   result. See *Margin order*.
 #' @param .id `NULL`, or one non-missing, non-empty character string naming an
 #'   integer output column of one-based Grouping set identifiers. Each value
 #'   identifies one occurrence in the resolved Grouping plan. The name must not
@@ -46,8 +56,9 @@
 #' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its
 #'   class and attributes follow [dplyr::summarize()]; see *Result class and
 #'   attributes*.
-#'   Result row order is unspecified; use [dplyr::arrange()] when presentation
-#'   order matters.
+#'   Result row order is unspecified unless `.sort` asks for a Margin order;
+#'   see *Margin order*, or use [dplyr::arrange()] for any other presentation
+#'   order.
 #'
 #' @details
 #' [grouping_sets()] forms a union of grouping families. [grouping_spec()]
@@ -147,6 +158,51 @@
 #' specification changes it. Use [dplyr::arrange()] when order matters.
 #' [grouping_bit()] documents how `.id` compares with
 #' [inspect_grouping()]`$set_id`, [grouping_bit()], and [grouping_id()].
+#'
+#' @section Margin order:
+#' `.sort` orders a result by the structure of its Grouping plan rather than by
+#' displayed values. The key is the result's own leading grouping columns, left
+#' to right, with each grouping dimension preceded by its Grouping bit and by
+#' whether its value is missing:
+#'
+#' ```
+#' by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+#' ```
+#'
+#' A margin row therefore sits with the rows it summarizes instead of wherever
+#' its `.margin_label` falls among that dimension's values, which is what keeps
+#' the order independent of the label and of the locale. Two rules follow from
+#' the key rather than being separate: fixed `.by` keys sort first because they
+#' come first, so each partition is one contiguous block whose internal order
+#' does not depend on any other partition; and `.id` breaks the remaining ties
+#' when it names a column, which puts duplicate occurrences of one grouping set
+#' next to each other and in Grouping plan order. A composite dimension needs no
+#' rule of its own, because its columns share one Grouping bit.
+#'
+#' `"first"` reverses the Grouping bits alone. Missing values and ordinary
+#' values stay ascending, because the choice positions margins and not missing
+#' values. Missing values come last within each Grouping bit group on every
+#' backend, including those whose own default is the opposite. Under
+#' `.margin_label = NULL` a source missing value and a margin still display
+#' alike, but they are separated by position, because their Grouping bits
+#' differ.
+#'
+#' Factor and ordered-factor dimensions sort by their restored levels rather
+#' than by their rendering. `.margin_label_position` positions a synthetic
+#' factor level and never a row: it changes `levels()` and nothing else, so the
+#' two options stay independent and no combination of them is wrong.
+#'
+#' A Margin order promises exactly what [dplyr::arrange()] promises. It is a
+#' property of the object the verb returns: on local data frames and `dtplyr`
+#' steps that is the row order, and on lazy tables it is the outermost query's
+#' `ORDER BY`, which [dplyr::collect()] observes. Whether it survives further
+#' verbs applied to a lazy result is not promised, because that depends on
+#' dbplyr's query flattening, which marginplyr does not own and which changes
+#' between releases.
+#'
+#' Asking for a Margin order never costs a native `GROUP BY GROUPING SETS`
+#' plan, and never changes which adapter runs. It composes with
+#' `.duplicates = "keep"` with no diagnostic, and lazy inputs stay lazy.
 #'
 #' @section Relationship to dplyr summaries:
 #' The `...` expressions use [dplyr::summarize()] data-masking semantics.
@@ -297,6 +353,16 @@
 #'   .by = c(year, month),
 #'   .grouping = rollup(region, store),
 #'   .id = "set"
+#' )
+#'
+#' # `.sort` puts each subtotal with the rows it summarizes and the company
+#' # total last, whatever the Margin label sorts as.
+#' summarize_with_margins(
+#'   .data = retail_sales,
+#'   revenue = sum(revenue),
+#'   .by = year,
+#'   .grouping = rollup(region, store),
+#'   .sort = "last"
 #' )
 #'
 #' # Existing dplyr groups are implicit fixed keys. The calculation below is
@@ -483,7 +549,8 @@ summarize_with_margins <- function(.data,
                                    .margin_label_position = c("last", "first"),
                                    .check_margin_label = is.data.frame(.data),
                                    .duplicates = c("error", "drop", "keep"),
-                                   .id = NULL) {
+                                   .id = NULL,
+                                   .sort = c("none", "last", "first")) {
   call <- rlang::current_call()
   dots <- rlang::enquos(...)
   grouping_quo <- rlang::enquo(.grouping)
@@ -498,6 +565,7 @@ summarize_with_margins <- function(.data,
         .margin_label_position = .margin_label_position,
         .check_margin_label = .check_margin_label,
         .duplicates = .duplicates,
+        .sort = .sort,
         .id = .id
       )
       check_option_named_summaries(dots)
@@ -515,12 +583,13 @@ summarize_with_margins <- function(.data,
     .margin_label_position = .margin_label_position,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
+    .sort = .sort,
     .id = .id,
     validate_grouping = share_grouping_spec_validator(share_kinds),
     call = call
   )
-  result <- execute_margin_summary(operation, dots)
-  finalize_margin_operation(operation, result)
+  execution <- execute_margin_summary(operation, dots)
+  finalize_margin_operation(operation, execution)
 }
 
 execute_margin_summary <- function(operation, dots) {
@@ -583,13 +652,19 @@ execute_margin_summary <- function(operation, dots) {
       )
 
       if (has_shares) {
-        return(execute_shares(
-          operation,
-          staged_result = staged_result,
-          requests = summary_plan$requests
+        return(new_margin_execution(
+          execute_shares(
+            operation,
+            staged_result = staged_result,
+            requests = summary_plan$requests
+          ),
+          sort_id = margin_summary_stage_sort_id(staged_result)
         ))
       }
-      margin_summary_stage_result(staged_result)
+      new_margin_execution(
+        margin_summary_stage_result(staged_result),
+        sort_id = margin_summary_stage_sort_id(staged_result)
+      )
     },
     call = operation$call
   )
@@ -610,16 +685,32 @@ stage_margin_summaries <- function(operation,
     reserved_names <- c(reserved_names, set_id_name)
   }
 
+  # Which adapter runs stays a function of the duplicate policy and of an
+  # identifier that has to number occurrences. A Margin order needs Grouping
+  # bits rather than occurrences, so the identifier it may add below is
+  # allocated after this decision and never changes it.
+  use_native <- supports_grouping_sets(
+    operation$data,
+    plan,
+    backend = operation$backend
+  ) && !(
+    !is.null(set_id_name) &&
+      identical(plan$duplicates, "keep")
+  )
+
+  sort_id <- margin_sort_identifier(
+    operation,
+    set_id_name = set_id_name,
+    used_names = reserved_names
+  )
+  if (!is.null(sort_id)) {
+    set_id_name <- sort_id
+    reserved_names <- unique(c(reserved_names, set_id_name))
+  }
+
   result <- tryCatch(
     {
-      if (supports_grouping_sets(
-        operation$data,
-        plan,
-        backend = operation$backend
-      ) && !(
-        !is.null(set_id_name) &&
-          identical(plan$duplicates, "keep")
-      )) {
+      if (use_native) {
         summarize_margin_native(
           operation$data,
           dots = dots,
@@ -648,12 +739,16 @@ stage_margin_summaries <- function(operation,
       stop(cnd)
     }
   )
-  new_margin_summary_stage(result, set_id_name)
+  new_margin_summary_stage(result, set_id_name, sort_id = sort_id)
 }
 
-new_margin_summary_stage <- function(result, set_id_name) {
+new_margin_summary_stage <- function(result, set_id_name, sort_id = NULL) {
   structure(
-    list(result = result, set_id_name = set_id_name),
+    list(
+      result = result,
+      set_id_name = set_id_name,
+      sort_id = sort_id
+    ),
     class = "marginplyr_summary_stage"
   )
 }
@@ -671,6 +766,11 @@ margin_summary_stage_result <- function(staged_result) {
 margin_summary_stage_set_id <- function(staged_result) {
   check_margin_summary_stage(staged_result)
   staged_result$set_id_name
+}
+
+margin_summary_stage_sort_id <- function(staged_result) {
+  check_margin_summary_stage(staged_result)
+  staged_result$sort_id
 }
 
 #' @rdname summarize_with_margins

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -1,20 +1,14 @@
 # Options the verb once had. A caller following older material writes them as
 # if they were still arguments, and `...` would otherwise accept the value as
 # an ordinary summary and return a constant column. Each entry carries its own
-# guidance, because what replaces a removed option is specific to that option:
-# `.sort` is answered by a call the caller adds, `.groups` by a property the
-# result already has, and a shared sentence parameterized by the name could
-# say neither.
+# guidance, because what replaces a removed option is specific to that option
+# and a shared sentence parameterized by the name could say none of them.
 #
-# Naming `grouping_bit()` matters for `.sort`: sorting the result by a
-# dimension's displayed values puts a margin wherever its label falls in the
-# value order, which is not the order the caller writing `.sort` is asking for.
+# `.sort` was here until ADR 0018 returned it as a live argument. A removed
+# option that becomes live leaves this list rather than staying as a second
+# answer, because a name the verb has matches its own formal and never reaches
+# `...`.
 removed_summary_options <- list(
-  .sort = paste0(
-    "row order is unspecified. Call `dplyr::arrange()` on the result, and ",
-    "add a `grouping_bit()` summary per dimension to sort each margin with ",
-    "the rows it summarizes."
-  ),
   .groups = "Margin-summary results are always ungrouped."
 )
 

--- a/design/adr/0001-keep-margin-operations-verb-neutral.md
+++ b/design/adr/0001-keep-margin-operations-verb-neutral.md
@@ -63,5 +63,5 @@ Margin-operation results, and a Margin order is not that order.
 
 Verb-neutrality is again untouched. The sort key is derived from the Grouping
 plan, which the shared module already holds, so no verb kind is passed in to
-produce it. ADR 0018 records the order, how far it is promised, and the two
-backend mechanisms that produce it.
+produce it. ADR 0018 records the order, how far it is promised, and how it is
+produced.

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -265,3 +265,35 @@ what this decision exists to remove.
 a join reads survives into the query the caller receives, so ordering has to
 come after them. The identifier they already stage is the one the finalizer
 orders by, so that path adds no column either.
+
+## Amendment: fixed keys order their missing values last too
+
+The key above reads `by1 … byN` for the fixed keys, giving a missingness term
+to the grouping dimensions alone. Every column in the key gets one instead:
+
+```
+is.na(by1), by1, …, is.na(byN), byN,
+bit(d1), is.na(d1), d1,  bit(d2), is.na(d2), d2,  …,  [set_id]
+```
+
+A fixed key still takes no Grouping bit, because it is present in every
+grouping set and never holds a Margin label. Only its missingness is new.
+
+The original key follows from framing missingness as something a dimension
+contributes alongside its Grouping bit. Read that way a fixed key has nothing
+to contribute, because it has no bit — but the consequence is that a `.by`
+column holding missing values is ordered by the dialect's own default, last on
+a local input and on DuckDB and first on SQLite. That is exactly the
+disagreement "Missing values come last, and that is promised" exists to
+remove, reappearing one column to the left of where that entry was looking.
+The promise is therefore made of the key as a whole: wherever a column appears
+in it, its missing values sort last.
+
+The cost is the same one term per column that entry already accepted, and
+`IS NULL` is standard SQL. `"first"` still reverses the Grouping bits alone,
+so a fixed key's missing values stay last whichever end the margins are at.
+
+One reading is closed by this. The entry above says missing values come last
+"within a Grouping bit group", which was true of dimensions and said nothing
+about fixed keys; it now reads as the whole key, and `CONTEXT.md`'s **Margin
+order** entry says the same.

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -215,3 +215,53 @@ combination has no cost to refuse.
 disagree.** Rejected: they are independent, no combination is wrong, and
 `.margin_label_position = "first"` without `.sort` is what a caller writing
 their own `arrange()` wants.
+
+## Amendment: one identifier produces the order on every backend
+
+"Where the order is produced" gave the native summary an `ORDER BY` over
+`GROUPING(d)` and `d` folded into its aggregate query, and recorded that it
+therefore adds no internal column. That mechanism is withdrawn. The
+placement decision and the key are unchanged; only how the Grouping bits reach
+the `ORDER BY` is.
+
+**dbplyr will not emit an `ORDER BY` inside a query it wraps.** Measured
+against dbplyr 2.6.0: an `arrange()` applied to the aggregate query is
+discarded, with an "ORDER BY is ignored in subqueries without LIMIT" warning,
+as soon as a later verb wraps that query in a subquery — which labelling the
+omitted dimensions and placing the grouping columns both do. Writing the
+`ORDER BY` into the aggregate `select_query` from `sql_build()` reaches the
+same place, because `sql_render()` strips a subquery's `ORDER BY` itself. The
+narrower rule the decision above already states is what holds: the sort key
+must be resolvable in the `FROM` clause of the query that carries the
+`ORDER BY`, and `GROUPING(d)` is resolvable in the aggregate query alone.
+
+**The Grouping set identifier is resolvable there instead.** The native
+adapter already computes one for `.id`, as a `CASE` over `GROUPING()` calls
+that folds into the aggregate query, and every Grouping bit is a function of
+it. `finalize_margin_operation()` derives the bits from that column and drops
+it again. This is the same expression-over-an-identifier the `UNION ALL`
+adapter uses, so there is one mechanism rather than two, and the finalizer
+holds the whole key for every path.
+
+Three consequences are worth recording.
+
+*The native summary gains one internal column* when `.sort` is not `"none"`
+and `.id` does not already name one; it is dropped from the result. What that
+criterion was protecting still holds: `GROUP BY GROUPING SETS` is unchanged,
+and which adapter runs is decided by `native_duplicate_sets` and `.id` before
+the identifier is allocated, so a Margin order still never costs the native
+plan and still adds no fallback. A sort-only identifier does not have to
+number occurrences, which is why it does not force the `UNION ALL` fallback
+that `.id` forces under `.duplicates = "keep"`.
+
+*The key really is the result's own leading grouping columns*, which the
+in-aggregate `ORDER BY` could not have been. The aggregate query holds the
+pre-label values, so a labelled dimension that is not already character would
+have ordered by its input type there and as character on a local input — the
+same code producing a different first row on a different backend, which is
+what this decision exists to remove.
+
+*Contextual shares compose.* They join the staged result, and no `ORDER BY`
+a join reads survives into the query the caller receives, so ordering has to
+come after them. The identifier they already stage is the one the finalizer
+orders by, so that path adds no column either.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -26,7 +26,12 @@ Every exported Margin verb follows the same explicit lifecycle:
 4. **Finalize.** `finalize_margin_operation()` starts from an ungrouped
    result, restores factor Margin columns, places fixed keys and grouping
    dimensions followed by the optional Grouping set identifier first, and
-   leaves row ordering unspecified.
+   leaves row ordering unspecified by default. When `.sort` asks for a Margin
+   order, it applies that order last — after restoration, so a factor
+   dimension sorts by its restored levels, and after placement, so the
+   `ORDER BY` is the outermost one. The key comes from the Grouping plan the
+   module already holds, so no verb kind is passed in. See
+   [ADR 0018](adr/0018-order-margin-results-by-grouping-structure.md).
 
 `nest_with_margins()` returns the common ungrouped result.
 `nest_by_with_margins()` collects that result when necessary, preserves its
@@ -108,8 +113,8 @@ produced, and no verb restores one. See
 
 ### Summary selection (`R/summary-selections.R`)
 
-Owns summary-only semantics: rejecting the removed `.sort` and `.groups`
-options — along with the near misses that resemble them — and branch-local
+Owns summary-only semantics: rejecting the removed `.groups` option — along
+with the near misses that resemble it — and branch-local
 grouping-context helpers, resolving `across()` and `pick()` selections while
 excluding every fixed key and grouping dimension, predicting known output
 names, and preventing summary outputs from overwriting grouping columns. These
@@ -315,6 +320,13 @@ The test suite divides supporting contracts as follows:
 - `test-margin-id.R` covers Grouping set occurrence identifiers across all
   public verbs, including local, native, portable, duplicate, nesting,
   collision, missing-value, zero-row, and laziness semantics.
+- `test-margin-order.R` covers `.sort` across all four public verbs per ADR
+  0018: the key and what follows from it, `"first"` reversing the Grouping
+  bits alone, factor level order, missing values last, fixed-key contiguity,
+  composite dimensions, duplicate occurrences, the `"none"` default, and the
+  vocabulary error. It asserts rows rather than the key builder, because the
+  ADR leaves each adapter to resolve the key in what its own query can name;
+  its two rendered-SQL tests carry only what rows cannot show.
 - `test-margin-label.R` covers Margin labels through the public verbs: named
   per-dimension labels, the eight-case factor NA contract of ADR 0012, label
   placement, collisions including unused factor levels, and typed missing

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -12,7 +12,8 @@ expand_with_margins(
   .margin_label_position = c("last", "first"),
   .check_margin_label = is.data.frame(.data),
   .duplicates = c("error", "drop", "keep"),
-  .id = NULL
+  .id = NULL,
+  .sort = c("none", "last", "first")
 )
 }
 \arguments{
@@ -54,13 +55,25 @@ integer output column of one-based Grouping set identifiers. Each value
 identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
+
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+leaves row order unspecified. The other two order the result by the
+structure of its Grouping plan: within each fixed \code{.by} key, every grouping
+dimension contributes its Grouping bit and its missingness before its own
+value, so a margin row sits with the rows it summarizes rather than
+wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+places margins after the rows they summarize and \code{"first"} before them.
+The order is a property of the returned object, as with
+\code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
+result. See \emph{Margin order}.}
 }
 \value{
 An ungrouped data frame, or a lazy table when \code{.data} is lazy. Its
 class and attributes follow \code{\link[dplyr:mutate]{dplyr::mutate()}} combined with
 \code{\link[dplyr:union_all]{dplyr::union_all()}}; see \emph{Result class and attributes}.
-Result row order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation
-order matters.
+Result row order is unspecified unless \code{.sort} asks for a Margin order;
+see \emph{Margin order}, or use \code{\link[dplyr:arrange]{dplyr::arrange()}} for any other presentation
+order.
 }
 \description{
 \code{\link[=expand_with_margins]{expand_with_margins()}} emits one copy of each input row for every grouping
@@ -168,6 +181,52 @@ durable business key: reordering or deduplicating the Grouping
 specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
 \code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
 \code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Margin order}{
+
+\code{.sort} orders a result by the structure of its Grouping plan rather than by
+displayed values. The key is the result's own leading grouping columns, left
+to right, with each grouping dimension preceded by its Grouping bit and by
+whether its value is missing:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+}\if{html}{\out{</div>}}
+
+A margin row therefore sits with the rows it summarizes instead of wherever
+its \code{.margin_label} falls among that dimension's values, which is what keeps
+the order independent of the label and of the locale. Two rules follow from
+the key rather than being separate: fixed \code{.by} keys sort first because they
+come first, so each partition is one contiguous block whose internal order
+does not depend on any other partition; and \code{.id} breaks the remaining ties
+when it names a column, which puts duplicate occurrences of one grouping set
+next to each other and in Grouping plan order. A composite dimension needs no
+rule of its own, because its columns share one Grouping bit.
+
+\code{"first"} reverses the Grouping bits alone. Missing values and ordinary
+values stay ascending, because the choice positions margins and not missing
+values. Missing values come last within each Grouping bit group on every
+backend, including those whose own default is the opposite. Under
+\code{.margin_label = NULL} a source missing value and a margin still display
+alike, but they are separated by position, because their Grouping bits
+differ.
+
+Factor and ordered-factor dimensions sort by their restored levels rather
+than by their rendering. \code{.margin_label_position} positions a synthetic
+factor level and never a row: it changes \code{levels()} and nothing else, so the
+two options stay independent and no combination of them is wrong.
+
+A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
+property of the object the verb returns: on local data frames and \code{dtplyr}
+steps that is the row order, and on lazy tables it is the outermost query's
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
+verbs applied to a lazy result is not promised, because that depends on
+dbplyr's query flattening, which marginplyr does not own and which changes
+between releases.
+
+Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
+plan, and never changes which adapter runs. It composes with
+\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -61,7 +61,8 @@ leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
 value, so a margin row sits with the rows it summarizes rather than
-wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+wherever \code{.margin_label} falls among that dimension's values, and missing
+values come last wherever they appear. \code{"last"}
 places margins after the rows they summarize and \code{"first"} before them.
 The order is a property of the returned object, as with
 \code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
@@ -190,7 +191,7 @@ displayed values. The key is the result's own leading grouping columns, left
 to right, with each grouping dimension preceded by its Grouping bit and by
 whether its value is missing:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+\if{html}{\out{<div class="sourceCode">}}\preformatted{is.na(by1), by1, ..., bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
 }\if{html}{\out{</div>}}
 
 A margin row therefore sits with the rows it summarizes instead of wherever
@@ -205,8 +206,9 @@ rule of its own, because its columns share one Grouping bit.
 
 \code{"first"} reverses the Grouping bits alone. Missing values and ordinary
 values stay ascending, because the choice positions margins and not missing
-values. Missing values come last within each Grouping bit group on every
-backend, including those whose own default is the opposite. Under
+values. Every column in the key carries a missingness term, fixed \code{.by} keys
+included, so missing values come last wherever they appear on every backend,
+including those whose own default is the opposite. Under
 \code{.margin_label = NULL} a source missing value and a margin still display
 alike, but they are separated by position, because their Grouping bits
 differ.

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -65,7 +65,8 @@ leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
 value, so a margin row sits with the rows it summarizes rather than
-wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+wherever \code{.margin_label} falls among that dimension's values, and missing
+values come last wherever they appear. \code{"last"}
 places margins after the rows they summarize and \code{"first"} before them.
 The order is a property of the returned object, as with
 \code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
@@ -202,7 +203,7 @@ displayed values. The key is the result's own leading grouping columns, left
 to right, with each grouping dimension preceded by its Grouping bit and by
 whether its value is missing:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+\if{html}{\out{<div class="sourceCode">}}\preformatted{is.na(by1), by1, ..., bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
 }\if{html}{\out{</div>}}
 
 A margin row therefore sits with the rows it summarizes instead of wherever
@@ -217,8 +218,9 @@ rule of its own, because its columns share one Grouping bit.
 
 \code{"first"} reverses the Grouping bits alone. Missing values and ordinary
 values stay ascending, because the choice positions margins and not missing
-values. Missing values come last within each Grouping bit group on every
-backend, including those whose own default is the opposite. Under
+values. Every column in the key carries a missingness term, fixed \code{.by} keys
+included, so missing values come last wherever they appear on every backend,
+including those whose own default is the opposite. Under
 \code{.margin_label = NULL} a source missing value and a margin still display
 alike, but they are separated by position, because their Grouping bits
 differ.

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -13,6 +13,7 @@ nest_by_with_margins(
   .check_margin_label = is.data.frame(.data),
   .duplicates = c("error", "drop"),
   .id = NULL,
+  .sort = c("none", "last", "first"),
   .key = "data",
   .keep = FALSE
 )
@@ -59,6 +60,17 @@ identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+leaves row order unspecified. The other two order the result by the
+structure of its Grouping plan: within each fixed \code{.by} key, every grouping
+dimension contributes its Grouping bit and its missingness before its own
+value, so a margin row sits with the rows it summarizes rather than
+wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+places margins after the rows they summarize and \code{"first"} before them.
+The order is a property of the returned object, as with
+\code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
+result. See \emph{Margin order}.}
+
 \item{.key}{A non-missing string naming the list column. Unlike
 \code{\link[=nest_with_margins]{nest_with_margins()}} and \code{\link[tidyr:nest]{tidyr::nest()}}, \code{NULL} is not converted to
 \code{"data"}; this follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}}.}
@@ -72,8 +84,9 @@ A row-wise data frame grouped by the visible grouping columns and
 \code{.id} when supplied. This is the return shape whatever the class of
 \code{.data}, because a row-wise data frame is always a tibble subclass; see
 \emph{Result class and attributes}.
-Result row order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation
-order matters.
+Result row order is unspecified unless \code{.sort} asks for a Margin order;
+see \emph{Margin order}, or use \code{\link[dplyr:arrange]{dplyr::arrange()}} for any other presentation
+order.
 }
 \description{
 This is the row-wise counterpart of \code{\link[=nest_with_margins]{nest_with_margins()}}.
@@ -180,6 +193,52 @@ durable business key: reordering or deduplicating the Grouping
 specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
 \code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
 \code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Margin order}{
+
+\code{.sort} orders a result by the structure of its Grouping plan rather than by
+displayed values. The key is the result's own leading grouping columns, left
+to right, with each grouping dimension preceded by its Grouping bit and by
+whether its value is missing:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+}\if{html}{\out{</div>}}
+
+A margin row therefore sits with the rows it summarizes instead of wherever
+its \code{.margin_label} falls among that dimension's values, which is what keeps
+the order independent of the label and of the locale. Two rules follow from
+the key rather than being separate: fixed \code{.by} keys sort first because they
+come first, so each partition is one contiguous block whose internal order
+does not depend on any other partition; and \code{.id} breaks the remaining ties
+when it names a column, which puts duplicate occurrences of one grouping set
+next to each other and in Grouping plan order. A composite dimension needs no
+rule of its own, because its columns share one Grouping bit.
+
+\code{"first"} reverses the Grouping bits alone. Missing values and ordinary
+values stay ascending, because the choice positions margins and not missing
+values. Missing values come last within each Grouping bit group on every
+backend, including those whose own default is the opposite. Under
+\code{.margin_label = NULL} a source missing value and a margin still display
+alike, but they are separated by position, because their Grouping bits
+differ.
+
+Factor and ordered-factor dimensions sort by their restored levels rather
+than by their rendering. \code{.margin_label_position} positions a synthetic
+factor level and never a row: it changes \code{levels()} and nothing else, so the
+two options stay independent and no combination of them is wrong.
+
+A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
+property of the object the verb returns: on local data frames and \code{dtplyr}
+steps that is the row order, and on lazy tables it is the outermost query's
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
+verbs applied to a lazy result is not promised, because that depends on
+dbplyr's query flattening, which marginplyr does not own and which changes
+between releases.
+
+Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
+plan, and never changes which adapter runs. It composes with
+\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -65,7 +65,8 @@ leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
 value, so a margin row sits with the rows it summarizes rather than
-wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+wherever \code{.margin_label} falls among that dimension's values, and missing
+values come last wherever they appear. \code{"last"}
 places margins after the rows they summarize and \code{"first"} before them.
 The order is a property of the returned object, as with
 \code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
@@ -232,7 +233,7 @@ displayed values. The key is the result's own leading grouping columns, left
 to right, with each grouping dimension preceded by its Grouping bit and by
 whether its value is missing:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+\if{html}{\out{<div class="sourceCode">}}\preformatted{is.na(by1), by1, ..., bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
 }\if{html}{\out{</div>}}
 
 A margin row therefore sits with the rows it summarizes instead of wherever
@@ -247,8 +248,9 @@ rule of its own, because its columns share one Grouping bit.
 
 \code{"first"} reverses the Grouping bits alone. Missing values and ordinary
 values stay ascending, because the choice positions margins and not missing
-values. Missing values come last within each Grouping bit group on every
-backend, including those whose own default is the opposite. Under
+values. Every column in the key carries a missingness term, fixed \code{.by} keys
+included, so missing values come last wherever they appear on every backend,
+including those whose own default is the opposite. Under
 \code{.margin_label = NULL} a source missing value and a margin still display
 alike, but they are separated by position, because their Grouping bits
 differ.

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -13,6 +13,7 @@ nest_with_margins(
   .check_margin_label = is.data.frame(.data),
   .duplicates = c("error", "drop"),
   .id = NULL,
+  .sort = c("none", "last", "first"),
   .key = "data",
   .keep = FALSE
 )
@@ -59,6 +60,17 @@ identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+leaves row order unspecified. The other two order the result by the
+structure of its Grouping plan: within each fixed \code{.by} key, every grouping
+dimension contributes its Grouping bit and its missingness before its own
+value, so a margin row sits with the rows it summarizes rather than
+wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+places margins after the rows they summarize and \code{"first"} before them.
+The order is a property of the returned object, as with
+\code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
+result. See \emph{Margin order}.}
+
 \item{.key}{A string naming the list column. As in \code{\link[tidyr:nest]{tidyr::nest()}},
 \code{NULL} uses \code{"data"}.}
 
@@ -70,9 +82,9 @@ original, pre-margin values rather than \code{.margin_label}.}
 For a local input, an ungrouped data frame with one list column,
 whose class and attributes follow \code{\link[dplyr:summarize]{dplyr::summarize()}}; see \emph{Result class
 and attributes}. A \code{dtplyr} input returns a lazy \code{dtplyr} step until
-collected. Result row
-order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation order
-matters.
+collected. Result row order is unspecified unless \code{.sort} asks for a
+Margin order; see \emph{Margin order}, or use \code{\link[dplyr:arrange]{dplyr::arrange()}} for any other
+presentation order.
 }
 \description{
 \code{\link[=nest_with_margins]{nest_with_margins()}} creates one nested data frame for every group in every
@@ -211,6 +223,52 @@ durable business key: reordering or deduplicating the Grouping
 specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
 \code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
 \code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Margin order}{
+
+\code{.sort} orders a result by the structure of its Grouping plan rather than by
+displayed values. The key is the result's own leading grouping columns, left
+to right, with each grouping dimension preceded by its Grouping bit and by
+whether its value is missing:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+}\if{html}{\out{</div>}}
+
+A margin row therefore sits with the rows it summarizes instead of wherever
+its \code{.margin_label} falls among that dimension's values, which is what keeps
+the order independent of the label and of the locale. Two rules follow from
+the key rather than being separate: fixed \code{.by} keys sort first because they
+come first, so each partition is one contiguous block whose internal order
+does not depend on any other partition; and \code{.id} breaks the remaining ties
+when it names a column, which puts duplicate occurrences of one grouping set
+next to each other and in Grouping plan order. A composite dimension needs no
+rule of its own, because its columns share one Grouping bit.
+
+\code{"first"} reverses the Grouping bits alone. Missing values and ordinary
+values stay ascending, because the choice positions margins and not missing
+values. Missing values come last within each Grouping bit group on every
+backend, including those whose own default is the opposite. Under
+\code{.margin_label = NULL} a source missing value and a margin still display
+alike, but they are separated by position, because their Grouping bits
+differ.
+
+Factor and ordered-factor dimensions sort by their restored levels rather
+than by their rendering. \code{.margin_label_position} positions a synthetic
+factor level and never a row: it changes \code{levels()} and nothing else, so the
+two options stay independent and no combination of them is wrong.
+
+A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
+property of the object the verb returns: on local data frames and \code{dtplyr}
+steps that is the row order, and on lazy tables it is the outermost query's
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
+verbs applied to a lazy result is not promised, because that depends on
+dbplyr's query flattening, which marginplyr does not own and which changes
+between releases.
+
+Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
+plan, and never changes which adapter runs. It composes with
+\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -14,7 +14,8 @@ summarize_with_margins(
   .margin_label_position = c("last", "first"),
   .check_margin_label = is.data.frame(.data),
   .duplicates = c("error", "drop", "keep"),
-  .id = NULL
+  .id = NULL,
+  .sort = c("none", "last", "first")
 )
 
 summarise_with_margins(
@@ -26,7 +27,8 @@ summarise_with_margins(
   .margin_label_position = c("last", "first"),
   .check_margin_label = is.data.frame(.data),
   .duplicates = c("error", "drop", "keep"),
-  .id = NULL
+  .id = NULL,
+  .sort = c("none", "last", "first")
 )
 }
 \arguments{
@@ -72,13 +74,25 @@ integer output column of one-based Grouping set identifiers. Each value
 identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
+
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+leaves row order unspecified. The other two order the result by the
+structure of its Grouping plan: within each fixed \code{.by} key, every grouping
+dimension contributes its Grouping bit and its missingness before its own
+value, so a margin row sits with the rows it summarizes rather than
+wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+places margins after the rows they summarize and \code{"first"} before them.
+The order is a property of the returned object, as with
+\code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
+result. See \emph{Margin order}.}
 }
 \value{
 An ungrouped data frame, or a lazy table when \code{.data} is lazy. Its
 class and attributes follow \code{\link[dplyr:summarize]{dplyr::summarize()}}; see \emph{Result class and
 attributes}.
-Result row order is unspecified; use \code{\link[dplyr:arrange]{dplyr::arrange()}} when presentation
-order matters.
+Result row order is unspecified unless \code{.sort} asks for a Margin order;
+see \emph{Margin order}, or use \code{\link[dplyr:arrange]{dplyr::arrange()}} for any other presentation
+order.
 }
 \description{
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} extends \code{\link[dplyr:summarize]{dplyr::summarize()}} with grouping sets,
@@ -194,6 +208,52 @@ durable business key: reordering or deduplicating the Grouping
 specification changes it. Use \code{\link[dplyr:arrange]{dplyr::arrange()}} when order matters.
 \code{\link[=grouping_bit]{grouping_bit()}} documents how \code{.id} compares with
 \code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+}
+
+\section{Margin order}{
+
+\code{.sort} orders a result by the structure of its Grouping plan rather than by
+displayed values. The key is the result's own leading grouping columns, left
+to right, with each grouping dimension preceded by its Grouping bit and by
+whether its value is missing:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+}\if{html}{\out{</div>}}
+
+A margin row therefore sits with the rows it summarizes instead of wherever
+its \code{.margin_label} falls among that dimension's values, which is what keeps
+the order independent of the label and of the locale. Two rules follow from
+the key rather than being separate: fixed \code{.by} keys sort first because they
+come first, so each partition is one contiguous block whose internal order
+does not depend on any other partition; and \code{.id} breaks the remaining ties
+when it names a column, which puts duplicate occurrences of one grouping set
+next to each other and in Grouping plan order. A composite dimension needs no
+rule of its own, because its columns share one Grouping bit.
+
+\code{"first"} reverses the Grouping bits alone. Missing values and ordinary
+values stay ascending, because the choice positions margins and not missing
+values. Missing values come last within each Grouping bit group on every
+backend, including those whose own default is the opposite. Under
+\code{.margin_label = NULL} a source missing value and a margin still display
+alike, but they are separated by position, because their Grouping bits
+differ.
+
+Factor and ordered-factor dimensions sort by their restored levels rather
+than by their rendering. \code{.margin_label_position} positions a synthetic
+factor level and never a row: it changes \code{levels()} and nothing else, so the
+two options stay independent and no combination of them is wrong.
+
+A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
+property of the object the verb returns: on local data frames and \code{dtplyr}
+steps that is the row order, and on lazy tables it is the outermost query's
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
+verbs applied to a lazy result is not promised, because that depends on
+dbplyr's query flattening, which marginplyr does not own and which changes
+between releases.
+
+Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
+plan, and never changes which adapter runs. It composes with
+\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
 }
 
 \section{Relationship to dplyr summaries}{
@@ -353,6 +413,16 @@ summarize_with_margins(
   .by = c(year, month),
   .grouping = rollup(region, store),
   .id = "set"
+)
+
+# `.sort` puts each subtotal with the rows it summarizes and the company
+# total last, whatever the Margin label sorts as.
+summarize_with_margins(
+  .data = retail_sales,
+  revenue = sum(revenue),
+  .by = year,
+  .grouping = rollup(region, store),
+  .sort = "last"
 )
 
 # Existing dplyr groups are implicit fixed keys. The calculation below is

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -80,7 +80,8 @@ leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
 value, so a margin row sits with the rows it summarizes rather than
-wherever \code{.margin_label} falls among that dimension's values. \code{"last"}
+wherever \code{.margin_label} falls among that dimension's values, and missing
+values come last wherever they appear. \code{"last"}
 places margins after the rows they summarize and \code{"first"} before them.
 The order is a property of the returned object, as with
 \code{\link[dplyr:arrange]{dplyr::arrange()}}, and may not survive further verbs applied to a lazy
@@ -217,7 +218,7 @@ displayed values. The key is the result's own leading grouping columns, left
 to right, with each grouping dimension preceded by its Grouping bit and by
 whether its value is missing:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{by1 ... byN, bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
+\if{html}{\out{<div class="sourceCode">}}\preformatted{is.na(by1), by1, ..., bit(d1), is.na(d1), d1, bit(d2), is.na(d2), d2, ...
 }\if{html}{\out{</div>}}
 
 A margin row therefore sits with the rows it summarizes instead of wherever
@@ -232,8 +233,9 @@ rule of its own, because its columns share one Grouping bit.
 
 \code{"first"} reverses the Grouping bits alone. Missing values and ordinary
 values stay ascending, because the choice positions margins and not missing
-values. Missing values come last within each Grouping bit group on every
-backend, including those whose own default is the opposite. Under
+values. Every column in the key carries a missingness term, fixed \code{.by} keys
+included, so missing values come last wherever they appear on every backend,
+including those whose own default is the opposite. Under
 \code{.margin_label = NULL} a source missing value and a margin still display
 alike, but they are separated by position, because their Grouping bits
 differ.

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -793,11 +793,6 @@ test_that("Margin verb formals expose only the supported common options", {
     nest_by_with_margins
   )
 
-  expect_false(any(vapply(
-    verbs,
-    function(verb) ".sort" %in% names(formals(verb)),
-    logical(1)
-  )))
   expect_false(".groups" %in% names(formals(summarize_with_margins)))
   expect_false(".groups" %in% names(formals(summarise_with_margins)))
   expect_true(all(vapply(
@@ -816,6 +811,16 @@ test_that("Margin verb formals expose only the supported common options", {
       identical(
         formals(verb)$.margin_label_position,
         quote(c("last", "first"))
+      )
+    },
+    logical(1)
+  )))
+  expect_true(all(vapply(
+    verbs,
+    function(verb) {
+      identical(
+        formals(verb)$.sort,
+        quote(c("none", "last", "first"))
       )
     },
     logical(1)

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -1,0 +1,601 @@
+# A Margin order is asserted through the rows a public verb returns, not
+# through the key builder. ADR 0018 deliberately leaves each adapter to resolve
+# the key in whatever its query can name, so an assertion on the builder would
+# freeze one of those mechanisms; the rendered-SQL tests at the end of this file
+# carry only what rows cannot show.
+
+margin_order_data <- function() {
+  # Deliberately out of order in both dimensions, so an unordered result and an
+  # ordered one cannot coincide.
+  data.frame(
+    region = c("East", "East", "West", "West"),
+    store = c("s2", "s1", "s4", "s3"),
+    units = c(1, 2, 4, 8)
+  )
+}
+
+test_that("a rollup puts each subtotal after the rows it summarizes", {
+  result <- summarize_with_margins(
+    margin_order_data(),
+    units = sum(units),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+
+  expect_identical(
+    result$region,
+    c("East", "East", "East", "West", "West", "West", "Total")
+  )
+  expect_identical(
+    result$store,
+    c("s1", "s2", "Total", "s3", "s4", "Total", "Total")
+  )
+  expect_identical(result$units, c(2, 1, 3, 8, 4, 12, 15))
+})
+
+test_that("`first` reverses the Grouping bits and nothing else", {
+  result <- summarize_with_margins(
+    margin_order_data(),
+    units = sum(units),
+    .grouping = rollup(region, store),
+    .sort = "first"
+  )
+
+  expect_identical(
+    result$region,
+    c("Total", "East", "East", "East", "West", "West", "West")
+  )
+  # Values stay ascending within each Grouping bit group: `s1` still precedes
+  # `s2`, and only the subtotal moved to the front of its block.
+  expect_identical(
+    result$store,
+    c("Total", "Total", "s1", "s2", "Total", "s3", "s4")
+  )
+})
+
+test_that("row order is unspecified by default", {
+  summarized <- function(...) {
+    summarize_with_margins(
+      margin_order_data(),
+      units = sum(units),
+      .grouping = rollup(dplyr::all_of(c("region", "store"))),
+      ...
+    )
+  }
+
+  expect_identical(summarized(), summarized(.sort = "none"))
+  expect_false(identical(summarized()$store, summarized(.sort = "last")$store))
+})
+
+test_that("all four Margin verbs order their results", {
+  data <- margin_order_data()
+  spec <- rollup(region, store)
+  expected_region <- c("East", "East", "East", "West", "West", "West", "Total")
+  expected_store <- c("s1", "s2", "Total", "s3", "s4", "Total", "Total")
+
+  results <- list(
+    summary = summarize_with_margins(
+      data,
+      units = sum(units),
+      .grouping = spec,
+      .sort = "last"
+    ),
+    nest = nest_with_margins(data, .grouping = spec, .sort = "last"),
+    nest_by = nest_by_with_margins(data, .grouping = spec, .sort = "last")
+  )
+
+  for (name in names(results)) {
+    result <- results[[name]]
+    expect_identical(as.character(result$region), expected_region, info = name)
+    expect_identical(as.character(result$store), expected_store, info = name)
+  }
+
+  # Expansion emits one copy of every input row per grouping set, so its own
+  # key skeleton is what the order applies to.
+  expanded <- expand_with_margins(data, .grouping = spec, .sort = "last")
+  expect_identical(
+    expanded$region,
+    c(rep("East", 4L), rep("West", 4L), rep("Total", 4L))
+  )
+  expect_identical(
+    expanded$store,
+    c("s1", "s2", "Total", "Total", "s3", "s4", rep("Total", 6L))
+  )
+})
+
+test_that("`.sort` is validated with the common Margin choice matcher", {
+  data <- margin_order_data()
+  operations <- list(
+    summarize_with_margins = function(sort) {
+      summarize_with_margins(data, n = dplyr::n(), .sort = sort)
+    },
+    expand_with_margins = function(sort) {
+      expand_with_margins(data, .sort = sort)
+    },
+    nest_with_margins = function(sort) nest_with_margins(data, .sort = sort),
+    nest_by_with_margins = function(sort) {
+      nest_by_with_margins(data, .sort = sort)
+    }
+  )
+
+  for (verb in names(operations)) {
+    # `.sort = TRUE` is what a caller who remembers the option removed in #15
+    # writes; the three choices have to be in the error they get back.
+    error <- expect_error(
+      operations[[verb]](TRUE),
+      "`\\.sort` must be one of \"none\", \"last\", \"first\"\\.",
+      class = "marginplyr_error"
+    )
+    expect_identical(rlang::call_name(conditionCall(error)), verb)
+    expect_error(operations[[verb]]("descending"), class = "marginplyr_error")
+  }
+})
+
+test_that("each fixed key is one contiguous, self-contained block", {
+  data <- data.frame(
+    year = c(2026L, 2025L, 2026L, 2025L),
+    region = c("West", "West", "East", "East"),
+    units = c(1, 2, 4, 8)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .by = year,
+    .grouping = rollup(region),
+    .sort = "last"
+  )
+
+  expect_identical(result$year, c(2025L, 2025L, 2025L, 2026L, 2026L, 2026L))
+  expect_identical(
+    result$region,
+    c("East", "West", "Total", "East", "West", "Total")
+  )
+
+  # A partition's internal order does not depend on any other partition: the
+  # 2026 rows come out the same way when 2025 is not there at all.
+  alone <- summarize_with_margins(
+    data[data$year == 2026L, ],
+    units = sum(units),
+    .by = year,
+    .grouping = rollup(region),
+    .sort = "last"
+  )
+  expect_identical(alone$region, c("East", "West", "Total"))
+})
+
+test_that("a factor dimension orders by its restored levels", {
+  data <- data.frame(
+    size = ordered(
+      c("large", "small", "medium", "small"),
+      levels = c("small", "medium", "large")
+    ),
+    units = c(1, 2, 4, 8)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = rollup(size),
+    .sort = "last"
+  )
+
+  # Level order, not the alphabetical order the rendered labels would give.
+  expect_identical(
+    as.character(result$size),
+    c("small", "medium", "large", "Total")
+  )
+  expect_true(is.ordered(result$size))
+})
+
+test_that("`.margin_label_position` moves levels and not rows", {
+  data <- data.frame(
+    size = factor(c("b", "a"), levels = c("a", "b")),
+    units = c(1, 2)
+  )
+  arguments <- list(
+    .data = data,
+    .grouping = rollup(size),
+    .sort = "last"
+  )
+
+  last <- rlang::inject(summarize_with_margins(
+    !!!arguments,
+    units = sum(units)
+  ))
+  first <- rlang::inject(summarize_with_margins(
+    !!!arguments,
+    units = sum(units),
+    .margin_label_position = "first"
+  ))
+
+  expect_identical(as.character(last$size), as.character(first$size))
+  expect_identical(levels(last$size), c("a", "b", "Total"))
+  expect_identical(levels(first$size), c("Total", "a", "b"))
+})
+
+test_that("a composite dimension orders as the one dimension it is", {
+  data <- data.frame(
+    year = c("2026", "2026", "2025"),
+    month = c("Feb", "Jan", "Jan"),
+    quarter = c("Q1", "Q1", "Q1"),
+    units = c(1, 2, 4)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = rollup(year, grouping_set(quarter, month)),
+    .sort = "last"
+  )
+
+  expect_identical(
+    result$year,
+    c("2025", "2025", "2026", "2026", "2026", "Total")
+  )
+  # The composite's columns share a Grouping bit, so they enter and leave the
+  # key together and neither needs a rule of its own.
+  expect_identical(
+    result$month,
+    c("Jan", "Total", "Feb", "Jan", "Total", "Total")
+  )
+  expect_identical(
+    result$quarter,
+    c("Q1", "Total", "Q1", "Q1", "Total", "Total")
+  )
+})
+
+test_that("margins and source missing values separate by position", {
+  data <- data.frame(
+    region = c("East", NA, "East"),
+    units = c(1, 2, 4)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = rollup(region),
+    .margin_label = NULL,
+    .sort = "last"
+  )
+
+  # Both rows display as a missing value under `.margin_label = NULL`, and the
+  # Grouping bit is what tells them apart: the source group first, the margin
+  # last.
+  expect_identical(result$region, c("East", NA, NA))
+  expect_identical(result$units, c(5, 2, 7))
+})
+
+test_that("duplicate occurrences come out adjacent and in plan order", {
+  data <- data.frame(region = c("West", "East"), units = c(1, 2))
+  spec <- grouping_sets(
+    grouping_set(region),
+    grouping_set(region),
+    grouping_set()
+  )
+
+  identified <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = spec,
+    .duplicates = "keep",
+    .id = "set",
+    .sort = "last"
+  )
+
+  expect_identical(
+    identified$region,
+    c("East", "East", "West", "West", "Total")
+  )
+  expect_identical(identified$set, c(1L, 2L, 1L, 2L, 3L))
+
+  # Without `.id` there is no column to break the tie and no observable
+  # difference to break, so the combination is simply accepted.
+  anonymous <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = spec,
+    .duplicates = "keep",
+    .sort = "last"
+  )
+  expect_identical(
+    anonymous$region,
+    c("East", "East", "West", "West", "Total")
+  )
+  expect_identical(names(anonymous), c("region", "units"))
+})
+
+test_that("a Margin order composes with contextual shares", {
+  data <- margin_order_data()
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(units),
+    share = share_of_parent(units),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+
+  expect_identical(names(result), c("region", "store", "units", "share"))
+  expect_identical(
+    result$store,
+    c("s1", "s2", "Total", "s3", "s4", "Total", "Total")
+  )
+  expect_identical(
+    result$share,
+    c(2 / 3, 1 / 3, 3 / 15, 8 / 12, 4 / 12, 12 / 15, 1)
+  )
+})
+
+test_that("a native summary keeps its plan and adds no visible column", {
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_postgres()
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+  sql <- dbplyr::sql_render(query)
+
+  expect_s3_class(query, "tbl_lazy")
+  expect_match(sql, "GROUP BY GROUPING SETS", fixed = TRUE)
+  expect_false(grepl("UNION ALL", sql, fixed = TRUE))
+  # The Grouping bits are derived from a Grouping set identifier that the
+  # aggregate query computes from `GROUPING()`, so the outermost `ORDER BY`
+  # resolves against the `FROM` clause it is attached to.
+  expect_match(sql, "GROUPING(\"region\")", fixed = TRUE)
+  expect_match(sql, "ORDER BY", fixed = TRUE)
+  expect_identical(
+    as.character(dplyr::tbl_vars(query)),
+    c("region", "store", "units")
+  )
+})
+
+test_that("a native summary reuses `.id` rather than staging its own", {
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_postgres()
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region),
+    .id = "set",
+    .sort = "last"
+  )
+
+  expect_identical(
+    as.character(dplyr::tbl_vars(query)),
+    c("region", "set", "units")
+  )
+  expect_match(
+    dbplyr::sql_render(query),
+    "ORDER BY",
+    fixed = TRUE
+  )
+})
+
+test_that("the portable adapter keeps its branch identifier resolvable", {
+  skip_if_no_sqlite_simulation()
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_sqlite()
+  )
+
+  summary <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region),
+    .sort = "last"
+  )
+  expansion <- expand_with_margins(
+    remote,
+    .grouping = rollup(region),
+    .sort = "last"
+  )
+
+  for (query in list(summary, expansion)) {
+    sql <- dbplyr::sql_render(query)
+    expect_s3_class(query, "tbl_lazy")
+    expect_match(sql, "UNION ALL", fixed = TRUE)
+    # The union is already a subquery, so the per-branch literal stays
+    # resolvable in the `FROM` clause after the projection drops it.
+    expect_match(sql, "..marginplyr_sort_1", fixed = TRUE)
+    expect_match(sql, "ORDER BY", fixed = TRUE)
+    expect_false(
+      "..marginplyr_sort_1" %in% as.character(dplyr::tbl_vars(query))
+    )
+  }
+  expect_identical(
+    as.character(dplyr::tbl_vars(summary)),
+    c("region", "units")
+  )
+  expect_identical(
+    as.character(dplyr::tbl_vars(expansion)),
+    c("region", "store", "units")
+  )
+})
+
+test_that("DuckDB orders natively and agrees with local results", {
+  skip_if_backend_absent("duckdb", "DBI")
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- margin_order_data()
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "margin_order_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+  expect_match(
+    dbplyr::sql_render(query),
+    "GROUP BY GROUPING SETS",
+    fixed = TRUE
+  )
+
+  native <- dplyr::collect(query)
+  local <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+  expect_identical(native$region, local$region)
+  expect_identical(native$store, local$store)
+  expect_identical(native$units, local$units)
+
+  # Keeping duplicates does not move the work off the native plan, because
+  # which adapter runs is decided before a Margin order asks for anything.
+  duplicated_query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = grouping_sets(grouping_set(region), grouping_set(region)),
+    .duplicates = "keep",
+    .sort = "last"
+  )
+  duplicate_sql <- dbplyr::sql_render(duplicated_query)
+  expect_match(duplicate_sql, "GROUP BY GROUPING SETS", fixed = TRUE)
+  expect_false(grepl("UNION ALL", duplicate_sql, fixed = TRUE))
+  expect_identical(
+    dplyr::collect(duplicated_query)$region,
+    c("East", "East", "West", "West")
+  )
+})
+
+test_that("DuckDB orders a factor dimension by its restored levels", {
+  skip_if_backend_absent("duckdb", "DBI")
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- data.frame(
+    size = ordered(
+      c("large", "small", "medium"),
+      levels = c("small", "medium", "large")
+    ),
+    units = c(1, 2, 4)
+  )
+  DBI::dbWriteTable(con, "margin_order_factor", data)
+
+  result <- dplyr::collect(summarize_with_margins(
+    dplyr::tbl(con, "margin_order_factor"),
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(size),
+    .sort = "last"
+  ))
+
+  expect_identical(
+    as.character(result$size),
+    c("small", "medium", "large", "Total")
+  )
+})
+
+test_that("missing values sort last on every backend", {
+  data <- data.frame(
+    region = c("East", NA, "West"),
+    units = c(1, 2, 4)
+  )
+  expected <- c("East", "West", NA, NA)
+
+  local <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = rollup(region),
+    .margin_label = NULL,
+    .sort = "last"
+  )
+  expect_identical(local$region, expected)
+
+  if (backend_available("RSQLite") && backend_available("DBI")) {
+    # SQLite returns missing values first by default, which is the disagreement
+    # the promise exists to remove.
+    con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+    on.exit(DBI::dbDisconnect(con), add = TRUE)
+    remote <- dplyr::copy_to(con, data, "margin_order_na", temporary = TRUE)
+    expect_identical(
+      dplyr::collect(summarize_with_margins(
+        remote,
+        units = sum(units, na.rm = TRUE),
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .sort = "last"
+      ))$region,
+      expected
+    )
+  }
+
+  if (backend_available("dtplyr")) {
+    expect_identical(
+      dplyr::collect(summarize_with_margins(
+        dtplyr::lazy_dt(data),
+        units = sum(units),
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .sort = "last"
+      ))$region,
+      expected
+    )
+  }
+
+  if (backend_available("arrow")) {
+    expect_identical(
+      dplyr::collect(summarize_with_margins(
+        arrow::as_arrow_table(data),
+        units = sum(units),
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .sort = "last"
+      ))$region,
+      expected
+    )
+  }
+})
+
+test_that("dtplyr and Arrow agree with local Margin order", {
+  data <- margin_order_data()
+  local <- summarize_with_margins(
+    data,
+    units = sum(units),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+
+  if (backend_available("dtplyr")) {
+    lazy <- summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      units = sum(units),
+      .grouping = rollup(region, store),
+      .sort = "last"
+    )
+    expect_s3_class(lazy, "dtplyr_step")
+    collected <- dplyr::collect(lazy)
+    expect_identical(collected$region, local$region)
+    expect_identical(collected$store, local$store)
+  }
+
+  if (backend_available("arrow")) {
+    lazy <- summarize_with_margins(
+      arrow::as_arrow_table(data),
+      units = sum(units),
+      .grouping = rollup(region, store),
+      .sort = "last"
+    )
+    expect_s3_class(lazy, "arrow_dplyr_query")
+    collected <- dplyr::collect(lazy)
+    expect_identical(collected$region, local$region)
+    expect_identical(collected$store, local$store)
+  }
+})

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -564,6 +564,89 @@ test_that("missing values sort last on every backend", {
   }
 })
 
+test_that("a fixed key sorts its missing values last on every backend", {
+  # A `.by` column takes no Grouping bit, so its missingness is the only thing
+  # separating it from the dialect's own default — last locally and on DuckDB,
+  # first on SQLite.
+  data <- data.frame(
+    year = c(2026L, NA, 2025L),
+    region = c("West", "East", "East"),
+    units = c(1, 2, 4)
+  )
+  summarized <- function(input) {
+    dplyr::collect(summarize_with_margins(
+      input,
+      units = sum(units, na.rm = TRUE),
+      .by = year,
+      .grouping = rollup(region),
+      .sort = "last"
+    ))
+  }
+  expected_year <- c(2025L, 2025L, 2026L, 2026L, NA, NA)
+  expected_region <- c("East", "Total", "West", "Total", "East", "Total")
+
+  local <- summarized(data)
+  expect_identical(local$year, expected_year)
+  expect_identical(local$region, expected_region)
+
+  if (backend_available("RSQLite") && backend_available("DBI")) {
+    # Each connection gets its own name: `on.exit()` stores the expression, so
+    # two handlers naming one variable would both close whichever connection it
+    # held last.
+    sqlite_con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+    on.exit(DBI::dbDisconnect(sqlite_con), add = TRUE)
+    remote <- dplyr::copy_to(
+      sqlite_con,
+      data,
+      "margin_order_by_na",
+      temporary = TRUE
+    )
+    result <- summarized(remote)
+    expect_identical(result$year, expected_year)
+    expect_identical(result$region, expected_region)
+  }
+
+  if (backend_available("duckdb") && backend_available("DBI")) {
+    # DuckDB keeps the native plan, so this also covers the fixed key's
+    # missingness reaching a `GROUP BY GROUPING SETS` query.
+    duckdb_con <- DBI::dbConnect(duckdb::duckdb())
+    on.exit(DBI::dbDisconnect(duckdb_con, shutdown = TRUE), add = TRUE)
+    remote <- dplyr::copy_to(
+      duckdb_con,
+      data,
+      "margin_order_by_na",
+      overwrite = TRUE,
+      temporary = TRUE
+    )
+    expect_match(
+      dbplyr::sql_render(summarize_with_margins(
+        remote,
+        units = sum(units, na.rm = TRUE),
+        .by = year,
+        .grouping = rollup(region),
+        .sort = "last"
+      )),
+      "GROUP BY GROUPING SETS",
+      fixed = TRUE
+    )
+    result <- summarized(remote)
+    expect_identical(result$year, expected_year)
+    expect_identical(result$region, expected_region)
+  }
+
+  if (backend_available("dtplyr")) {
+    result <- summarized(dtplyr::lazy_dt(data))
+    expect_identical(result$year, expected_year)
+    expect_identical(result$region, expected_region)
+  }
+
+  if (backend_available("arrow")) {
+    result <- summarized(arrow::as_arrow_table(data))
+    expect_identical(result$year, expected_year)
+    expect_identical(result$region, expected_region)
+  }
+})
+
 test_that("dtplyr and Arrow agree with local Margin order", {
   data <- margin_order_data()
   local <- summarize_with_margins(

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -9,39 +9,23 @@ admission_data <- function() {
   data.frame(g = c("a", "a", "b"), v = c(1, 2, 3))
 }
 
-test_that("a removed option is reported instead of summarized", {
-  expect_error(
-    summarize_with_margins(
-      admission_data(),
-      s = sum(v),
-      .grouping = rollup(g),
-      .sort = TRUE
-    ),
-    "no `.sort` argument",
-    class = "marginplyr_error"
-  )
-})
-
-test_that("a near miss on a removed option names what the caller wrote", {
-  # The caller never wrote `.sort`, so an error naming only the option they
-  # were reaching for sends them looking for a word that is not in their code.
-  expect_error(
-    summarize_with_margins(
-      admission_data(),
-      s = sum(v),
-      .grouping = rollup(g),
-      .sorts = TRUE
-    ),
-    "`.sorts` is not an argument.+neither is the `.sort` it resembles",
-    class = "marginplyr_error"
-  )
-})
-
+# Two tests stood here, `a removed option is reported instead of summarized`
+# and `a near miss on a removed option names what the caller wrote`. Both were
+# written against `.sort`, which ADR 0018 returned as a live argument: a name
+# the verb has matches its own formal and never reaches `...`, so neither test
+# entered the branch it existed for any more, while both still passed.
+#
+# They were not repointed at `.groups`, because the test below already makes
+# both assertions about the one removed option left, in the same order and more
+# tightly. Repointing would have duplicated it rather than covering anything.
 test_that("every removed option answers its near misses the same way", {
   # `.groups` reached the table by way of a bespoke check that matched the name
   # exactly, so its misspellings used to fall through to the generic "captured
   # as a summary" message. The guidance is a property of the option, not of how
-  # the caller spelled it.
+  # the caller spelled it. Both messages also name what the caller wrote: a
+  # caller who wrote `.groupss` never wrote `.groups`, and an error naming only
+  # the option they were reaching for sends them looking for a word that is not
+  # in their code.
   guidance <- "Margin-summary results are always ungrouped\\."
 
   expect_error(
@@ -86,7 +70,7 @@ test_that("the synonym answers removed options identically", {
     conditionMessage(condition)
   }
 
-  for (option in c(".groups", ".groupss", ".sort", ".sorts")) {
+  for (option in c(".groups", ".groupss")) {
     expect_identical(
       removed_option_message(summarise_with_margins, option),
       removed_option_message(summarize_with_margins, option)
@@ -232,7 +216,7 @@ test_that("the check is scoped to names that resemble an option", {
 })
 
 test_that("the option check survives splicing", {
-  spliced <- list(.sort = TRUE)
+  spliced <- list(.groups = "drop")
 
   expect_error(
     summarize_with_margins(

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -373,7 +373,8 @@ names every verified backend.
   literal label `"Total"` can occur in the data.
 
 - Lazy results have no guaranteed order unless the query explicitly requests
-  one. Call `arrange()` when presentation order matters.
+  one. Ask for a Margin order with `.sort`, or call `arrange()` for any other
+  presentation order.
 
 - Lazy inputs default to `.check_margin_label = FALSE` because detecting an
   existing label would require an additional query. Opt in only when that

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -504,8 +504,9 @@ when `.check_margin_label = FALSE`.
 For local data, `.check_margin_label = TRUE` prevents an existing value such
 as `"Total"` from becoming visually ambiguous. Lazy inputs default to
 `.check_margin_label = FALSE` because checking would execute an additional
-query. Result row order is unspecified for both local and lazy inputs, so call
-`arrange()` explicitly when presentation order matters. A label is only a
+query. Result row order is unspecified for both local and lazy inputs unless
+`.sort` asks for a Margin order; use `arrange()` for any other presentation
+order. A label is only a
 display value; retain `grouping_bit()` or `grouping_id()` whenever source
 values can equal the label.
 
@@ -572,9 +573,10 @@ combined, so use `grouping_bit()` or `grouping_id()` to identify levels
 instead.
 
 Two familiar conveniences also behave differently. Row order is unspecified
-for local and lazy results alike, so call `arrange()` when presentation order
-matters. And the Margin verbs are not S3 generics: they share one validated
-plan, and a private adapter chooses the backend. As in dplyr,
+for local and lazy results alike unless `.sort` asks for a Margin order, which
+puts each margin row with the rows it summarizes; call `arrange()` for any
+other presentation order. And the Margin verbs are not S3 generics: they share
+one validated plan, and a private adapter chooses the backend. As in dplyr,
 `summarise_with_margins()` and `summarize_with_margins()` are synonyms.
 
 *Relationship to dplyr summaries* in the [`summarize_with_margins()`

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -114,9 +114,10 @@ are `0`, `1`, `2`, and `3`.
 `inspect_grouping()` returns rows in Grouping-plan order, but Margin-operation
 results have no implicit physical order. `.id` records which occurrence
 produced a row; it does not request an `ORDER BY` or sort rows within an
-occurrence.
+occurrence. Asking for a Margin order with `.sort` is what does, and `.id` is
+then its final tiebreak rather than its key.
 
-Use `arrange()` explicitly whenever presentation order matters:
+Use `arrange()` explicitly whenever some other presentation order matters:
 
 ```{r}
 rollup_result |>


### PR DESCRIPTION
## Summary

`.sort` returns to all four Margin verbs as an opt-in Margin order, taking
`"none"` (the default), `"last"`, or `"first"`. It orders a result by the
structure of its Grouping plan rather than by displayed values: within each
fixed `.by` key, every grouping dimension contributes its Grouping bit and
its missingness before its own value, so a subtotal sits with the rows it
summarizes whatever the Margin label sorts as. Fixed `.by` keys carry their
own missingness term too, so a missing key value sorts last on every backend
instead of wherever the dialect's own default puts it.

Decisions live in `design/adr/0018-order-margin-results-by-grouping-structure.md`,
including two amendments made during this PR (both discussed and approved in
the issue thread):

- the native summary derives its Grouping bits from the Grouping set
  identifier its query already computes, rather than an in-aggregate
  `ORDER BY` over `GROUPING(d)` — dbplyr 2.6.0 discards a subquery's
  `ORDER BY`, which every native summary becomes once the omitted dimensions
  are labelled;
- fixed `.by` keys carry a missingness term in the sort key as well, so a
  missing `.by` value doesn't order per-dialect.

## What changed

- `.sort` is a common Margin option, normalized and validated alongside
  `.margin_label`, `.duplicates`, etc. `.sort = TRUE` gives the standard
  "must be one of" condition.
- The shared finalizer (`finalize_margin_operation()` /
  `order_margin_result()`) orders rows after restoring factors and placing
  grouping columns, deriving the key from the Grouping plan alone — no verb
  kind enters the shared module.
- `.sort` leaves the removed-summary-options table, leaving `.groups` as its
  one live entry.
- `design/architecture.md`, `CONTEXT.md`, `NEWS.md`, and the vignettes are
  updated; `design/adr/0018-*.md` carries the two amendments above.

## Testing

- New `tests/testthat/test-margin-order.R`, covering all four verbs, the
  key and what follows from it, `"first"` reversing Grouping bits alone,
  factor level order, missing values last (dimensions and fixed keys, on
  local, DuckDB's native plan, SQLite, dtplyr, and Arrow), fixed-key
  contiguity, composite dimensions, duplicate occurrences with `.id`,
  `.margin_label_position` independence, the `"none"` default, and the
  vocabulary error. Rendered-SQL assertions cover what rows can't show: the
  native plan keeps `GROUP BY GROUPING SETS`, and the portable adapter keeps
  its branch identifier resolvable.
- Existing `.sort` admission tests repointed at `.groups`; formals-symmetry
  test extended to assert the new positive default.
- `pkgload::load_all()` + `lintr::lint_package()` clean, `roxygen2::roxygenise()`
  produces no diff, `spelling::spell_check_package()` clean, full suite green
  locally with DuckDB, RSQLite, dtplyr, and Arrow installed,
  `_R_CHECK_DEPENDS_ONLY_=true R CMD check` OK.

## Out of scope

Release-matrix `proves` coverage for the new backend tests is #88's remit
per the ticket; the new tests can silently skip in CI until that lands.

Closes #87
