### PR TITLE
Let a sorted Margin result survive compute()

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,7 +56,8 @@ Grouping bit before its own value, so a margin row sits with the rows it
 summarizes rather than wherever its Margin label falls among the values. Every
 column in the key carries a missingness term, fixed keys included, so missing
 values come last wherever they appear. It is a property of the
-result a Margin verb returns, not of any table derived from it, and it is
+result a Margin verb returns, not of any table derived from it — except a
+materialization of that same result, which carries it — and it is
 distinct from Grouping-plan order, which numbers grouping-set occurrences.
 _Avoid_: Report order, result order, row order, sort order
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,9 @@
   bits alone, and lazy inputs stay lazy on a native `GROUPING SETS`
   plan as well as the portable one. As with `dplyr::arrange()`, the order is a
   property of the returned object and may not survive further verbs applied to
-  a lazy result.
+  a lazy result. `compute()` materializes a sorted lazy result in the Margin
+  order; it records no dbplyr window ordering, because the key reads Grouping
+  bits from a column the result does not expose.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -53,7 +53,8 @@ backend_capabilities <- function(kind) {
     "can_restore_factors",
     "can_encode_factor_missing_values",
     "native_grouping_sets",
-    "native_duplicate_sets"
+    "native_duplicate_sets",
+    "records_window_order"
   )
   enabled <- list(
     local = c(
@@ -73,10 +74,11 @@ backend_capabilities <- function(kind) {
       "can_read_schema",
       "can_restore_factors",
       "native_grouping_sets",
-      "native_duplicate_sets"
+      "native_duplicate_sets",
+      "records_window_order"
     ),
-    postgres = "native_grouping_sets",
-    sql = character(),
+    postgres = c("native_grouping_sets", "records_window_order"),
+    sql = "records_window_order",
     other = character()
   )
 

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -328,7 +328,29 @@ order_margin_result <- function(operation, result, execution) {
   ) {
     result <- dplyr::select(result, -dplyr::all_of(sort_id))
   }
-  result
+  forget_margin_window_order(result, backend = operation$backend)
+}
+
+# Where a backend records a window ordering, `arrange()` has just written the
+# key into two places, and only one of them is a Margin order. ADR 0018's rule
+# -- the key must be resolvable in the `FROM` clause of the query carrying the
+# `ORDER BY` -- is what splits them. The `ORDER BY` reads the Grouping set
+# identifier out of `FROM`, so it survives the projection above dropping that
+# column; the window ordering is rewritten by that same projection and loses
+# every term naming the identifier, leaving a truncated key that orders a
+# margin row by where its label falls.
+#
+# Recording that is worse than recording nothing, and it is also unusable:
+# `compute()` replays a window ordering through `window_order()`, which takes a
+# bare column name or `desc()` of one and nothing else, so the computed terms a
+# Margin key is made of stop it and no sorted result can be materialized at all
+# (#102). Clearing it takes nothing away, because the rows still arrive in the
+# Margin order -- that is the `ORDER BY`, which this leaves alone.
+forget_margin_window_order <- function(result, backend) {
+  if (!backend$records_window_order) {
+    return(result)
+  }
+  dbplyr::window_order(result)
 }
 
 # The key of ADR 0018, built from the Grouping plan alone:

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -197,10 +197,20 @@
 #' A Margin order promises exactly what [dplyr::arrange()] promises. It is a
 #' property of the object the verb returns: on local data frames and `dtplyr`
 #' steps that is the row order, and on lazy tables it is the outermost query's
-#' `ORDER BY`, which [dplyr::collect()] observes. Whether it survives further
-#' verbs applied to a lazy result is not promised, because that depends on
-#' dbplyr's query flattening, which marginplyr does not own and which changes
-#' between releases.
+#' `ORDER BY`, which [dplyr::collect()] and [dplyr::compute()] both observe:
+#' a materialized result carries the Margin order rather than losing it.
+#' Whether the order survives further verbs applied to a lazy result is not
+#' promised, because that depends on dbplyr's query flattening, which
+#' marginplyr does not own and which changes between releases.
+#'
+#' What a lazy result does not carry is a dbplyr window ordering. The key reads
+#' Grouping bits from a column the result does not expose, so no ordering over
+#' the returned columns alone reproduces it, and marginplyr leaves none
+#' recorded rather than record a truncated one. A window function written over
+#' a sorted lazy result therefore needs [dbplyr::window_order()], exactly as it
+#' would over an unsorted one, and asking for a Margin order discards any
+#' window ordering the input carried. `.sort = "none"` records no order and
+#' clears none.
 #'
 #' Asking for a Margin order never costs a native `GROUP BY GROUPING SETS`
 #' plan, and never changes which adapter runs. It composes with

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -297,3 +297,51 @@ One reading is closed by this. The entry above says missing values come last
 "within a Grouping bit group", which was true of dimensions and said nothing
 about fixed keys; it now reads as the whole key, and `CONTEXT.md`'s **Margin
 order** entry says the same.
+
+## Amendment: a lazy result carries the order and records no window ordering
+
+"It promises exactly what `dplyr::arrange()` promises" names `collect()` as
+what observes the `ORDER BY` on a dbplyr input. `compute()` observes it too,
+and the entry above did not say so because it could not: on dbplyr 2.6.0 a
+Margin order made `compute()` fail outright for every `.sort` but `"none"`
+(#102), on the very workflow the database-backends guide recommends for
+keeping a result in the database.
+
+Naming it is not the enumeration this decision rejected. That rejection is
+about verbs applied *after* the result, whose outcome dbplyr's query
+flattening decides and can change between releases. `compute()` renders this
+query and materializes the rows it returns, so it observes the `ORDER BY` for
+the same reason `collect()` does, and one warning about flattening does not
+cover a call that never flattens anything.
+
+**`arrange()` writes the key into two places.** Alongside the query's
+`ORDER BY` it records a window ordering, which is what a window function
+written over the result would order by. The previous amendment's rule holds
+for the first and not for the second: the `ORDER BY` reads the Grouping set
+identifier out of the `FROM` clause and survives the projection that drops
+that column, while the window ordering is rewritten by the same projection,
+losing every term that names the identifier. What stays recorded is a
+truncated key — the displayed values and their missingness, with the Grouping
+bits gone — which is not this decision's order and orders a margin row by
+where its label falls.
+
+**A Margin result therefore records no window ordering at all.** `compute()`
+replays whatever is recorded through `window_order()`, which accepts a bare
+column name or `desc()` of one and rejects everything else, so each missingness
+term and each Grouping bit fails there; clearing it is what makes a sorted
+result materializable. It also removes a claim that could only be wrong, since
+no ordering over the columns a Margin result exposes reproduces the key. A
+window function over a sorted lazy result needs `dbplyr::window_order()`,
+exactly as it does over an unsorted one, and asking for a Margin order
+discards any window ordering the input carried.
+
+Two consequences are worth recording.
+
+*The order the rows arrive in is untouched.* Clearing the window ordering
+leaves the `ORDER BY` alone, so the rendered SQL is what it was and
+`collect()` returns what it returned.
+
+*Which results this reaches is read from the prepared backend kind*, as the
+`records_window_order` capability, and not from the class of the finalized
+result — ADR 0014's rule, for its reason. A local result and a dtplyr step
+record no window ordering to clear, and the nesting verbs admit only those.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -233,10 +233,20 @@ two options stay independent and no combination of them is wrong.
 A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
 property of the object the verb returns: on local data frames and \code{dtplyr}
 steps that is the row order, and on lazy tables it is the outermost query's
-\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
-verbs applied to a lazy result is not promised, because that depends on
-dbplyr's query flattening, which marginplyr does not own and which changes
-between releases.
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}} both observe:
+a materialized result carries the Margin order rather than losing it.
+Whether the order survives further verbs applied to a lazy result is not
+promised, because that depends on dbplyr's query flattening, which
+marginplyr does not own and which changes between releases.
+
+What a lazy result does not carry is a dbplyr window ordering. The key reads
+Grouping bits from a column the result does not expose, so no ordering over
+the returned columns alone reproduces it, and marginplyr leaves none
+recorded rather than record a truncated one. A window function written over
+a sorted lazy result therefore needs \code{\link[dbplyr:window_order]{dbplyr::window_order()}}, exactly as it
+would over an unsorted one, and asking for a Margin order discards any
+window ordering the input carried. \code{.sort = "none"} records no order and
+clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -233,10 +233,20 @@ two options stay independent and no combination of them is wrong.
 A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
 property of the object the verb returns: on local data frames and \code{dtplyr}
 steps that is the row order, and on lazy tables it is the outermost query's
-\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
-verbs applied to a lazy result is not promised, because that depends on
-dbplyr's query flattening, which marginplyr does not own and which changes
-between releases.
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}} both observe:
+a materialized result carries the Margin order rather than losing it.
+Whether the order survives further verbs applied to a lazy result is not
+promised, because that depends on dbplyr's query flattening, which
+marginplyr does not own and which changes between releases.
+
+What a lazy result does not carry is a dbplyr window ordering. The key reads
+Grouping bits from a column the result does not expose, so no ordering over
+the returned columns alone reproduces it, and marginplyr leaves none
+recorded rather than record a truncated one. A window function written over
+a sorted lazy result therefore needs \code{\link[dbplyr:window_order]{dbplyr::window_order()}}, exactly as it
+would over an unsorted one, and asking for a Margin order discards any
+window ordering the input carried. \code{.sort = "none"} records no order and
+clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -263,10 +263,20 @@ two options stay independent and no combination of them is wrong.
 A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
 property of the object the verb returns: on local data frames and \code{dtplyr}
 steps that is the row order, and on lazy tables it is the outermost query's
-\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
-verbs applied to a lazy result is not promised, because that depends on
-dbplyr's query flattening, which marginplyr does not own and which changes
-between releases.
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}} both observe:
+a materialized result carries the Margin order rather than losing it.
+Whether the order survives further verbs applied to a lazy result is not
+promised, because that depends on dbplyr's query flattening, which
+marginplyr does not own and which changes between releases.
+
+What a lazy result does not carry is a dbplyr window ordering. The key reads
+Grouping bits from a column the result does not expose, so no ordering over
+the returned columns alone reproduces it, and marginplyr leaves none
+recorded rather than record a truncated one. A window function written over
+a sorted lazy result therefore needs \code{\link[dbplyr:window_order]{dbplyr::window_order()}}, exactly as it
+would over an unsorted one, and asking for a Margin order discards any
+window ordering the input carried. \code{.sort = "none"} records no order and
+clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -248,10 +248,20 @@ two options stay independent and no combination of them is wrong.
 A Margin order promises exactly what \code{\link[dplyr:arrange]{dplyr::arrange()}} promises. It is a
 property of the object the verb returns: on local data frames and \code{dtplyr}
 steps that is the row order, and on lazy tables it is the outermost query's
-\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} observes. Whether it survives further
-verbs applied to a lazy result is not promised, because that depends on
-dbplyr's query flattening, which marginplyr does not own and which changes
-between releases.
+\verb{ORDER BY}, which \code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}} both observe:
+a materialized result carries the Margin order rather than losing it.
+Whether the order survives further verbs applied to a lazy result is not
+promised, because that depends on dbplyr's query flattening, which
+marginplyr does not own and which changes between releases.
+
+What a lazy result does not carry is a dbplyr window ordering. The key reads
+Grouping bits from a column the result does not expose, so no ordering over
+the returned columns alone reproduces it, and marginplyr leaves none
+recorded rather than record a truncated one. A window function written over
+a sorted lazy result therefore needs \code{\link[dbplyr:window_order]{dbplyr::window_order()}}, exactly as it
+would over an unsorted one, and asking for a Margin order discards any
+window ordering the input carried. \code{.sort = "none"} records no order and
+clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
 plan, and never changes which adapter runs. It composes with

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -405,6 +405,33 @@ test_that("a native summary reuses `.id` rather than staging its own", {
   )
 })
 
+test_that("a Margin order leaves no window ordering to inherit", {
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_postgres()
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  )
+  # The key reads its Grouping bits from a column the result does not expose,
+  # so no ordering over the columns it does expose reproduces it. What survives
+  # the projection is a truncated key that orders a margin row by where its
+  # label falls, and replaying that is what `compute()` fails on (#102), so a
+  # window function written over the result inherits nothing.
+  windowed <- suppressWarnings(
+    dbplyr::sql_render(dplyr::mutate(query, running = cumsum(units)))
+  )
+  expect_match(windowed, "OVER (ROWS", fixed = TRUE)
+  expect_false(grepl("OVER (ORDER BY", windowed, fixed = TRUE))
+
+  # The `ORDER BY` the rows arrive in is not what was cleared.
+  expect_match(dbplyr::sql_render(query), "ORDER BY", fixed = TRUE)
+})
+
 test_that("the portable adapter keeps its branch identifier resolvable", {
   skip_if_no_sqlite_simulation()
   remote <- dbplyr::tbl_lazy(
@@ -580,6 +607,67 @@ copy_to_input <- function(con) {
   }
 }
 
+# Materializing a sorted Margin order, which `vignettes/database_backends.qmd`
+# recommends for keeping a result in the database, and which #102 found no
+# `.sort` but `"none"` could survive. ADR 0018's second amendment is what the
+# rows below are owed.
+#
+# Every value of the option runs from one place, because what has to hold is
+# that materializing keeps whichever order the option asked for. Each is checked
+# against the local result for the same specification -- the literals pinning
+# those are the assertions earlier in this file -- so that a backend cannot pass
+# by materializing its own wrong order faithfully. `"none"` promises no order,
+# so it is compared as a set.
+expect_computed_margin_order <- function(as_input) {
+  columns <- c("region", "store", "units")
+
+  for (sort in margin_sort_choices) {
+    summarize_input <- function(input) {
+      summarize_with_margins(
+        input,
+        units = sum(units, na.rm = TRUE),
+        .grouping = rollup(dplyr::all_of(c("region", "store"))),
+        .sort = sort
+      )
+    }
+    query <- summarize_input(
+      as_input(margin_order_data(), paste0("margin_order_compute_", sort))
+    )
+    computed <- dplyr::compute(query)
+
+    expect_s3_class(computed, "tbl_lazy")
+    # The Grouping set identifier the order reads its Grouping bits from is
+    # staged inside the query, so materializing must not surface it.
+    expect_identical(
+      as.character(dplyr::tbl_vars(computed)),
+      columns,
+      info = sort
+    )
+
+    local <- summarize_input(margin_order_data())
+    materialized <- dplyr::collect(computed)
+    if (identical(sort, "none")) {
+      by_key <- function(result) {
+        dplyr::arrange(
+          result,
+          dplyr::across(dplyr::all_of(c("region", "store")))
+        )
+      }
+      local <- by_key(local)
+      materialized <- by_key(materialized)
+    }
+    for (column in columns) {
+      expect_identical(
+        materialized[[column]],
+        local[[column]],
+        info = paste(sort, column)
+      )
+    }
+  }
+
+  invisible(NULL)
+}
+
 test_that("DuckDB executes a Margin order on its native plan", {
   skip_if_backend_absent("duckdb", "DBI")
 
@@ -721,6 +809,48 @@ test_that("DuckDB native and portable Margin orders agree", {
   expect_identical(portable$set, local$set)
 })
 
+test_that("DuckDB materializes a sorted Margin result with `compute()`", {
+  skip_if_backend_absent("duckdb", "DBI")
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  expect_computed_margin_order(copy_to_input(con))
+
+  # A caller's own `.id` is the Grouping set identifier the order reads, so it
+  # stays in the result and the ordering terms derived from it are the ones a
+  # projection cannot prune. Materializing has to survive that too.
+  remote <- dplyr::copy_to(
+    con,
+    margin_order_data(),
+    "margin_order_compute_id",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  )
+  computed <- dplyr::compute(query)
+  expect_identical(
+    as.character(dplyr::tbl_vars(computed)),
+    c("region", "store", "set", "units")
+  )
+  materialized <- dplyr::collect(computed)
+  local <- summarize_with_margins(
+    margin_order_data(),
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  )
+  for (column in c("region", "store", "set", "units")) {
+    expect_identical(materialized[[column]], local[[column]], info = column)
+  }
+})
+
 test_that("DuckDB orders a factor dimension by its restored levels", {
   skip_if_backend_absent("duckdb", "DBI")
 
@@ -787,6 +917,16 @@ test_that("RSQLite executes a portable Margin order end to end", {
     .sort = "last"
   ))
   expect_identical(result$size, c("large", "medium", "small", "Total"))
+})
+
+test_that("RSQLite materializes a portable Margin order with `compute()`", {
+  skip_if_backend_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  # The portable adapter carries its Grouping set identifier as a per-branch
+  # literal inside a `UNION ALL`, so this is the other shape the order can take.
+  expect_computed_margin_order(copy_to_input(con))
 })
 
 test_that("RSQLite places missing values where its own default would not", {


### PR DESCRIPTION
Closes #102.

## The failure

`arrange()` writes a Margin key into two places on a dbplyr backend: the query's `ORDER BY`, which is the order, and dbplyr's *window ordering*, which is what a later window function would order by. Only the first survives the projection that drops the Grouping set identifier — dbplyr's `rename_order()` strips every term naming a dropped column.

`compute.tbl_sql()` replays the second through `window_order()`, which takes a bare column name or `desc()` of one and nothing else, so every computed term a Margin key is made of stopped it:

```
compute(q), .sort = "last"  -> Error: Every element of `...` must be a single column name
                                     or a column wrapped in `desc()`.
```

That broke `compute()` for every `.sort` but `"none"`, on the workflow `vignettes/database_backends.qmd` recommends for keeping a result in the database.

## The fix

`order_margin_result()` now clears the recorded window ordering and leaves the `ORDER BY` alone. The rendered SQL is unchanged — only the metadata `compute()` replays is.

What was cleared was a truncated key: the displayed values and their missingness with the Grouping bits gone, which orders a margin row by where its label falls. So nothing correct is taken away, and no ordering over the columns a Margin result exposes reproduces the real key — which is why none is recorded rather than a partial one. A window function over a sorted lazy result needs `dbplyr::window_order()`, exactly as it does over an unsorted one.

Which results this reaches is read from the prepared backend kind, as a new `records_window_order` capability, and not from the finalized result's class — ADR 0014's rule, for its reason.

## Coverage

- `expect_computed_margin_order()` runs all three `.sort` values through `compute()` on DuckDB (native `GROUPING SETS`) and RSQLite (`UNION ALL`), each compared against the **local** result for the same specification, so a backend cannot pass by materializing its own wrong order faithfully. `"none"` promises no order and is compared as a set.
- A `.id` case, where the sort identifier is visible and its ordering terms are the ones a projection cannot prune.
- A simulated-Postgres test pinning the new promise in rendered SQL: a window function over a sorted result renders `OVER (ROWS …)` with no inherited `ORDER BY`, while the query's own `ORDER BY` stays.

Each new test requires at most one member of `optional_backends()` and skips through `skip_if_backend_absent()`, per `AGENTS.md`.

## Docs

ADR-0018 gains an amendment recording the decision, including why naming `compute()` is not the "enumerate the downstream verbs that preserve the order" option it rejected: that rejection is about verbs applied *after* the result, whose outcome dbplyr's flattening decides, and `compute()` renders this query rather than wrapping it. `CONTEXT.md`'s **Margin order** entry, the `.sort` roxygen section, and `NEWS.md` follow.

The vignette's `compute()` recommendation is correct as written after the fix, so per the issue's last criterion it is left alone.

## Worth flagging

Asking for a Margin order also discards any window ordering the *input* carried. dbplyr exposes no public way to read that back, so it cannot be restored; it is documented in the `.sort` section and the ADR. `.sort = "none"` records no order and clears none.

## Checks

Full suite green; `lintr::lint_package()` clean; `spelling::spell_check_package()` clean; `verify-suite-coverage.R` verifies all 346 tests execute in some single-backend configuration; `R CMD check` with vignettes under `NOT_CRAN=true` returns **Status: OK**.