### PR TITLE
Add a recipes vignette for common reporting tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,32 @@ honest: any leak into `man/` fails CI.
 `.github/workflows/document.yaml` regenerates both and fails when either
 differs from what the roxygen comments produce.
 
+### Chunks that must fail
+
+A vignette showing a rejected call executes it rather than quoting its error,
+so the reader sees the diagnostic their own session would produce. Quarto's
+`error: true` is the wrong option on its own: it *permits* an error without
+requiring one, so a chunk that stops failing renders a success underneath
+prose that still claims a failure, and nothing reports it. knitr and Quarto
+offer no option for the other half, and no package supplies one
+(`investigation/margin-order-and-plan-joins.md`).
+
+`vignettes/recipes.qmd` therefore defines a `must_error: true` chunk option in
+a hidden setup chunk. It implies `error: true`, so the two are never set
+inconsistently, and it halts the render naming the chunk when a chunk marked
+with it completes without raising an error. Mark a chunk with it instead of
+`error: true` whenever the surrounding prose asserts that the call fails.
+
+Two properties are load-bearing and easy to lose in a rewrite. It is
+implemented as a wrapper around knitr's `evaluate` hook, which inspects the
+returned result objects; that keeps knitr's own error rendering, whereas
+catching the condition in a helper prints an `<error/rlang_error>` header and
+a backtrace through the helper, which no reader would see. And because knitr
+does not call that hook for a chunk it does not evaluate, a chunk withheld by
+an availability guard is skipped without a special case — a guarded chunk that
+never runs must not be reported as a chunk that stopped failing, or
+`_R_CHECK_DEPENDS_ONLY_` builds break.
+
 ### Dependency metadata
 
 `DESCRIPTION`'s Imports/Suggests split is audited by hand, not with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ so the reader sees the diagnostic their own session would produce. Quarto's
 requiring one, so a chunk that stops failing renders a success underneath
 prose that still claims a failure, and nothing reports it. knitr and Quarto
 offer no option for the other half, and no package supplies one
-(`investigation/margin-order-and-plan-joins.md`).
+(`investigation/requiring-a-documentation-chunk-to-fail.md`).
 
 `vignettes/recipes.qmd` therefore defines a `must_error: true` chunk option in
 a hidden setup chunk. It implies `error: true`, so the two are never set

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -12,6 +12,18 @@
 #' row copies. Naming the public operation for row expansion keeps the SQL
 #' implementation strategy out of the user-facing API.
 #'
+#' @section Calculations one summary pass cannot express:
+#' Expanded rows are also the route to a calculation the aggregation pass
+#' cannot express. A summary that needs both a group-level value and the rows
+#' behind it works directly in [summarize_with_margins()] on a local data
+#' frame, because dplyr hands the expression the whole group; against a
+#' database the same expression has to compile to SQL aggregates, and a nested
+#' aggregate is rejected. Expanding first gives ordinary window functions over
+#' the copies and stays lazy, at the cost of one copy of the input per
+#' grouping set. The [recipes guide][recipes] works the case through.
+#'
+#' [recipes]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
+#'
 #' @inheritParams summarize_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -55,9 +55,14 @@
 #' optimizer plan.
 #'
 #' The [grouping identity guide][guide] walks through inspecting a plan and
-#' reading it back off a Margin result.
+#' reading it back off a Margin result. The [recipes guide][recipes] uses a
+#' plan to choose which grouping set to keep, and joins one against `.id` to
+#' name the set behind every row. Because the plan is local, that join needs a
+#' `copy` argument when the Margin result is lazy, and it does not preserve a
+#' Margin order.
 #'
 #' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
+#' [recipes]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
 #'
 #' @family grouping plans and grouping identity
 #' @seealso [summarize_with_margins()] to run a Margin operation on the

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -64,6 +64,7 @@
 #'
 #' @section Guides:
 #' - [Get started][g1]
+#' - [Recipes for common reporting tasks][g5]
 #' - [Database and lazy backends][g2]
 #' - [Grouping identity][g3]
 #' - [Complete absent keys before margins][g4]
@@ -72,6 +73,7 @@
 #' [g2]: https://sayuks.github.io/marginplyr/vignettes/database_backends.html
 #' [g3]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
 #' [g4]: https://sayuks.github.io/marginplyr/vignettes/completing_keys.html
+#' [g5]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
 #'
 #' @keywords internal
 #' @examples

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -206,6 +206,12 @@
 #' plan, and never changes which adapter runs. It composes with
 #' `.duplicates = "keep"` with no diagnostic, and lazy inputs stay lazy.
 #'
+#' The [recipes guide][recipes] shows a Margin order before and after, and
+#' shows a join dropping one from a lazy result with no diagnostic naming this
+#' package.
+#'
+#' [recipes]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
+#'
 #' @section Relationship to dplyr summaries:
 #' The `...` expressions use [dplyr::summarize()] data-masking semantics.
 #' [dplyr::across()] and [dplyr::pick()] cannot select any column named in the

--- a/README.Rmd
+++ b/README.Rmd
@@ -72,6 +72,8 @@ and combine yourself.
 
 New to the idea? Start with [Get
 started](https://sayuks.github.io/marginplyr/vignettes/get_started.html).
+Know the task and want the call? See [Recipes for common reporting
+tasks](https://sayuks.github.io/marginplyr/vignettes/recipes.html).
 Need to compare `.id`, Grouping bits, and Grouping identifiers? See [Grouping
 identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html).
 Need absent dimension keys? See [Complete absent keys before

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ build and combine yourself.
 
 New to the idea? Start with [Get
 started](https://sayuks.github.io/marginplyr/vignettes/get_started.html).
-Need to compare `.id`, Grouping bits, and Grouping identifiers? See
-[Grouping
+Know the task and want the call? See [Recipes for common reporting
+tasks](https://sayuks.github.io/marginplyr/vignettes/recipes.html). Need
+to compare `.id`, Grouping bits, and Grouping identifiers? See [Grouping
 identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html).
 Need absent dimension keys? See [Complete absent keys before
 margins](https://sayuks.github.io/marginplyr/vignettes/completing_keys.html).

--- a/altdoc/quarto_website.yml
+++ b/altdoc/quarto_website.yml
@@ -14,6 +14,8 @@ website:
     left:
       - text: Get started
         href: vignettes/get_started.qmd
+      - text: Recipes
+        href: vignettes/recipes.qmd
       - text: Grouping identity
         href: vignettes/grouping_identity.qmd
       - text: Complete absent keys
@@ -30,6 +32,7 @@ website:
       # - text: Home
         # file: index.md
       - vignettes/get_started.qmd
+      - vignettes/recipes.qmd
       - vignettes/grouping_identity.qmd
       - vignettes/completing_keys.qmd
       - vignettes/database_backends.qmd

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,3 +1,4 @@
+ADR
 CMD
 Codecov
 DuckDB
@@ -24,6 +25,8 @@ presentational
 quartabs
 rollup
 rollups
+subqueries
+subquery
 tabset
 tabsets
 tibble

--- a/investigation/margin-order-and-plan-joins.md
+++ b/investigation/margin-order-and-plan-joins.md
@@ -1,0 +1,169 @@
+# Joining a Grouping plan onto a Margin result
+
+Investigated: 2026-08-06
+
+Evidence gathered while settling the shape of `vignettes/recipes.qmd` (#82).
+The recipes make four claims a reader cannot check for themselves — that a
+lazy plan join needs a `copy` argument, that it silently loses the Margin
+order, that `.format = "list"` cannot take part in one, and that a two-pass
+summary expression is rejected by databases but not locally. Each was
+measured rather than reasoned about, and two of #82's original acceptance
+criteria did not survive the measurement.
+
+## Environment
+
+All measurements on 2026-08-06, one machine, macOS (Darwin 25.5.0).
+
+| Component | Version |
+|---|---|
+| R | 4.6.1 |
+| dplyr | 1.2.1 |
+| dbplyr | 2.6.0 |
+| rlang | 1.3.0 |
+| duckdb (R package) | 1.5.5 |
+| DuckDB engine | v1.5.5 |
+| RSQLite | 3.53.3 |
+| SQLite engine | 3.53.3 |
+
+Every measurement used `retail_sales`, `.by = year`,
+`.grouping = rollup(region, store)`, `.id = "set"`, and where stated
+`.sort = "last"`.
+
+## A `copy`-less lazy join is refused, and the refusal names the fix
+
+`left_join()` of `inspect_grouping()` onto a lazy Margin result:
+
+```
+Error in `left_join()`:
+! `x` and `y` must share the same source.
+ℹ Use `copy = "temp-table"` to copy `y` to a temporary table.
+ℹ USe `copy = "inline"` to convert `y` to inline SQL.
+```
+
+Identical on `dbplyr::simulate_postgres()`, on `dbplyr::simulate_sqlite()`,
+and on a live DuckDB connection. The capitalisation of "USe" is dbplyr's, not
+a transcription error.
+
+#82 as written assumed this error was "a dbplyr error about a local table,
+which does not point back here". It names two fixes. What it does not name is
+`copy = TRUE`, which #82's acceptance criteria required the vignette to teach.
+
+## Which `copy` values work
+
+| Value | Live DuckDB | `dbplyr::simulate_sqlite()` |
+|---|---|---|
+| `TRUE` | works | fails |
+| `"inline"` | works | works |
+| `"temp-table"` | works | not attempted |
+
+`copy = TRUE` on a simulated connection fails with
+
+```
+no applicable method for `@` applied to an object of class "SQLiteConnection"
+```
+
+because it writes a real temporary table, which a simulated connection has no
+way to do. `"inline"` compiles the plan into a `VALUES` subquery instead, so
+it needs neither a live connection nor write permission. For a table of one
+row per grouping set that is the cheaper form as well.
+
+This is why the vignette teaches `"inline"`: it is the only value whose
+demonstration produces output when Suggested packages are absent.
+
+## Which simulated connection is free of Suggests
+
+`dbplyr::simulate_sqlite()` is not. Rendering SQL through it loads R6, and
+`vignettes/database_backends.qmd:55-57` records that it also reads the
+installed driver version through RSQLite, which is why that vignette guards
+its simulator chunks behind `has_sqlite_simulator`.
+
+`dbplyr::simulate_postgres()` loaded no additional namespace. Each of the
+three failures above — the `copy`-less refusal, the `ORDER BY is ignored`
+warning under `copy = "inline"`, and the `sql_cast_dispatch` failure for
+`.format = "list"` — reproduced on it unchanged. `vignettes/get_started.qmd:725`
+already uses it in an unguarded chunk, so it is the established form here for
+lazy demonstration that must render everywhere.
+
+## The join destroys the Margin order, and says so only generically
+
+On a live DuckDB connection, with `.sort = "last"`, joining the plan scrambles
+the result under **all three** `copy` values. The only diagnostic is dbplyr's
+
+```
+Warning: ORDER BY is ignored in subqueries without LIMIT
+ℹ Do you need to move arrange() later in the pipeline or use window_order() instead?
+```
+
+emitted twice, naming nothing in marginplyr. `show_query()` on the joined
+table still prints a `# Ordered by:` line describing the Margin order key, so
+the object continues to claim an order the database does not honour.
+
+`.sort` is an argument of the Margin verb, not a verb of its own, so it cannot
+be applied again after the join. The remedies measured were `arrange()` after
+the join, and `collect()` before it.
+
+`collect()`-ing the Margin result first and joining the plan locally preserved
+the Margin order exactly, with no warning. This is consistent with
+`CONTEXT.md`'s **Margin order** entry — "a property of the result a Margin
+verb returns, not of any table derived from it" — and with ADR 0018; the
+measurement establishes what that costs in practice on a lazy backend, which
+neither states.
+
+## `.format = "list"` cannot be joined lazily
+
+`inspect_grouping(..., .format = "list")` joined with `copy = "inline"` fails
+during SQL rendering:
+
+```
+no applicable method for 'sql_cast_dispatch' applied to an object of class "list"
+```
+
+on both the simulator and a live connection. The message names neither
+marginplyr nor `.format`. The lazy route therefore requires the default
+`.format = "text"`; `"list"` remains usable once the result is local.
+
+## A two-pass summary expression is local-only
+
+`sum(revenue[revenue > mean(revenue)]) / sum(revenue)` as a summary inside
+`summarize_with_margins()`:
+
+| Input | Outcome |
+|---|---|
+| local data frame | returns a value for every grouping set |
+| DuckDB | `Binder Error: aggregate function calls cannot be nested` |
+| SQLite | `misuse of aggregate function AVG()` |
+
+Locally dplyr hands a summary expression the group's whole vector, so the
+row-level comparison is already available and no escape hatch is needed. Both
+databases reject the compiled nested aggregate, with different messages; the
+rejection is an External condition in `CONTEXT.md`'s sense, propagated with
+its own class.
+
+`expand_with_margins()` followed by `group_by()`, a `mutate()` window, and
+`summarize()` returned the same values as the local expression and stayed
+lazy on DuckDB. Expansion produced 72 rows from 24 source rows for a
+three-set rollup, one copy per grouping set.
+
+## No mechanism exists for requiring a documentation chunk to fail
+
+Searched 2026-08-07, while deciding how the vignette should show these
+failures. knitr 1.51 exposes exactly one relevant chunk option, `error`, whose
+`TRUE` value permits an error without requiring one; there is no option,
+hook, or documented idiom for asserting that a chunk *must* fail. Quarto 1.9.38
+documents `error: true` with the same permissive meaning. No package on CRAN
+was found that supplies the assertion, and the knitr and rmarkdown issue
+trackers discuss only the permissive direction (yihui/knitr#2366,
+rstudio/rmarkdown#149).
+
+The gap is what `vignettes/recipes.qmd` fills with its own `must_error: true`
+chunk option; `AGENTS.md` is authoritative for what that option does.
+
+Two candidate implementations were built and measured. Wrapping each call in a
+helper that catches the condition works, but renders the condition object
+rather than knitr's error output — an `<error/rlang_error>` header and a
+backtrace naming the helper, `tryCatch`, and `tryCatchList`, none of which a
+reader would see in their own console. Overriding knitr's `evaluate` hook and
+inspecting the returned result objects preserves knitr's own error rendering
+exactly, and needs no special case for a chunk withheld by an availability
+guard, because knitr does not call the hook for a chunk it does not evaluate.
+The second was adopted.

--- a/investigation/margin-order-and-plan-joins.md
+++ b/investigation/margin-order-and-plan-joins.md
@@ -67,8 +67,9 @@ way to do. `"inline"` compiles the plan into a `VALUES` subquery instead, so
 it needs neither a live connection nor write permission. For a table of one
 row per grouping set that is the cheaper form as well.
 
-This is why the vignette teaches `"inline"`: it is the only value whose
-demonstration produces output when Suggested packages are absent.
+Only `"inline"` therefore produces output in a documentation chunk built
+without Suggested packages. `AGENTS.md` and `vignettes/recipes.qmd` are
+authoritative for what the package documents.
 
 ## Which simulated connection is free of Suggests
 
@@ -80,9 +81,8 @@ its simulator chunks behind `has_sqlite_simulator`.
 `dbplyr::simulate_postgres()` loaded no additional namespace. Each of the
 three failures above — the `copy`-less refusal, the `ORDER BY is ignored`
 warning under `copy = "inline"`, and the `sql_cast_dispatch` failure for
-`.format = "list"` — reproduced on it unchanged. `vignettes/get_started.qmd:725`
-already uses it in an unguarded chunk, so it is the established form here for
-lazy demonstration that must render everywhere.
+`.format = "list"` — reproduced on it unchanged. As of 2026-08-06
+`vignettes/get_started.qmd:725` used it in an unguarded chunk.
 
 ## The join destroys the Margin order, and says so only generically
 
@@ -143,27 +143,3 @@ its own class.
 `summarize()` returned the same values as the local expression and stayed
 lazy on DuckDB. Expansion produced 72 rows from 24 source rows for a
 three-set rollup, one copy per grouping set.
-
-## No mechanism exists for requiring a documentation chunk to fail
-
-Searched 2026-08-07, while deciding how the vignette should show these
-failures. knitr 1.51 exposes exactly one relevant chunk option, `error`, whose
-`TRUE` value permits an error without requiring one; there is no option,
-hook, or documented idiom for asserting that a chunk *must* fail. Quarto 1.9.38
-documents `error: true` with the same permissive meaning. No package on CRAN
-was found that supplies the assertion, and the knitr and rmarkdown issue
-trackers discuss only the permissive direction (yihui/knitr#2366,
-rstudio/rmarkdown#149).
-
-The gap is what `vignettes/recipes.qmd` fills with its own `must_error: true`
-chunk option; `AGENTS.md` is authoritative for what that option does.
-
-Two candidate implementations were built and measured. Wrapping each call in a
-helper that catches the condition works, but renders the condition object
-rather than knitr's error output — an `<error/rlang_error>` header and a
-backtrace naming the helper, `tryCatch`, and `tryCatchList`, none of which a
-reader would see in their own console. Overriding knitr's `evaluate` hook and
-inspecting the returned result objects preserves knitr's own error rendering
-exactly, and needs no special case for a chunk withheld by an availability
-guard, because knitr does not call the hook for a chunk it does not evaluate.
-The second was adopted.

--- a/investigation/requiring-a-documentation-chunk-to-fail.md
+++ b/investigation/requiring-a-documentation-chunk-to-fail.md
@@ -1,0 +1,83 @@
+# Requiring a documentation chunk to fail
+
+Investigated: 2026-08-07
+
+Searched while deciding how `vignettes/recipes.qmd` (#82) should show the
+calls it says are rejected. The question was whether a chunk can be made to
+*require* an error rather than merely tolerate one, so that prose asserting a
+failure cannot outlive the failure. The evidence for what those calls do is in
+`margin-order-and-plan-joins.md`; this note covers only the mechanism.
+
+## Environment
+
+| Component | Version |
+|---|---|
+| R | 4.6.1 |
+| knitr | 1.51 |
+| Quarto CLI | 1.9.38 |
+| rlang | 1.3.0 |
+
+## Nothing supplies the assertion
+
+knitr 1.51 exposes one chunk option in this area, `error`. Enumerating
+`knitr::opts_chunk$get(default = TRUE)` and matching names against
+`err|cond|expect|assert|fail` returned `error` alone. Its `TRUE` value permits
+an error without requiring one. `knitr::knit_hooks$get()` names twelve hooks —
+`source`, `output`, `warning`, `message`, `error`, `plot`, `inline`, `chunk`,
+`text`, `evaluate.inline`, `evaluate`, `document` — and the `error` hook is
+called only when an error occurs, so its absence cannot be observed through
+it.
+
+Quarto 1.9.38 documents `error: true` with the same permissive meaning.
+
+No package supplying the assertion was found. The knitr and rmarkdown issue
+trackers discuss only the permissive direction (yihui/knitr#2366,
+rstudio/rmarkdown#149).
+
+## Two implementations were built and compared
+
+**A helper that catches the condition.** Wrapping each call in a function that
+`tryCatch`es and re-`stop()`s on success is the shorter form, and needs no
+knitr internals. It renders the condition object rather than knitr's error
+output:
+
+```
+<error/rlang_error>
+Error in `left_join()`:
+! `x` and `y` must share the same source.
+---
+Backtrace:
+ 1. ├─global must_fail(left_join(report, plan, by = c(set = "set_id")))
+ 2. │ └─base::tryCatch(...)
+ 3. │   └─base (local) tryCatchList(expr, classes, parentenv, handlers)
+```
+
+The header and the three frames through the helper are not what a reader would
+see in their own console.
+
+**A wrapper around knitr's `evaluate` hook.** The hook receives the evaluated
+result objects, and `knitr::opts_current$get()` supplies the chunk's options
+inside it, so one hook can both preserve knitr's own error rendering and
+inspect what the chunk produced. Twenty lines against forty-one for a version
+built from the `error` hook plus a chunk hook plus an environment to carry
+state between them.
+
+Measured behaviour of the `evaluate`-hook version, on a document with a chunk
+marked to require an error:
+
+| Case | Result |
+|---|---|
+| chunk raises an error | renders; knitr's error output appears in the HTML |
+| chunk completes normally | `quarto render` exits 1, no HTML, message names the chunk |
+| chunk withheld by `eval: false` | renders; no assertion |
+| option set without `error: true` | cannot occur; an `opts_hooks` entry supplies it |
+
+The third row is a property of knitr rather than of the implementation: knitr
+does not call the `evaluate` hook for a chunk it does not evaluate. A version
+built from the `error` hook had to test `options$eval` explicitly, and failed
+the case before that test was added — a guarded chunk that never ran was
+reported as a chunk that had stopped failing, which would break a
+`_R_CHECK_DEPENDS_ONLY_` build.
+
+`AGENTS.md` is authoritative for which version the repository uses and for the
+rule about when to mark a chunk.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -91,6 +91,18 @@ row copies. Naming the public operation for row expansion keeps the SQL
 implementation strategy out of the user-facing API.
 }
 
+\section{Calculations one summary pass cannot express}{
+
+Expanded rows are also the route to a calculation the aggregation pass
+cannot express. A summary that needs both a group-level value and the rows
+behind it works directly in \code{\link[=summarize_with_margins]{summarize_with_margins()}} on a local data
+frame, because dplyr hands the expression the whole group; against a
+database the same expression has to compile to SQL aggregates, and a nested
+aggregate is rejected. Expanding first gives ordinary window functions over
+the copies and stays lazy, at the cost of one copy of the input per
+grouping set. The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} works the case through.
+}
+
 \section{Fixed columns and grouping dimensions}{
 
 \code{.by} marks columns that are present in every grouping set, while
@@ -229,6 +241,10 @@ between releases.
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with
 \code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
+shows a join dropping one from a lazy result with no diagnostic naming this
+package.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -77,7 +77,11 @@ Grouping plan. It is deliberately separate from a SQL execution plan. Use
 optimizer plan.
 
 The \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} walks through inspecting a plan and
-reading it back off a Margin result.
+reading it back off a Margin result. The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} uses a
+plan to choose which grouping set to keep, and joins one against \code{.id} to
+name the set behind every row. Because the plan is local, that join needs a
+\code{copy} argument when the Margin result is lazy, and it does not preserve a
+Margin order.
 }
 
 \examples{

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -78,6 +78,7 @@ your call can avoid; please report those at
 
 \itemize{
 \item \href{https://sayuks.github.io/marginplyr/vignettes/get_started.html}{Get started}
+\item \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{Recipes for common reporting tasks}
 \item \href{https://sayuks.github.io/marginplyr/vignettes/database_backends.html}{Database and lazy backends}
 \item \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{Grouping identity}
 \item \href{https://sayuks.github.io/marginplyr/vignettes/completing_keys.html}{Complete absent keys before margins}

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -241,6 +241,10 @@ between releases.
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with
 \code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
+shows a join dropping one from a lazy result with no diagnostic naming this
+package.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -271,6 +271,10 @@ between releases.
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with
 \code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
+shows a join dropping one from a lazy result with no diagnostic naming this
+package.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -256,6 +256,10 @@ between releases.
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with
 \code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
+shows a join dropping one from a lazy result with no diagnostic naming this
+package.
 }
 
 \section{Relationship to dplyr summaries}{

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -395,7 +395,9 @@ reference](https://sayuks.github.io/marginplyr/man/grouping_bit.html) compares
 `.id`, `inspect_grouping()$set_id`, `grouping_bit()`, and `grouping_id()` in
 full. The [Grouping identity
 guide](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
-works through the same values with executable examples.
+works through the same values with executable examples, and
+[Recipes](https://sayuks.github.io/marginplyr/vignettes/recipes.html) uses
+them to keep one grouping set and to name the set behind every row.
 
 `grouping_id()` combines the flags as a bit mask. Its last argument is the
 least-significant bit:
@@ -506,7 +508,9 @@ as `"Total"` from becoming visually ambiguous. Lazy inputs default to
 `.check_margin_label = FALSE` because checking would execute an additional
 query. Result row order is unspecified for both local and lazy inputs unless
 `.sort` asks for a Margin order; use `arrange()` for any other presentation
-order. A label is only a
+order. [Put each subtotal with the rows it
+summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html)
+shows `.sort` at work and what it does not promise. A label is only a
 display value; retain `grouping_bit()` or `grouping_id()` whenever source
 values can equal the label.
 
@@ -701,6 +705,11 @@ and the value rules — and the
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 documents both helpers.
 
+Which rows the denominator covers is decided by the fixed `.by` keys. [Compare
+each row with the right
+total](https://sayuks.github.io/marginplyr/vignettes/recipes.html) works
+through that choice.
+
 ## Complete absent keys before summarizing
 
 Grouping specifications choose reporting grains; they do not create
@@ -779,6 +788,12 @@ dbplyr::tbl_lazy(
   ) |>
   show_query()
 ```
+
+Expanded rows are also the way to compute something one aggregation pass
+cannot express, which is a real limit on a database rather than a local one.
+[Compute what the summary pass cannot
+express](https://sayuks.github.io/marginplyr/vignettes/recipes.html) works
+through that case.
 
 ### Nest locally or with dtplyr
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -24,6 +24,20 @@ started](https://sayuks.github.io/marginplyr/vignettes/get_started.html) first
 if Grouping specifications are new to you. Each recipe links to the concept
 guide that explains why its answer works.
 
+## Installation
+
+Install the development version of marginplyr from GitHub:
+
+```{r}
+#| eval: false
+
+install.packages("pak")
+pak::pkg_install("sayuks/marginplyr")
+
+# Used for the sections of this guide that execute against a database.
+install.packages(c("DBI", "duckdb"))
+```
+
 ```{r setup}
 #| message: false
 
@@ -31,28 +45,21 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. One recipe executes against DuckDB, so its
-chunks evaluate only when DuckDB is installed. Where a package is missing the
-code is still shown, but its output is absent. Everything else runs either
-locally or against `dbplyr::simulate_postgres()`, which needs no database and
-no optional package.
+Only dplyr and dbplyr are required. Two recipes execute against DuckDB, so
+their chunks evaluate only when DuckDB is installed. Where a package is
+missing the code is still shown, but its output is absent. Everything else
+runs either locally or against `dbplyr::simulate_postgres()`, which needs no
+database and no optional package.
 
 ```{r}
 #| include: false
 
 has_duckdb <- requireNamespace("DBI", quietly = TRUE) &&
   requireNamespace("duckdb", quietly = TRUE)
-```
 
-```{r}
-#| include: false
-
-# Several recipes below show a call that is meant to fail, so the reader sees
-# the real diagnostic rather than a quotation of one. Quarto's `error: true`
-# permits an error without requiring one, which would let this prose outlive
-# the behavior it describes. `must_error: true` adds the missing half: it
-# implies `error: true` and halts the render if the chunk stops failing.
-# See AGENTS.md.
+# Chunks marked `must_error: true` show a call that is meant to fail, so the
+# reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
+# authoritative for what the option does and why it exists.
 local({
   knitr::opts_hooks$set(must_error = function(options) {
     if (isTRUE(options$must_error)) options$error <- TRUE
@@ -105,8 +112,10 @@ retail_sales |>
 
 `"first"` puts each subtotal above its rows instead. Neither choice looks at
 `.margin_label`, so the placement does not change if the label does, and it
-does not depend on the locale. The `NA` store keeps its own position because
-missing values sort last wherever they appear, independently of the margins.
+does not depend on the locale. The `NA` store sorts after the named stores but
+still ahead of the region subtotal: each dimension contributes its Grouping
+bit before its missingness, so a margin outranks a missing value rather than
+competing with one.
 
 **A Margin order belongs to the object the verb returned, not to anything
 derived from it.** Any later verb is free to reorder, and on a lazy backend
@@ -138,9 +147,11 @@ retail_sales |>
   )
 ```
 
-The shares inside each year add up to one, and 2025 contributes nothing to
-2026's denominator. Move the dimension out of `.by` and into the Grouping
-specification, and the same helper measures against the whole table instead:
+The region rows inside each year add up to one, and 2025 contributes nothing
+to 2026's denominator. The year's own row is the denominator, so its share is
+one by definition rather than by addition. Move the dimension out of `.by` and
+into the Grouping specification, and the same helper measures against the
+whole table instead:
 
 ```{r}
 retail_sales |>
@@ -224,7 +235,8 @@ compares all four identity values and states their duplicate-occurrence rules.
 Joining them attaches whatever name you care to write.
 
 Build the name on the plan first. `inspect_grouping()` returns an ordinary
-tibble with no custom class (ADR 0013), so ordinary dplyr applies, and cutting
+tibble with no custom class ([ADR 0013][adr13]), so ordinary dplyr applies,
+and cutting
 it down to two columns keeps the plan's five description columns out of the
 report:
 
@@ -263,9 +275,11 @@ retail_sales |>
 ### The same join against a lazy table
 
 `inspect_grouping()` is local even when `.data` is not: it reads captured
-column metadata and the Grouping plan, never the source rows (ADR 0013). A
-lazy result and a local tibble have no common source, so dbplyr refuses the
-join outright:
+column metadata and the Grouping plan, never the source rows
+([ADR 0013][adr13]). A lazy result and a local tibble have no common source,
+so dbplyr refuses the join outright:
+
+[adr13]: https://github.com/sayuks/marginplyr/blob/main/design/adr/0013-inspect-grouping-plans-as-ordinary-tibbles.md
 
 ```{r}
 postgres_sales <- dbplyr::tbl_lazy(
@@ -302,15 +316,39 @@ postgres_report |>
 
 Two conditions come with that route, and neither announces itself.
 
-**The Margin order does not survive the join.** As the previous recipe put it,
-a Margin order is a property of the object the verb returned, not of anything
-derived from it. Here the database is entitled to ignore an `ORDER BY` buried
-in a subquery, and does; the only warning is dbplyr's generic *ORDER BY is
-ignored in subqueries without LIMIT*, which names nothing in marginplyr, while
-`show_query()` goes on printing an `# Ordered by:` line for an order that is
-no longer honored. `.sort` is an argument of the Margin verb, so it cannot be
-applied again afterwards — order with `arrange()` after the join, or collect
-first as below.
+**The Margin order does not survive the join.** As [Put each subtotal with the
+rows it summarizes](#put-each-subtotal-with-the-rows-it-summarizes) put it, a
+Margin order is a property of the object the verb returned, not of anything
+derived from it. A simulated connection renders SQL without running it, so
+seeing this needs a live database:
+
+```{r}
+#| eval: !expr has_duckdb
+
+con <- DBI::dbConnect(duckdb::duckdb())
+duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
+
+duckdb_report <- duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    .by = year,
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  )
+
+duckdb_report |>
+  left_join(sales_levels, by = c(set = "set_id"), copy = "inline") |>
+  collect()
+```
+
+The subtotals are scattered and the years interleave. A database is entitled
+to ignore an `ORDER BY` buried in a subquery, and this one does; the only
+warning is dbplyr's generic *ORDER BY is ignored in subqueries without LIMIT*,
+which names nothing in marginplyr, while `show_query()` goes on printing an
+`# Ordered by:` line for an order that is no longer honored. `.sort` is an
+argument of the Margin verb, so it cannot be applied again afterwards — order
+with `arrange()` after the join, or collect first as below.
 
 **The plan has to be in the default `.format = "text"`.** The list columns of
 `.format = "list"` have no SQL type, and the failure surfaces while dbplyr
@@ -335,28 +373,22 @@ postgres_report |>
 ```
 
 Prefer `collect()` before the join whenever the result is a report you are
-about to read. The plan is one row per grouping set and a finished summary is
-already small, so nothing is gained by making the database perform the join —
-and collecting first keeps the Margin order, allows `.format = "list"`, and
-needs no `copy` argument at all:
+about to read. It is the same shape as the local join at the top of this
+recipe: the plan is one row per grouping set and a finished summary is already
+small, so nothing is gained by making the database perform the join — and
+collecting first keeps the Margin order, allows `.format = "list"`, and needs
+no `copy` argument at all:
 
 ```{r}
 #| eval: !expr has_duckdb
 
-con <- DBI::dbConnect(duckdb::duckdb())
-duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
-
-duckdb_sales |>
-  summarize_with_margins(
-    revenue = sum(revenue, na.rm = TRUE),
-    .by = year,
-    .grouping = rollup(region, store),
-    .id = "set",
-    .sort = "last"
-  ) |>
+duckdb_report |>
   collect() |>
   left_join(sales_levels, by = c(set = "set_id"))
 ```
+
+Same query, same plan, same join — and every subtotal is back under the rows
+it summarizes.
 
 ```{r}
 #| include: false
@@ -447,7 +479,11 @@ duckdb_sales |>
 DBI::dbDisconnect(con, shutdown = TRUE)
 ```
 
-The values match the local calculation above. The cost is in the row count:
+Every value matches the local calculation above. The two tables are not laid
+out alike — this one carries the `set` column and is in no Margin order,
+because the pipeline ends in an ordinary `summarize()` rather than in a Margin
+verb — so compare them by key rather than row by row. The cost is in the row
+count:
 expansion produces one copy of the input per grouping set, so a plan with many
 sets multiplies the rows the database has to scan. Reach for this when the
 aggregation pass genuinely cannot express the calculation, not to avoid

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -1,0 +1,459 @@
+---
+title: Recipes for common reporting tasks
+vignette: >
+  %\VignetteIndexEntry{Recipes for common reporting tasks}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+format:
+  html:
+    code-tools: true
+    toc: true
+    toc-expand: true
+    number-sections: true
+date: last-modified
+---
+
+The other guides are organized by concept. This one is organized by task: each
+section states a reporting question, answers it with one worked pipeline, and
+stops. Read them in any order and skip the rest — no recipe uses a value
+another recipe defined, so every one starts from `retail_sales` or from its
+own lazy table.
+
+Read [Get
+started](https://sayuks.github.io/marginplyr/vignettes/get_started.html) first
+if Grouping specifications are new to you. Each recipe links to the concept
+guide that explains why its answer works.
+
+```{r setup}
+#| message: false
+
+library(marginplyr)
+library(dplyr)
+```
+
+Only dplyr and dbplyr are required. One recipe executes against DuckDB, so its
+chunks evaluate only when DuckDB is installed. Where a package is missing the
+code is still shown, but its output is absent. Everything else runs either
+locally or against `dbplyr::simulate_postgres()`, which needs no database and
+no optional package.
+
+```{r}
+#| include: false
+
+has_duckdb <- requireNamespace("DBI", quietly = TRUE) &&
+  requireNamespace("duckdb", quietly = TRUE)
+```
+
+```{r}
+#| include: false
+
+# Several recipes below show a call that is meant to fail, so the reader sees
+# the real diagnostic rather than a quotation of one. Quarto's `error: true`
+# permits an error without requiring one, which would let this prose outlive
+# the behavior it describes. `must_error: true` adds the missing half: it
+# implies `error: true` and halts the render if the chunk stops failing.
+# See AGENTS.md.
+local({
+  knitr::opts_hooks$set(must_error = function(options) {
+    if (isTRUE(options$must_error)) options$error <- TRUE
+    options
+  })
+  default_evaluate <- knitr::knit_hooks$get("evaluate")
+  knitr::knit_hooks$set(evaluate = function(...) {
+    res <- default_evaluate(...)
+    opts <- knitr::opts_current$get()
+    if (isTRUE(opts$must_error) &&
+          !any(vapply(res, inherits, logical(1), "error"))) {
+      stop(
+        "Chunk `", opts$label, "` is marked `must_error: true` but ",
+        "completed without raising an error.",
+        call. = FALSE
+      )
+    }
+    res
+  })
+})
+```
+
+## Put each subtotal with the rows it summarizes
+
+By default a Margin result promises no particular arrangement, so subtotals
+can land anywhere:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .by = year,
+    .grouping = rollup(region, store)
+  )
+```
+
+`.sort = "last"` asks for a Margin order instead. Within each fixed `.by` key
+every dimension contributes its Grouping bit before its own value, so each
+subtotal sits directly beneath the rows it summarizes:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .by = year,
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+```
+
+`"first"` puts each subtotal above its rows instead. Neither choice looks at
+`.margin_label`, so the placement does not change if the label does, and it
+does not depend on the locale. The `NA` store keeps its own position because
+missing values sort last wherever they appear, independently of the margins.
+
+**A Margin order belongs to the object the verb returned, not to anything
+derived from it.** Any later verb is free to reorder, and on a lazy backend
+one usually does — see [Name the grouping set on every
+row](#name-the-grouping-set-on-every-row) for a join that drops it silently.
+When some other presentation order is what you want, `arrange()` after the
+fact and do not ask for a Margin order at all.
+
+[Grouping
+identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
+explains why Grouping-plan order and a Margin order answer different
+questions.
+
+## Compare each row with the right total
+
+`share_of_total()` divides a summary by the same summary on the Grand total
+set. Which rows that set covers is decided by the fixed `.by` keys, and that
+is the whole of the choice. With `.by = year`, each year is its own
+denominator:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    share_of_year = share_of_total(revenue),
+    .by = year,
+    .grouping = rollup(region),
+    .sort = "last"
+  )
+```
+
+The shares inside each year add up to one, and 2025 contributes nothing to
+2026's denominator. Move the dimension out of `.by` and into the Grouping
+specification, and the same helper measures against the whole table instead:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    share_overall = share_of_total(revenue),
+    .grouping = rollup(year, region),
+    .sort = "last"
+  )
+```
+
+Now every row is a share of all four region-years together, and the year rows
+are subtotals rather than partitions. Both calls are correct; they answer
+different questions, and `.by` is what distinguishes them.
+
+For a denominator one rollup level up rather than at the top, use
+`share_of_parent()`. The
+[`share_of_parent()`
+reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
+documents both helpers, and [Get
+started](https://sayuks.github.io/marginplyr/vignettes/get_started.html)
+compares them side by side.
+
+## Keep only one grouping set
+
+Filtering on a Margin label is unsafe: a source value can equal the label, and
+the label can be changed or set to `NULL`. Filter on Grouping identity
+instead. The obstacle is knowing which value to ask for — and guessing the bit
+order is easy to get backwards.
+
+Do not guess. `inspect_grouping()` prints the answer for every set in the plan
+before any data is summarized:
+
+```{r}
+inspect_grouping(
+  .data = retail_sales,
+  .grouping = cube(region, channel)
+)
+```
+
+Read `grouping_bits` beside `grouping_id`: the last dimension is the least
+significant bit, so `channel` alone being omitted is `1`, `region` alone is
+`2`, and both is `3`. Retain the identifier in the summary and filter on it:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    absence = grouping_id(region, channel),
+    .grouping = cube(region, channel),
+    .sort = "last"
+  ) |>
+  filter(absence == 1L)
+```
+
+Two steps are required because `grouping_id()` and `grouping_bit()` are
+contextual summary helpers. They read the Grouping set that produced a row,
+which only the summary knows, so calling one inside `filter()` is rejected:
+
+```{r}
+#| label: grouping-bit-in-filter
+#| must_error: true
+
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .grouping = cube(region, channel)
+  ) |>
+  filter(grouping_bit(channel) == 1L)
+```
+
+For a single dimension, `grouping_bit()` avoids the bit arithmetic altogether:
+retain one flag column per dimension and filter on the flags. [Grouping
+identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
+compares all four identity values and states their duplicate-occurrence rules.
+
+## Name the grouping set on every row
+
+`.id` numbers the Grouping-set occurrence behind each row, and
+`inspect_grouping()` returns one row per occurrence keyed by the same number.
+Joining them attaches whatever name you care to write.
+
+Build the name on the plan first. `inspect_grouping()` returns an ordinary
+tibble with no custom class (ADR 0013), so ordinary dplyr applies, and cutting
+it down to two columns keeps the plan's five description columns out of the
+report:
+
+```{r}
+sales_levels <- retail_sales |>
+  inspect_grouping(
+    .by = year,
+    .grouping = rollup(region, store)
+  ) |>
+  mutate(
+    level = case_when(
+      omitted == "()" ~ "Store detail",
+      omitted == "(store)" ~ "Region subtotal",
+      .default = "All regions"
+    )
+  ) |>
+  select(set_id, level)
+
+sales_levels
+```
+
+Then join it onto the result:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .by = year,
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  ) |>
+  left_join(sales_levels, by = c(set = "set_id"))
+```
+
+### The same join against a lazy table
+
+`inspect_grouping()` is local even when `.data` is not: it reads captured
+column metadata and the Grouping plan, never the source rows (ADR 0013). A
+lazy result and a local tibble have no common source, so dbplyr refuses the
+join outright:
+
+```{r}
+postgres_sales <- dbplyr::tbl_lazy(
+  retail_sales,
+  con = dbplyr::simulate_postgres()
+)
+
+postgres_report <- postgres_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    .by = year,
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  )
+```
+
+```{r}
+#| label: join-without-copy
+#| must_error: true
+
+postgres_report |>
+  left_join(sales_levels, by = c(set = "set_id"))
+```
+
+`copy = "inline"` compiles the plan into the query as a `VALUES` list, which
+suits a table holding one row per grouping set and needs no permission to
+write one:
+
+```{r}
+postgres_report |>
+  left_join(sales_levels, by = c(set = "set_id"), copy = "inline")
+```
+
+Two conditions come with that route, and neither announces itself.
+
+**The Margin order does not survive the join.** As the previous recipe put it,
+a Margin order is a property of the object the verb returned, not of anything
+derived from it. Here the database is entitled to ignore an `ORDER BY` buried
+in a subquery, and does; the only warning is dbplyr's generic *ORDER BY is
+ignored in subqueries without LIMIT*, which names nothing in marginplyr, while
+`show_query()` goes on printing an `# Ordered by:` line for an order that is
+no longer honored. `.sort` is an argument of the Margin verb, so it cannot be
+applied again afterwards — order with `arrange()` after the join, or collect
+first as below.
+
+**The plan has to be in the default `.format = "text"`.** The list columns of
+`.format = "list"` have no SQL type, and the failure surfaces while dbplyr
+renders the query, without naming `.format`:
+
+```{r}
+list_levels <- inspect_grouping(
+  .data = postgres_sales,
+  .by = year,
+  .grouping = rollup(region, store),
+  .format = "list"
+)
+```
+
+```{r}
+#| label: join-list-format
+#| must_error: true
+
+postgres_report |>
+  left_join(list_levels, by = c(set = "set_id"), copy = "inline") |>
+  show_query()
+```
+
+Prefer `collect()` before the join whenever the result is a report you are
+about to read. The plan is one row per grouping set and a finished summary is
+already small, so nothing is gained by making the database perform the join —
+and collecting first keeps the Margin order, allows `.format = "list"`, and
+needs no `copy` argument at all:
+
+```{r}
+#| eval: !expr has_duckdb
+
+con <- DBI::dbConnect(duckdb::duckdb())
+duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
+
+duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    .by = year,
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  ) |>
+  collect() |>
+  left_join(sales_levels, by = c(set = "set_id"))
+```
+
+```{r}
+#| include: false
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(con, shutdown = TRUE)
+```
+
+[Database and lazy
+backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
+covers query shape and execution for lazy inputs generally.
+
+## Compute what the summary pass cannot express
+
+A summary expression can do more than call one aggregate. On a local data
+frame dplyr hands it the whole group, so a calculation that needs both a
+group-level value and the rows behind it works directly — here, the share of
+revenue coming from rows above their own set's mean:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    above_mean_share =
+      sum(revenue[revenue > mean(revenue)]) / sum(revenue),
+    .by = year,
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+```
+
+Against a database the same expression has to compile to SQL aggregates, and
+this one does not: the comparison needs an average that is itself an aggregate
+over the same group, which no dialect allows inside another aggregate. The
+error comes from the database, with its own wording:
+
+```{r}
+#| eval: !expr has_duckdb
+
+con <- DBI::dbConnect(duckdb::duckdb())
+duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
+```
+
+```{r}
+#| label: nested-aggregate
+#| must_error: true
+#| eval: !expr has_duckdb
+
+duckdb_sales |>
+  summarize_with_margins(
+    above_mean_share =
+      sum(revenue[revenue > mean(revenue)]) / sum(revenue),
+    .by = year,
+    .grouping = rollup(region, store)
+  ) |>
+  collect()
+```
+
+`expand_with_margins()` is the way through. It emits one copy of each source
+row for every grouping set, which turns the one summary pass into ordinary
+rows you can take as many passes over as the calculation needs — a window
+function for the group's mean, then an aggregate over the comparison. It stays
+lazy throughout:
+
+```{r}
+#| eval: !expr has_duckdb
+
+duckdb_sales |>
+  expand_with_margins(
+    .by = year,
+    .grouping = rollup(region, store),
+    .id = "set"
+  ) |>
+  group_by(year, region, store, set) |>
+  mutate(set_mean = mean(revenue, na.rm = TRUE)) |>
+  summarize(
+    above_mean_share =
+      sum(ifelse(revenue > set_mean, revenue, 0), na.rm = TRUE) /
+      sum(revenue, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  collect()
+```
+
+```{r}
+#| include: false
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(con, shutdown = TRUE)
+```
+
+The values match the local calculation above. The cost is in the row count:
+expansion produces one copy of the input per grouping set, so a plan with many
+sets multiplies the rows the database has to scan. Reach for this when the
+aggregation pass genuinely cannot express the calculation, not to avoid
+writing a summary.
+
+[Database and lazy
+backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
+shows the SQL `expand_with_margins()` generates on native and fallback
+backends.


### PR DESCRIPTION
## Summary

Adds `vignettes/recipes.qmd`: five task-shaped recipes, each self-contained
(shared setup only, no recipe references a value another recipe defined).
Shape was settled in a `/grill-with-docs` session before writing, recorded in
`#82`'s comments; the session's measurements are in
`investigation/margin-order-and-plan-joins.md`.

Two of the issue's original acceptance criteria did not survive measurement
and were corrected in the issue before this PR was written — `copy = "inline"`
rather than `copy = TRUE`, and registration in
`altdoc/quarto_website.yml` rather than `DESCRIPTION`. See the issue for the
evidence.

## Recipes

1. **Put each subtotal with the rows it summarizes** — `.sort`'s first worked
   example anywhere in the package.
2. **Compare each row with the right total** — which rows the Grand total set
   covers is decided by `.by`, shown with and without a fixed key.
3. **Keep only one grouping set** — read `grouping_bits`/`grouping_id` off
   `inspect_grouping()` rather than guess the mask.
4. **Name the grouping set on every row** — joining `inspect_grouping()` onto
   a lazy Margin result silently destroys the Margin order under every `copy`
   mode; `collect()` first is recommended, the lazy fallback is shown with its
   three conditions.
5. **Compute what the summary pass cannot express** — a two-pass expression
   works locally but is rejected by DuckDB and SQLite as a nested aggregate;
   `expand_with_margins()` plus window functions stays lazy.

## Failure-case chunks

Chunks that show a rejected call execute it rather than quote it, guarded by a
new `must_error: true` chunk option (documented in `AGENTS.md`) instead of
`error: true` alone — the render halts if a chunk marked as failing stops
failing.

## Checks run locally

- [x] `_R_CHECK_DEPENDS_ONLY_=true R CMD check --as-cran` against the built
      source tarball: exit 0, vignette re-builds, only the expected
      `New submission` / unreachable-URL NOTE (the URL is real but not yet
      published).
- [x] `pkgload::load_all(".")` + `lintr::lint_package()`: no lints.
- [x] `spelling::spell_check_package()`: clean.
- [x] `roxygen2::roxygenise()`: run, committed, output stable across two runs.
- [x] Rendered with and without DuckDB available; `must_error` chunks halt the
      render correctly in both directions (verified in the working session,
      not part of this diff).
- [x] Local vs. `expand_with_margins()` values for recipe 5 checked equal by
      `all.equal()` across all 16 rows.

## Not in scope

Pre-existing `CONTEXT.md` `_Avoid_` violations found along the way ("grand
total row", "root row") are tracked in #95.

Closes #82
