### PR TITLE
Check actual summary names on the native grouping-sets path

### DIFF
--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -49,9 +49,8 @@ summarize_margin_native <- function(.data,
     flag_quos <- list()
   }
 
-  check_native_summary_names(
-    .data,
-    dots = dots,
+  check_summary_output_names(
+    native_summary_output_names(.data, dots),
     group_vars = group_vars,
     internal_names = flag_names,
     set_id_name = set_id_name
@@ -93,38 +92,23 @@ summarize_margin_native <- function(.data,
   result
 }
 
-# The pre-execution checks run against `known_summary_output_names()`, which is
-# a prediction rather than a reading: an `across()` whose `.fns` is a variable
-# has no function-name component the expression can supply, so the predictor
-# substitutes a placeholder and the collision goes unseen. The union path
-# re-checks the names its branches actually produce; this is that check for the
-# native path, which builds one summarize over every grouping set instead.
-#
-# Reading the names back off the grouped summarize would not answer the
-# question. A summary output that shadows a grouping dimension takes that
-# dimension's place in the result, so the name is present exactly once either
-# way and the two cases are indistinguishable. Building the same expressions
-# over the ungrouped table names the outputs on their own. Every `across()`,
-# `pick()`, and `if_any()` selection was resolved to an `all_of()` literal
-# before either adapter ran, so dropping the grouping cannot change which
-# columns they cover.
+# What `check_summary_output_names()` needs and the grouped summarize above
+# cannot supply. A summary output that shadows a grouping dimension takes that
+# dimension's place in the result, so the name is present exactly once whether
+# or not the collision happened, and the two cases are indistinguishable there.
+# Building the same expressions over the ungrouped table names the outputs on
+# their own. Every `across()`, `pick()`, and `if_any()` selection was resolved
+# to an `all_of()` literal before either adapter ran, so dropping the grouping
+# cannot change which columns they cover.
 #
 # A lazy summarize computes its result names without reading from the backend,
 # so this stays a locally detectable error rejected before any backend read
 # (ADR 0005).
-check_native_summary_names <- function(.data,
-                                       dots,
-                                       group_vars,
-                                       internal_names,
-                                       set_id_name) {
-  output_names <- get_col_names(
+native_summary_output_names <- function(.data, dots) {
+  get_col_names(
     dplyr::summarize(dplyr::ungroup(.data), !!!dots),
     dplyr::everything()
   )
-
-  check_internal_summary_names(output_names, internal_names)
-  check_summary_group_overwrite(output_names, group_vars = group_vars)
-  check_margin_id_collision(set_id_name, output_names, "a summary output")
 }
 
 grouping_set_id_sql_expr <- function(plan, con) {

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -49,6 +49,14 @@ summarize_margin_native <- function(.data,
     flag_quos <- list()
   }
 
+  check_native_summary_names(
+    .data,
+    dots = dots,
+    group_vars = group_vars,
+    internal_names = flag_names,
+    set_id_name = set_id_name
+  )
+
   result <- dplyr::summarize(
     .data = dplyr::group_by(
       .data,
@@ -83,6 +91,40 @@ summarize_margin_native <- function(.data,
   }
 
   result
+}
+
+# The pre-execution checks run against `known_summary_output_names()`, which is
+# a prediction rather than a reading: an `across()` whose `.fns` is a variable
+# has no function-name component the expression can supply, so the predictor
+# substitutes a placeholder and the collision goes unseen. The union path
+# re-checks the names its branches actually produce; this is that check for the
+# native path, which builds one summarize over every grouping set instead.
+#
+# Reading the names back off the grouped summarize would not answer the
+# question. A summary output that shadows a grouping dimension takes that
+# dimension's place in the result, so the name is present exactly once either
+# way and the two cases are indistinguishable. Building the same expressions
+# over the ungrouped table names the outputs on their own. Every `across()`,
+# `pick()`, and `if_any()` selection was resolved to an `all_of()` literal
+# before either adapter ran, so dropping the grouping cannot change which
+# columns they cover.
+#
+# A lazy summarize computes its result names without reading from the backend,
+# so this stays a locally detectable error rejected before any backend read
+# (ADR 0005).
+check_native_summary_names <- function(.data,
+                                       dots,
+                                       group_vars,
+                                       internal_names,
+                                       set_id_name) {
+  output_names <- get_col_names(
+    dplyr::summarize(dplyr::ungroup(.data), !!!dots),
+    dplyr::everything()
+  )
+
+  check_internal_summary_names(output_names, internal_names)
+  check_summary_group_overwrite(output_names, group_vars = group_vars)
+  check_margin_id_collision(set_id_name, output_names, "a summary output")
 }
 
 grouping_set_id_sql_expr <- function(plan, con) {

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -59,21 +59,13 @@ summarize_margin_union <- function(.data,
         .by = unname(key_names[grouping_set])
       )
 
-      result_names <- get_col_names(result, dplyr::everything())
-      check_internal_summary_names(
-        result_names,
-        unname(key_names[setdiff(group_vars, grouping_set)])
+      check_summary_output_names(
+        get_col_names(result, dplyr::everything()),
+        group_vars = group_vars,
+        internal_names = unname(key_names[setdiff(group_vars, grouping_set)]),
+        set_id_name = set_id_name
       )
 
-      check_summary_group_overwrite(
-        result_names,
-        group_vars = group_vars
-      )
-      check_margin_id_collision(
-        set_id_name,
-        result_names,
-        "a summary output"
-      )
       if (length(grouping_set) > 0L) {
         rename_pairs <- rlang::set_names(
           rlang::syms(unname(key_names[grouping_set])),

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -60,20 +60,10 @@ summarize_margin_union <- function(.data,
       )
 
       result_names <- get_col_names(result, dplyr::everything())
-      unexpected_internal_names <- intersect(
+      check_internal_summary_names(
         result_names,
         unname(key_names[setdiff(group_vars, grouping_set)])
       )
-      if (length(unexpected_internal_names) > 0L) {
-        abort_marginplyr(
-          paste0(
-            "Dynamically generated summary output names conflict with ",
-            "internal grouping columns: ",
-            paste0("`", unexpected_internal_names, "`", collapse = ", "),
-            ". Use different summary output names."
-          )
-        )
-      }
 
       check_summary_group_overwrite(
         result_names,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -154,11 +154,22 @@ check_summary_group_overwrite <- function(output_names, group_vars) {
   )
 }
 
-# Both execution paths put columns of their own beside the summary outputs --
-# the union path's renamed grouping keys, the native path's Grouping bit flags
-# and its Grouping set identifier -- and a summary whose real output name is not
-# statically predictable can land on one of them. The message is shared so the
-# two paths report the same conflict the same way.
+# The three questions to ask of the names a summary really produced, which the
+# pre-execution checks can only ask of the names the static predictor could
+# guess. Both execution paths ask them, and the point of asking twice is that
+# the two agree: a call one backend rejects must be rejected on every other.
+# Composing them here is what keeps the checks, their wording, and their order
+# from drifting apart. Only `internal_names` differs between the callers,
+# because each path puts columns of its own beside the summary outputs.
+check_summary_output_names <- function(output_names,
+                                       group_vars,
+                                       internal_names,
+                                       set_id_name) {
+  check_internal_summary_names(output_names, internal_names)
+  check_summary_group_overwrite(output_names, group_vars = group_vars)
+  check_margin_id_collision(set_id_name, output_names, "a summary output")
+}
+
 check_internal_summary_names <- function(output_names, internal_names) {
   conflicting_names <- intersect(output_names, internal_names)
   if (length(conflicting_names) == 0L) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -154,6 +154,27 @@ check_summary_group_overwrite <- function(output_names, group_vars) {
   )
 }
 
+# Both execution paths put columns of their own beside the summary outputs --
+# the union path's renamed grouping keys, the native path's Grouping bit flags
+# and its Grouping set identifier -- and a summary whose real output name is not
+# statically predictable can land on one of them. The message is shared so the
+# two paths report the same conflict the same way.
+check_internal_summary_names <- function(output_names, internal_names) {
+  conflicting_names <- intersect(output_names, internal_names)
+  if (length(conflicting_names) == 0L) {
+    return(invisible(NULL))
+  }
+
+  abort_marginplyr(
+    paste0(
+      "Dynamically generated summary output names conflict with ",
+      "internal grouping columns: ",
+      paste0("`", conflicting_names, "`", collapse = ", "),
+      ". Use different summary output names."
+    )
+  )
+}
+
 plan_summary_expressions <- function(dots,
                                      data_proxy,
                                      data_vars,

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -734,6 +734,184 @@ test_that("native adapters reserve generated summary names", {
   )
 })
 
+# An `across()` whose `.fns` arrives as a variable hides the function-name
+# component from the static predictor, so `known_summary_output_names()` cannot
+# report the name these calls really produce. That is the one gap the adapters'
+# own result-name checks exist to close, and the whole point of the data below
+# is that the pre-execution check passes it through.
+shadowed_summary_data <- function() {
+  data.frame(
+    group = c("x", "x", "y"),
+    value = c(1, 2, 3)
+  )
+}
+
+shadowed_summary_fns <- function(name) {
+  stats::setNames(list(sum), name)
+}
+
+test_that("native adapters reject a summary output shadowing a dimension", {
+  data <- shadowed_summary_data()
+  fns <- shadowed_summary_fns("group")
+
+  # Local takes the union path, whose result-name check already rejects this.
+  # Its condition is the contract the native path has to match, so it is read
+  # here rather than restated.
+  local_error <- expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(local_error),
+    "cannot overwrite grouping column.*`group`"
+  )
+
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+  native_error <- expect_error(
+    summarize_with_margins(
+      postgres,
+      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_identical(
+    conditionMessage(native_error),
+    conditionMessage(local_error)
+  )
+  expect_identical(class(native_error), class(local_error))
+})
+
+test_that("DuckDB rejects a summary output shadowing a dimension", {
+  skip_if_backend_absent("duckdb", "DBI")
+
+  # The reported failure: two dimensions where the second is named for the
+  # first, so `across(all_of("x"), list(region = sum))` produces `x_region`.
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    x_region = c("p", "q", "p"),
+    x = c(1, 2, 3)
+  )
+  fns <- shadowed_summary_fns("region")
+
+  local_error <- expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(dplyr::all_of("x"), fns),
+      .grouping = rollup(region, x_region)
+    ),
+    class = "marginplyr_error"
+  )
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "shadowed_dimension",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+
+  duckdb_error <- expect_error(
+    summarize_with_margins(
+      remote,
+      dplyr::across(dplyr::all_of("x"), fns),
+      .grouping = rollup(region, x_region)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_identical(
+    conditionMessage(duckdb_error),
+    conditionMessage(local_error)
+  )
+})
+
+test_that("native adapters reject summary outputs on their own columns", {
+  data <- shadowed_summary_data()
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+
+  # The native path names its Grouping bit flags `..marginplyr_grouping_*` and
+  # takes the Grouping set identifier from `.id`; both are written beside the
+  # summary outputs in one `summarize()`, so a collision would silently drop
+  # the summary rather than the internal column.
+  fns <- shadowed_summary_fns("..marginplyr_grouping_1")
+  flag_error <- expect_error(
+    summarize_with_margins(
+      postgres,
+      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      .grouping = rollup(group)
+    ),
+    "summary output names conflict with internal grouping columns"
+  )
+  expect_s3_class(flag_error, "marginplyr_error")
+
+  fns <- shadowed_summary_fns("sid")
+  id_error <- expect_error(
+    summarize_with_margins(
+      postgres,
+      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      .grouping = rollup(group),
+      .id = "sid"
+    ),
+    "`.id` \\(`sid`\\) conflicts with a summary output"
+  )
+  expect_s3_class(id_error, "marginplyr_error")
+})
+
+test_that("native adapters keep unpredictable names that collide with none", {
+  data <- shadowed_summary_data()
+  fns <- shadowed_summary_fns("total")
+  expected <- summarize_with_margins(
+    data,
+    dplyr::across(dplyr::all_of("value"), fns),
+    .grouping = rollup(group)
+  )
+
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+  query <- summarize_with_margins(
+    postgres,
+    dplyr::across(dplyr::all_of("value"), fns),
+    .grouping = rollup(group)
+  )
+  expect_identical(
+    get_col_names(query, dplyr::everything()),
+    names(expected)
+  )
+  expect_match(
+    dbplyr::sql_render(query),
+    "GROUPING SETS",
+    fixed = TRUE
+  )
+
+  skip_if_backend_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "unshadowed_summary",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  result <- summarize_with_margins(
+    remote,
+    dplyr::across(dplyr::all_of("value"), fns),
+    .grouping = rollup(group)
+  ) |>
+    dplyr::collect() |>
+    dplyr::arrange(group)
+  expect_equal(
+    as.data.frame(result),
+    dplyr::arrange(expected, group),
+    ignore_attr = TRUE
+  )
+})
+
 test_that("column-wise summaries share one lazy-backend selection", {
   data <- data.frame(
     group = c("b", "a", "b"),


### PR DESCRIPTION
Check actual summary names on the native grouping-sets path

The native grouping-sets adapter built one `summarize()` over every grouping
set and returned it, relying entirely on the pre-execution checks against
`known_summary_output_names()`. That predictor is incomplete by construction:
an `across()` whose `.fns` arrives as a variable has no function-name
component the expression can supply, so the predictor substitutes a
positional placeholder and the real output name is never checked. The union
path re-checks the names each branch actually produces, which is why local
and SQLite reject

```r
fns <- list(region = sum)
summarize_with_margins(
  d, across(all_of("x"), fns), .grouping = rollup(region, x_region)
)
```

with "Summary results cannot overwrite grouping column `x_region`.", while
DuckDB and Postgres returned six rows in which `x_region` holds aggregates
and the `x` summary is absent: `SUM(x) AS x_region` shadows the dimension in
the subquery and the outer `CASE` then labels the aggregate as the dimension.

`check_summary_output_names()` composes the three checks -- internal-name
conflict, group overwrite, `.id` collision -- and both adapters now call it,
so the checks, their wording, and their order are shared rather than
repeated. Holding that agreement by convention across two call sites is what
let them diverge in the first place. Only `internal_names` differs between
the callers, because each path puts columns of its own beside the summary
outputs: the union path's renamed `..marginplyr_key_*` grouping keys, the
native path's `..marginplyr_grouping_*` Grouping bit flags. The union path's
inline `abort_marginplyr()` moved into `check_internal_summary_names()` with
its wording unchanged.

The native path cannot read the names off its grouped result, because a
summary output that shadows a dimension takes that dimension's place and the
name appears exactly once whether or not the collision happened.
`native_summary_output_names()` builds the same expressions over the
ungrouped table instead, where the outputs name themselves. Every `across()`,
`pick()`, and `if_any()` selection is resolved to an `all_of()` literal
before either adapter runs, so dropping the grouping cannot change which
columns they cover, and a lazy summarize computes its result names without
reading from the backend, which keeps this inside ADR 0005.

Four tests in test-grouping-backends.R cover the native path: dimension
shadowing on `dbplyr::simulate_postgres()` and on DuckDB, each asserting the
condition local raises rather than restating its message; a collision with a
`..marginplyr_grouping_*` flag and with the Grouping set identifier; and a
legal unpredictable name, which still returns local's result. All four fail
against the unpatched adapter. The simulated-Postgres cases need no optional
backend, and the two DuckDB cases require one member of
`optional_backends()` each.

Verified: full suite green with no skips, `lintr::lint_package()` clean,
`roxygen2::roxygenise()` no diff, `verify-suite-coverage.R` reports 328 tests
with none executing in zero configurations, and `R CMD check` on the built
tarball is Status OK including vignette re-building.

Two review findings were recorded rather than actioned here: #125, a Package
condition that names `.id` for an identifier the package allocated for
itself, which reproduces identically on both paths and so predates this
change; and #126, whether these tests should share a fixture that makes their
defeat-the-predictor precondition structural.

Closes #98