### PR TITLE
Hold the share source-type rule on every backend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,10 @@
   preceding numeric scalar summary by the same measure one `rollup()` level
   up, partitioned by the fixed `.by` keys. Local data frames, dbplyr, and
   dtplyr are supported, and lazy inputs stay lazy; Arrow rejects Parent shares
-  before a query is built.
+  before a query is built. A share source must be a plain integer or double on
+  every backend: where the type is not readable without asking, marginplyr
+  reads the ordinary summaries over one input row rather than leaving the rule
+  to the dialect.
 * Added the contextual `share_of_total()` summary helper, which divides the
   same kind of source summary by the Grand total set within each fixed `.by`
   partition. It shares every rule of `share_of_parent()` except the

--- a/R/share.R
+++ b/R/share.R
@@ -373,16 +373,18 @@
 #' are requested.
 #'
 #' Syntax, source-name, written-order, and `across()` errors are always
-#' reported locally, before execution, on every backend. Only the *result*
-#' rules — eligible numeric type and exactly-one-value cardinality — depend on
-#' what the backend can prove:
+#' reported locally, before execution, on every backend. The eligible-type
+#' rule is also enforced on every backend, and no backend calculates a share
+#' from a source it has shown to be ineligible. What differs is when the
+#' source's type becomes readable, and whether the exactly-one-value
+#' cardinality rule can be read with it:
 #'
 #' | Backend | Where source type and cardinality are checked |
 #' |---|---|
 #' | Local data frame | Before any share is calculated |
 #' | `dtplyr` step | At explicit execution, before an invalid row is emitted |
 #' | Arrow | Not reached; shares are rejected outright |
-#' | General dbplyr | Not by marginplyr; the database may error at collection |
+#' | General dbplyr | Type only, from one input row, before the query returns |
 #'
 #' Arrow inputs reject both helpers after expression planning and common
 #' Margin-operation validation but before constructing a summary query. The
@@ -396,20 +398,29 @@
 #' diagnostics keep the share's output name, the source summary name, and
 #' the original public call, so they read like the local ones.
 #'
-#' General dbplyr backends are not queried solely to discover an arbitrary
-#' summary result's type or cardinality. Statically detectable syntax and
-#' dependency errors remain local, while an incompatible lazy summary may
-#' report its backend error when [dplyr::collect()] executes the staged query.
+#' A general dbplyr backend evaluates the source summary in the database, so
+#' its type is readable only from a value the database returns. marginplyr
+#' reads one: when a share is requested, it collects the ordinary summaries
+#' over a single input row and rejects an ineligible source before returning
+#' the query. The read is bounded in rows requested and returned, not in the
+#' work the input may have to do to produce that one row. It is the staged
+#' query that stays lazy — nothing else is executed, [dplyr::show_query()]
+#' remains non-executing, and no further query is run to improve an error.
+#'
+#' A source that read of the input cannot type is left alone rather than
+#' rejected. A dialect that types values rather than columns says nothing
+#' about a summary whose one sampled value is missing, and a summary the
+#' database refuses is reported by the database when [dplyr::collect()]
+#' executes the staged query, where its own diagnostic is the useful one.
+#' Cardinality is not read this way at all: a SQL aggregate returns one value
+#' per grouping row by construction, so there is nothing for the sample to
+#' disprove.
+#'
 #' The portable value guarantee covers finite numbers, missing values, and
 #' zero denominators. Infinite values and backend-specific `NaN`
 #' representations are outside that guarantee because supported SQL dialects
 #' do not share one portable finite-value predicate. Normalize potentially
 #' non-finite summaries explicitly with operations supported by the backend.
-#'
-#' marginplyr does not run a schema query, execute the staged query, or collect
-#' it solely to improve type or cardinality errors. This preserves laziness and
-#' makes [dplyr::show_query()] non-executing; runtime-only incompatibilities
-#' remain errors at the backend execution boundary.
 #'
 #' @param x The bare name of one preceding eligible ordinary summary.
 #'
@@ -863,6 +874,15 @@ share_cardinality_records <- function(analyses, requests) {
     seen_sources <- c(seen_sources, pair$source)
   }
   cardinality
+}
+
+# The backends whose ordinary summaries evaluate R code, so
+# `wrap_share_sources()` below can put the eligible-type and cardinality rules
+# inside the summary itself. The planner reads it to decide whether to wrap,
+# and `unsampled_share_sources()` asserts it: a kind may only be left unsampled
+# because it carries the rule in its own summary.
+wraps_share_sources_in_summary <- function(backend_kind) {
+  backend_kind %in% c("local", "dtplyr")
 }
 
 wrap_share_sources <- function(dots,
@@ -1755,7 +1775,8 @@ check_total_grouping_kind <- function(plan) {
 
 execute_shares <- function(operation,
                            staged_result,
-                           requests) {
+                           requests,
+                           summary_dots) {
   check_margin_operation(operation)
   check_margin_summary_stage(staged_result)
   if (length(requests) == 0L) {
@@ -1769,6 +1790,20 @@ execute_shares <- function(operation,
   )
   staged_set_id_name <- margin_summary_stage_set_id(
     staged_result
+  )
+  # The eligible-type rule is a property of the source summary, not of the
+  # join that follows, so it is settled once here rather than inside the
+  # adapter that happens to run. Only where its answer comes from is a backend
+  # question, and that is what the sampler below decides.
+  check_share_source_types(
+    sample_share_sources(
+      operation,
+      result = result,
+      requests = requests,
+      summary_dots = summary_dots
+    ),
+    requests = requests,
+    call = operation$call
   )
   adapter <- share_adapter(operation$backend$kind)
   # One adapter pass per requested kind. Every pass reads the same staged
@@ -1809,12 +1844,12 @@ execute_shares <- function(operation,
 
 share_adapter <- function(backend_kind) {
   adapters <- list(
-    local = execute_local_shares,
+    local = execute_row_matched_shares,
     duckdb = execute_dbplyr_shares,
     postgres = execute_dbplyr_shares,
     sql = execute_dbplyr_shares,
-    dtplyr = execute_non_sql_shares,
-    other = execute_non_sql_shares
+    dtplyr = execute_row_matched_shares,
+    other = execute_row_matched_shares
   )
   adapter <- adapters[[backend_kind]]
   if (is.null(adapter)) {
@@ -1826,12 +1861,11 @@ share_adapter <- function(backend_kind) {
   adapter
 }
 
-execute_local_shares <- function(operation,
-                                 result,
-                                 requests,
-                                 set_id_name,
-                                 kind) {
-  check_local_share_types(result, requests, call = operation$call)
+execute_row_matched_shares <- function(operation,
+                                       result,
+                                       requests,
+                                       set_id_name,
+                                       kind) {
   apply_joined_shares(
     result,
     requests = requests,
@@ -1857,19 +1891,131 @@ execute_dbplyr_shares <- function(operation,
   )
 }
 
-execute_non_sql_shares <- function(operation,
-                                   result,
-                                   requests,
-                                   set_id_name,
-                                   kind) {
-  apply_joined_shares(
-    result,
-    requests = requests,
-    plan = operation$plan,
-    set_id_name = set_id_name,
-    kind = kind,
-    sql_join = FALSE
+# Where the eligible-type rule reads its source values, chosen from the
+# prepared backend kind exactly as the adapter above is. The samplers share
+# the adapters' signature and, like them, the lookup has no default: an
+# unrecognized kind is a marginplyr defect rather than something a caller can
+# rewrite.
+share_source_sampler <- function(backend_kind) {
+  samplers <- list(
+    local = sample_materialized_sources,
+    duckdb = probe_share_sources,
+    postgres = probe_share_sources,
+    sql = probe_share_sources,
+    dtplyr = unsampled_share_sources,
+    other = probe_share_sources
   )
+  sampler <- samplers[[backend_kind]]
+  if (is.null(sampler)) {
+    stop(
+      "Unknown contextual-share source-sampler backend kind: ", backend_kind,
+      call. = FALSE
+    )
+  }
+  sampler
+}
+
+sample_share_sources <- function(operation,
+                                 result,
+                                 requests,
+                                 summary_dots) {
+  sampler <- share_source_sampler(operation$backend$kind)
+  sampler(
+    operation,
+    result = result,
+    requests = requests,
+    summary_dots = summary_dots
+  )
+}
+
+# A materialized result carries the summaries' own types, so the staged result
+# is the sample and nothing is read.
+sample_materialized_sources <- function(operation,
+                                        result,
+                                        requests,
+                                        summary_dots) {
+  values <- as.list(result)
+  values[intersect(share_source_names(requests), names(values))]
+}
+
+# `wrap_share_sources()` put the same rule inside the ordinary summary for the
+# backends that evaluate summaries in R and stay lazy, where it raises at
+# execution with the caller's own call. Sampling here would collect their
+# input on the caller's behalf to say what they already say themselves.
+unsampled_share_sources <- function(operation,
+                                    result,
+                                    requests,
+                                    summary_dots) {
+  stopifnot(wraps_share_sources_in_summary(operation$backend$kind))
+  list()
+}
+
+# One bounded read: the planned ordinary summaries over a single input row,
+# collected so each share source comes back with the type the backend gives
+# it. It is the only way to learn that type in a dialect that types values
+# rather than columns -- a zero-row read there answers every computed column
+# with no type at all -- and it is bounded in rows read and returned, though
+# not in the work the lazy input may still have to do to produce that one row.
+#
+# Anything the probe cannot answer leaves the source unsampled rather than
+# rejected. A query that fails here fails again for the caller at collection,
+# where its own diagnostic is the useful one, and a missing value carries no
+# type in a weakly typed dialect, so it is not evidence of an ineligible
+# source. Warnings are already the staged query's, which was built first.
+probe_share_sources <- function(operation,
+                                result,
+                                requests,
+                                summary_dots) {
+  # The one row is read as if it were a row of the most detailed grouping set.
+  # `grouping_bit()` and `grouping_id()` only ever become integer constants, so
+  # which set that is cannot change a source's type -- but leaving them for a
+  # backend that has no such functions would fail the whole read, and a call
+  # that identifies its Margin levels would lose the check for its measures.
+  probed_dots <- rewrite_grouping_dots(
+    share_source_dots(summary_dots, share_source_names(requests)),
+    plan = operation$plan,
+    grouping_set = operation$plan$dimensions
+  )
+  probe <- tryCatch(
+    suppressMessages(suppressWarnings(
+      dplyr::collect(dplyr::summarize(
+        utils::head(operation$data, n = 1L),
+        !!!probed_dots
+      ))
+    )),
+    error = function(cnd) NULL
+  )
+  if (is.null(probe)) {
+    return(list())
+  }
+  values <- as.list(probe)
+  values <- values[intersect(share_source_names(requests), names(values))]
+  Filter(share_probe_carries_a_type, values)
+}
+
+share_probe_carries_a_type <- function(value) {
+  !(is.logical(value) && all(is.na(value)))
+}
+
+# Only the summaries a share reads. Reading the rest would let a summary no
+# share depends on decide whether the rule runs at all: one expression the
+# backend refuses fails the whole read, and the sources it was never asked
+# about would go unchecked with it.
+#
+# There is nothing to follow past the named source. `validate_share_request()`
+# refuses a source that depends on an earlier summary alias, so a source
+# summary is self-contained and carries no dependency to keep with it.
+#
+# A summary the caller did not name is kept rather than guessed at. Its outputs
+# are the names an `across()` expands to, which the planner resolved and this
+# frame did not, and reading one summary too many costs a column while dropping
+# one costs the source it defines.
+share_source_dots <- function(dots, sources) {
+  dot_names <- names(dots)
+  if (is.null(dot_names)) {
+    dot_names <- rep("", length(dots))
+  }
+  dots[!nzchar(dot_names) | dot_names %in% sources]
 }
 
 apply_joined_shares <- function(result,
@@ -1882,7 +2028,7 @@ apply_joined_shares <- function(result,
   target_ids <- rule$target_ids(plan)
   own_denominator_ids <- plan$set_ids[is.na(target_ids)]
   pairs <- share_pairs(requests)
-  sources <- unique(vapply(pairs, `[[`, character(1), "source"))
+  sources <- share_source_names(requests)
   result_names <- get_col_names(result, dplyr::everything())
   denominator_names <- new_margin_internal_names(
     length(sources),
@@ -2154,6 +2300,12 @@ share_pairs <- function(requests) {
   )
 }
 
+# The source summaries a set of requests reads, each named once however many
+# shares are calculated from it.
+share_source_names <- function(requests) {
+  unique(vapply(share_pairs(requests), `[[`, character(1), "source"))
+}
+
 build_lazy_parent_mapping <- function(result,
                                       child_ids,
                                       parent_ids,
@@ -2222,26 +2374,29 @@ add_lazy_parent_join_keys <- function(result,
   dplyr::mutate(result, !!!join_key_exprs)
 }
 
-check_local_share_types <- function(result, requests, call) {
-  pairs <- share_pairs(requests)
-  checked_sources <- character()
+# `values` is whatever the backend's sampler could say about the source
+# summaries, keyed by source name. A source it does not name went unsampled,
+# which is not a verdict: the rule is what an eligible type is, never how many
+# backends can be asked.
+check_share_source_types <- function(values, requests, call) {
+  sampled <- names(values)
 
-  for (pair in pairs) {
+  for (pair in share_pairs(requests)) {
     source <- pair$source
-    if (source %in% checked_sources) {
+    if (!source %in% sampled) {
       next
     }
-    values <- result[[source]]
-    if (!is_share_source_type(values)) {
-      abort_share_source_type(
-        values,
-        share_output = pair$output,
-        source_summary = source,
-        share_kind = pair$kind,
-        call = call
-      )
+    value <- values[[source]]
+    if (is_share_source_type(value)) {
+      next
     }
-    checked_sources <- c(checked_sources, source)
+    abort_share_source_type(
+      value,
+      share_output = pair$output,
+      source_summary = source,
+      share_kind = pair$kind,
+      call = call
+    )
   }
   invisible(NULL)
 }

--- a/R/share.R
+++ b/R/share.R
@@ -407,14 +407,17 @@
 #' query that stays lazy — nothing else is executed, [dplyr::show_query()]
 #' remains non-executing, and no further query is run to improve an error.
 #'
-#' A source that read of the input cannot type is left alone rather than
-#' rejected. A dialect that types values rather than columns says nothing
-#' about a summary whose one sampled value is missing, and a summary the
-#' database refuses is reported by the database when [dplyr::collect()]
-#' executes the staged query, where its own diagnostic is the useful one.
-#' Cardinality is not read this way at all: a SQL aggregate returns one value
-#' per grouping row by construction, so there is nothing for the sample to
-#' disprove.
+#' A source the read cannot type is left alone rather than rejected. A dialect
+#' that types values rather than columns says nothing about a summary whose
+#' one sampled value is missing, and a summary the database refuses is
+#' reported by the database when [dplyr::collect()] executes the staged
+#' query, where its own diagnostic is the useful one. Cardinality is not read
+#' this way at all: a SQL aggregate returns one value per grouping row by
+#' construction, so there is nothing for the sample to disprove. What the
+#' sample cannot type and every non-scalar summary therefore remain
+#' runtime-only incompatibilities: errors the database reports for itself at
+#' [dplyr::collect()] rather than ones marginplyr raises before returning the
+#' query.
 #'
 #' The portable value guarantee covers finite numbers, missing values, and
 #' zero denominators. Infinite values and backend-specific `NaN`

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -278,10 +278,10 @@
 #' Local data frames reject an ineligible source before any share is
 #' calculated. `dtplyr` steps stay lazy and report the same conditions during
 #' explicit execution, before an invalid grouping row is emitted. General
-#' dbplyr backends are not executed or probed solely to validate an arbitrary
-#' summary result's type or cardinality: statically detectable helper errors
-#' remain targeted before execution, while an incompatible lazy expression may
-#' instead fail with its database error at [dplyr::collect()].
+#' dbplyr backends read the ordinary summaries over one input row and reject
+#' an ineligible source with the same condition; cardinality remains a
+#' local-and-`dtplyr` rule, because a SQL aggregate returns one value per
+#' grouping row by construction.
 #'
 #' [share_of_parent()] is the canonical reference for the complete
 #' direct-expression, source, ordering, value, empty-input, and `across()`
@@ -676,7 +676,8 @@ execute_margin_summary <- function(operation, dots) {
           execute_shares(
             operation,
             staged_result = staged_result,
-            requests = summary_plan$requests
+            requests = summary_plan$requests,
+            summary_dots = dots
           ),
           sort_id = margin_summary_stage_sort_id(staged_result)
         ))

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -224,7 +224,7 @@ plan_summary_expressions <- function(dots,
     selection_proxy = selection_proxy,
     plan = plan,
     set_id_name = set_id_name,
-    validate_cardinality = backend_kind %in% c("local", "dtplyr")
+    validate_cardinality = wraps_share_sources_in_summary(backend_kind)
   )
   summary_plan$dots <- resolve_summary_selections(
     summary_plan$dots,

--- a/design/adr/0002-acquire-typed-metadata-once.md
+++ b/design/adr/0002-acquire-typed-metadata-once.md
@@ -7,3 +7,20 @@ collections remain hidden behind the Margin operation seam so later stages
 cannot issue duplicate metadata queries or observe a different schema. A
 prepared operation belongs to one public verb call and is not cached, reused,
 or returned to users, which bounds the lifetime of that snapshot.
+
+## What this does not govern
+
+This decision is about the schema an operation plans against: one snapshot, so
+that two stages cannot plan against two different schemas. It is not a rule
+that a Margin operation reads a backend exactly once. A Margin label validation
+query already reads values rather than a schema, and so does the bounded type
+sample a contextual share takes of its source summaries
+([ADR 0010](0010-compute-parent-shares-as-a-contextual-summary.md)) on a
+backend that evaluates them in the database.
+
+Neither is a metadata query, and neither can disagree with the snapshot about a
+schema, because neither asks for one. What keeps them admissible is a different
+rule — [ADR 0005](0005-reject-local-errors-before-backend-reads.md): a read may
+happen only after the snapshot and only for something the call cannot be shown
+to be wrong about locally. A read that could be answered by the snapshot
+belongs to the snapshot, and this decision is what says so.

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -425,6 +425,38 @@ relaxation this decision already granted it: no extra schema or cardinality
 query, no implicit collection, and an incompatible type or non-scalar result
 surfacing as a database condition at execution.
 
+## Amendment: the eligible-type rule holds on every backend
+
+The relaxation granted to general dbplyr above was written as a statement
+about cost — no extra query — but it was read by callers as a statement about
+the contract, and it was not one. Because the type rule was reached only from
+the local adapter, which sources a call rejected became a property of the
+dialect: DuckDB raised its own error naming the internal denominator column
+`..marginplyr_share_value_1`, while SQLite silently returned an all-missing
+share column carrying the grand total's own-denominator `1`, which reads as
+100% (#106). Two backends disagreeing about whether a call is valid is not a
+relaxation; it is the absence of a rule.
+
+The eligible-type rule is therefore enforced on every backend, and no backend
+calculates a share from a source shown to be ineligible. A general dbplyr
+backend evaluates the source summary in the database, so the only thing that
+can report its type is a value the database returns: when a share is
+requested, marginplyr collects the planned ordinary summaries over a single
+input row and rejects an ineligible source before returning the query. This
+amends the "no additional query" half of the decision above, deliberately: one
+read bounded in rows requested and returned buys the same rejection everywhere,
+and the alternative was a contract that no two dialects agreed on. The staged
+query itself is still not executed, `show_query()` still runs nothing, and no
+further query is issued to improve an error.
+
+What a read of one row cannot answer, it does not answer. A summary whose
+sampled value is missing carries no type in a dialect that types values rather
+than columns, and a summary the database refuses is left to the database, whose
+own diagnostic at collection is the useful one; neither is treated as evidence
+of an ineligible source. Cardinality is unamended and remains a local and
+dtplyr rule: a SQL aggregate returns one value per grouping row by
+construction, so the sample has nothing to disprove.
+
 ## Considered options
 
 `rollup_share()` was rejected because it names the input structure rather than

--- a/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
+++ b/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
@@ -9,42 +9,70 @@ result, and never by a chain of capability predicates rebuilt at this seam.
 ## Decision
 
 Parent mapping, ratio calculation, and temporary-name cleanup are shared by
-every backend. There are three adapters, and each carries only what its
-backends do differently:
+every backend. Two things vary, so there are two lookups on the same key, and
+each entry carries only what its backends do differently.
+
+How the ratio is joined:
 
 | Adapter | Backend kinds | What it adds to the shared work |
 |---|---|---|
-| Local | `local` | Checks the materialized source types first |
+| Row-matched | `local`, `dtplyr`, `other` | Nothing |
 | General dbplyr | `duckdb`, `postgres`, `sql` | Missing-safe `sql_on` join |
-| Lazy non-SQL | `dtplyr`, `other` | Nothing |
 
-The third adapter adds nothing, and that is the decision rather than an
-accident of implementation. A lazy non-SQL backend joins exactly as local data
-does, and differs from local only in what it cannot do: there is no
-materialized result to type-check, so its source validation has already
-happened inside the ordinary summary. Naming that as its own adapter keeps
-the difference visible at the seam obliged to honour it, and keeps the branch
-where a future lazy non-SQL divergence belongs. Merging it into the local
-adapter would give `dtplyr` a type check it cannot run; merging it into the
-dbplyr adapter would give it a `sql_on` condition it has no connection for.
+Where the eligible-type rule reads the source values it judges:
 
-Arrow is not in the table. A valid Arrow Parent-share request is rejected at
+| Sampler | Backend kinds | Where the source values come from |
+|---|---|---|
+| Materialized | `local` | The staged result; no read |
+| Bounded probe | `duckdb`, `postgres`, `sql`, `other` | One input row |
+| None | `dtplyr` | Nowhere |
+
+The bounded probe reads the summaries a share reads — and only those — over
+one row of the input, so the source comes back with the type the backend gives
+it. The sampler that reads nothing is not missing a source: `dtplyr` carries
+the rule inside its own ordinary summary, where it raises at execution.
+
+Splitting them this way is the decision rather than an accident of
+implementation. Whether a source summary is eligible is a property of that
+summary, not of the join that follows it, so the rule is applied once above
+adapter selection and the adapters never carry it. What is genuinely
+backend-specific is only how the answer becomes readable, and that is a
+different partition of the same kinds: `local` and `dtplyr` join alike but are
+sampled differently, while `other` is sampled like a database but joins like
+local data. Two lookups keep both partitions honest; one lookup would have to
+pick a partition and hide the other inside a branch.
+
+The row-matched adapter adds nothing at all. A lazy non-SQL backend joins
+exactly as local data does, and once the type rule is no longer an adapter's
+work, so does local data itself — merging them removes a difference that no
+contract asks for. Merging either into the dbplyr adapter would give it a
+`sql_on` condition it has no connection for.
+
+`unsampled_share_sources()` asserts `wraps_share_sources_in_summary()` for
+the kind it was reached with, so a kind may only be left unsampled because
+`wrap_share_sources()` put the same rule inside its ordinary summary. That
+assertion is what keeps the sampler table from silently disagreeing with the
+planner about which backends validate themselves.
+
+Arrow is in neither table. A valid Arrow Parent-share request is rejected at
 the executor boundary immediately before ordinary summaries are staged, so no
-Arrow adapter is ever reached. ADR 0005 records why that rejection is
-admissible after the typed metadata snapshot.
+Arrow adapter and no Arrow sampler is ever reached. ADR 0005 records why that
+rejection is admissible after the typed metadata snapshot.
 
-The lookup has no default. An unrecognized backend kind is a marginplyr defect
-rather than something a caller can rewrite their way out of, so it stops with
-a bare `stop()` under ADR 0015 rather than silently falling through to the
-adapter that happens to look plausible.
+Neither lookup has a default. An unrecognized backend kind is a marginplyr
+defect rather than something a caller can rewrite their way out of, so it
+stops with a bare `stop()` under ADR 0015 rather than silently falling through
+to the adapter or sampler that happens to look plausible.
 
 Every adapter has the same signature: the prepared Margin operation, the
 staged result, the planned requests, and the internal Grouping set identifier
-name. Adapters are dispatch targets rather than independent entry points, so
-they receive the operation whole; they read the Grouping plan from it and
-nothing else. `execute_shares()` reads the backend kind and the
-caller-visible Grouping set identifier name and is the only place the
-operation crosses into the module.
+name. Every sampler has one signature too: the operation, the staged result,
+the planned requests, and the planned ordinary summaries. Adapters and
+samplers are dispatch targets rather than independent entry points, so they
+receive the operation whole; the adapters read the Grouping plan from it and
+nothing else, and the samplers read the input it prepared. `execute_shares()`
+reads the backend kind and the caller-visible Grouping set identifier name and
+is the only place the operation crosses into the module.
 
 The seam sits after ordinary Margin summaries are staged and before
 Margin-operation finalization. Placing it there is what lets one adapter set
@@ -63,10 +91,10 @@ to execute, not to what the operation prepared. A DuckDB summary that reached
 the portable `UNION ALL` adapter and a DuckDB summary that used native
 `GROUPING SETS` are the same Parent-share problem and must take the same
 branch; a local tibble collected out of a lazy pipeline by an unrelated step
-would take the local branch and quietly acquire validation the lazy contract
-says it does not have. Reading the prepared kind keeps the branch decision on
-state that was validated once during preparation and cannot drift between the
-two query stages.
+would take the local branch and be sampled as a materialized result the lazy
+contract never promised to produce. Reading the prepared kind keeps the branch
+decision on state that was validated once during preparation and cannot drift
+between the two query stages.
 
 It also keeps the Arrow rejection honest. That rejection is decided from the
 prepared kind before any query is constructed; if adapter selection used the
@@ -88,11 +116,20 @@ backend classification, free to disagree with the first.
 **S3 dispatch on a backend class.** Rejected: it would make the adapter set a
 public extension point by construction, which contradicts keeping one Grouping
 plan and one lifecycle for every backend, and it would put the dispatch table
-in the method registry where the three-way grouping is no longer readable in
+in the method registry where the grouping of kinds is no longer readable in
 one place.
 
 **A separate adapter per backend kind**, mirroring the six kinds one to one.
-Rejected: four of the six would repeat a body that already exists — three SQL
-kinds share one, and `dtplyr` and `other` share another — and the duplication
-would invite them to drift into differences no contract asked for. Backend
-kinds are grouped by what their Parent-share execution actually needs.
+Rejected: most of them would repeat a body that already exists — three SQL
+kinds share one, and `local`, `dtplyr`, and `other` share another — and the
+duplication would invite them to drift into differences no contract asked
+for. Backend kinds are grouped by what their Parent-share execution actually
+needs.
+
+**Keeping the type rule in the adapter that could run it.** Rejected: it was
+reachable only from the local adapter, so which sources were rejected became a
+property of the dialect the caller happened to use — a strict one raised its
+own error naming an internal column, and a permissive one returned an
+all-missing share column with the grand total's own-denominator `1` (#106).
+Eligibility is not adapter-specific, so it is settled above adapter selection
+and each backend contributes only the sample it can produce.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -164,7 +164,11 @@ points, and no other:
   execute; and
 - `execute_shares()`, called by `execute_margin_summary()`, which
   receives the prepared Margin operation, the staged ordinary-summary result,
-  and all planned requests together.
+  all planned requests, and the planned ordinary summaries together. It takes
+  the summaries as well as the result they produced because a backend that
+  evaluates them in the database can only be told their types by a value it
+  returns, which `probe_share_sources()` reads by running them over one input
+  row.
 
 Planning and wrapping are two calls rather than one because the summary
 selections have to be resolved between them: the plan names which summaries a
@@ -187,12 +191,19 @@ The responsibilities divide as follows:
   name-based tidyselect against preceding ordinary summaries only, and checks
   output-name collisions against fixed keys, dimensions, ordinary summaries,
   the Grouping set identifier, and other contextual shares.
-- **Validation** is placed where each backend can prove it. Local and dtplyr
+- **Validation** applies one eligible-type rule to every backend, and only
+  where its source values come from is a backend question.
+  `check_share_source_types()` runs once above adapter selection, over
+  whatever `share_source_sampler()` could sample: the staged result itself
+  when it is materialized, one bounded read of the ordinary summaries over a
+  single input row when the backend evaluates them elsewhere, and nothing for
+  the lazy backends that carry the rule inside the summary. Local and dtplyr
   operations wrap the referenced source summaries in a type-and-cardinality
   validator inside the ordinary summary itself, so validation costs no extra
-  pass over the input and no validation-only query; the local adapter then
-  checks the materialized source types. General dbplyr keeps the documented
-  relaxation and issues no probe. Arrow is rejected before any of this.
+  pass over the input and no validation-only query, and cardinality stays
+  theirs alone — a SQL aggregate returns one value per grouping row by
+  construction. A sample that answers nothing rejects nothing. Arrow is
+  rejected before any of this.
 - **Mapping** is the one responsibility a kind supplies for itself, through
   `share_denominator_rule()`: which occurrence each row's denominator comes
   from, and the denominator rows with the columns they are matched on. A
@@ -289,18 +300,21 @@ Direct field reads are confined to:
 - the Margin operation module, for validation and finalization;
 - the three dedicated verb executors, for their schema-aware preflight and
   calls into low-level adapters;
-- `execute_shares()`, which reads the prepared backend kind to select
-  an adapter and the caller-visible Grouping set identifier name to restore
-  it after the join; and
-- the three contextual-share adapters, which read the Grouping plan and
+- `execute_shares()`, which reads the prepared backend kind to select an
+  adapter and a source sampler, and the caller-visible Grouping set identifier
+  name to restore it after the join;
+- the contextual-share source samplers, which read the input the operation
+  prepared and, for the one that asserts it may sample nothing, the backend
+  kind; and
+- the two contextual-share adapters, which read the Grouping plan and
   nothing else.
 
 The native and portable Grouping adapters receive the specific derived values
-they need, not the Margin operation itself. The contextual-share adapters take
-it whole because they are dispatch targets of one signature rather than
-independent entry points. This boundary lets the operation, Grouping plan, and
-backend representations change without spreading field access through public
-verbs or adapters.
+they need, not the Margin operation itself. The contextual-share adapters and
+samplers take it whole because they are dispatch targets of one signature
+rather than independent entry points. This boundary lets the operation,
+Grouping plan, and backend representations change without spreading field
+access through public verbs or adapters.
 
 ## Test seams
 
@@ -418,10 +432,16 @@ A backend change should:
    executor;
 3. reuse the existing portable adapter unless native `GROUPING SETS` support
    is confirmed and covered by the native adapter contract;
-4. name the new backend kind in `share_adapter()`, choosing one of the three
-   existing contextual-share adapters or adding a fourth. The lookup has no
-   default: an unnamed kind stops the operation rather than falling through to
-   a plausible-looking join;
+4. name the new backend kind in `share_adapter()` and in
+   `share_source_sampler()`, choosing one of the existing contextual-share
+   adapters and one of the existing source samplers, or adding one. Neither
+   lookup has a default: an unnamed kind stops the operation rather than
+   falling through to a plausible-looking join. Answer
+   `wraps_share_sources_in_summary()` for it as well — it is the third
+   kind-keyed decision and the only one that cannot stop, since a kind it
+   answers `FALSE` for is simply a kind whose ordinary summaries do not
+   evaluate R code and therefore cannot carry the cardinality rule inside
+   themselves;
 5. keep label rules, factor restoration, summary selection, and finalization
    in their owning modules rather than duplicating them in the adapter;
 6. add contract coverage for metadata acquisition, observable results,

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -788,6 +788,44 @@ it.
 
 ---
 
+## 9. Dispositions reversed by #106
+
+Two entries above were dispositioned on a premise that a later bug disproved.
+They are not amended in place — they were correct about the evidence available
+when they were written — but a reader who reaches them now needs to arrive at
+this section.
+
+**"General dbplyr must stay lazy with no validation-only probe" (§1, #30) is
+reversed.** The relaxation it recorded was stated as a cost — no extra query —
+and was read as a contract. It was not one: because the eligible-type rule was
+reached only from the local adapter, which sources a call rejected became a
+property of the dialect. DuckDB raised its own error naming the internal
+`..marginplyr_share_value_1`; SQLite returned an all-missing share column
+carrying the grand total's own-denominator `1`, which reads as 100% (#106).
+Two dialects disagreeing about whether a call is valid is the absence of a
+rule, not a relaxation of one. A general dbplyr backend now reads the summaries
+a share reads over one input row and rejects an ineligible source before
+returning the query. *Evidence:* `test-share-backends.R` "RSQLite rejects an
+ineligible share source like the local backend" and "DuckDB rejects an
+ineligible share source like the local backend", both comparing the condition
+message against the local one; ADR 0010's second amendment records the
+reasoning, and ADR 0002 records why a value read is not the typed snapshot.
+
+**"The emptiness of the third adapter is the contract" (§7, #39) no longer
+holds.** That rejection rested on one difference: the local adapter ran the
+type check and a lazy non-SQL adapter could not. With the rule settled above
+adapter selection, the two bodies are the same function, and the merge that
+was refused as a line-count change is now behaviour-preserving. The
+one-adapter-per-kind rejection it defended stands unchanged. *Evidence:*
+`git show HEAD:R/share.R` shows `execute_local_shares()` and
+`execute_non_sql_shares()` with byte-identical bodies once the check moves out;
+the contracts it named — "dtplyr validates Parent-share source types during
+collection" and "dtplyr integer and double Parent shares match local results" —
+still pass, because `share_source_sampler()` now carries the difference the
+adapter used to.
+
+---
+
 ## Status
 
 Every observation from every recorded review is dispositioned above. The

--- a/investigation/share-source-schema-vs-data-read.md
+++ b/investigation/share-source-schema-vs-data-read.md
@@ -1,0 +1,182 @@
+# Schema reads vs. data reads for share-source typing
+
+Investigated: 2026-08-08
+
+This note follows up on `git show e08c3fa` (the one-row `probe_share_sources()`
+read) and the handoff that reopened it. The open question was whether some
+form of *schema* read — one that does not fetch a data row — can answer the
+same question the one-row probe answers: the type a backend will give a share
+source's summary expression (`max(region)`, `sum(x)`, `n()`, …). Tested against
+in-memory RSQLite 3.53.3 (via RSQLite) and DuckDB 1.5.5 (via the `duckdb`
+package, both current in the environment), DBI 1.3.0, dbplyr 2.6.0. Scripts
+referenced below are throwaway and not committed; the commands to reproduce
+each result are quoted inline.
+
+## What was run
+
+### 1. `DBI::dbSendQuery()` + `DBI::dbColumnInfo()`, never calling `dbFetch()`
+
+Against the rendered SQL for `tb |> group_by(region) |> summarise(lab =
+max(region), tot = sum(amt), cnt = n(), flag = any(amt > 1))` on a 3-row
+table with an `NA` in `amt`:
+
+```r
+res <- DBI::dbSendQuery(con, as.character(sql))
+info <- DBI::dbColumnInfo(res)   # no dbFetch() call anywhere
+DBI::dbClearResult(res)
+```
+
+On RSQLite this returned real, non-`NA`-carrying types for every computed
+column: `lab` character, `tot` double, `cnt` integer, `flag` integer. That
+looked like the schema-only answer the handoff's "unverified lead" hoped for.
+
+It is not one. Two further measurements against a 3,000,000-row table
+(`SELECT SUM(x) AS tot, COUNT(*) AS cnt FROM big`) show why:
+
+```r
+system.time({ res <- dbSendQuery(con, big_q); dbFetch(res, n = -1); dbClearResult(res) })
+#>    user  system elapsed
+#>   0.054   0.005   0.058
+system.time({ res <- dbSendQuery(con, big_q); dbColumnInfo(res); dbClearResult(res) })
+#>    user  system elapsed
+#>   0.048   0.004   0.052
+system.time({ res <- dbSendQuery(con, big_q); dbClearResult(res) })   # neither call
+#>    user  system elapsed
+#>   0.047   0.004   0.052
+```
+
+`dbSendQuery()` alone — before `dbColumnInfo()` or `dbFetch()` is ever called —
+already costs the same as fetching the full result. RSQLite's `dbSendQuery()`
+executes the statement to completion and buffers the result immediately; nothing
+about it is deferred until `dbFetch()`. `dbColumnInfo()` just reads metadata off
+that already-materialized buffer.
+
+A row-consumption check confirms the buffer is intact and complete, not merely
+that timing looks similar:
+
+```r
+res <- dbSendQuery(con, "SELECT region, SUM(amt) AS tot FROM t GROUP BY region")
+info <- dbColumnInfo(res)               # queried first
+rows <- dbFetch(res, n = -1)             # then fetched from the same handle
+nrow(rows)   # 2 — both groups, values unchanged from a fresh, untouched fetch
+```
+
+Calling `dbColumnInfo()` first does not shrink, consume, or alter what
+`dbFetch()` later returns. The two calls read the same fully-computed result;
+`dbColumnInfo()` is a data read that happens not to be exposed to the caller as
+row values, not a schema-only operation.
+
+### 2. The same call, wrapped so the query truly cannot compute a row
+
+```r
+sql0 <- paste0("SELECT * FROM (", as.character(sql), ") AS q_ LIMIT 0")
+res0 <- dbSendQuery(con, sql0)
+info0 <- dbColumnInfo(res0)
+dbClearResult(res0)
+```
+
+Against the 3,000,000-row table this timed at 0 elapsed seconds — genuinely
+deferred, nothing computed. But every computed column reported `type =
+"logical"`: `tot`, `cnt`, `lab`, `flag` all lost their real type, while the
+passthrough column (`region`, a declared base-table column) kept `character`.
+This is the same emptiness the handoff already measured for
+`collect(head(<query>, 0))` (`investigation` handoff, fact 3), reproduced here
+one layer lower, at the DBI `dbColumnInfo()` call instead of dbplyr's
+`collect()`. Re-running `collect(head(q, 0))` directly in this session
+reproduced the identical result: every computed column `<lgl>`, `NA` typed.
+
+SQLite assigns a value's type when the value is computed, not when the column
+is declared (this is `sqlite3_column_type()` semantics, and it is the reason a
+declared base-table column keeps its type while an expression does not: the
+declared column has *static* type affinity from the `CREATE TABLE` statement,
+which is available in the schema without evaluating anything, while an
+expression's result type has no such static record). A `LIMIT 0` prevents any
+row from ever being computed, and there is no such thing on this dialect as a
+type of a row that was never computed.
+
+### 3. `dbplyr::db_query_fields()` / `dbplyr:::dbplyr_query_fields()`
+
+`db_query_fields()` is not exported from the installed dbplyr (2.6.0):
+
+```
+Error: 'db_query_fields' is not an exported object from 'namespace:dbplyr'
+```
+
+The current internal equivalent is `dbplyr:::dbplyr_query_fields()`. Its
+source, read directly from the installed namespace:
+
+```r
+function (con, sql, ...) {
+    check_2ed(con)
+    sql <- sql_query_fields(con, sql, ...)
+    df <- db_get_query(con, sql, "Can't query fields.")
+    names(df)
+}
+```
+
+and `sql_query_fields.DBIConnection` (the method dispatched to for both
+RSQLite and DuckDB connections, since neither defines its own):
+
+```r
+function (con, sql, ...) {
+    sql <- as_table_source(sql, con)
+    sql_query_select(con, sql("*"), dbplyr_sql_subquery(con, sql),
+      where = sql("0 = 1"))
+}
+```
+
+It is exactly a `WHERE 0 = 1` subquery — the same construct as fact 2 above —
+and the outer function discards whatever type information `db_get_query()`
+might carry, keeping only `names(df)`. Running it directly confirmed both
+halves of that reading:
+
+```r
+dbplyr:::dbplyr_query_fields(con, sql)
+#> [1] "region" "tot"    "cnt"
+```
+
+No types at all, by construction — not merely typeless on SQLite the way
+`WHERE 0=1` is elsewhere. This function cannot answer the type question on any
+dialect; it was never designed to.
+
+### 4. DuckDB, all of the above
+
+Every method above — raw `dbColumnInfo()`, `LIMIT 0`-wrapped `dbColumnInfo()`,
+and `collect(head(q, 0))` — reported correct computed types on DuckDB with
+zero rows: `tot` numeric, `cnt` numeric, `flag` logical, `lab` character. This
+reconfirms the prior session's fact 6 (DuckDB types columns, not values) and
+extends it to `dbColumnInfo()` specifically, which had not been tried before.
+DuckDB needs none of the above investigation to get a genuine, zero-row,
+zero-cost schema read — it already has one through the existing
+`collect(head(x, 0))` route.
+
+## What this establishes
+
+On RSQLite — the dialect that reproduces #106, and the representative
+available for the generic `"sql"` backend kind, which covers every dbplyr
+connection that is neither DuckDB nor Postgres — no method tried reports a
+computed expression's real type without the backend fully computing at least
+one row:
+
+- `DBI::dbColumnInfo()` without `dbFetch()` *looks* like a schema-only read
+  but is not one: RSQLite executes and buffers the whole result inside
+  `dbSendQuery()` itself, before `dbColumnInfo()` or `dbFetch()` are ever
+  called. Measured cost is identical whether or not `dbFetch()` follows.
+- The only way measured to make RSQLite skip that computation (`LIMIT 0`,
+  at either the dbplyr or the raw-DBI layer) also makes every computed
+  column typeless (`logical`, `NA`). This is not an implementation gap;
+  SQLite types values, not columns, and a `LIMIT 0` query computes no value.
+- `dbplyr`'s own field-introspection entry point discards type information
+  by construction and is itself built on `WHERE 0=1`, so it inherits both
+  problems and adds a third (no types returned at all, ever).
+
+DuckDB has no such problem on any method tried, because it types columns
+rather than values and therefore answers a zero-row query correctly. Its
+existing `can_read_schema`/`collect_selection_proxy` route already gets this
+for free today.
+
+The tradeoff on RSQLite is exact, not approximate: a query can be made to
+return zero rows (cheap, no data computed, no data read by any reasonable
+reading of that phrase) or it can be made to report real computed-expression
+types (only by computing — and, on the methods tried, fully materializing —
+at least one row). No measured method gets both on this dialect.

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -427,14 +427,17 @@ work the input may have to do to produce that one row. It is the staged
 query that stays lazy — nothing else is executed, \code{\link[dplyr:show_query]{dplyr::show_query()}}
 remains non-executing, and no further query is run to improve an error.
 
-A source that read of the input cannot type is left alone rather than
-rejected. A dialect that types values rather than columns says nothing
-about a summary whose one sampled value is missing, and a summary the
-database refuses is reported by the database when \code{\link[dplyr:collect]{dplyr::collect()}}
-executes the staged query, where its own diagnostic is the useful one.
-Cardinality is not read this way at all: a SQL aggregate returns one value
-per grouping row by construction, so there is nothing for the sample to
-disprove.
+A source the read cannot type is left alone rather than rejected. A dialect
+that types values rather than columns says nothing about a summary whose
+one sampled value is missing, and a summary the database refuses is
+reported by the database when \code{\link[dplyr:collect]{dplyr::collect()}} executes the staged
+query, where its own diagnostic is the useful one. Cardinality is not read
+this way at all: a SQL aggregate returns one value per grouping row by
+construction, so there is nothing for the sample to disprove. What the
+sample cannot type and every non-scalar summary therefore remain
+runtime-only incompatibilities: errors the database reports for itself at
+\code{\link[dplyr:collect]{dplyr::collect()}} rather than ones marginplyr raises before returning the
+query.
 
 The portable value guarantee covers finite numbers, missing values, and
 zero denominators. Infinite values and backend-specific \code{NaN}

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -393,14 +393,16 @@ kind, shared by every measure requested of that kind, however many measures
 are requested.
 
 Syntax, source-name, written-order, and \code{across()} errors are always
-reported locally, before execution, on every backend. Only the \emph{result}
-rules — eligible numeric type and exactly-one-value cardinality — depend on
-what the backend can prove:\tabular{ll}{
+reported locally, before execution, on every backend. The eligible-type
+rule is also enforced on every backend, and no backend calculates a share
+from a source it has shown to be ineligible. What differs is when the
+source's type becomes readable, and whether the exactly-one-value
+cardinality rule can be read with it:\tabular{ll}{
    Backend \tab Where source type and cardinality are checked \cr
    Local data frame \tab Before any share is calculated \cr
    \code{dtplyr} step \tab At explicit execution, before an invalid row is emitted \cr
    Arrow \tab Not reached; shares are rejected outright \cr
-   General dbplyr \tab Not by marginplyr; the database may error at collection \cr
+   General dbplyr \tab Type only, from one input row, before the query returns \cr
 }
 
 
@@ -416,20 +418,29 @@ added and nothing is collected on your behalf. Its execution-time
 diagnostics keep the share's output name, the source summary name, and
 the original public call, so they read like the local ones.
 
-General dbplyr backends are not queried solely to discover an arbitrary
-summary result's type or cardinality. Statically detectable syntax and
-dependency errors remain local, while an incompatible lazy summary may
-report its backend error when \code{\link[dplyr:collect]{dplyr::collect()}} executes the staged query.
+A general dbplyr backend evaluates the source summary in the database, so
+its type is readable only from a value the database returns. marginplyr
+reads one: when a share is requested, it collects the ordinary summaries
+over a single input row and rejects an ineligible source before returning
+the query. The read is bounded in rows requested and returned, not in the
+work the input may have to do to produce that one row. It is the staged
+query that stays lazy — nothing else is executed, \code{\link[dplyr:show_query]{dplyr::show_query()}}
+remains non-executing, and no further query is run to improve an error.
+
+A source that read of the input cannot type is left alone rather than
+rejected. A dialect that types values rather than columns says nothing
+about a summary whose one sampled value is missing, and a summary the
+database refuses is reported by the database when \code{\link[dplyr:collect]{dplyr::collect()}}
+executes the staged query, where its own diagnostic is the useful one.
+Cardinality is not read this way at all: a SQL aggregate returns one value
+per grouping row by construction, so there is nothing for the sample to
+disprove.
+
 The portable value guarantee covers finite numbers, missing values, and
 zero denominators. Infinite values and backend-specific \code{NaN}
 representations are outside that guarantee because supported SQL dialects
 do not share one portable finite-value predicate. Normalize potentially
 non-finite summaries explicitly with operations supported by the backend.
-
-marginplyr does not run a schema query, execute the staged query, or collect
-it solely to improve type or cardinality errors. This preserves laziness and
-makes \code{\link[dplyr:show_query]{dplyr::show_query()}} non-executing; runtime-only incompatibilities
-remain errors at the backend execution boundary.
 }
 
 \examples{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -331,10 +331,10 @@ metadata before returning the requested column order.
 Local data frames reject an ineligible source before any share is
 calculated. \code{dtplyr} steps stay lazy and report the same conditions during
 explicit execution, before an invalid grouping row is emitted. General
-dbplyr backends are not executed or probed solely to validate an arbitrary
-summary result's type or cardinality: statically detectable helper errors
-remain targeted before execution, while an incompatible lazy expression may
-instead fail with its database error at \code{\link[dplyr:collect]{dplyr::collect()}}.
+dbplyr backends read the ordinary summaries over one input row and reject
+an ineligible source with the same condition; cardinality remains a
+local-and-\code{dtplyr} rule, because a SQL aggregate returns one value per
+grouping row by construction.
 
 \code{\link[=share_of_parent]{share_of_parent()}} is the canonical reference for the complete
 direct-expression, source, ordering, value, empty-input, and \code{across()}

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -630,7 +630,12 @@ test_that("PostgreSQL renders one staged Parent-share mapping for all measures",
   expect_match(many_sql, "CAST(", fixed = TRUE)
 })
 
-test_that("general dbplyr leaves incompatible summary types to execution", {
+# This connection cannot collect at all, so it stands for a backend the type
+# sample learns nothing from: the read fails, the source goes unsampled, and
+# the staged query is returned for the caller to execute. The counters are
+# what hold the rest of the contract — nothing asks this connection for the
+# staged query's fields, its row count, or its results.
+test_that("general dbplyr leaves a source it cannot sample to execution", {
   remote <- new_parent_lazy_probe(
     data.frame(group = "x", label = "value")
   )
@@ -878,6 +883,243 @@ test_that("RSQLite Parent shares preserve runtime backend conditions", {
   expect_identical(class(error), class(baseline))
   expect_identical(class(error$parent), class(baseline$parent))
   expect_false(inherits(error, "marginplyr_error"))
+})
+
+# The reproduction from #106. A weakly typed dialect used to answer it with an
+# all-missing share column plus the grand total's own-denominator `1`, because
+# the eligible-type rule was reached only from the local adapter. Comparing the
+# condition against the local one is what makes "the same rejection" checkable
+# without a second backend in this test.
+test_that("RSQLite rejects an ineligible share source like the local backend", {
+  skip_if_backend_absent("RSQLite", "DBI")
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    store = c("s1", "s2", "s3"),
+    revenue = c(1, 3, 2)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_source_type_sqlite_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source) {
+    summarize_with_margins(
+      source,
+      lab = max(region),
+      p = share_of_parent(lab),
+      .grouping = rollup(region, store)
+    )
+  }
+
+  local_error <- expect_error(summarize(data), "plain integer or double scalar")
+  remote_error <- expect_error(
+    summarize(remote),
+    "plain integer or double scalar"
+  )
+
+  expect_s3_class(remote_error, "marginplyr_error")
+  expect_identical(
+    conditionMessage(remote_error),
+    conditionMessage(local_error)
+  )
+  expect_identical(remote_error$share_output, "p")
+  expect_identical(remote_error$source_summary, "lab")
+  expect_identical(
+    rlang::call_name(conditionCall(remote_error)),
+    "summarize_with_margins"
+  )
+  # The internal denominator and match columns are marginplyr's own names for
+  # temporaries the caller never wrote and cannot act on.
+  expect_false(grepl(
+    "..marginplyr",
+    conditionMessage(remote_error),
+    fixed = TRUE
+  ))
+})
+
+test_that("RSQLite rejects an ineligible source beside a Margin level", {
+  skip_if_backend_absent("RSQLite", "DBI")
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data.frame(
+      region = c("E", "E", "W"),
+      store = c("s1", "s2", "s3"),
+      revenue = c(1, 3, 2)
+    ),
+    "share_source_level_sqlite_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+
+  # `grouping_bit()` and `grouping_id()` are marginplyr's own summary-context
+  # helpers, so the backend has no such functions and the read that types the
+  # source summaries would fail on them as a whole. A call that identifies its
+  # Margin levels must not lose the rule for its measures.
+  error <- expect_error(
+    summarize_with_margins(
+      remote,
+      level = grouping_id(region, store),
+      bit = grouping_bit(store),
+      lab = max(region),
+      p = share_of_parent(lab),
+      .grouping = rollup(region, store)
+    ),
+    "plain integer or double scalar"
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(error$source_summary, "lab")
+})
+
+test_that("RSQLite types a share source past an unrelated failing summary", {
+  skip_if_backend_absent("RSQLite", "DBI")
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data.frame(
+      region = c("E", "E", "W"),
+      store = c("s1", "s2", "s3"),
+      revenue = c(1, 3, 2)
+    ),
+    "share_source_scope_sqlite_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+
+  # A summary no share reads must not decide whether the rule runs. Reading it
+  # too would fail the whole read on this expression the backend refuses, and
+  # the source it was never asked about would go unchecked with it.
+  error <- expect_error(
+    summarize_with_margins(
+      remote,
+      unrelated = no_such_aggregate(revenue),
+      lab = max(region),
+      p = share_of_parent(lab),
+      .grouping = rollup(region, store)
+    ),
+    "plain integer or double scalar"
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(error$source_summary, "lab")
+})
+
+test_that("RSQLite keeps eligible share sources working after the probe", {
+  skip_if_backend_absent("RSQLite", "DBI")
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  data <- data.frame(
+    group = c("x", "x", "y"),
+    revenue = c(1, 3, 2),
+    units = c(1L, 3L, 0L),
+    # The first input row is missing, so a weakly typed dialect answers the
+    # type probe with a value carrying no type at all. That is not evidence of
+    # an ineligible source, and rejecting on it would break a working call.
+    sparse = c(NA_real_, 4, 5)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_source_probe_sqlite_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source) {
+    summarize_with_margins(
+      source,
+      revenue_total = sum(revenue),
+      units_total = sum(units),
+      sparse_total = sum(sparse, na.rm = TRUE),
+      revenue_share = share_of_parent(revenue_total),
+      units_share = share_of_total(units_total),
+      sparse_share = share_of_parent(sparse_total),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    ) |>
+      dplyr::arrange(is.na(group), group)
+  }
+
+  expected <- summarize(data)
+  query <- summarize(remote)
+
+  expect_s3_class(query, "tbl_lazy")
+  expect_equal(
+    as.data.frame(dplyr::collect(query)),
+    as.data.frame(expected)
+  )
+})
+
+test_that("a lazy backend that answers nothing keeps its share source", {
+  skip_if_no_sqlite_simulation()
+  # A simulated connection executes no query, so the type probe learns nothing
+  # and the call must stay lazy rather than reject a source it cannot read.
+  remote <- dbplyr::tbl_lazy(
+    data.frame(group = c("x", "y"), value = 1:2),
+    con = dbplyr::simulate_sqlite()
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    total = sum(value),
+    share = share_of_parent(total),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  )
+
+  expect_s3_class(query, "tbl_lazy")
+  expect_match(dbplyr::sql_render(query), "UNION ALL", fixed = TRUE)
+})
+
+test_that("DuckDB rejects an ineligible share source like the local backend", {
+  skip_if_backend_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    store = c("s1", "s2", "s3"),
+    revenue = c(1, 3, 2)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_source_type_duckdb_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source) {
+    summarize_with_margins(
+      source,
+      lab = max(region),
+      p = share_of_total(lab),
+      .grouping = rollup(region, store)
+    )
+  }
+
+  local_error <- expect_error(summarize(data), "plain integer or double scalar")
+  remote_error <- expect_error(
+    summarize(remote),
+    "plain integer or double scalar"
+  )
+
+  expect_s3_class(remote_error, "marginplyr_error")
+  expect_identical(
+    conditionMessage(remote_error),
+    conditionMessage(local_error)
+  )
+  expect_identical(remote_error$share_output, "p")
+  expect_identical(remote_error$source_summary, "lab")
+  # The backend used to raise its own error here, naming the internal
+  # denominator column the join reserved.
+  expect_false(grepl(
+    "..marginplyr",
+    conditionMessage(remote_error),
+    fixed = TRUE
+  ))
 })
 
 test_that("DuckDB Parent shares agree across native, portable, and local paths", { # nolint: line_length_linter

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -748,8 +748,13 @@ test_that("Parent-share sources are numeric scalar summaries", {
   )
 })
 
-test_that("the local eligible-type check raises the shared diagnostic", {
+test_that("the sampled eligible-type check raises the shared diagnostic", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
+  requests <- list(list(
+    outputs = "share",
+    sources = "total",
+    kind = "parent"
+  ))
 
   wrapped_error <- expect_error(
     summarize_with_margins(
@@ -761,34 +766,37 @@ test_that("the local eligible-type check raises the shared diagnostic", {
     "plain integer or double scalar"
   )
 
-  # The local backend re-checks the collected result, so the same diagnostic
-  # has a second raising site. It is called directly here because the wrapped
-  # summary check reaches every ineligible type first from a public call, and
-  # a second copy of the message is exactly what drifted before.
-  local_error <- expect_error(
-    check_local_share_types(
+  # Every backend checks its sampled source types, so the same diagnostic has a
+  # second raising site. It is called directly here because the wrapped summary
+  # check reaches every ineligible type first from a public call, and a second
+  # copy of the message is exactly what drifted before.
+  sampled_error <- expect_error(
+    check_share_source_types(
       data.frame(group = "x", total = TRUE),
-      requests = list(list(
-        outputs = "share",
-        sources = "total",
-        kind = "parent"
-      )),
+      requests = requests,
       call = rlang::call2("summarize_with_margins")
     ),
     "plain integer or double scalar"
   )
 
   expect_identical(
-    conditionMessage(local_error),
+    conditionMessage(sampled_error),
     conditionMessage(wrapped_error)
   )
-  expect_s3_class(local_error, "marginplyr_error")
-  expect_identical(local_error$share_output, "share")
-  expect_identical(local_error$source_summary, "total")
+  expect_s3_class(sampled_error, "marginplyr_error")
+  expect_identical(sampled_error$share_output, "share")
+  expect_identical(sampled_error$source_summary, "total")
   expect_identical(
-    rlang::call_name(conditionCall(local_error)),
+    rlang::call_name(conditionCall(sampled_error)),
     "summarize_with_margins"
   )
+
+  # A source the backend could not sample is not a source it disproved.
+  expect_null(check_share_source_types(
+    list(other = "x"),
+    requests = requests,
+    call = rlang::call2("summarize_with_margins")
+  ))
 })
 
 test_that("cardinality errors identify the affected Parent-share request", {

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -283,11 +283,16 @@ postgres_sales |>
 ```
 
 Syntax, source-name, written-order, and `across()` errors are validated before
-execution. General dbplyr backends do not expose every arbitrary aggregate's
-result type or cardinality from metadata, and marginplyr does not run an extra
-schema query or collect the result to discover them. A runtime-only type or
-cardinality incompatibility can therefore surface from the database when the
-staged query executes.
+execution. A share source must still be a plain integer or double, and that
+rule holds here too. A general dbplyr backend exposes no metadata for an
+arbitrary aggregate's result type, so marginplyr reads the summaries a share
+reads over a single input row and rejects an ineligible source before
+returning the query. That read is bounded in the rows it asks for and gets
+back, not in the work the input may have to do to produce one row — the staged
+query above is still not executed, and `show_query()` runs nothing. A source
+the sample cannot type is left alone rather than rejected, so a runtime-only
+incompatibility, and any non-scalar summary, can still surface from the
+database when the staged query executes.
 
 The portable value contract covers finite numbers, missing values, and zero
 denominators. Backend-specific non-finite representations are outside that


### PR DESCRIPTION
Closes #106.

## Fix

`check_local_share_types()` was reached only from the local adapter, so which share sources a call rejected was a property of the dialect rather than of the rule: DuckDB raised its own error naming the internal `..marginplyr_share_value_1`, SQLite silently returned an all-missing share column carrying the grand total's own-denominator `1`.

The eligible-type rule now runs once, above adapter selection, over whatever `share_source_sampler()` can sample for the prepared backend kind: the staged result where it's already materialized (`local`), nothing where the rule already lives inside the ordinary summary (`dtplyr`), and otherwise one bounded read of just the summaries a share reads, over a single input row (`duckdb`, `postgres`, `sql`, `other`) — a zero-row read cannot answer this on a dialect that types values rather than columns (SQLite), so the read has to return one row. What a read can't answer (a NULL sample, a query the backend refuses) is left alone rather than rejected.

This amends the "no additional query" half of ADR-0010's relaxation for general dbplyr, and reverses ADR-0014's rejection of merging the local and lazy non-SQL adapters — that rejection rested on a type check `dtplyr` couldn't run, and with the check moved out the two adapter bodies are identical. Both reversals are recorded in `design/review-dispositions.md` §9 against the entries they overturn, rather than silently edited in place.

## Follow-up investigation

A second commit records a negative result from chasing a schema-only replacement for the one-row read (requested after the fix landed): on RSQLite, every method tried (`DBI::dbColumnInfo()` without `dbFetch()`, a `LIMIT 0` wrapper, `dbplyr:::dbplyr_query_fields()`) either fully computes the result before reporting anything, or returns every computed column as typeless. SQLite assigns a value's type when it's computed, not when a column is declared, so a query that computes zero rows has no type to report for an expression column. DuckDB has no such problem on any method tried. No decision follows from the note — it's evidence, per `AGENTS.md`'s investigation conventions — but it means a schema-only design would leave the backend that motivated #106 uncovered.

## Verification

- `lintr::lint_package()` clean (after `pkgload::load_all()`, per `AGENTS.md`)
- `roxygen2::roxygenise()` regenerated and committed
- `spelling::spell_check_package()` clean
- Full `testthat` suite green under `NOT_CRAN=true`
- `Rscript .github/scripts/verify-suite-coverage.R`: all 361 tests execute in at least one single-backend configuration
- `R CMD check` on a built tarball: `Status: OK`
