### PR TITLE
Report an internally allocated set identifier as an internal column

### DIFF
--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -3,7 +3,8 @@ summarize_margin_native <- function(.data,
                                     plan,
                                     margin_labels,
                                     reserved_names,
-                                    set_id_name = NULL) {
+                                    set_id_name = NULL,
+                                    set_id_is_internal = FALSE) {
   con <- dbplyr::remote_con(.data)
   dots <- rewrite_grouping_dots(
     dots,
@@ -53,7 +54,8 @@ summarize_margin_native <- function(.data,
     native_summary_output_names(.data, dots),
     group_vars = group_vars,
     internal_names = flag_names,
-    set_id_name = set_id_name
+    set_id_name = set_id_name,
+    set_id_is_internal = set_id_is_internal
   )
 
   result <- dplyr::summarize(

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -29,7 +29,8 @@ summarize_margin_union <- function(.data,
                                    margin_labels,
                                    column_info,
                                    reserved_names,
-                                   set_id_name = NULL) {
+                                   set_id_name = NULL,
+                                   set_id_is_internal = FALSE) {
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
     length(group_vars),
@@ -63,7 +64,8 @@ summarize_margin_union <- function(.data,
         get_col_names(result, dplyr::everything()),
         group_vars = group_vars,
         internal_names = unname(key_names[setdiff(group_vars, grouping_set)]),
-        set_id_name = set_id_name
+        set_id_name = set_id_name,
+        set_id_is_internal = set_id_is_internal
       )
 
       if (length(grouping_set) > 0L) {

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -718,6 +718,14 @@ stage_margin_summaries <- function(operation,
     reserved_names <- unique(c(reserved_names, set_id_name))
   }
 
+  # Both branches above may replace the caller's `.id` with a name allocated
+  # here -- for keeping set identity under a share, or for a Margin order. The
+  # adapters check their result names against whichever they were handed, and
+  # only this frame can still tell the two apart. Getting it wrong is not
+  # cosmetic: `check_margin_id_collision()` names `.id` in its message, which a
+  # caller who wrote no `.id` cannot act on.
+  set_id_is_internal <- !identical(set_id_name, operation$set_id_name)
+
   result <- tryCatch(
     {
       if (use_native) {
@@ -727,7 +735,8 @@ stage_margin_summaries <- function(operation,
           plan = plan,
           margin_labels = operation$margin_labels,
           reserved_names = reserved_names,
-          set_id_name = set_id_name
+          set_id_name = set_id_name,
+          set_id_is_internal = set_id_is_internal
         )
       } else {
         summarize_margin_union(
@@ -737,7 +746,8 @@ stage_margin_summaries <- function(operation,
           margin_labels = operation$margin_labels,
           column_info = operation$column_info,
           reserved_names = reserved_names,
-          set_id_name = set_id_name
+          set_id_name = set_id_name,
+          set_id_is_internal = set_id_is_internal
         )
       }
     },

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -164,7 +164,16 @@ check_summary_group_overwrite <- function(output_names, group_vars) {
 check_summary_output_names <- function(output_names,
                                        group_vars,
                                        internal_names,
-                                       set_id_name) {
+                                       set_id_name,
+                                       set_id_is_internal = FALSE) {
+  # A Grouping set identifier the package allocated for itself is one of the
+  # internal columns, not the caller's `.id`, and reporting it as `.id` names
+  # an argument the caller never wrote and a column they cannot see.
+  if (set_id_is_internal) {
+    internal_names <- c(internal_names, set_id_name)
+    set_id_name <- NULL
+  }
+
   check_internal_summary_names(output_names, internal_names)
   check_summary_group_overwrite(output_names, group_vars = group_vars)
   check_margin_id_collision(set_id_name, output_names, "a summary output")

--- a/tests/testthat/helper-unpredictable-summary-names.R
+++ b/tests/testthat/helper-unpredictable-summary-names.R
@@ -1,0 +1,86 @@
+# Summary dots whose output names the static predictor cannot see.
+#
+# The adapters re-check the names a summary really produced, and every test of
+# those checks depends on the pre-execution check in `execute_margin_summary()`
+# letting the call through first. When the predictor can name the output, that
+# earlier check raises the same condition and the test passes without the
+# adapter guard ever running -- green, and proving something else.
+#
+# What produces the case the guards exist for is `.fns` bound to a variable:
+# the function-name component then lives in the value rather than in the
+# expression, so `known_across_function_names()` cannot read it and falls back
+# to a positional placeholder. That shape is load-bearing rather than
+# incidental, and it used to be spelled out in each test beside a comment
+# saying so -- where an edit that inlined `.fns` back into a literal `list()`
+# would have left every test passing and none of them still reaching a guard
+# (#126).
+#
+# The assertion is what makes the precondition structural instead of
+# remembered. It asks the predictor directly and refuses to hand back dots the
+# predictor could see through, so a future predictor that closed this gap fails
+# here, naming this helper, rather than quietly retargeting its callers at the
+# pre-execution check.
+#
+# Splice the result into a Margin verb with `rlang::inject()`, as the suite's
+# other generated-argument tests do.
+#
+# `.names` takes the two shapes the callers need and no others, because the
+# expected output names are derived from it rather than resolved through glue:
+# `"{.fn}"` names the output for the function alone, and `NULL` leaves
+# `across()`'s own `{.col}_{.fn}`.
+#
+# `predict` is a parameter for the same reason `backend_available()` takes
+# `known`: this helper's own tests need to drive both outcomes, and the shape
+# that reaches the failing one is the shape this helper exists to avoid
+# building. Every other call site takes the default.
+unpredictable_summary_dots <- function(fn,
+                                       cols = "value",
+                                       .names = "{.fn}",
+                                       predict = known_summary_output_names) {
+  stopifnot(
+    is.character(fn),
+    length(fn) == 1L,
+    is.character(cols),
+    length(cols) >= 1L,
+    is.null(.names) || identical(.names, "{.fn}")
+  )
+
+  # `fns` is a symbol the quosure resolves from the environment attached
+  # below, which codetools cannot follow.
+  # nolint start: object_usage_linter.
+  expr <- if (is.null(.names)) {
+    rlang::expr(dplyr::across(dplyr::all_of(cols), fns))
+  } else {
+    rlang::expr(dplyr::across(dplyr::all_of(cols), fns, .names = !!.names))
+  }
+  # nolint end
+  dots <- list(rlang::new_quosure(
+    expr,
+    env = rlang::env(
+      fns = stats::setNames(list(sum), fn),
+      cols = cols
+    )
+  ))
+
+  outputs <- if (is.null(.names)) paste0(cols, "_", fn) else fn
+  # `.cols` resolves to `cols` and nothing else, so a proxy carrying just those
+  # columns answers the predictor exactly as the real selection proxy would.
+  proxy <- as.data.frame(stats::setNames(
+    rep(list(double()), length(cols)),
+    cols
+  ))
+  seen <- intersect(outputs, predict(dots, proxy))
+  if (length(seen) > 0L) {
+    stop(sprintf(
+      paste0(
+        "`known_summary_output_names()` predicts %s, so a call built from ",
+        "these dots is rejected before any adapter runs and cannot reach an ",
+        "adapter's own result-name check. Find a summary shape the predictor ",
+        "still cannot name, or retire the callers that need one."
+      ),
+      paste0("`", seen, "`", collapse = ", ")
+    ))
+  }
+
+  dots
+}

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -734,11 +734,6 @@ test_that("native adapters reserve generated summary names", {
   )
 })
 
-# An `across()` whose `.fns` arrives as a variable hides the function-name
-# component from the static predictor, so `known_summary_output_names()` cannot
-# report the name these calls really produce. That is the one gap the adapters'
-# own result-name checks exist to close, and the whole point of the data below
-# is that the pre-execution check passes it through.
 shadowed_summary_data <- function() {
   data.frame(
     group = c("x", "x", "y"),
@@ -746,23 +741,19 @@ shadowed_summary_data <- function() {
   )
 }
 
-shadowed_summary_fns <- function(name) {
-  stats::setNames(list(sum), name)
-}
-
 test_that("native adapters reject a summary output shadowing a dimension", {
   data <- shadowed_summary_data()
-  fns <- shadowed_summary_fns("group")
+  dots <- unpredictable_summary_dots("group")
 
   # Local takes the union path, whose result-name check already rejects this.
   # Its condition is the contract the native path has to match, so it is read
   # here rather than restated.
   local_error <- expect_error(
-    summarize_with_margins(
+    rlang::inject(summarize_with_margins(
       data,
-      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      !!!dots,
       .grouping = rollup(group)
-    ),
+    )),
     class = "marginplyr_error"
   )
   expect_match(
@@ -772,11 +763,11 @@ test_that("native adapters reject a summary output shadowing a dimension", {
 
   postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
   native_error <- expect_error(
-    summarize_with_margins(
+    rlang::inject(summarize_with_margins(
       postgres,
-      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      !!!dots,
       .grouping = rollup(group)
-    ),
+    )),
     class = "marginplyr_error"
   )
   expect_identical(
@@ -789,21 +780,23 @@ test_that("native adapters reject a summary output shadowing a dimension", {
 test_that("DuckDB rejects a summary output shadowing a dimension", {
   skip_if_backend_absent("duckdb", "DBI")
 
-  # The reported failure: two dimensions where the second is named for the
-  # first, so `across(all_of("x"), list(region = sum))` produces `x_region`.
+  # The reported failure, kept in the shape it was reported in: two dimensions
+  # where the second is named for the first, so `across(all_of("x"), fns)` with
+  # `fns <- list(region = sum)` produces `x_region` under `across()`'s own
+  # naming.
   data <- data.frame(
     region = c("E", "E", "W"),
     x_region = c("p", "q", "p"),
     x = c(1, 2, 3)
   )
-  fns <- shadowed_summary_fns("region")
+  dots <- unpredictable_summary_dots("region", cols = "x", .names = NULL)
 
   local_error <- expect_error(
-    summarize_with_margins(
+    rlang::inject(summarize_with_margins(
       data,
-      dplyr::across(dplyr::all_of("x"), fns),
+      !!!dots,
       .grouping = rollup(region, x_region)
-    ),
+    )),
     class = "marginplyr_error"
   )
 
@@ -818,11 +811,11 @@ test_that("DuckDB rejects a summary output shadowing a dimension", {
   )
 
   duckdb_error <- expect_error(
-    summarize_with_margins(
+    rlang::inject(summarize_with_margins(
       remote,
-      dplyr::across(dplyr::all_of("x"), fns),
+      !!!dots,
       .grouping = rollup(region, x_region)
-    ),
+    )),
     class = "marginplyr_error"
   )
   expect_identical(
@@ -839,25 +832,25 @@ test_that("native adapters reject summary outputs on their own columns", {
   # takes the Grouping set identifier from `.id`; both are written beside the
   # summary outputs in one `summarize()`, so a collision would silently drop
   # the summary rather than the internal column.
-  fns <- shadowed_summary_fns("..marginplyr_grouping_1")
+  flag_dots <- unpredictable_summary_dots("..marginplyr_grouping_1")
   flag_error <- expect_error(
-    summarize_with_margins(
+    rlang::inject(summarize_with_margins(
       postgres,
-      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      !!!flag_dots,
       .grouping = rollup(group)
-    ),
+    )),
     "summary output names conflict with internal grouping columns"
   )
   expect_s3_class(flag_error, "marginplyr_error")
 
-  fns <- shadowed_summary_fns("sid")
+  id_dots <- unpredictable_summary_dots("sid")
   id_error <- expect_error(
-    summarize_with_margins(
+    rlang::inject(summarize_with_margins(
       postgres,
-      dplyr::across(dplyr::all_of("value"), fns, .names = "{.fn}"),
+      !!!id_dots,
       .grouping = rollup(group),
       .id = "sid"
-    ),
+    )),
     "`.id` \\(`sid`\\) conflicts with a summary output"
   )
   expect_s3_class(id_error, "marginplyr_error")
@@ -865,19 +858,19 @@ test_that("native adapters reject summary outputs on their own columns", {
 
 test_that("native adapters keep unpredictable names that collide with none", {
   data <- shadowed_summary_data()
-  fns <- shadowed_summary_fns("total")
-  expected <- summarize_with_margins(
+  dots <- unpredictable_summary_dots("total", .names = NULL)
+  expected <- rlang::inject(summarize_with_margins(
     data,
-    dplyr::across(dplyr::all_of("value"), fns),
+    !!!dots,
     .grouping = rollup(group)
-  )
+  ))
 
   postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
-  query <- summarize_with_margins(
+  query <- rlang::inject(summarize_with_margins(
     postgres,
-    dplyr::across(dplyr::all_of("value"), fns),
+    !!!dots,
     .grouping = rollup(group)
-  )
+  ))
   expect_identical(
     get_col_names(query, dplyr::everything()),
     names(expected)
@@ -898,11 +891,11 @@ test_that("native adapters keep unpredictable names that collide with none", {
     overwrite = TRUE,
     temporary = TRUE
   )
-  result <- summarize_with_margins(
+  result <- rlang::inject(summarize_with_margins(
     remote,
-    dplyr::across(dplyr::all_of("value"), fns),
+    !!!dots,
     .grouping = rollup(group)
-  ) |>
+  )) |>
     dplyr::collect() |>
     dplyr::arrange(group)
   expect_equal(

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -200,6 +200,81 @@ test_that(".id rejects output-name collisions", {
   )
 })
 
+# The checks above run before execution, against the names the static
+# predictor could guess. The two below run inside the adapters, against the
+# names a summary really produced, and are reachable only for a summary the
+# predictor could not name -- which is what `unpredictable_summary_dots()`
+# builds and asserts.
+test_that("an internally allocated set identifier is not reported as `.id`", {
+  data <- data.frame(group = c("x", "x", "y"), value = c(1, 2, 3))
+  # `.sort` needs an identifier and the caller supplied none, so
+  # `margin_sort_identifier()` allocates `..marginplyr_sort_1`.
+  dots <- unpredictable_summary_dots("..marginplyr_sort_1")
+
+  local_error <- expect_error(
+    rlang::inject(summarize_with_margins(
+      data,
+      !!!dots,
+      .grouping = rollup(group),
+      .sort = "last"
+    )),
+    class = "marginplyr_error"
+  )
+  # Naming `.id` here would report an argument the caller never wrote, for a
+  # column the public interface does not expose.
+  expect_false(grepl("`.id`", conditionMessage(local_error), fixed = TRUE))
+  expect_match(
+    conditionMessage(local_error),
+    "conflict with internal grouping columns.*`..marginplyr_sort_1`"
+  )
+
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+  native_error <- expect_error(
+    rlang::inject(summarize_with_margins(
+      postgres,
+      !!!dots,
+      .grouping = rollup(group),
+      .sort = "last"
+    )),
+    class = "marginplyr_error"
+  )
+  expect_identical(
+    conditionMessage(native_error),
+    conditionMessage(local_error)
+  )
+})
+
+test_that("a caller's `.id` is still reported as `.id`", {
+  data <- data.frame(group = c("x", "x", "y"), value = c(1, 2, 3))
+  dots <- unpredictable_summary_dots("sid")
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+
+  for (source in list(local = data, native = postgres)) {
+    expect_error(
+      rlang::inject(summarize_with_margins(
+        source,
+        !!!dots,
+        .grouping = rollup(group),
+        .id = "sid"
+      )),
+      "`\\.id` \\(`sid`\\) conflicts with a summary output"
+    )
+  }
+
+  # `.sort` reuses a caller's identifier rather than allocating one, so the
+  # name stays the caller's and the message must not change with it.
+  expect_error(
+    rlang::inject(summarize_with_margins(
+      data,
+      !!!dots,
+      .grouping = rollup(group),
+      .id = "sid",
+      .sort = "last"
+    )),
+    "`\\.id` \\(`sid`\\) conflicts with a summary output"
+  )
+})
+
 test_that(".id preserves ordinary unnamed summary expressions", {
   data <- data.frame(value = 1:2)
 

--- a/tests/testthat/test-unpredictable-summary-names.R
+++ b/tests/testthat/test-unpredictable-summary-names.R
@@ -1,0 +1,64 @@
+# `unpredictable_summary_dots()` is the precondition of every adapter
+# result-name test: those tests reach an adapter's own guard only because the
+# pre-execution check could not name the output first. A helper that quietly
+# stopped delivering that would leave its callers green and pointed at the
+# wrong check, so the helper is held to the same standard it enforces.
+
+test_that("the dots produce the output names the helper claims", {
+  data <- data.frame(group = c("x", "x", "y"), value = c(1, 2, 3))
+
+  from_fn <- rlang::inject(summarize_with_margins(
+    data,
+    !!!unpredictable_summary_dots("total"),
+    .grouping = rollup(group)
+  ))
+  expect_identical(names(from_fn), c("group", "total"))
+
+  from_col_fn <- rlang::inject(summarize_with_margins(
+    data,
+    !!!unpredictable_summary_dots("total", .names = NULL),
+    .grouping = rollup(group)
+  ))
+  expect_identical(names(from_col_fn), c("group", "value_total"))
+
+  expect_equal(from_fn$total, c(3, 3, 6))
+  expect_equal(from_col_fn$value_total, c(3, 3, 6))
+})
+
+test_that("the helper refuses dots the predictor can name", {
+  # Driving the failing branch needs a predictor that reports the name, since
+  # producing one through the ordinary interface is precisely what this helper
+  # is written to prevent.
+  expect_error(
+    unpredictable_summary_dots(
+      "total",
+      predict = function(dots, proxy) "total"
+    ),
+    "predicts `total`"
+  )
+
+  # Nothing is claimed when the predictor reports some other name.
+  expect_no_error(
+    unpredictable_summary_dots(
+      "total",
+      predict = function(dots, proxy) "something_else"
+    )
+  )
+})
+
+test_that("the predictor does name the literal shape the helper avoids", {
+  # Without this, the guard above could pass while asserting nothing: a
+  # predictor that named no output at all would accept every shape, including
+  # the ones that reach the pre-execution check instead of an adapter. The
+  # difference the helper trades on is `.fns` as a variable rather than as a
+  # literal `list()`, so the literal has to be visible for the variable's
+  # invisibility to mean anything.
+  proxy <- data.frame(value = double())
+  literal <- list(rlang::quo(dplyr::across(
+    dplyr::all_of("value"),
+    list(total = sum),
+    .names = "{.fn}"
+  )))
+
+  expect_true("total" %in% known_summary_output_names(literal, proxy))
+})


### PR DESCRIPTION
Two issues in one PR, which this repo otherwise does not do. They are together
because #126 is what makes #125's regression tests reach the code they test:
both tickets turn on a summary output name the static predictor cannot see,
and #125's tests are the fourth caller of the shape #126 extracts. Split
across two PRs they would land in the same test file and conflict, and the
first would have had to build the helper anyway.

## Make the defeat-the-predictor test precondition structural (#126)

Every test of an adapter's own result-name check depends on the pre-execution
check in `execute_margin_summary()` letting the call through first. When the
static predictor can name the summary output, that earlier check raises the
same condition and the test passes without the adapter guard ever running --
green, and proving something else. The shape that produces the case the guards
exist for is `.fns` bound to a variable, so the function-name component lives
in the value rather than the expression and `known_across_function_names()`
falls back to a positional placeholder.

That was spelled out in each test beside a comment saying it mattered. An edit
inlining `.fns` back into a literal `list()` would have left every one of them
passing and none of them still reaching a guard.

`unpredictable_summary_dots()` builds the dots and asks the predictor whether
it can name the result, refusing to hand back dots the predictor could see
through. A future predictor that closed this gap now fails there, naming the
helper, rather than quietly retargeting its callers at the pre-execution
check. `.names` takes the two shapes its callers need and no others, because
the expected output names are derived from it rather than resolved through
glue; `NULL` is what keeps the DuckDB test in the shape #98 was reported in,
`across()`'s own `{.col}_{.fn}` naming included.

`predict` is a parameter for the same reason `backend_available()` takes
`known`: the helper's own tests need to drive both outcomes, and the shape
reaching the failing one is the shape the helper exists to avoid building.
test-unpredictable-summary-names.R drives both, checks the dots really produce
the names the helper claims, and asserts the predictor does name the literal
`list()` shape -- without which the guard could pass while asserting nothing,
since a predictor naming no output at all would accept every shape.

## Report an internally allocated set identifier as an internal column (#125)

`check_margin_id_collision()` names `.id` in its message, which is right for
the three call sites handed the caller's `.id` and wrong for the fourth.
`stage_margin_summaries()` may replace that name with one it allocated itself
-- `..marginplyr_set_id_*` to keep set identity under a share,
`..marginplyr_sort_*` for a Margin order -- and the adapters then check their
result names against whatever they were handed. A caller who wrote no `.id`
could reach

```
Error in `summarize_with_margins()`:
! `.id` (`..marginplyr_sort_1`) conflicts with a summary output.
```

naming an argument they did not write and a column the public interface does
not expose. CONTEXT.md asks a Package condition to report something the caller
can avoid by rewriting the call within the documented interface, and the
rewrite that avoids this one was discoverable only by guessing.

An identifier the package allocated for itself is one of the internal columns,
alongside the union path's `..marginplyr_key_*` and the native path's
`..marginplyr_grouping_*`, so it is now reported as one and the existing
wording covers it. Only `stage_margin_summaries()` can still tell the two
apart, since the replacement happens there; it passes what it knows down as
`set_id_is_internal`, and `check_summary_output_names()` routes the name to
whichever check reports it honestly.

The regression tests cover both execution paths and both directions: the
internal identifier no longer mentions `.id`, and a caller's `.id` still does
-- including under `.sort`, where `margin_sort_identifier()` reuses the
caller's name rather than allocating one, and the message must not change with
it. Reverting `R/` alone fails them.

## Verified

Full suite green with no skips, `lintr::lint_package()` clean,
`roxygen2::roxygenise()` no diff, `verify-suite-coverage.R` reports 333 tests
with none executing in zero configurations, and `R CMD check` on the built
tarball is Status OK including vignette re-building.

Closes #126
Closes #125