### PR TITLE
Stop reading a `$` field name as a data-mask reference

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2628,14 +2628,30 @@ expression_data_symbols <- function(expr) {
       return(character())
     }
   }
+  # Any other `a$b` or `a@b` names `b` literally: the field or slot name is
+  # fixed text rather than a lookup, so only the object is walked. Collecting
+  # the name made `cfg$share` claim a dependency on a column named `share`,
+  # which the share analysis then read as an ordinary summary using an earlier
+  # share, and put the two spellings of one access -- `cfg$share` and
+  # `cfg[["share"]]` -- into disagreement (#101). `[[` is not the same shape:
+  # its index is evaluated, so `cfg[[bucket]]` really does read `bucket` and
+  # falls through to the walk below.
+  if (
+    !is.null(call_name) &&
+      call_name %in% c("$", "@") &&
+      length(expr) >= 2L
+  ) {
+    return(expression_data_symbols(expr[[2L]]))
+  }
   # Element 1 is the function position, dropped because a symbol there names a
   # function rather than a column -- that is what keeps `sum` out of every
   # result. A `[[` there is the one head shape whose parts are all evaluated
   # in the data mask, so `fns[[bucket]](x)` reads `bucket` and the walk has to
-  # see it (#100). The other head shapes are left alone deliberately: `a$b`
-  # names `b` literally rather than reading it, and a function definition
-  # binds its own formals, so walking either would report a read that is not
-  # one and reject a call dplyr accepts (#130).
+  # see it (#100). The other head shapes are left alone: a function definition
+  # binds its own formals, so walking one would report a read that is not one
+  # and reject a call dplyr accepts. A `$` head is no longer that case now
+  # that its field name contributes nothing, and the read of its object is
+  # missed here -- #130 owns the head, and this line is not its fix.
   parts <- as.list(expr)[-1L]
   if (rlang::is_call(expr[[1L]], "[[")) {
     parts <- c(list(expr[[1L]]), parts)

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -74,10 +74,11 @@ test_that("falling through a call head still sees its arguments", {
 test_that("a `[[` call head is walked, and other head shapes are not", {
   # The function position is dropped so `sum` never counts as a column, which
   # leaves a read inside a call-valued head unseen. `[[` is the one head shape
-  # whose parts are all mask reads, so it is walked; `$` and a function
-  # definition are not, because walking them with the rules this analysis has
-  # today would report a read that is not one. #130 carries the rest, and
-  # these are the two halves that must not drift into each other.
+  # whose parts are all mask reads, so it is walked; a function definition is
+  # not, because it binds its own formals and walking it would report a read
+  # that is not one. A `$` head is not walked either, so the object it reads
+  # is missed -- #130 carries that, and these are the two halves that must not
+  # drift into each other.
   data <- data.frame(
     region = c("East", "East", "West"),
     value = c(1, 3, 6)
@@ -115,6 +116,181 @@ test_that("a `[[` call head is walked, and other head shapes are not", {
       .grouping = rollup(region)
     )
   )
+})
+
+test_that("an ordinary `$` field name is not a data-mask read", {
+  # `cfg$share` reads a field of a list. The name after `$` is fixed text
+  # rather than a lookup, so collecting it made the guard against reading an
+  # earlier share believe an ordinary summary read the share of that name, and
+  # legal code was rejected -- while `cfg[["share"]]`, the same access spelled
+  # with a string, ran and returned the right answer (#101).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # nolint start: object_usage_linter.
+  # `cfg` is read from the summary expressions below, which codetools cannot
+  # follow through the data mask.
+  cfg <- list(share = "annual", total = 99)
+  # nolint end
+
+  from_dollar <- summarize_with_margins(
+    data,
+    total = sum(value),
+    share = share_of_parent(total),
+    note = cfg$share,
+    .grouping = rollup(region)
+  )
+  from_bracket <- summarize_with_margins(
+    data,
+    total = sum(value),
+    share = share_of_parent(total),
+    note = cfg[["share"]],
+    .grouping = rollup(region)
+  )
+
+  expect_equal(from_dollar, from_bracket)
+  expect_identical(unique(from_dollar$note), "annual")
+
+  # The same disagreement reached from the other side: the field name made a
+  # share source look as though it depended on an earlier summary alias.
+  source_dollar <- summarize_with_margins(
+    data,
+    total = sum(value),
+    scaled = sum(value) * cfg$total,
+    sh = share_of_parent(scaled),
+    .grouping = rollup(region)
+  )
+  source_bracket <- summarize_with_margins(
+    data,
+    total = sum(value),
+    scaled = sum(value) * cfg[["total"]],
+    sh = share_of_parent(scaled),
+    .grouping = rollup(region)
+  )
+
+  expect_equal(source_dollar, source_bracket)
+})
+
+test_that("the object of a `$` and the index of a `[[` are still read", {
+  # Only the field name stops counting. Dropping `$` calls from the walk
+  # altogether would let a read of the object through, and `[[` is not the
+  # same shape at all: its index is evaluated, so `cfg[[share]]` reads the
+  # share the guard exists to catch.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  from_object <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = share$field,
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_object, "marginplyr_error")
+
+  from_index <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = list(a = 1)[[share]],
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_index, "marginplyr_error")
+
+  expect_identical(expression_data_symbols(quote(cfg$share)), "cfg")
+  expect_identical(
+    expression_data_symbols(quote(cfg[[share]])),
+    c("cfg", "share")
+  )
+  # `@` names a slot the same literal way, and the walk reaches it through the
+  # same fall-through, so it is fixed in the same pass (#101). It is asserted
+  # on the walk rather than through a summary because an S4 object in a
+  # summary expression would add a dependency the package does not otherwise
+  # need.
+  expect_identical(expression_data_symbols(quote(cfg@share)), "cfg")
+})
+
+test_that("a genuine read of an earlier share is still rejected", {
+  # The two true positives the false positives above sit next to: an ordinary
+  # summary that really does name the share, and a share source that really
+  # does depend on an earlier alias. Both messages are the ones #101 must
+  # leave untouched.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  ordinary <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      share = share_of_parent(total),
+      note = share,
+      .grouping = rollup(region)
+    ),
+    "Ordinary summaries cannot use an earlier Parent share (`share`)",
+    fixed = TRUE
+  )
+  expect_s3_class(ordinary, "marginplyr_error")
+
+  source <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      scaled = total * 2,
+      sh = share_of_parent(scaled),
+      .grouping = rollup(region)
+    ),
+    paste0(
+      "Parent share `sh` cannot use source summary `scaled` because it ",
+      "depends on earlier summary alias `total`"
+    ),
+    fixed = TRUE
+  )
+  expect_s3_class(source, "marginplyr_error")
+})
+
+test_that("`.data$x` still reads a column and `.env$x` still reads none", {
+  # The pronoun branches sit above the `$` handling and are unchanged: the
+  # fix must not reach them.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # nolint start: object_usage_linter.
+  # Read through `.env` from the summary expression below.
+  share <- "from the environment"
+  # nolint end
+
+  pronoun <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = .data$share * 2,
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(pronoun, "marginplyr_error")
+
+  from_env <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    note = .env$share,
+    .grouping = rollup(region)
+  )
+  expect_identical(unique(from_env$note), "from the environment")
 })
 
 test_that("a `get()` call with no name argument raises the caller's error", {


### PR DESCRIPTION
`expression_data_symbols()` answers one question — which columns of the data
mask does this expression read — and every consumer of that answer trusts it.
A `$` call whose head is neither `.data` nor `.env` fell through to the generic
branch, which walks every argument, so the field name of an ordinary list
access was collected as a column read.

That made the share analysis draw correct conclusions from wrong input:

| Expression | Before | After |
|---|---|---|
| `note = cfg$share` alongside a share named `share` | rejected: "Ordinary summaries cannot use an earlier Parent share (`share`)…" | runs |
| `scaled = sum(v) * cfg$total` feeding `share_of_parent(scaled)` | rejected: "…depends on earlier summary alias `total`." | runs |
| `note = cfg[["share"]]` — same intent, other spelling | runs | runs |

Neither rejected expression names either share. The two spellings of one access
disagreed because the index of a `[[` is evaluated and is a genuine read, while
the name after a `$` is fixed text.

`a@b` names its slot the same literal way and reaches the same fall-through, so
it is fixed in the same pass rather than left as a twin defect. Both now walk
the object alone, which keeps the read the object may contain: an ordinary
summary writing `share$field` is still rejected, and a fix that stopped walking
`$` calls entirely would pass the false-positive tests and fail that one.

The `.data`/`.env` branches sit above this one and are untouched, as are the
dependency rules themselves. What counts as an illegal dependency has not
changed; only the input to that judgement was wrong.

## Scope

The call head keeps its existing treatment. Walking a `$` head is safe now that
its field name contributes nothing, and the read of its object is still missed —
that is #130's, not this ticket's. The comments in `R/share.R` and in
`test-static-expression-analysis.R` that justified skipping a `$` head by the
field-name rule are updated, since that reason no longer holds; the behaviour
they describe does. This PR is independently mergeable and does not wait on #130.

## Tests

Four new blocks in `tests/testthat/test-static-expression-analysis.R`, written
red first:

- both false positives above, each compared against its `[[` spelling
- the object of a `$` and the index of a `[[` are still read, so a fix that
  simply stopped walking `$` calls would fail
- both true positives still rejected, asserted on their existing messages
- `.data$x` still registers a dependency, `.env$x` still registers none

Local: `lintr::lint_package()` clean after `pkgload::load_all()`; full suite
green under `NOT_CRAN=true`. No roxygen changes, so `man/` and `NAMESPACE` are
unaffected. Every new test builds a plain `data.frame()` and requires no
optional backend.

Closes #101.