### PR TITLE
Refuse a renaming selection in a Grouping specification

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -642,11 +642,42 @@ grouping_arg_spec <- function(arg, data_vars) {
   NULL
 }
 
+# tidyselect reports a selection under the names the caller gave it, so
+# `all_of(c(area = "region"))` selects `region` and calls it `area`. A grouping
+# dimension is a column of the input, so a renamed selection would put a name
+# the data does not have into the plan. Renaming is refused here, the one place
+# that sees both names, rather than with `eval_select(allow_rename = FALSE)`,
+# whose diagnostic says only that renaming is disallowed and never names the
+# pair the caller has to fix. A name that repeats its own column renames
+# nothing and is left alone.
 resolve_grouping_selection <- function(arg, data_proxy) {
   selected <- tidyselect::eval_select(
     arg,
     data = data_proxy,
     strict = TRUE
   )
-  names(selected)
+  selected_names <- names(selected)
+  # `tidyselect_data_proxy()` is how tidyselect itself sees the columns the
+  # positions in `selected` index, so it reads a lazy table's columns rather
+  # than the fields of the object holding them, which `names()` would return.
+  source_names <- names(tidyselect::tidyselect_data_proxy(data_proxy))[selected]
+  renamed <- selected_names != source_names
+  if (any(renamed)) {
+    abort_grouping_rename(selected_names[renamed], source_names[renamed])
+  }
+  selected_names
+}
+
+abort_grouping_rename <- function(selected_names, source_names) {
+  abort_marginplyr(
+    paste0(
+      "Can't rename grouping dimension",
+      if (length(selected_names) == 1L) " " else "s ",
+      paste0(
+        "`", selected_names, " = ", source_names, "`",
+        collapse = ", "
+      ),
+      ". Grouping dimensions must name existing columns."
+    )
+  )
 }

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -38,6 +38,10 @@
 #'   valid nested Grouping specification, and with no arguments represents the
 #'   identity product (the empty grouping set).
 #'
+#'   A dimension is a column of the input, so a selection cannot rename it:
+#'   `c(area = region)` is an error rather than a dimension named `area`.
+#'   Rename the result afterwards with [dplyr::rename()].
+#'
 #' @return A grouping specification for use in `.grouping`.
 #' @family grouping plans and grouping identity
 #' @seealso [summarize_with_margins()], [expand_with_margins()],

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -31,7 +31,11 @@ specifications and require at least one resolved dimension.
 nested Grouping specification, and requires at least one argument.
 \code{\link[=grouping_spec]{grouping_spec()}} combines its arguments by Cartesian product, accepts any
 valid nested Grouping specification, and with no arguments represents the
-identity product (the empty grouping set).}
+identity product (the empty grouping set).
+
+A dimension is a column of the input, so a selection cannot rename it:
+\code{c(area = region)} is an error rather than a dimension named \code{area}.
+Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 }
 \value{
 A grouping specification for use in \code{.grouping}.

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -349,6 +349,37 @@ test_that("public Arrow table classes are supported", {
   )
 })
 
+# Deciding whether a selection renames means comparing what it selected against
+# the columns it selected from, and a lazy selection proxy is the table object
+# itself: `names()` on it returns `con`, `src`, and `lazy_query`, so reading it
+# would report a rename for a selection that renames nothing and would name the
+# proxy's own fields when one does rename. Both halves are asserted here because
+# the first fails only on a backend that never collects its proxy.
+test_that("a lazy selection proxy resolves renames against its columns", {
+  source <- dbplyr::tbl_lazy(
+    data.frame(region = c("x", "y"), value = 1:2),
+    con = dbplyr::simulate_sqlite()
+  )
+
+  plan <- inspect_grouping(source, .grouping = rollup(region))
+  expect_identical(plan$included, c("(region)", "()"))
+
+  error <- expect_error(
+    inspect_grouping(
+      source,
+      .grouping = rollup(tidyselect::all_of(c(area = "region")))
+    )
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(
+    conditionMessage(error),
+    paste0(
+      "Can't rename grouping dimension `area = region`. ",
+      "Grouping dimensions must name existing columns."
+    )
+  )
+})
+
 margin_label_check_data <- function() {
   data.frame(
     first = c("Total", "x"),

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -218,6 +218,95 @@ test_that("selectors and fixed .by columns are resolved once", {
   )
 })
 
+test_that("a renaming grouping selection is refused by every constructor", {
+  data_vars <- c("region", "year", "value")
+  renamed_message <- paste0(
+    "Can't rename grouping dimension `area = region`. ",
+    "Grouping dimensions must name existing columns."
+  )
+  renaming_calls <- list(
+    quote(tidyselect::all_of(c(area = "region"))),
+    quote(c(area = region))
+  )
+  constructors <- c(
+    "grouping_set",
+    "grouping_sets",
+    "rollup",
+    "cube",
+    "grouping_spec"
+  )
+
+  for (constructor in constructors) {
+    for (selection in renaming_calls) {
+      spec <- eval(rlang::call2(constructor, selection))
+      error <- expect_error(compile_grouping_spec(spec, data_vars))
+      expect_s3_class(error, "marginplyr_error")
+      expect_identical(conditionMessage(error), renamed_message)
+    }
+  }
+
+  nested <- expect_error(
+    compile_grouping_spec(
+      rollup(grouping_set(tidyselect::all_of(c(area = "region")))),
+      data_vars
+    )
+  )
+  expect_s3_class(nested, "marginplyr_error")
+  expect_identical(conditionMessage(nested), renamed_message)
+
+  several <- expect_error(
+    compile_grouping_spec(
+      rollup(tidyselect::all_of(c(area = "region", when = "year"))),
+      data_vars
+    )
+  )
+  expect_s3_class(several, "marginplyr_error")
+  expect_identical(
+    conditionMessage(several),
+    paste0(
+      "Can't rename grouping dimensions `area = region`, `when = year`. ",
+      "Grouping dimensions must name existing columns."
+    )
+  )
+})
+
+test_that("non-renaming grouping selections keep resolving", {
+  data_vars <- c("region", "region_code", "year")
+  selected <- c("region", "year")
+
+  expect_equal(
+    compile_grouping_spec(rollup(region, year), data_vars)$dimensions,
+    c("region", "year")
+  )
+  expect_equal(
+    compile_grouping_spec(
+      rollup(tidyselect::all_of(selected)),
+      data_vars
+    )$dimensions,
+    c("region", "year")
+  )
+  expect_equal(
+    compile_grouping_spec(
+      rollup(tidyselect::starts_with("region")),
+      data_vars
+    )$dimensions,
+    c("region", "region_code")
+  )
+  expect_equal(
+    compile_grouping_spec(rollup(-year), data_vars)$dimensions,
+    c("region", "region_code")
+  )
+  # A name that repeats the column it selects renames nothing, so the plan it
+  # builds still names a column of the input.
+  expect_equal(
+    compile_grouping_spec(
+      rollup(tidyselect::all_of(c(region = "region"))),
+      data_vars
+    )$dimensions,
+    "region"
+  )
+})
+
 test_that("duplicate grouping sets have explicit policies", {
   spec <- grouping_sets(grouping_set(a), grouping_set(a))
 

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -224,6 +224,88 @@ test_that("inspection shares grouped and row-wise input validation", {
   )
 })
 
+renaming_grouping_data <- function() {
+  data.frame(region = c("x", "y"), revenue = 1:2)
+}
+
+renaming_grouping_message <- function() {
+  paste0(
+    "Can't rename grouping dimension `area = region`. ",
+    "Grouping dimensions must name existing columns."
+  )
+}
+
+test_that("inspection and execution refuse a renaming selection alike", {
+  data <- renaming_grouping_data()
+
+  inspected <- expect_error(
+    inspect_grouping(
+      data,
+      .grouping = rollup(tidyselect::all_of(c(area = "region")))
+    )
+  )
+  expect_s3_class(inspected, "marginplyr_error")
+  expect_identical(conditionMessage(inspected), renaming_grouping_message())
+  expect_identical(
+    rlang::call_name(conditionCall(inspected)),
+    "inspect_grouping"
+  )
+
+  # Every Margin verb resolves the same specification, so each one reports what
+  # the inspection verb reported. The calls are written out rather than built
+  # from the verb names, so `codetools` can follow them.
+  summarized <- expect_error(
+    summarize_with_margins(
+      data,
+      revenue = sum(revenue),
+      .grouping = rollup(tidyselect::all_of(c(area = "region")))
+    )
+  )
+  expect_identical(conditionMessage(summarized), renaming_grouping_message())
+
+  expanded <- expect_error(
+    expand_with_margins(
+      data,
+      .grouping = rollup(tidyselect::all_of(c(area = "region")))
+    )
+  )
+  expect_identical(conditionMessage(expanded), renaming_grouping_message())
+
+  nested <- expect_error(
+    nest_with_margins(
+      data,
+      .grouping = rollup(tidyselect::all_of(c(area = "region")))
+    )
+  )
+  expect_identical(conditionMessage(nested), renaming_grouping_message())
+
+  nested_by <- expect_error(
+    nest_by_with_margins(
+      data,
+      .grouping = rollup(tidyselect::all_of(c(area = "region")))
+    )
+  )
+  expect_identical(conditionMessage(nested_by), renaming_grouping_message())
+
+  for (error in list(summarized, expanded, nested, nested_by)) {
+    expect_s3_class(error, "marginplyr_error")
+  }
+})
+
+test_that("a renaming selection resolved from typed metadata is refused", {
+  # A selection carrying a predicate cannot be resolved from column names
+  # alone, so it reaches the typed selection proxy rather than the name proxy
+  # that rejects every other renaming selection before a backend is read.
+  error <- expect_error(
+    inspect_grouping(
+      renaming_grouping_data(),
+      .grouping = rollup(c(area = region, where(is.numeric)))
+    )
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(conditionMessage(error), renaming_grouping_message())
+})
+
 inspect_proxy_capture <- new.env(parent = emptyenv())
 
 inspect_proxy_counter_head <- function(x, ...) {


### PR DESCRIPTION
Closes #103.

## The failure

`resolve_grouping_selection()` returned the names tidyselect reports, and those are the names the caller wrote — not the columns they selected. A renaming selection therefore built a plan naming a column the data does not have:

```r
inspect_grouping(retail_sales, .grouping = rollup(all_of(c(area = "region"))))
#>   set_id fixed included omitted grouping_bits grouping_id
#> 1      1    ()   (area)      ()        area=0           0
#> 2      2    ()       ()  (area)        area=1           1
```

`retail_sales` has no `area`. The inspection API described a plan that cannot execute, and the executing verbs died later with a bare `simpleError` from base R:

```r
summarize_with_margins(retail_sales, revenue = sum(revenue),
                       .grouping = rollup(all_of(c(area = "region"))))
#> undefined columns selected
```

## The fix

A grouping dimension is a column of the input, so the selection that names it cannot rename it. A selection whose output name differs from the column it selected is now refused where both names are still in hand, naming every offending pair:

```
Can't rename grouping dimension `area = region`. Grouping dimensions must name existing columns.
```

A name that repeats its own column renames nothing and is left alone: `all_of(c(region = "region"))` still builds a plan naming a column of the input.

## Two decisions worth flagging

**`eval_select(allow_rename = FALSE)` is the mechanism the ticket names, and it is not used.** Its diagnostic is `Can't rename variables in this context.` — it never names the pair the caller has to fix, which the acceptance criteria require. Comparing the names directly supplies the pair and depends on no tidyselect-internal condition class. That also decides the identity case above, which `allow_rename = FALSE` would refuse.

**Selection positions are read back through `tidyselect::tidyselect_data_proxy()`, not `names()`.** A lazy selection proxy is the table object itself, whose `names()` are `con`, `src`, and `lazy_query`. Reading those reports a rename for a selection that renames nothing — the first draft did exactly that, and the existing dbplyr tests caught it.

## Where the rejection happens

Every selection resolvable from column names alone — which is every form but a predicate — is rejected against the name proxy, before any backend read, as ADR-0005 requires. A selection carrying a `where()` predicate cannot be resolved that way and reaches the typed selection proxy; it is rejected there, under the same message. Both paths have a test.

## Coverage

- Every constructor family — `grouping_set()`, `grouping_sets()`, `rollup()`, `cube()`, `grouping_spec()` — against both renaming spellings, plus a nested specification and a multi-rename message.
- `inspect_grouping()` and all four Margin verbs report the identical message for the identical input.
- Non-renaming forms still resolve: bare symbols, `all_of()` with an unnamed character vector, `starts_with()`, a negative selection, and the identity name.
- The lazy-proxy path, against a simulated dbplyr source: a valid selection is not misread as a rename, and a renaming one is refused. It needs no optional backend, and no new test requires any member of `optional_backends()`.

## Docs

The `@param ...` block shared by the Grouping constructors states the restriction and points at `dplyr::rename()` for the job it is not. `man/` regenerated.

`NEWS.md` is untouched: 0.1.0 is the initial CRAN submission, so this behaviour has never shipped.

## Verification

`testthat` suite, `lintr::lint_package()`, `spelling::spell_check_package()`, and `.github/scripts/verify-suite-coverage.R` all clean.
