### PR TITLE
Number an unnamed `across()` argument by its own position

### DIFF
--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -664,8 +664,21 @@ known_across_function_names <- function(parsed) {
   if (is.null(fns_names)) {
     fns_names <- rep("", length(fns))
   }
-  fns_names[fns_names == ""] <- as.character(which(fns_names == ""))
-  fns_names
+  name_unnamed_by_position(fns_names, "")
+}
+
+# Both callers name the unnamed entries of an argument list by position, which
+# is how dplyr refers to them: an argument forwarded through `across()`'s `...`
+# is `..n`, and an unnamed `.fns` list entry takes its index. The replacement
+# has to be indexed by the same positions that select it. Building it over the
+# whole list instead makes the two sides differ in length whenever any entry is
+# named, so base R recycles -- warning from a call that otherwise succeeds --
+# and numbers the survivors by their position among the unnamed entries rather
+# than among all of them (#104).
+name_unnamed_by_position <- function(arg_names, prefix) {
+  unnamed <- which(arg_names == "")
+  arg_names[unnamed] <- paste0(prefix, unnamed)
+  arg_names
 }
 
 parse_across_arguments <- function(expr) {
@@ -690,11 +703,7 @@ parse_across_arguments <- function(expr) {
   unpack_index <- match(".unpack", arg_names, nomatch = 0L)
   used <- c(cols_index, fns_index, names_index, unpack_index)
   additional <- setdiff(seq_along(call_args), used[used > 0L])
-  additional_names <- arg_names[additional]
-  additional_names[additional_names == ""] <- paste0(
-    "..",
-    seq_along(additional_names)
-  )
+  additional_names <- name_unnamed_by_position(arg_names[additional], "..")
 
   list(
     call_args = call_args,

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -352,6 +352,103 @@ test_that("an `across()` `.names` template must name one output per column", {
   )
 })
 
+test_that("an unnamed `across()` argument is numbered by its own position", {
+  # The placeholder names the analysis gives the unnamed additional arguments
+  # of an `across()` call are only ever read back in a diagnostic, so a wrong
+  # one is invisible until something quotes it. Building them over *every*
+  # additional argument while assigning to the unnamed ones is visible sooner
+  # than that: the two sides differ in length whenever any additional argument
+  # is named, so base R recycles and warns from a call that otherwise
+  # succeeds, once per grouping-set branch (#104).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+
+  # Only untyped warnings are collected. Passing an argument through
+  # `across()`'s `...` at all is deprecated by dplyr, which warns for its own
+  # reasons from the same call; that warning is dplyr's to raise, carries its
+  # own class, and is untouched by this fix, whereas a bare `simpleWarning`
+  # here can only have come from the analysis.
+  untyped_warnings <- character()
+  withCallingHandlers(
+    summarize_with_margins(
+      data,
+      dplyr::across(c(units, revenue), sum, na.rm = TRUE, TRUE),
+      .grouping = rollup(region)
+    ),
+    warning = function(cnd) {
+      if (inherits(cnd, "simpleWarning")) {
+        untyped_warnings <<- c(untyped_warnings, conditionMessage(cnd))
+      }
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_identical(untyped_warnings, character())
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(revenue),
+      dplyr::across(
+        c(total),
+        share_of_total,
+        .names = "{.col}_s",
+        na.rm = TRUE,
+        TRUE
+      ),
+      .grouping = rollup(region)
+    ),
+    "does not accept additional function arguments"
+  )
+  # dplyr names an argument passed on to the function by its position among
+  # those arguments, so the unnamed one here -- second of the two -- is `..2`.
+  expect_match(conditionMessage(error), "`na.rm`, `..2`", fixed = TRUE)
+})
+
+test_that("`across()` argument numbering holds without a mix of names", {
+  # The two ends of the same rule: with no named argument the ordinals are
+  # already what a sequence over everything would produce, and with no unnamed
+  # one there is nothing to number. Neither reaches the subassignment that
+  # #104 was about, so both must keep behaving as they did.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    revenue = c(2, 4, 8)
+  )
+  base_call <- function(...) {
+    summarize_with_margins(
+      data,
+      total = sum(revenue),
+      ...,
+      .grouping = rollup(region)
+    )
+  }
+
+  all_unnamed <- expect_error(
+    base_call(dplyr::across(
+      c(total),
+      share_of_total,
+      .names = "{.col}_s",
+      TRUE,
+      TRUE
+    )),
+    "does not accept additional function arguments"
+  )
+  expect_match(conditionMessage(all_unnamed), "`..1`, `..2`", fixed = TRUE)
+
+  all_named <- expect_error(
+    base_call(dplyr::across(
+      c(total),
+      share_of_total,
+      .names = "{.col}_s",
+      na.rm = TRUE
+    )),
+    "does not accept additional function arguments"
+  )
+  expect_match(conditionMessage(all_named), "`na.rm`.", fixed = TRUE)
+})
+
 test_that("no analysed shape reaches the caller as an untyped condition", {
   # The classes below are what each site raised before #100. Asserting their
   # absence together keeps a future rewrite that reintroduces one of them from


### PR DESCRIPTION
Closes #104.

## Fix

`parse_across_arguments()` named the unnamed additional arguments of an `across()` call by assigning `paste0("..", seq_along(additional_names))` to the unnamed positions. The left side selects only the unnamed arguments while the right side is built over all of them, so the two sides differ in length whenever any additional argument is named. Base R recycled the replacement and warned — `number of items to replace is not a multiple of replacement length`, once per grouping-set branch, from a call that otherwise returned its result — and the surviving names were numbered by position among the unnamed arguments rather than among all of them: the unnamed argument of `across(c(total), share_of_total, .names = "{.col}_s", na.rm = TRUE, TRUE)` is the second additional argument and was reported as `..1`.

The replacement is now indexed by the same `which()` that selects the positions it fills, so an unnamed argument is named for its own position — which is how dplyr refers to an argument forwarded through `...`.

`known_across_function_names()` already had that form, spelled inline, for the unnamed entries of a `.fns` list. The ticket asked for the two to be made consistent, so rather than leave one rule written two ways in one file — one of them the correct-by-accident version of the bug — both sites now call `name_unnamed_by_position()`, with the reason the indices must match stated once on the helper.

The names reach exactly one consumer, the `R/share.R` diagnostic that refuses additional arguments to a share `across()`, so that message is where the ordinals are asserted.

## Tests

Two tests in `test-static-expression-analysis.R`, the file that already holds the analysis's condition behaviour (#100). Both were confirmed non-vacuous: against `main`'s `R/summary-selections.R` they fail 2, pass 47; with the fix, pass 49.

The first asserts the warning's absence as well as the message, since a message-only test passes on `..1` becoming `..2` while the recycling stays. It collects untyped warnings alone, and that narrowing is the one thing worth review here: passing any argument through `across()`'s `...` is deprecated by dplyr, which warns from the same call for its own reasons and with its own class. So the repro in the ticket still emits one warning, and acceptance criterion 1 ("produces no warning") is met for the base-R warnings the ticket is about, not literally. A bare `simpleWarning` from that call can only have come from the analysis, and there are now none.

That leftover warning turned out to sit on top of a separate defect — every warning from a user summary expression is repeated once per grouping set, contextualized with internal names like `..marginplyr_key_1` — which is filed as #141 rather than fixed here. It is not specific to `across()`, and what a Margin verb owes the caller for a warning is undefined: CONTEXT.md states the Package/External condition contract for errors only.

The second test covers the two ends where no mixing occurs — all-named and all-unnamed additional arguments — which never reached the faulty subassignment and must keep behaving as they did.

## Verification

- `lintr::lint_package()` clean (after `pkgload::load_all()`, per `AGENTS.md`)
- No roxygen touched, so `man/` and `NAMESPACE` need no regeneration
- No dependency metadata change: the tests use `dplyr::` (an Import) and base R only, and need no optional backend
- `spelling::spell_check_package()` clean
- Full `testthat` suite green under `NOT_CRAN=true`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2170`
- `Rscript .github/scripts/verify-suite-coverage.R`: all 363 tests execute in at least one single-backend configuration
- `R CMD check` on a built tarball: `Status: OK`