### PR TITLE
Give the static summary-expression analysis typed conditions

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2574,7 +2574,12 @@ expression_data_symbols <- function(expr) {
   if (!rlang::is_call(expr)) {
     return(character())
   }
-  if (identical(rlang::call_name(expr), "get") && length(expr) >= 2L) {
+  # A call whose head is itself a call -- `fns$total(x)`, an inline lambda --
+  # has no name, so `call_name()` returns `NULL`. Every comparison below is
+  # written to be NULL-safe, since such a call is simply not the shape this
+  # analysis recognizes and must fall through to its parts (#100).
+  call_name <- rlang::call_name(expr)
+  if (identical(call_name, "get") && length(expr) >= 2L) {
     if (get_has_external_env(expr)) {
       return(character())
     }
@@ -2585,19 +2590,22 @@ expression_data_symbols <- function(expr) {
     }
     name_index <- match("x", arg_names, nomatch = 0L)
     if (name_index == 0L) {
-      name_index <- which(arg_names == "")[[1L]]
+      name_index <- match("", arg_names, nomatch = 0L)
     }
-    name <- args[[name_index]]
-    if (
-      is.character(name) &&
-        length(name) == 1L &&
-        !is.na(name)
-    ) {
-      return(name)
+    if (name_index > 0L) {
+      name <- args[[name_index]]
+      if (
+        is.character(name) &&
+          length(name) == 1L &&
+          !is.na(name)
+      ) {
+        return(name)
+      }
     }
   }
   if (
-    rlang::call_name(expr) %in% c("$", "[[") &&
+    !is.null(call_name) &&
+      call_name %in% c("$", "[[") &&
       length(expr) >= 3L &&
       rlang::is_symbol(expr[[2L]])
   ) {
@@ -2620,9 +2628,20 @@ expression_data_symbols <- function(expr) {
       return(character())
     }
   }
-  args <- as.list(expr)[-1L]
+  # Element 1 is the function position, dropped because a symbol there names a
+  # function rather than a column -- that is what keeps `sum` out of every
+  # result. A `[[` there is the one head shape whose parts are all evaluated
+  # in the data mask, so `fns[[bucket]](x)` reads `bucket` and the walk has to
+  # see it (#100). The other head shapes are left alone deliberately: `a$b`
+  # names `b` literally rather than reading it, and a function definition
+  # binds its own formals, so walking either would report a read that is not
+  # one and reject a call dplyr accepts (#130).
+  parts <- as.list(expr)[-1L]
+  if (rlang::is_call(expr[[1L]], "[[")) {
+    parts <- c(list(expr[[1L]]), parts)
+  }
   unique(unlist(
-    lapply(args, expression_data_symbols),
+    lapply(parts, expression_data_symbols),
     use.names = FALSE
   ))
 }

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -602,7 +602,8 @@ known_across_output_names <- function(expr, env, data_proxy) {
         vapply(
           function_names,
           function(fn) {
-            expand_across_name(names_template, column, fn, env)
+            expanded <- expand_across_name(names_template, column, fn, env)
+            check_across_name_count(expanded, names_template, column)
           },
           character(1)
         )
@@ -618,6 +619,28 @@ expand_across_name <- function(template, column, function_name, env) {
     template,
     .envir = env
   ))
+}
+
+# The expansion names one output per selected column, so a template that
+# expands to any other number is one `across()` will reject too. That is what
+# separates this from the `character()` the caller above returns: there the
+# template could not be evaluated at all and the analysis simply does not
+# know the names, whereas here it knows them and knows they are wrong. Saying
+# so here reaches the caller before the summary is staged, rather than as a
+# size error out of the query built from it (ADR-0005).
+check_across_name_count <- function(expanded, template, column) {
+  if (length(expanded) == 1L) {
+    return(expanded)
+  }
+
+  abort_marginplyr(
+    paste0(
+      "The `across()` `.names` template `", template, "` must produce one ",
+      "name per column, but it produced ", length(expanded),
+      " for column `", column,
+      "`. Use a template that expands to a single name."
+    )
+  )
 }
 
 known_across_source_names <- function(expr, env, data_proxy) {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -1,0 +1,222 @@
+# The analysis that reads summary expressions before execution used to assume
+# shapes real expressions do not always have, and raised the base-R condition
+# that assumption produced: an `NA` `if()` condition, an out-of-bounds `[[`,
+# and a `vapply()` type error (#100). None of the three is catchable by class
+# or tells the caller what to change, so each is asserted here by class as
+# well as by message.
+#
+# Which outcome is right differs per site, and that is the point ADR-0015
+# draws: a shape the analysis simply does not recognize must fall through and
+# evaluate, an error raised by the caller's own code must reach them with its
+# own class intact, and only a fault the analysis itself detects becomes a
+# Package condition.
+
+test_that("a call whose head is a call is evaluated, not classified", {
+  # `call_name()` answers `NULL` here, so the `$`/`[[` test used to compare
+  # `NULL` against a character vector, yielding `NA` inside `if()`. Such a call
+  # is not a data-mask reference, so the analysis has nothing to say about it
+  # and dplyr must see it unchanged.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  fns <- list(total = function(x, na_rm) sum(x, na.rm = na_rm))
+
+  from_list <- summarize_with_margins(
+    data,
+    value = fns$total(value, TRUE),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  from_lambda <- summarize_with_margins(
+    data,
+    value = (function(x) sum(x))(value),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expected <- data |>
+    dplyr::group_by(region) |>
+    dplyr::summarise(value = fns$total(value, TRUE), .groups = "drop")
+
+  expect_equal(
+    dplyr::arrange(from_list[!is.na(from_list$region), ], region),
+    as.data.frame(expected),
+    ignore_attr = "row.names"
+  )
+  expect_equal(from_lambda, from_list)
+})
+
+test_that("falling through a call head still sees its arguments", {
+  # Falling through must reach the arguments rather than abandon the
+  # expression: the dependency check that forbids reading an earlier share
+  # from an ordinary summary is the same walk, so a blind fall-through would
+  # let this call through and produce a wrong number instead of an error.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  fns <- list(double = function(x) x * 2)
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      share = share_of_total(total),
+      derived = fns$double(share),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(error, "marginplyr_error")
+})
+
+test_that("a `[[` call head is walked, and other head shapes are not", {
+  # The function position is dropped so `sum` never counts as a column, which
+  # leaves a read inside a call-valued head unseen. `[[` is the one head shape
+  # whose parts are all mask reads, so it is walked; `$` and a function
+  # definition are not, because walking them with the rules this analysis has
+  # today would report a read that is not one. #130 carries the rest, and
+  # these are the two halves that must not drift into each other.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # nolint start: object_usage_linter.
+  # `fns` is read from the summary expressions below, which codetools cannot
+  # follow through the data mask.
+  fns <- list(
+    total = function(x, na_rm) sum(x, na_rm),
+    double = function(x) x * 2
+  )
+  # nolint end
+
+  from_head <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = fns[[if (length(share)) "double" else "double"]](value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_head, "marginplyr_error")
+
+  # `total` in `fns$total` names a field of `fns` rather than reading the
+  # share of that name, so this call must execute. Rejecting it is the defect
+  # #100 was filed against, reached from the other direction.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      total = share_of_total(units),
+      derived = fns$total(value, TRUE),
+      .grouping = rollup(region)
+    )
+  )
+})
+
+test_that("a `get()` call with no name argument raises the caller's error", {
+  # The analysis reads the looked-up name out of `get()`, and a call that
+  # supplies neither `x` nor a positional argument has none to read. Nothing
+  # is wrong with the analysis, so the call evaluates and base R's own
+  # condition reaches the caller -- as it does from plain `summarise()`.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  baseline <- expect_error(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(z = get(mode = "numeric"), .groups = "drop")
+  )
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      z = get(mode = "numeric"),
+      .grouping = rollup(region)
+    )
+  )
+
+  expect_identical(class(error), class(baseline))
+  expect_identical(class(error$parent), class(baseline$parent))
+  expect_s3_class(error$parent, "missingArgError")
+  expect_false(inherits(error, "marginplyr_error"))
+})
+
+test_that("an `across()` `.names` template must name one output per column", {
+  # This one the analysis does detect: it expands the template itself, so it
+  # knows before any backend read that the template names two outputs for one
+  # column. ADR-0005 puts the rejection here rather than leaving it to the
+  # query dplyr would otherwise build.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(c(units), sum, .names = "{c('x','y')}"),
+      .grouping = rollup(region)
+    ),
+    "must produce one name per column"
+  )
+
+  expect_s3_class(error, "marginplyr_error")
+  # The template is what the caller has to rewrite, so the message quotes it.
+  expect_match(conditionMessage(error), "{c('x','y')}", fixed = TRUE)
+  expect_match(conditionMessage(error), "`units`", fixed = TRUE)
+  expect_identical(
+    rlang::call_name(conditionCall(error)),
+    "summarize_with_margins"
+  )
+})
+
+test_that("no analysed shape reaches the caller as an untyped condition", {
+  # The classes below are what each site raised before #100. Asserting their
+  # absence together keeps a future rewrite that reintroduces one of them from
+  # passing on the message alone.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+  fns <- list(total = function(x, na_rm) sum(x, na.rm = na_rm))
+
+  errors <- list(
+    call_head = tryCatch(
+      summarize_with_margins(
+        data,
+        units = fns$total(units, TRUE),
+        .grouping = rollup(region)
+      ),
+      error = function(cnd) cnd
+    ),
+    missing_get_name = tryCatch(
+      summarize_with_margins(
+        data,
+        z = get(mode = "numeric"),
+        .grouping = rollup(region)
+      ),
+      error = function(cnd) cnd
+    ),
+    across_names = tryCatch(
+      summarize_with_margins(
+        data,
+        dplyr::across(c(units), sum, .names = "{c('x','y')}"),
+        .grouping = rollup(region)
+      ),
+      error = function(cnd) cnd
+    )
+  )
+
+  expect_s3_class(errors$call_head, "data.frame")
+  for (error in errors[c("missing_get_name", "across_names")]) {
+    expect_s3_class(error, "condition")
+    expect_false(inherits(error, "simpleError"))
+    expect_false(inherits(error, "subscriptOutOfBoundsError"))
+  }
+})


### PR DESCRIPTION
Closes #100.

Three sites in the static summary-expression analysis raised a bare base-R
condition on input a caller can legitimately write: an `NA` `if()` condition,
an out-of-bounds `[[` on an empty `which()`, and a `vapply()` a multi-value
glue string overflowed. None is catchable by class or says what to change.

The right outcome differs per site. That is the split ADR-0015 draws, not a
uniform reclassification, and it is the part of this PR worth reviewing.

| Site | Before | After |
|---|---|---|
| `$`/`[[` test, `R/share.R` | `simpleError`: missing value where TRUE/FALSE needed | executes, matching plain dplyr |
| `get()` name lookup, `R/share.R` | `subscriptOutOfBoundsError` | base R's `missingArgError`, `$parent` intact |
| `.names` expansion, `R/summary-selections.R` | `simpleError` from `vapply` | `marginplyr_error` naming template and column |

## Two judgement calls

**The ticket's acceptance criteria were internally inconsistent.** Criteria 2
and 3 each demanded a `marginplyr_error`; criterion 6 forbids converting an
External condition into a Package one. Sites (b) and (c) fall on opposite
sides of that line, so they are treated differently:

- `get(mode = "numeric")` — marginplyr detects nothing. The analysis has no
  name to read, so it reports no data symbols, the expression evaluates, and
  base R raises against the caller's own code. External condition, propagates
  unchanged, `identical()` in class and `$parent` to what plain
  `dplyr::summarise()` produces.
- The `.names` template — marginplyr expands it itself, so it knows one column
  produced two names before anything is staged. Package condition, and
  ADR-0005 puts it before the query built from it.

Issue #100's body now carries an `## Amendments` section recording this; the
triage comment is left as written, as the record of what triage said.

**Falling through at site (a) exposed a gap the crash had been hiding.** The
function position of a call is dropped, so a share read inside a call-valued
head is invisible to the dependency walk and the guard against an ordinary
summary using an earlier share does not fire. `[[` is the one head shape whose
parts are all data-mask reads, so it is walked now. `$` and function-definition
heads are left alone deliberately — `a$b` names `b` literally and a lambda
binds its own formals, so walking either with the rules this analysis has today
rejects a call dplyr accepts, which is the defect this ticket exists to remove.
A first attempt at a general head walk did exactly that, rejecting
`fns$total(value)` whenever a share happened to be named `total`. Tracked as
#130; this PR does not wait for it.

## Verification

`tests/testthat/test-static-expression-analysis.R` is new. Its five relevant
assertions were confirmed to fail on the pre-fix tree, not only to pass on this
one, and each asserts the condition class rather than the message alone.

- Full suite: 1990 passing, 0 failures, 0 skips
- `lintr::lint_package()` clean; `roxygen2::roxygenise()` produces no diff
- `verify-suite-coverage.R`: all 339 tests execute in at least one backend
  configuration
- `R CMD check` on a built tarball: Status: OK

No `NEWS.md` entry: 0.1.0 is unreleased and this is a fix to code that has not
shipped.