### PR TITLE
Refuse a named across() share source as the pack it is

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -281,6 +281,10 @@
 #'   `tibble::tibble(total = sum(value))` cannot provide `total`. Rewrite it as
 #'   the top-level `total = sum(value)` or create a statically named column with
 #'   a preceding `across()`.
+#' - **Named `across()` source:** `total = across(c(revenue, units), sum)`
+#'   packs both results into one data-frame-valued `total` column, so `total`
+#'   is not a scalar source. Drop the `total =` name to get one column per
+#'   selected column, or define each summary at top level.
 #' - **Summary-alias dependency:** `gross = sum(value)`,
 #'   `net = gross - sum(discount)` is rejected when `net` is a source. Use
 #'   `net = sum(value) - sum(discount)`.
@@ -1264,21 +1268,21 @@ analyze_ordinary_summaries <- function(dots, selection_proxy) {
 
     if (nzchar(output_name)) {
       output_names <- output_name
-      eligible <- !is_across_call(expr)
+      eligibility <- if (is_across_call(expr)) "named_across" else "eligible"
     } else if (is_across_call(expr)) {
       output_names <- known_across_output_names(
         expr,
         env,
         selection_proxy
       )
-      eligible <- TRUE
+      eligibility <- "eligible"
     } else {
       output_names <- known_data_frame_output_names(
         expr,
         env,
         selection_proxy
       )
-      eligible <- FALSE
+      eligibility <- "expanded"
     }
 
     selected_dependencies <- if (is_across_call(expr)) {
@@ -1297,35 +1301,21 @@ analyze_ordinary_summaries <- function(dots, selection_proxy) {
       expression_alias_dependencies(expr, preceding_names),
       selected_dependencies
     ))
-    across_inputs <- if (is_across_call(expr)) {
-      inputs <- known_across_source_names(
-        expr,
-        env,
-        selection_proxy
-      )
-      rep(inputs, each = length(known_across_function_names(
-        parse_across_arguments(expr)
-      )))
-    } else {
-      rep(NA_character_, length(output_names))
-    }
-    across_functions <- if (is_across_call(expr)) {
-      function_count <- length(known_across_function_names(
-        parse_across_arguments(expr)
-      ))
-      rep(
-        seq_len(function_count),
-        times = length(across_inputs) / function_count
-      )
-    } else {
-      rep(NA_integer_, length(output_names))
-    }
+    provenance <- across_output_provenance(
+      expr,
+      env,
+      selection_proxy,
+      output_names,
+      expands_own_names = is_across_call(expr) && !nzchar(output_name)
+    )
+    across_inputs <- provenance$inputs
+    across_functions <- provenance$functions
     records <- Map(
       function(name, across_input, across_function) {
         list(
           name = name,
           position = i,
-          eligible = eligible,
+          eligibility = eligibility,
           dependencies = dependencies,
           across_input = across_input,
           across_function = across_function
@@ -1340,6 +1330,44 @@ analyze_ordinary_summaries <- function(dots, selection_proxy) {
   }
 
   analyses
+}
+
+# Which selected column and which `.fns` entry produced each output name. Only
+# an `across()` that expanded its own names has that correspondence: one name
+# per (column, function) pair, in that order. A named `across()` packs every
+# pair into the single column the caller named, so its one name came from all
+# of them and from none in particular; recording `NA` there rather than zipping
+# the two lists is what keeps that name from being multiplied into one record
+# per selected column (#105). A single-column named `across()` is why this
+# takes the caller's naming rather than comparing counts: one output and one
+# column agree in count while still standing for a pack.
+across_output_provenance <- function(expr,
+                                     env,
+                                     data_proxy,
+                                     output_names,
+                                     expands_own_names) {
+  unknown <- list(
+    inputs = rep(NA_character_, length(output_names)),
+    functions = rep(NA_integer_, length(output_names))
+  )
+  if (!expands_own_names) {
+    return(unknown)
+  }
+
+  inputs <- known_across_source_names(expr, env, data_proxy)
+  function_count <- length(known_across_function_names(
+    parse_across_arguments(expr)
+  ))
+  # A `.names` template the analysis could not expand leaves the output names
+  # unknown, so the pairs it would have named cannot be matched to them.
+  if (length(inputs) * function_count != length(output_names)) {
+    return(unknown)
+  }
+
+  list(
+    inputs = rep(inputs, each = function_count),
+    functions = rep(seq_len(function_count), times = length(inputs))
+  )
 }
 
 # The share outputs written so far, each with its kind: a diagnostic naming
@@ -1416,7 +1444,7 @@ plan_across_share <- function(expr,
   selectable <- vapply(
     preceding,
     function(record) {
-      isTRUE(record$eligible) &&
+      identical(record$eligibility, "eligible") &&
         length(record$dependencies) == 0L &&
         context$ordinary_counts[[record$name]] == 1L
     },
@@ -1622,14 +1650,12 @@ validate_share_request <- function(outputs,
       )
     }
     record <- preceding[[max(which(preceding_names == source))]]
-    if (!isTRUE(record$eligible)) {
-      abort_marginplyr(
-        paste0(
-          label, " `", output, "` cannot use `", source,
-          "` because it was expanded from a data-frame-valued summary. ",
-          "Rewrite it as a top-level named summary or a preceding `across()` ",
-          "output."
-        )
+    if (!identical(record$eligibility, "eligible")) {
+      abort_ineligible_share_source(
+        label = label,
+        output = output,
+        source = source,
+        eligibility = record$eligibility
       )
     }
     if (length(record$dependencies) > 0L) {
@@ -1662,6 +1688,31 @@ validate_share_request <- function(outputs,
     )
   }
   invisible(NULL)
+}
+
+# An ineligible source is refused in the terms of the summary the caller wrote,
+# because the two ways a name can be ineligible need opposite rewrites. A
+# column expanded from an unnamed data-frame-valued summary needs a top-level
+# name; a named `across()` already has one, and needs that name dropped so
+# dplyr writes a column per selected column instead of packing them all into
+# it. Telling the second caller to add a top-level name would name the summary
+# they already named (#105).
+abort_ineligible_share_source <- function(label, output, source, eligibility) {
+  advice <- if (identical(eligibility, "named_across")) {
+    paste0(
+      "a named `across()` packs its outputs into one data-frame-valued ",
+      "column. Drop the `", source, " =` name so each selected column is ",
+      "named on its own, or define `", source, "` as a top-level summary."
+    )
+  } else {
+    paste0(
+      "it was expanded from a data-frame-valued summary. Rewrite it as a ",
+      "top-level named summary or a preceding `across()` output."
+    )
+  }
+  abort_marginplyr(
+    paste0(label, " `", output, "` cannot use `", source, "` because ", advice)
+  )
 }
 
 # Each kind states what the compiled plan must provide. A call requesting both

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -77,13 +77,16 @@ summary has the same name as a source-data column, the helper refers to the
 preceding summary output, not the source-data column.
 
 An eligible ordinary summary is either a top-level explicitly named summary
-or a statically named column produced by a preceding `across()`. A column
-expanded from an unnamed data-frame-valued summary is not eligible, although
-such summaries otherwise retain their existing margin-summary behavior. The
-expanded column's provenance, type, and expression position are not
-consistently available for static dependency validation across local and lazy
-backends. The error shows how to rewrite it as top-level named summaries or a
-preceding `across()`.
+or a statically named column produced by a preceding `across()`. A named
+`across()` is neither: dplyr packs its outputs into one data-frame-valued
+column under that name, so the name stands for the pack rather than for one of
+the columns in it, and the error says to drop the name instead of adding one.
+A column expanded from an unnamed data-frame-valued summary is not eligible,
+although such summaries otherwise retain their existing margin-summary
+behavior. The expanded column's provenance, type, and expression position are
+not consistently available for static dependency validation across local and
+lazy backends. The error shows how to rewrite it as top-level named summaries
+or a preceding `across()`.
 
 The eligible source name must be defined exactly once in the call before the
 Parent share expression. Redefining a summary name makes its provenance and

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -296,6 +296,10 @@ complete expression such as \code{net = sum(revenue) - sum(discount)} before
 \code{tibble::tibble(total = sum(value))} cannot provide \code{total}. Rewrite it as
 the top-level \code{total = sum(value)} or create a statically named column with
 a preceding \code{across()}.
+\item \strong{Named \code{across()} source:} \code{total = across(c(revenue, units), sum)}
+packs both results into one data-frame-valued \code{total} column, so \code{total}
+is not a scalar source. Drop the \verb{total =} name to get one column per
+selected column, or define each summary at top level.
 \item \strong{Summary-alias dependency:} \code{gross = sum(value)},
 \code{net = gross - sum(discount)} is rejected when \code{net} is a source. Use
 \code{net = sum(value) - sum(discount)}.

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -171,6 +171,56 @@ test_that("Parent shares use statically named across function-list outputs", {
   expect_type(result$value_average_share, "double")
 })
 
+test_that("a named across() source is one packed column, not many summaries", {
+  data <- data.frame(
+    group = c("a", "a", "b"),
+    v = c(1, 2, 3),
+    u = c(4, 5, 6),
+    w = c(7, 8, 9)
+  )
+  # One selected column, several, and a `.names` template: the refusal is the
+  # caller's one packed name in every case, never the multiplicity the earlier
+  # analysis inferred by zipping that name against the selected columns (#105).
+  packing_sources <- list(
+    quote(dplyr::across(v, sum)),
+    quote(dplyr::across(c(v, u), sum)),
+    quote(dplyr::across(c(v, u, w), sum)),
+    quote(dplyr::across(c(v, u), sum, .names = "{.col}_total"))
+  )
+
+  for (source in packing_sources) {
+    condition <- expect_error(
+      rlang::inject(summarize_with_margins(
+        data,
+        tot = !!source,
+        sh = share_of_parent(tot),
+        .grouping = rollup(group)
+      )),
+      "a named `across\\(\\)` packs its outputs"
+    )
+    expect_s3_class(condition, "marginplyr_error")
+    expect_match(conditionMessage(condition), "Drop the `tot =` name")
+    expect_false(grepl(
+      "defined exactly once",
+      conditionMessage(condition),
+      fixed = TRUE
+    ))
+  }
+
+  # The true positive the analysis must keep: two `across()` calls really do
+  # define `v` twice.
+  expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(v, sum),
+      dplyr::across(v, mean),
+      sh = share_of_parent(v),
+      .grouping = rollup(group)
+    ),
+    "defined exactly once"
+  )
+})
+
 test_that(paste0(
   "Parent shares support composite dimensions, fixed keys, ",
   "and duplicates"


### PR DESCRIPTION
Closes #105.

## The failure

`analyze_ordinary_summaries()` built one dependency record per element of a `Map()` over the summary's output names *and* the `across()` call's selected columns. A named `across()` has one output name and n selected columns, so the shorter side recycled and the record set claimed n definitions of that one name:

```r
d <- data.frame(r = c("a", "a", "b"), v = c(1, 2, 3), u = c(4, 5, 6))

summarize_with_margins(d, tot = across(c(v, u), sum), sh = share_of_parent(tot),
                       .grouping = rollup(r))
#> Parent share `sh` requires source summary `tot` to be defined exactly once.
#>   Use one uniquely named ordinary summary.
```

`tot` is named exactly once. The multiplicity check in `validate_share_request()` was drawing a correct conclusion from a wrong record set.

## The fix

Provenance is derived from the outputs instead of zipped against them. `across_output_provenance()` reports which selected column and which `.fns` entry produced each output name only for an `across()` that expanded its own names, where the correspondence exists — one name per (column, function) pair — and `NA` otherwise. It keys on the caller's naming rather than on comparing counts, because `tot = across(v, sum)` has one output and one column and still stands for a pack.

## The call is still refused, and that is not the bug

A named `across()` is not a share source. dplyr packs its outputs into one data-frame-valued column under that name, so `tot` is the pack, not a scalar:

```r
summarize_with_margins(d, tot = across(c(v, u), sum), .grouping = rollup(r)) |> str()
#> 'data.frame': 3 obs. of 2 variables:
#>  $ r  : chr  "a" "b" "Total"
#>  $ tot: tibble [3 x 2]
#>   ..$ v: num  3 3 6
#>   ..$ u: num  9 6 15
```

**Acceptance criteria 1 and 2 are therefore unsatisfiable as written.** They ask for the share to be "computed against `tot`", and there is no scalar `tot` to divide by. ADR-0010 already excludes data-frame classes from eligible sources, so the outcome — a refusal — is the existing decision, not a new one. What the ticket found is that the *diagnostic* was wrong, and that is what changes.

ADR-0010's eligibility paragraph now says which side of the rule a named `across()` falls on, because "either a top-level explicitly named summary or a statically named column produced by a preceding `across()`" read as though it included one.

## The diagnostic

The two ways a name can be ineligible want opposite rewrites, so the record's boolean `eligible` becomes a three-valued `eligibility` and `abort_ineligible_share_source()` speaks to the summary the caller actually wrote:

```
Parent share `sh` cannot use `tot` because a named `across()` packs its outputs
into one data-frame-valued column. Drop the `tot =` name so each selected column
is named on its own, or define `tot` as a top-level summary.
```

The pre-existing message — "it was expanded from a data-frame-valued summary. Rewrite it as a top-level named summary or a preceding `across()` output" — is unchanged for the case it was written for, an unnamed `tibble::tibble(total = sum(value))`. Reused here it would have told this caller to give `tot` the name they had already given it. The rejection is listed with the others in `share_of_parent()`'s checklist.

## Scope note

The brief scoped the change to "the helper that builds dependency records" and said the multiplicity check stays unchanged. It does. The `eligibility` field and the new abort helper are beyond that one helper, and deliberately so: without them the fixed record set falls through to a message that misdescribes the summary, which acceptance criterion 3 rules out ("rejected with a message that says why"). Say the word if you would rather have the minimal record-set fix and the old message.

## Coverage

One test, on a local data frame, so it requires no member of `optional_backends()`:

- Four packing sources — one selected column, two, three, and a `.names` template — each refused with the packing message and the `Drop the `tot =` name` advice, each asserted *not* to mention "defined exactly once". One column and three columns are both there so the fix cannot be special-cased to two.
- The true positive it must preserve: two `across()` calls that both define `v` still raise the exactly-once error.

`test-share.R` passes 364 assertions; the full suite passes with `NOT_CRAN=true` with no skips. `lintr::lint_package()`, `spelling::spell_check_package()`, and `roxygen2::roxygenise()` are clean.
