### PR TITLE
Keep a failed share selection's own condition

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -1437,7 +1437,8 @@ plan_across_share <- function(expr,
     preceding_names = preceding_names,
     preceding = preceding,
     context = context,
-    kind = kind
+    kind = kind,
+    error_call = expr
   )
   outputs <- vapply(
     sources,
@@ -2419,12 +2420,21 @@ is_across_call <- function(expr) {
        identical(rlang::call_ns(expr), "dplyr"))
 }
 
+# `error_call` is the caller's own `across()` call rather than this frame,
+# because whatever tidyselect raises here is kept as the parent of the reported
+# condition. Left at its default the chain would name this function and a line
+# of this file, which is an internal frame no caller can act on. It reaches the
+# conditions tidyselect raises itself, which is every one a caller can act on
+# by rewriting the selection; a condition tidyselect re-signals from vctrs, such
+# as a scalar out-of-bounds subscript, keeps the call vctrs gave it, and nothing
+# short of rewriting that condition would change it.
 resolve_share_selection <- function(expr,
                                     env,
                                     preceding_names,
                                     preceding,
                                     context,
-                                    kind) {
+                                    kind,
+                                    error_call) {
   if (rlang::is_symbol(expr)) {
     source <- rlang::as_name(expr)
     if (!source %in% preceding_names) {
@@ -2440,7 +2450,8 @@ resolve_share_selection <- function(expr,
       rlang::new_quosure(expr, env = env),
       data = proxy,
       strict = TRUE,
-      allow_rename = FALSE
+      allow_rename = FALSE,
+      error_call = error_call
     )),
     error = function(cnd) {
       abort_share_selection_error(cnd, preceding, context, kind)
@@ -2448,15 +2459,21 @@ resolve_share_selection <- function(expr,
   )
 }
 
+# A selection naming something ineligible is marginplyr's own report and stays
+# parentless. Anything else -- a selection expression that raised, or tidyselect
+# rejecting the selection -- is an External condition, so it becomes the parent
+# rather than being flattened into the message. That keeps the class and the
+# chain a caller sees identical to the one the ordinary summary path propagates
+# for the same expression, with only marginplyr's context added on top.
 abort_share_selection_error <- function(cnd, preceding, context, kind) {
   missing <- share_selection_missing_names(cnd)
   if (length(missing) == 0L) {
     abort_marginplyr(
       paste0(
         "Invalid ", share_kind_modifier(kind), " `across()` selection. ",
-        "Select only eligible preceding ordinary summaries by name: ",
-        conditionMessage(cnd)
-      )
+        "Select only eligible preceding ordinary summaries by name."
+      ),
+      parent = cnd
     )
   }
 

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -2167,3 +2167,90 @@ test_that("across arguments are validated after evaluation, not as literals", {
     "Total-share `across\\(\\)` `.names` must be one non-missing character"
   )
 })
+
+test_that("a failed share selection keeps the original condition", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+  boom <- function() rlang::abort("boom", class = "my_user_error")
+
+  share_error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      dplyr::across(
+        dplyr::all_of(boom()),
+        share_of_total,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(share_error),
+    "Total-share `across\\(\\)` selection"
+  )
+
+  # The share path adds its own context on top of the condition the ordinary
+  # path propagates unchanged, so the chain below the marginplyr frame is the
+  # same one `summarise()` would have surfaced for the same selection.
+  ordinary_error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      dplyr::across(dplyr::all_of(boom()), sum),
+      .grouping = rollup(group)
+    )
+  )
+  expect_s3_class(share_error$parent, class(ordinary_error))
+  expect_s3_class(share_error$parent$parent, "my_user_error")
+  expect_s3_class(ordinary_error$parent, "my_user_error")
+})
+
+test_that("an ineligible share selection raises a parentless condition", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+
+  # A selection that evaluates cleanly and names something ineligible is
+  # marginplyr's own report, so it has no external condition to preserve.
+  ineligible <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      dplyr::across(
+        dplyr::all_of("missing"),
+        share_of_total,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_null(ineligible$parent)
+})
+
+test_that("a share selection tidyselect rejects keeps tidyselect's condition", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+
+  # A rename is refused by tidyselect rather than by marginplyr, so the
+  # condition to preserve is tidyselect's own. Its class comes from asking
+  # tidyselect the same question directly, rather than from naming an internal
+  # class of another package here.
+  rejected <- expect_error(tidyselect::eval_select(
+    rlang::quo(c(copy = total)),
+    data = list(total = 1L),
+    allow_rename = FALSE
+  ))
+  renamed <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      dplyr::across(
+        c(copy = total),
+        share_of_total,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_s3_class(renamed$parent, class(rejected))
+})


### PR DESCRIPTION
Closes #107.

## The failure

`abort_share_selection_error()` pasted `conditionMessage(cnd)` into a new `marginplyr_error` and set no `parent`. An error raised by the caller's own selection expression reached them with marginplyr's class and a `NULL` parent:

```r
boom <- function() rlang::abort("boom", class = "my_user_error")

summarize_with_margins(d, total = sum(v),
                       across(all_of(boom()), share_of_total, .names = "{.col}_share"),
                       .grouping = rollup(g))
#> Invalid Total-share `across()` selection. Select only eligible preceding
#> ordinary summaries by name: ℹ In argument: `all_of(boom())`. …
#> $parent: NULL
```

The ordinary summary path, given the identical `across()`, propagates the original condition intact — `$parent` of class `my_user_error`. `CONTEXT.md` defines an External condition as one propagated with its original class and provenance intact, and ADR-0015 separates Package conditions from ones that merely pass through. This was the one place a share selection broke both.

## The fix

The caught condition becomes the parent of the reported one, and its message is no longer interpolated, since the chain displays it:

```
Invalid Total-share `across()` selection. Select only eligible preceding ordinary summaries by name.
Caused by error in `dplyr::across()`:
ℹ In argument: `dplyr::all_of(boom())`.
Caused by error in `boom()`:
! boom
```

A selection that evaluates cleanly and names an ineligible summary is unchanged: it is marginplyr's own report, has no external condition to preserve, and still raises parentless through `abort_share_source_name()`.

`eval_select()` is also given the caller's `across()` call as its `error_call`. Preserving a condition preserves the call it was born with, and at its default that call was `resolve_share_selection()` plus a line of `R/share.R` — an internal frame the chain would now show to every caller.

## Three things worth flagging

**Acceptance criterion 1 is unsatisfiable as written.** `tryCatch(my_user_error = ...)` cannot fire: it matches only the raised condition's own class, and criterion 3 requires the condition to stay a `marginplyr_error`. It does not fire on the ordinary path either — that condition is a plain `rlang_error` with `my_user_error` as its parent. The intent (chain preserved, reachable by walking `$parent` or `rlang::cnd_inherits()`) holds.

**Criterion 2 holds one level down.** The chain is `marginplyr_error` → tidyselect's `rlang_error` → `my_user_error`. `$parent` is the tidyselect wrapper, not `my_user_error` directly — but that wrapper *is* the condition the ordinary path surfaces at top level, so the share condition is exactly the ordinary path's condition with marginplyr's context on top. Unwrapping to `cnd$parent` would satisfy the line literally while discarding a real condition and its `In argument:` context, which is the provenance destruction the ticket is about. The test asserts `$parent` matches `class(<ordinary path error>)` and `$parent$parent` is `my_user_error`.

**The scope is wider than one line of the brief.** The brief says only a selection expression that itself raises is affected, but tidyselect's own rejections now get parents too — `Can't rename variables in this context.`, `Can't select columns past the end.` `CONTEXT.md` names tidyselect an External source, and marginplyr has no more claim to tidyselect's condition than to the caller's, so treating them differently looked like the wrong split. Say the word if you want it narrowed.

## Residual

A *scalar* out-of-bounds subscript (`across(5, …)`) is re-signalled by tidyselect from vctrs and keeps the call vctrs gave it, so that one chain still reads `Caused by error in vars_select_eval()`. `error_call` does not reach it, and changing it would mean rewriting an external condition. Recorded in a comment at the call site rather than worked around.

## The audit criterion 6 asks for

`resolve_share_selection()` holds the only `tryCatch()` and the only `conditionMessage()` in `R/share.R`, so it was the only helper that could flatten an external condition. `abort_share_source_name()` and its `marginplyr_share_source_*` siblings, `abort_share_predicate()`, and the `validate_share_across_syntax()` family are raised from marginplyr's own checks and never receive a condition. Outside the file, `summarize_with_margins.R:739` and `with_margin_error_call()` both rethrow with `stop(cnd)`, and `summary-selections.R` catches only to fall back during static name inference, never to report.

## Coverage

Three tests, all on a local data frame, so none requires any member of `optional_backends()`:

- A selection expression that raises: the marginplyr condition's parent chain is compared against the condition the *ordinary* path produces for the same `across()`, and reaches `my_user_error`. Asserts on class, not message text.
- An ineligible named summary: still `marginplyr_share_source_unknown_error` with a `NULL` parent and its current message.
- A rename tidyselect refuses: the expected parent class is obtained by asking `tidyselect::eval_select(allow_rename = FALSE)` the same question directly, rather than naming another package's internal class here.

`man/` and `NAMESPACE` are untouched — no roxygen changed. `NEWS.md` is untouched: 0.1.0 is the initial CRAN submission, so this behaviour has never shipped.

## Verification

`testthat` suite (2120 pass, 0 skip under `NOT_CRAN`), `lintr::lint_package()`, `spelling::spell_check_package()`, and `.github/scripts/verify-suite-coverage.R` all clean.