### PR TITLE
Open every DuckDB connection with shared_home = FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Suggests:
     arrow (>= 13.0.0),
     DBI,
     dtplyr (>= 1.3.2),
-    duckdb,
+    duckdb (>= 1.5.5),
     knitr,
     quartabs (>= 0.1.1),
     quarto (>= 1.4),

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -526,7 +526,9 @@
 #'   requireNamespace("DBI", quietly = TRUE) &&
 #'   requireNamespace("duckdb", quietly = TRUE)
 #' ) {
-#'   con <- suppressMessages(DBI::dbConnect(duckdb::duckdb()))
+#'   # `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets
+#'   # inside the session's temporary directory instead of `~/.duckdb`.
+#'   con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
 #'
 #'   sales_db <- dplyr::copy_to(
 #'     con,

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -584,7 +584,9 @@ if (
   requireNamespace("DBI", quietly = TRUE) &&
   requireNamespace("duckdb", quietly = TRUE)
 ) {
-  con <- suppressMessages(DBI::dbConnect(duckdb::duckdb()))
+  # `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets
+  # inside the session's temporary directory instead of `~/.duckdb`.
+  con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
 
   sales_db <- dplyr::copy_to(
     con,

--- a/tests/testthat/helper-duckdb.R
+++ b/tests/testthat/helper-duckdb.R
@@ -1,0 +1,22 @@
+# The one place this suite opens a DuckDB connection.
+#
+# `shared_home = FALSE` is the whole reason the helper exists. DuckDB resolves a
+# home directory for its extension cache and stored secrets each time a driver
+# is created, and it picks the shared `~/.duckdb` whenever that directory is
+# already present -- which it is on any machine that has ever run DuckDB. A
+# connection opened without the argument therefore writes outside the R
+# session's temporary directory during `R CMD check`, which CRAN Repository
+# Policy forbids. The argument redirects both locations into `tempdir()`; it
+# needs duckdb (>= 1.5.5), which is what DESCRIPTION states.
+#
+# Passing it at one site rather than at each of the suite's connections is what
+# makes the rule checkable: `test-duckdb-storage.R` reads the resolved
+# directories back out of a connection, and its source scan holds every other
+# file to going through here.
+#
+# Callers keep their own `on.exit(DBI::dbDisconnect(con, shutdown = TRUE))`.
+# Deferring the disconnect from inside would need withr, which this package does
+# not depend on, and the tests that open a connection already tear it down.
+duckdb_test_connection <- function() {
+  DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+}

--- a/tests/testthat/test-duckdb-storage.R
+++ b/tests/testthat/test-duckdb-storage.R
@@ -1,0 +1,192 @@
+# CRAN Repository Policy allows a package to write in the R session's temporary
+# directory and nowhere else. DuckDB resolves a "home" for its extension cache
+# and its stored secrets when a driver is created, and its default is the shared
+# `~/.duckdb` whenever that directory already exists -- so every connection this
+# package opens has to say otherwise. These tests read the resolved directories
+# back out of the connection rather than trusting the argument, because
+# `duckdb::duckdb_storage_status()` reports the ambient default rather than what
+# a given driver settled on.
+
+# Paths arrive from two sources that agree on the directory but not on its
+# spelling: `tempdir()` keeps whatever separators `TMPDIR` carried, while DuckDB
+# echoes back the string it was handed. Neither is normalised, and normalising
+# here would not help -- the directories need not exist yet, so
+# `normalizePath()` would resolve one side's symlinks and leave the other's
+# alone.
+canonical_path <- function(path) {
+  gsub("/+", "/", gsub("\\\\", "/", path))
+}
+
+# Strictly inside, which is why the separator is appended to the directory
+# rather than left to the prefix: without it `/var/folders/ab` reads as a child
+# of `/var/folders/a`.
+is_inside <- function(path, directory) {
+  root <- sub("/?$", "/", canonical_path(directory))
+  startsWith(canonical_path(path), root)
+}
+
+duckdb_storage_directories <- function(con) {
+  settings <- DBI::dbGetQuery(
+    con,
+    "SELECT name, value FROM duckdb_settings()
+     WHERE name IN ('extension_directory', 'secret_directory')"
+  )
+  stats::setNames(settings$value, settings$name)
+}
+
+test_that("a test DuckDB connection stores its files under tempdir() alone", {
+  skip_if_backend_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  directories <- duckdb_storage_directories(con)
+  # Both locations, because DuckDB resolves them separately and either one
+  # landing in the shared home is the violation.
+  expect_setequal(
+    names(directories),
+    c("extension_directory", "secret_directory")
+  )
+
+  home <- path.expand("~")
+  for (directory in directories) {
+    expect_true(is_inside(directory, tempdir()))
+    expect_false(is_inside(directory, home))
+  }
+})
+
+# The test above proves one connection. The scan below is what extends that
+# proof to every driver call in the package, because a connection opened without
+# the argument is only observable when the code opening it runs -- an example
+# nobody executes and a vignette chunk behind an availability guard would each
+# write to `~/.duckdb` in silence.
+#
+# The text the scan searches for is assembled rather than written out, and the
+# prose here spells the constructor `duckdb-colon-colon-duckdb`, because this
+# file is one of the files scanned. A literal occurrence anywhere in it would be
+# read as a call site and reported against itself.
+duckdb_driver_prefix <- function() {
+  paste0("duckdb", "::", "duckdb", "(")
+}
+
+# Reads the call whole, from its opening parenthesis to the parenthesis that
+# closes it, so a site written across several lines is judged on all of its
+# arguments rather than on the line the constructor happens to sit on.
+duckdb_call_text <- function(text, open) {
+  remainder <- strsplit(substring(text, open, nchar(text)), "")[[1]]
+  depth <- 0L
+  for (index in seq_along(remainder)) {
+    if (remainder[[index]] == "(") {
+      depth <- depth + 1L
+    } else if (remainder[[index]] == ")") {
+      depth <- depth - 1L
+      if (depth == 0L) {
+        return(paste(remainder[seq_len(index)], collapse = ""))
+      }
+    }
+  }
+  # An unbalanced call is not something to pass over. The file is either
+  # truncated or the call is assembled by pasting strings, and neither can be
+  # read for the argument, so the remaining text is returned and fails the
+  # expectation rather than disappearing from it.
+  paste(remainder, collapse = "")
+}
+
+duckdb_call_sites <- function(path) {
+  text <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  prefix <- duckdb_driver_prefix()
+  matches <- gregexpr(prefix, text, fixed = TRUE)[[1]]
+  if (matches[[1]] == -1L) {
+    return(NULL)
+  }
+  lapply(matches, function(match) {
+    before <- substr(text, 1L, match)
+    list(
+      path = path,
+      line = length(regmatches(
+        before,
+        gregexpr("\n", before, fixed = TRUE)
+      )[[1]]) + 1L,
+      call = duckdb_call_text(text, match + nchar(prefix) - 1L)
+    )
+  })
+}
+
+site_locations <- function(sites) {
+  vapply(
+    sites,
+    function(site) sprintf("%s:%d", site$path, site$line),
+    character(1)
+  )
+}
+
+# Sources reachable from wherever the suite is running. `tests/testthat` is the
+# working directory and so is always readable, but `R CMD check` executes from
+# `<pkg>.Rcheck/tests`, where the package's R sources, vignette sources, and
+# `man/` were never unpacked. Those roots are therefore scanned when a source
+# checkout supplies them -- which is the `structure` job and any local run --
+# and passed over otherwise, the same accommodation `rd_topics()` makes in
+# `test-documentation.R`.
+#
+# `man/` is generated from the roxygen comments in `R/`, so scanning it largely
+# repeats what scanning `R/` covers. It is scanned anyway because the generated
+# file is the one that ships, and a `man/` left stale by a skipped
+# `roxygen2::roxygenise()` would otherwise keep a call site the sources no
+# longer have.
+source_files_in <- function(root, pattern) {
+  if (!dir.exists(root)) {
+    return(character())
+  }
+  list.files(root, pattern = pattern, full.names = TRUE, recursive = TRUE)
+}
+
+suite_files <- function() {
+  source_files_in(testthat::test_path("."), "[.]R$")
+}
+
+duckdb_source_files <- function() {
+  c(
+    suite_files(),
+    unlist(
+      lapply(
+        c(
+          testthat::test_path("..", "..", "R"),
+          testthat::test_path("..", "..", "vignettes"),
+          testthat::test_path("..", "..", "man")
+        ),
+        source_files_in,
+        pattern = "[.](R|r|Rd|qmd|Rmd)$"
+      ),
+      use.names = FALSE
+    )
+  )
+}
+
+sites_in <- function(files) {
+  unlist(lapply(files, duckdb_call_sites), recursive = FALSE)
+}
+
+test_that("no DuckDB driver call omits shared_home = FALSE", {
+  sites <- sites_in(duckdb_source_files())
+  # The scan asserts itself before it concludes anything. A scan that found
+  # nothing would report every call site as compliant, and `helper-duckdb.R`
+  # is in the working directory in every context this runs from -- including
+  # `<pkg>.Rcheck/tests/testthat` -- so finding no site means the scan broke,
+  # not that the package stopped opening connections. Skipping here instead
+  # would fail a `backend` job outright: `verify-backend.R` rejects any skip
+  # whose reason does not name a backend the job withheld.
+  expect_gt(length(sites), 0L)
+
+  offenders <- Filter(
+    function(site) !grepl("shared_home = FALSE", site$call, fixed = TRUE),
+    sites
+  )
+  expect_equal(site_locations(offenders), character())
+})
+
+test_that("the suite opens DuckDB connections only through the helper", {
+  sites <- sites_in(suite_files())
+  expect_equal(
+    unique(basename(vapply(sites, function(site) site$path, character(1)))),
+    "helper-duckdb.R"
+  )
+})

--- a/tests/testthat/test-expand-operation.R
+++ b/tests/testthat/test-expand-operation.R
@@ -182,7 +182,7 @@ test_that("Arrow expansion uses schema metadata without collecting", {
 test_that("DuckDB expansion acquires one typed selection proxy", {
   skip_if_backend_absent("duckdb", "DBI")
   register_expand_proxy_methods()
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(
     con,

--- a/tests/testthat/test-factor.R
+++ b/tests/testthat/test-factor.R
@@ -70,7 +70,7 @@ test_that("reconstruct_factor() works with duckdb", {
     x4 = factor(x, levels = c("a", "b", "c", "aaa"))
   )
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
 
   DBI::dbWriteTable(con, "data", data)

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -272,7 +272,7 @@ test_that("DuckDB constructs one typed selection proxy for predicates", {
     envir = asNamespace("dplyr")
   )
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(
     con,
@@ -390,7 +390,7 @@ test_that("Arrow checks margin labels across all dimensions", {
 
 test_that("DuckDB checks margin labels across all dimensions", {
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
     con,
@@ -708,7 +708,7 @@ test_that("native adapters reserve generated summary names", {
   expect_match(sql, "\"..marginplyr_grouping_1__\"", fixed = TRUE)
 
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
     con,
@@ -973,7 +973,7 @@ test_that("grouped SQL inputs use their groups as fixed keys", {
 test_that("DuckDB executes grouped lazy input as fixed keys", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
     year = c(2025L, 2025L, 2026L, 2026L),
@@ -1194,7 +1194,7 @@ test_that("PostgreSQL duplicate keep falls back conservatively", {
 test_that("DuckDB executes native grouping sets with unambiguous bits", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
     a = c("x", NA_character_, "Total"),
@@ -1224,7 +1224,7 @@ test_that("DuckDB executes native grouping sets with unambiguous bits", {
 test_that("DuckDB keeps input types available to summary expressions", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(a = c(1L, 1L, 2L), value = 1:3)
   dplyr::copy_to(
@@ -1248,7 +1248,7 @@ test_that("DuckDB keeps input types available to summary expressions", {
 test_that("DuckDB native and UNION adapters agree", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(a = c("x", "x", "y"), b = c("u", "v", "u"), value = 1:3)
   dplyr::copy_to(con, data, "adapter_data", overwrite = TRUE, temporary = TRUE)
@@ -1290,7 +1290,7 @@ test_that("DuckDB native and UNION adapters agree", {
 test_that("DuckDB duplicate keep and downstream verbs remain lazy", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   dplyr::copy_to(
     con,
@@ -1328,7 +1328,7 @@ test_that("DuckDB duplicate keep and downstream verbs remain lazy", {
 test_that("DuckDB safely quotes factor identifiers and labels", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(check.names = FALSE, "odd name" = factor(c("A", "B")))
   dplyr::copy_to(con, data, "factor_data", overwrite = TRUE, temporary = TRUE)

--- a/tests/testthat/test-internal-name-shadowing.R
+++ b/tests/testthat/test-internal-name-shadowing.R
@@ -143,7 +143,7 @@ test_that("duckdb factor restoration ignores a column named `sql_query`", {
   skip_if_backend_absent("duckdb", "DBI")
 
   data <- factor_shadow_data("sql_query")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   DBI::dbWriteTable(con, "shadow", data)
 

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -290,7 +290,7 @@ test_that("non-syntactic .id names work across Margin verbs", {
 test_that("DuckDB native and portable summaries agree on .id", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(group = c("x", "x", "y"), value = 1:3)
   remote <- dplyr::copy_to(

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -293,7 +293,7 @@ test_that("portable SQL consumes named per-column labels lazily", {
 
 test_that("DuckDB uses typed missing for a missing factor Margin label", {
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(
     con,

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -583,7 +583,7 @@ copy_to_input <- function(con) {
 test_that("DuckDB executes a Margin order on its native plan", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   expect_margin_order_agrees(copy_to_input(con))
 
@@ -656,7 +656,7 @@ test_that("DuckDB executes a Margin order on its native plan", {
 test_that("DuckDB native and portable Margin orders agree", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- margin_order_data()
   remote <- dplyr::copy_to(
@@ -724,7 +724,7 @@ test_that("DuckDB native and portable Margin orders agree", {
 test_that("DuckDB orders a factor dimension by its restored levels", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- margin_order_factor_data()
   DBI::dbWriteTable(con, "margin_order_factor", data)

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -882,7 +882,7 @@ test_that("RSQLite Parent shares preserve runtime backend conditions", {
 
 test_that("DuckDB Parent shares agree across native, portable, and local paths", { # nolint: line_length_linter
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
     fixed = c(NA_character_, NA_character_, "a", "a"),
@@ -1028,7 +1028,7 @@ test_that("dtplyr shares preserve empty-input grand total and partitions", {
 
 test_that("DuckDB shares preserve empty-input grand total and partitions", {
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(
     con,
@@ -1119,7 +1119,7 @@ test_that("DuckDB Parent shares skip duplicate grouping-set occurrences", {
     result |>
       dplyr::arrange(group, total, share)
   }
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(
     con,
@@ -1190,7 +1190,7 @@ test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
   }
 
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
     con,
@@ -1296,7 +1296,7 @@ test_that("RSQLite executes portable Total shares end to end", {
 
 test_that("DuckDB Total shares agree across native, portable, and local paths", { # nolint: line_length_linter
   skip_if_backend_absent("duckdb", "DBI")
-  con <- DBI::dbConnect(duckdb::duckdb())
+  con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
     fixed = c(NA_character_, NA_character_, "a", "a"),

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -156,7 +156,9 @@ same workflow execute against a live in-memory database:
 ```{r}
 #| eval: !expr has_duckdb
 
-con <- DBI::dbConnect(duckdb::duckdb())
+# `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets in
+# the session's temporary directory rather than in `~/.duckdb`.
+con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
 
 sales_db <- copy_to(
   con,

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -325,7 +325,9 @@ seeing this needs a live database:
 ```{r}
 #| eval: !expr has_duckdb
 
-con <- DBI::dbConnect(duckdb::duckdb())
+# `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets in
+# the session's temporary directory rather than in `~/.duckdb`.
+con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
 duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
 
 duckdb_report <- duckdb_sales |>
@@ -427,7 +429,7 @@ error comes from the database, with its own wording:
 ```{r}
 #| eval: !expr has_duckdb
 
-con <- DBI::dbConnect(duckdb::duckdb())
+con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
 duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
 ```
 


### PR DESCRIPTION
Open every DuckDB connection with shared_home = FALSE

duckdb 1.5.5 resolves a home directory for its extension cache and stored
secrets each time a driver is created, and it picks the shared `~/.duckdb`
whenever that directory already exists -- which it does on any machine that
has ever run DuckDB. All 27 call sites in the package omitted the argument,
so examples, tests, and vignettes wrote outside the R session's temporary
directory during `R CMD check`, and the build machine's absolute home path
was captured in two shipped vignette HTML files. CRAN Repository Policy
forbids both.

The 22 test call sites now go through `duckdb_test_connection()` in
tests/testthat/helper-duckdb.R, so the argument is stated once. The example
in R/summarize_with_margins.R and the three vignette sites pass it inline.
The example's `suppressMessages()` is dropped: it silenced duckdb's notice
without preventing the write, and with `shared_home = FALSE` there is no
notice to silence.

DESCRIPTION pins `duckdb (>= 1.5.5)`, not the `1.4.0` the issue proposed.
1.5.4.3's signature is `(dbdir, read_only, bigint, config, ...,
environment_scan)` with an explicit `stop("... must be empty")`, so 1.5.4.x
errors on the argument rather than ignoring it; the shared home root arrived
in 1.5.5. The pin sits on Suggests only, matching the unversioned
Config/Needs/website entries.

test-duckdb-storage.R holds the rule in two ways, because passing the
argument is not observable until the code opening the connection runs -- an
example nobody executes and a vignette chunk behind an availability guard
would each write to `~/.duckdb` in silence. It reads the resolved directories
back out of a live connection with `duckdb_settings()`, which is per-driver,
where `duckdb_storage_status()` reports only the ambient default; and it
scans R/, tests/, vignettes/, and man/ for a driver call that omits the
argument or bypasses the helper. The scan asserts it found sites before
concluding they are clean, rather than skipping, since `verify-backend.R`
rejects a skip whose reason names no withheld backend.

Verified with HOME redirected to a directory holding an empty `.duckdb`:
`R CMD check` is Status OK and leaves it empty, no check output mentions
"storing downloaded extensions", the tarball carries no build-machine path,
and `_R_CHECK_DEPENDS_ONLY_=true` is Status OK.

Closes #99

