### PR TITLE
Clear the remaining Grand total set _Avoid_ violations

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -218,7 +218,8 @@ parent_report |>
   dplyr::mutate(revenue_percent = 100 * revenue_share)
 ```
 
-The root row's share is one, and a missing or zero denominator gives `NA`.
+A row of the Grand total set has a parent share of one, and a missing or zero
+denominator gives `NA`.
 Parent matching is structural, so display labels never choose the parent.
 
 ## Compare each summary with the whole

--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ parent_report |>
 #> 8  Total         Total   23300     1.0000000       100.00000
 ```
 
-The root row’s share is one, and a missing or zero denominator gives
-`NA`. Parent matching is structural, so display labels never choose the
-parent.
+A row of the Grand total set has a parent share of one, and a missing or
+zero denominator gives `NA`. Parent matching is structural, so display
+labels never choose the parent.
 
 ## Compare each summary with the whole
 

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1336,7 +1336,7 @@ test_that("DuckDB Total shares agree across native, portable, and local paths", 
   expected <- summarize(data, "drop") |>
     dplyr::arrange(fixed, set, group, item)
   # A cube is the plan a Parent share cannot accept, and every cell of it
-  # divides by the one Grand total row of its own fixed partition.
+  # divides by the one row of the Grand total set in its own fixed partition.
   expect_identical(sum(expected$revenue_share == 1), 2L)
   expect_equal(
     expected$revenue_share[expected$level == 0L],

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -1823,7 +1823,8 @@ test_that("Total shares reuse the Parent-share value rules", {
     .grouping = rollup(group),
     .margin_label = NULL
   )
-  # A zero denominator is missing, and the grand total row is still one.
+  # A zero denominator is missing, and the row of the Grand total set is
+  # still one.
   expect_identical(zero_denominator$whole, c(NA_real_, NA_real_, 1))
 
   unclamped <- summarize_with_margins(

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -267,8 +267,8 @@ missing-safe keys rather than displayed Margin labels.
 
 `share_of_total()` stages the same way and asks less of the query. Its
 denominator depends on the fixed `.by` keys and nothing else, so its mapping
-is one filtered read of the grand total row, joined on those keys alone — and
-on a constant when, as here, there are none:
+is one filtered read of a row of the Grand total set, joined on those keys
+alone — and on a constant when, as here, there are none:
 
 ```{r}
 postgres_sales |>

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -667,8 +667,9 @@ parent_report |>
 
 ## Compare a summary with the whole
 
-`share_of_total()` divides by the grand total row instead of the parent level.
-It is written the same way, and both helpers can appear in one summary:
+`share_of_total()` divides by a row of the Grand total set instead of the
+parent level. It is written the same way, and both helpers can appear in one
+summary:
 
 ```{r}
 retail_sales |>


### PR DESCRIPTION
Clear the remaining Grand total set _Avoid_ violations

CONTEXT.md's Grand total set entry bans "root row", "total row", and "root
set" as names for the concept. Five places used a banned form anyway:
get_started.qmd and database_backends.qmd each called it "the grand total
row", README.Rmd called it "the root row", and two test comments
(test-share-backends.R, test-share.R) called it "the Grand total row" /
"the grand total row". None of them changes a result; each now names the
concept as the Grand total set, or refers to a row of it without using a
banned form as the name — matching the wording CONTEXT.md itself uses for
Parent share and Total share.

"Margin row" is left alone in R/summarize_with_margins.R (three places) and
get_started.qmd (two places): there it means a row carrying a Margin label,
which is a different concept from the Grand total set, so it is not a
violation of this entry's _Avoid_ list.

README.md is regenerated from the changed paragraph in README.Rmd.

Closes #95

