### PR TITLE
Admit only the documented spelling of an option value

### DIFF
--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -107,6 +107,7 @@ expand_with_margins <- function(.data,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
     .sort = .sort,
+    duplicates_choices = margin_duplicates_choices,
     .id = .id,
     call = call
   )

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -79,20 +79,26 @@ prepare_grouping_plan <- function(.data,
                                   by_quo,
                                   grouping_quo,
                                   .duplicates,
+                                  duplicates_choices,
                                   validate_grouping = NULL,
                                   validate_names = NULL,
                                   call = rlang::caller_call()) {
   stopifnot(rlang::is_quosure(by_quo), rlang::is_quosure(grouping_quo))
   stopifnot(is.null(validate_grouping) || is.function(validate_grouping))
   stopifnot(is.null(validate_names) || is.function(validate_names))
+  # Already matched against the calling verb's own vocabulary, which may be
+  # narrower than the Margin one. Re-matching here against the wider list is
+  # what made the nesting verbs' rejection message offer a value they refuse
+  # (#110), so this asserts the precondition instead of re-deciding it. The
+  # vocabulary travels on because the duplicate-set diagnostic names the
+  # policies the caller could have asked for instead.
+  stopifnot(
+    rlang::is_string(.duplicates),
+    .duplicates %in% duplicates_choices
+  )
 
   with_margin_error_call(
     {
-      .duplicates <- match_margin_choice(
-        .duplicates,
-        choices = margin_duplicates_choices,
-        arg_name = ".duplicates"
-      )
       grouping_spec <- rlang::eval_tidy(grouping_quo)
       validate_grouping_spec_early(grouping_spec)
       if (!is.null(validate_grouping)) {
@@ -117,7 +123,8 @@ prepare_grouping_plan <- function(.data,
           data_vars = data_vars,
           data_proxy = grouping_name_proxy(data_vars),
           .by = by,
-          .duplicates = .duplicates
+          .duplicates = .duplicates,
+          duplicates_choices = duplicates_choices
         )
       }
       data_proxy <- grouping_selection_proxy(data, backend = backend)
@@ -126,7 +133,8 @@ prepare_grouping_plan <- function(.data,
         data_vars = data_vars,
         data_proxy = data_proxy,
         .by = by,
-        .duplicates = .duplicates
+        .duplicates = .duplicates,
+        duplicates_choices = duplicates_choices
       )
 
       list(
@@ -304,7 +312,8 @@ compile_grouping_spec <- function(.grouping,
     data_vars = data_vars,
     data_proxy = data_proxy,
     .by = .by,
-    .duplicates = .duplicates
+    .duplicates = .duplicates,
+    duplicates_choices = margin_duplicates_choices
   )
 }
 
@@ -312,9 +321,10 @@ compile_grouping_spec_impl <- function(.grouping,
                                        data_vars,
                                        data_proxy,
                                        .by,
-                                       .duplicates) {
+                                       .duplicates,
+                                       duplicates_choices) {
   stopifnot(is.character(.by), !anyNA(.by))
-  stopifnot(.duplicates %in% margin_duplicates_choices)
+  stopifnot(.duplicates %in% duplicates_choices)
   if (is.null(data_proxy)) {
     data_proxy <- grouping_name_proxy(data_vars)
   }
@@ -365,12 +375,21 @@ compile_grouping_spec_impl <- function(.grouping,
   if (any(duplicate_keys) && identical(.duplicates, "error")) {
     groups <- split(which(duplicate_keys), keys[duplicate_keys])
     positions <- vapply(groups, paste, collapse = ", ", character(1))
+    # The policies this caller could have asked for instead, which is every
+    # value of its own vocabulary but the one that raised this. Reading them
+    # from the vocabulary is what keeps the nesting verbs, whose `.duplicates`
+    # excludes `"keep"`, from being offered it here (#110).
+    alternatives <- setdiff(duplicates_choices, .duplicates)
+    offered <- paste0("`\"", alternatives, "\"`")
+    offered[[1L]] <- paste0("`.duplicates = \"", alternatives[[1L]], "\"`")
     abort_marginplyr(
       paste0(
         "Duplicate grouping sets were produced at position",
         if (length(groups) == 1L) "s " else " groups ",
         paste(positions, collapse = "; "),
-        ". Use `.duplicates = \"drop\"` or `\"keep\"`."
+        ". Use ",
+        paste(offered, collapse = " or "),
+        "."
       )
     )
   }

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -139,11 +139,17 @@ inspect_grouping <- function(.data,
         choices = grouping_format_choices,
         arg_name = ".format"
       )
+      .duplicates <- match_margin_choice(
+        .duplicates,
+        choices = margin_duplicates_choices,
+        arg_name = ".duplicates"
+      )
       grouping <- prepare_grouping_plan(
         .data,
         by_quo = by_quo,
         grouping_quo = grouping_quo,
         .duplicates = .duplicates,
+        duplicates_choices = margin_duplicates_choices,
         call = call
       )
       format_grouping_plan(grouping$plan, format = .format)

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -95,36 +95,50 @@ with_margin_error_call <- function(expr, call) {
 # re-check it cannot drift apart. The public verbs still spell their defaults
 # out literally because those formals are the documented signature; a test in
 # test-grouping-interface.R holds each formal to the constant it mirrors.
-# Verb-specific vocabularies live with the verb that owns them.
+# Verb-specific vocabularies live with the verb that owns them, and a verb that
+# narrows one hands its own list down rather than being re-checked against the
+# wider one: see `duplicates_choices` below.
 margin_duplicates_choices <- c("error", "drop", "keep")
 
 margin_label_position_choices <- c("last", "first")
 
 margin_sort_choices <- c("none", "last", "first")
 
+# An option argument admits its documented spellings and nothing else.
+# `match.arg()` also resolved any unambiguous prefix of one, so `.sort = "f"`
+# and `.duplicates = "k"` were accepted (#110). Nothing documents a prefix, so
+# every one of them was API by accident: a later value sharing a prefix would
+# have redefined what an accepted abbreviation resolves to. The one
+# `match.arg()` behaviour the signatures rely on is kept: an untouched formal
+# default arrives as the whole vocabulary and stands for its first entry.
 match_margin_choice <- function(value, choices, arg_name) {
   call <- rlang::caller_call()
-  force(value)
-  tryCatch(
-    match.arg(value, choices),
-    error = function(...) {
-      abort_marginplyr(
-        paste0(
-          "`", arg_name, "` must be one of ",
-          paste0("\"", choices, "\"", collapse = ", "),
-          "."
-        ),
-        call = call
-      )
-    }
+  if (identical(value, choices)) {
+    return(choices[[1L]])
+  }
+  if (rlang::is_string(value) && value %in% choices) {
+    return(value)
+  }
+  abort_marginplyr(
+    paste0(
+      "`", arg_name, "` must be one of ",
+      paste0("\"", choices, "\"", collapse = ", "),
+      "."
+    ),
+    call = call
   )
 }
 
+# `duplicates_choices` has no default because it is the one vocabulary a verb
+# may narrow, and a default here is what let the nesting verbs be validated
+# against a list their own formals exclude. Every caller states the list its
+# own signature documents.
 normalize_margin_options <- function(.margin_label,
                                      .margin_label_position,
                                      .check_margin_label,
                                      .duplicates,
                                      .sort,
+                                     duplicates_choices,
                                      .id = NULL) {
   assert_logical_scalar(.check_margin_label)
   .id <- normalize_margin_id(.id)
@@ -140,7 +154,7 @@ normalize_margin_options <- function(.margin_label,
     check_margin_label = .check_margin_label,
     duplicates = match_margin_choice(
       .duplicates,
-      choices = margin_duplicates_choices,
+      choices = duplicates_choices,
       arg_name = ".duplicates"
     ),
     sort = match_margin_choice(
@@ -185,6 +199,7 @@ prepare_margin_operation <- function(.data,
                                      .check_margin_label,
                                      .duplicates,
                                      .sort,
+                                     duplicates_choices,
                                      .id = NULL,
                                      validate_grouping = NULL,
                                      call = rlang::caller_call()) {
@@ -199,6 +214,7 @@ prepare_margin_operation <- function(.data,
         .check_margin_label = .check_margin_label,
         .duplicates = .duplicates,
         .sort = .sort,
+        duplicates_choices = duplicates_choices,
         .id = .id
       )
       set_id_name <- options$set_id_name
@@ -213,6 +229,7 @@ prepare_margin_operation <- function(.data,
         by_quo = by_quo,
         grouping_quo = grouping_quo,
         .duplicates = .duplicates,
+        duplicates_choices = duplicates_choices,
         validate_grouping = validate_grouping,
         validate_names = function(data_vars) {
           check_margin_id_collision(

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -204,23 +204,13 @@ nest_margin_pipeline <- function(.data,
           "`.key` must not be empty."
         )
       }
-      # The nesting verbs' `.duplicates` formal is the whole vocabulary, so
-      # receiving it unchanged means the caller left the argument at its
-      # default. Resolve it here because the shared normalizer matches against
-      # the wider Margin vocabulary.
-      left_at_default <- identical(
-        .duplicates,
-        nest_duplicates_choices
-      )
-      if (left_at_default) {
-        .duplicates <- "error"
-      }
       options <- normalize_margin_options(
         .margin_label = .margin_label,
         .margin_label_position = .margin_label_position,
         .check_margin_label = .check_margin_label,
         .duplicates = .duplicates,
         .sort = .sort,
+        duplicates_choices = nest_duplicates_choices,
         .id = .id
       )
       set_id_name <- options$set_id_name
@@ -230,14 +220,6 @@ nest_margin_pipeline <- function(.data,
       .duplicates <- options$duplicates
       .sort <- options$sort
       check_margin_id_collision(set_id_name, .key, "nesting `.key`")
-      if (identical(.duplicates, "keep")) {
-        abort_marginplyr(
-          paste0(
-            "Nesting does not support `.duplicates = \"keep\"`. Use ",
-            "`\"error\"` or `\"drop\"`."
-          )
-        )
-      }
     },
     call = call
   )
@@ -251,6 +233,7 @@ nest_margin_pipeline <- function(.data,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
     .sort = .sort,
+    duplicates_choices = nest_duplicates_choices,
     .id = .id,
     call = call
   )

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -213,8 +213,9 @@
 #' clears none.
 #'
 #' Asking for a Margin order never costs a native `GROUP BY GROUPING SETS`
-#' plan, and never changes which adapter runs. It composes with
-#' `.duplicates = "keep"` with no diagnostic, and lazy inputs stay lazy.
+#' plan, and never changes which adapter runs. It composes with every
+#' `.duplicates` policy the verb accepts with no diagnostic, and lazy inputs
+#' stay lazy.
 #'
 #' The [recipes guide][recipes] shows a Margin order before and after, and
 #' shows a join dropping one from a lazy result with no diagnostic naming this
@@ -586,6 +587,7 @@ summarize_with_margins <- function(.data,
         .check_margin_label = .check_margin_label,
         .duplicates = .duplicates,
         .sort = .sort,
+        duplicates_choices = margin_duplicates_choices,
         .id = .id
       )
       check_option_named_summaries(dots)
@@ -604,6 +606,7 @@ summarize_with_margins <- function(.data,
     .check_margin_label = .check_margin_label,
     .duplicates = .duplicates,
     .sort = .sort,
+    duplicates_choices = margin_duplicates_choices,
     .id = .id,
     validate_grouping = share_grouping_spec_validator(share_kinds),
     call = call

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -249,8 +249,9 @@ window ordering the input carried. \code{.sort = "none"} records no order and
 clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
-plan, and never changes which adapter runs. It composes with
-\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+plan, and never changes which adapter runs. It composes with every
+\code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
+stay lazy.
 
 The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
 shows a join dropping one from a lazy result with no diagnostic naming this

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -249,8 +249,9 @@ window ordering the input carried. \code{.sort = "none"} records no order and
 clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
-plan, and never changes which adapter runs. It composes with
-\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+plan, and never changes which adapter runs. It composes with every
+\code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
+stay lazy.
 
 The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
 shows a join dropping one from a lazy result with no diagnostic naming this

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -279,8 +279,9 @@ window ordering the input carried. \code{.sort = "none"} records no order and
 clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
-plan, and never changes which adapter runs. It composes with
-\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+plan, and never changes which adapter runs. It composes with every
+\code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
+stay lazy.
 
 The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
 shows a join dropping one from a lazy result with no diagnostic naming this

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -264,8 +264,9 @@ window ordering the input carried. \code{.sort = "none"} records no order and
 clears none.
 
 Asking for a Margin order never costs a native \verb{GROUP BY GROUPING SETS}
-plan, and never changes which adapter runs. It composes with
-\code{.duplicates = "keep"} with no diagnostic, and lazy inputs stay lazy.
+plan, and never changes which adapter runs. It composes with every
+\code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
+stay lazy.
 
 The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
 shows a join dropping one from a lazy result with no diagnostic naming this

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -529,7 +529,7 @@ test_that("nesting rejects duplicate grouping sets without visible identity", {
       .grouping = spec,
       .duplicates = "keep"
     ),
-    "does not support `.duplicates = \"keep\"`"
+    "`\\.duplicates` must be one of \"error\", \"drop\"\\."
   )
   expect_error(
     nest_by_with_margins(
@@ -537,7 +537,7 @@ test_that("nesting rejects duplicate grouping sets without visible identity", {
       .grouping = spec,
       .duplicates = "keep"
     ),
-    "does not support `.duplicates = \"keep\"`"
+    "`\\.duplicates` must be one of \"error\", \"drop\"\\."
   )
 })
 

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -59,7 +59,7 @@ test_that("nest rejects grouping before typed metadata acquisition", {
   nest_proxy_capture$n <- 0L
   expect_error(
     nest_with_margins(source, .duplicates = "keep"),
-    "does not support `.duplicates = \"keep\"`"
+    "`\\.duplicates` must be one of \"error\", \"drop\"\\."
   )
   expect_identical(nest_proxy_capture$n, 0L)
 })
@@ -188,7 +188,11 @@ test_that("nesting option errors use the package condition seam", {
         .grouping = rollup(group),
         .duplicates = "keep"
       )),
-      message = "Nesting does not support `\\.duplicates = \"keep\"`"
+      # `"keep"` is refused by the nesting vocabulary itself rather than by a
+      # second guard, so it reads like any other value outside it (#110).
+      # test-verb-argument-admission.R asserts the whole message; what this
+      # case adds is that it reaches the caller through the condition seam.
+      message = "`\\.duplicates` must be one of \"error\", \"drop\"\\."
     ),
     key_grouping_column = list(
       expr = quote(nest_with_margins(

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -1,9 +1,10 @@
-# Two admission rules that keep a mistake from becoming a plausible result.
+# Three admission rules that keep a mistake from becoming a plausible result.
 #
 # `...` accepts any named expression, so an argument name the verb does not
-# have becomes a constant summary column instead of an error; and an input
+# have becomes a constant summary column instead of an error; an input
 # without dplyr methods reached `group_vars()` and reported an internal
-# generic rather than the argument the caller supplied.
+# generic rather than the argument the caller supplied; and an option argument
+# validated with `match.arg()` accepted abbreviations nothing documents.
 
 admission_data <- function() {
   data.frame(g = c("a", "a", "b"), v = c(1, 2, 3))
@@ -227,6 +228,201 @@ test_that("the option check survives splicing", {
     ),
     class = "marginplyr_error"
   )
+})
+
+# Every fixed-vocabulary option, paired with the verb that takes it and the
+# values that verb accepts. The vocabularies are read from the shared constants
+# rather than written out again here, so a vocabulary that grows is covered
+# without an edit; test-grouping-interface.R holds each verb's formal to the
+# same constants, which is what makes reading them here an assertion about the
+# documented signature rather than a tautology.
+option_vocabulary_cases <- function() {
+  margin_verbs <- c(
+    "summarize_with_margins",
+    "summarise_with_margins",
+    "expand_with_margins",
+    "nest_with_margins",
+    "nest_by_with_margins"
+  )
+  nesting_verbs <- c("nest_with_margins", "nest_by_with_margins")
+
+  cases <- list()
+  for (verb in margin_verbs) {
+    duplicates <- if (verb %in% nesting_verbs) {
+      nest_duplicates_choices
+    } else {
+      margin_duplicates_choices
+    }
+    cases <- c(cases, list(
+      list(verb = verb, option = ".duplicates", values = duplicates),
+      list(
+        verb = verb,
+        option = ".margin_label_position",
+        values = margin_label_position_choices
+      ),
+      list(verb = verb, option = ".sort", values = margin_sort_choices)
+    ))
+  }
+  # `inspect_grouping()` reads a plan rather than executing one, so it takes
+  # `.duplicates` and its own `.format` but no Margin presentation options.
+  c(cases, list(
+    list(
+      verb = "inspect_grouping",
+      option = ".duplicates",
+      values = margin_duplicates_choices
+    ),
+    list(
+      verb = "inspect_grouping",
+      option = ".format",
+      values = grouping_format_choices
+    )
+  ))
+}
+
+call_with_option <- function(verb, option, value) {
+  args <- list(quote(admission_data()), .grouping = quote(rollup(g)))
+  if (verb %in% c("summarize_with_margins", "summarise_with_margins")) {
+    args <- c(args, list(s = quote(sum(v))))
+  }
+  args[[option]] <- value
+  eval(rlang::call2(verb, !!!args))
+}
+
+option_case_label <- function(case, value) {
+  paste0(case$verb, "(", case$option, " = \"", value, "\")")
+}
+
+# The one message a rejected value may produce, built from the vocabulary the
+# case says the verb accepts. Asserting the whole sentence rather than a
+# pattern is what holds a verb to its own vocabulary: a message enumerating one
+# value more or fewer is a different string.
+expected_vocabulary_message <- function(case) {
+  paste0(
+    "`", case$option, "` must be one of ",
+    paste0("\"", case$values, "\"", collapse = ", "),
+    "."
+  )
+}
+
+option_rejection_message <- function(verb, option, value) {
+  condition <- rlang::catch_cnd(
+    call_with_option(verb, option, value),
+    classes = "marginplyr_error"
+  )
+  if (is.null(condition)) {
+    return(NA_character_)
+  }
+  conditionMessage(condition)
+}
+
+test_that("every documented option value is accepted", {
+  # The other half of the vocabulary contract, and the half that makes the
+  # rejection messages below assertions rather than assumptions: no verb may
+  # refuse a value its own rejection message offers.
+  refused <- character()
+
+  for (case in option_vocabulary_cases()) {
+    for (value in case$values) {
+      accepted <- tryCatch(
+        {
+          call_with_option(case$verb, case$option, value)
+          TRUE
+        },
+        marginplyr_error = function(cnd) FALSE
+      )
+      if (!accepted) {
+        refused <- c(refused, option_case_label(case, value))
+      }
+    }
+  }
+
+  expect_identical(refused, character())
+})
+
+test_that("an abbreviation of an option value is rejected", {
+  # `match.arg()` resolved any unambiguous prefix to the value it abbreviates,
+  # so `.sort = "f"` and `.duplicates = "k"` were accepted (#110). Every
+  # vocabulary here is distinct in its first character, so the one-character
+  # prefix is exactly the abbreviation `match.arg()` would have taken.
+  for (case in option_vocabulary_cases()) {
+    for (value in case$values) {
+      abbreviation <- substr(value, 1L, 1L)
+      expect_identical(
+        option_rejection_message(case$verb, case$option, abbreviation),
+        expected_vocabulary_message(case),
+        info = option_case_label(case, abbreviation)
+      )
+    }
+  }
+})
+
+test_that("a wholly invalid option value names only what the verb accepts", {
+  for (case in option_vocabulary_cases()) {
+    expect_identical(
+      option_rejection_message(case$verb, case$option, "zzz"),
+      expected_vocabulary_message(case),
+      info = option_case_label(case, "zzz")
+    )
+  }
+})
+
+test_that("a diagnostic offering a `.duplicates` policy offers a real one", {
+  # The rejection message above is not the only place a vocabulary is spoken
+  # aloud: refusing a duplicate grouping set names the policies that would have
+  # accepted it. That message enumerated `"drop"` and `"keep"` from a constant,
+  # so the nesting verbs told a caller to use a value they then refuse — the
+  # same defect as #110, one message further in.
+  duplicated_sets <- grouping_sets(grouping_set(g), grouping_set(g))
+
+  refusal <- function(verb) {
+    fn <- get(verb, envir = asNamespace("marginplyr"))
+    args <- list(admission_data(), .grouping = duplicated_sets)
+    if (verb %in% c("summarize_with_margins", "summarise_with_margins")) {
+      args <- c(args, list(s = quote(sum(v))))
+    }
+    conditionMessage(rlang::catch_cnd(
+      eval(rlang::call2(verb, !!!args)),
+      classes = "marginplyr_error"
+    ))
+  }
+
+  for (case in option_vocabulary_cases()) {
+    if (!identical(case$option, ".duplicates")) {
+      next
+    }
+    message <- refusal(case$verb)
+    expect_match(
+      message,
+      "^Duplicate grouping sets were produced",
+      info = case$verb
+    )
+    for (value in setdiff(margin_duplicates_choices, case$values)) {
+      expect_false(
+        grepl(paste0("\"", value, "\""), message, fixed = TRUE),
+        info = paste(case$verb, value)
+      )
+    }
+    for (value in setdiff(case$values, "error")) {
+      expect_true(
+        grepl(paste0("\"", value, "\""), message, fixed = TRUE),
+        info = paste(case$verb, value)
+      )
+    }
+  }
+})
+
+test_that("the nesting verbs answer `.duplicates = \"keep\"` in their terms", {
+  # The narrower formal used to be widened before validation and taken away
+  # again by a second guard, so the rejection message named `"keep"` and the
+  # verb then refused it (#110). One vocabulary owns the answer now, and the
+  # message the caller sees is the one every other invalid value gets.
+  for (verb in c("nest_with_margins", "nest_by_with_margins")) {
+    expect_identical(
+      option_rejection_message(verb, ".duplicates", "keep"),
+      "`.duplicates` must be one of \"error\", \"drop\".",
+      info = verb
+    )
+  }
 })
 
 test_that("input that dplyr cannot group is rejected in the caller's terms", {


### PR DESCRIPTION
Closes #110.

## Fix

`match_margin_choice()` validated every fixed-vocabulary option with base R's `match.arg()`, which resolves any unambiguous prefix of a choice to the choice it abbreviates. `.sort = "f"` returned the `"first"` result and `.duplicates = "k"` the `"keep"` one. Nothing documents a prefix, so every one of them was API by accident: a later value sharing a prefix would have redefined what an accepted abbreviation resolves to, breaking a caller who relied on it. The helper now admits a choice only when the caller wrote it exactly, and an abbreviation gets the same message any other invalid value gets.

The one `match.arg()` behaviour the public signatures rely on is kept deliberately: an untouched formal default arrives as the whole vocabulary and still stands for its first entry. One other `match.arg()` behaviour is **not** kept, and is the only user-visible change beyond the ticket — `match.arg(NULL, choices)` returns `choices[1]`, so `.sort = NULL` silently meant `"none"`. Nothing documents that either, and "only exact, documented values are accepted" reads against it, but it is a narrowing the ticket did not name.

## Audit

Every option argument in the package went through that one helper, so the audit is the whole of it: **`.duplicates`**, **`.margin_label_position`**, **`.sort`**, and `inspect_grouping()`'s **`.format`**. All four are changed, because the helper is. There is no other `match.arg()`, `pmatch()`, or `charmatch()` anywhere in `R/`.

`compile_grouping_spec()`'s remaining `match_margin_choice()` call is an internal entry point with a vector default and no user-facing caller, which the ticket's "Out of scope" covers; it goes through the same helper regardless.

## The nesting split

The nesting verbs' `.duplicates` formal is `c("error", "drop")`. They widened that value before validation so the shared normalizer would take it, were matched against the wider Margin vocabulary — which is why `.duplicates = "zzz"` was answered by offering `"keep"` — and then took `"keep"` away again with a guard of their own further down.

The vocabulary is now an argument rather than a constant inside the shared code, so each verb hands down the list its own signature documents. The widening step and the second guard are both gone, and a caller who writes `"keep"` reads the sentence every other out-of-vocabulary value produces. `duplicates_choices` deliberately has no default: a default is exactly what let a verb be validated against a list its own formals exclude.

`prepare_grouping_plan()` re-matched `.duplicates` after its caller had already matched it, and that is the site that supplied the wider list to the nesting verbs. It now asserts the precondition (ADR 0015: unreachable through the public interface) instead of re-deciding it, and `inspect_grouping()` — the one caller that reached it with an unmatched value — matches `.duplicates` alongside the `.format` it already matched there.

## The second message, found in review

The rejection message is not the only place a vocabulary is spoken aloud. Refusing a duplicate grouping set names the policies that would have accepted it, and `compile_grouping_spec_impl()` named them from the same wide constant:

```
nest_with_margins(d, .grouping = grouping_sets(c("g"), c("g")))
#> Duplicate grouping sets were produced at positions 1, 2. Use `.duplicates = "drop"` or `"keep"`.
```

That is the reported defect verbatim, one message further in — the verb tells the caller to use a value it then refuses. The vocabulary therefore travels as far as the plan compiler, and both messages now enumerate the calling verb's own values. Nesting now reads ``Use `.duplicates = "drop"`.``; the Margin verbs are unchanged.

This was caught by review, not by the tests written for the fix, which passed throughout. It has its own test now.

## Tests

New in `test-verb-argument-admission.R`, the file that already holds the two admission rules for what a verb accepts. Each verb's vocabulary is read from the shared constants rather than written out again, so a vocabulary that grows is covered without an edit — and `test-grouping-interface.R` already holds every formal to those same constants, which is what keeps reading them here an assertion about the documented signature rather than a tautology.

Four assertions, over every (verb, option) pair:

1. every documented value is accepted;
2. every one-character abbreviation is refused — one character because each vocabulary is distinct in its first, so that is precisely what `match.arg()` took;
3. the message a wholly invalid value produces enumerates exactly the values that verb accepts, and no others;
4. the duplicate-set diagnostic offers only policies the receiving verb accepts.

Between 1 and 3, no verb can refuse a value its own rejection message offered — the acceptance criterion is enforced by the pair rather than by a case per verb.

Non-vacuity, against `main`'s `R/` with the new test file dropped in: **FAIL 49 | PASS 62**, failing in 4 of the 5 new tests. The fifth, "every documented option value is accepted", passes on `main` too, as it must — nothing about this change was meant to narrow what is documented.

Two existing tests changed, both assertions of the removed bespoke message (`test-nest-operation.R`, `test-grouping-interface.R`). The `test-nest-operation.R` case is kept rather than deleted, because what it adds beyond the message is that the condition reaches the caller through the `nest_with_margins()` seam.

## Documentation

The `.sort` section claimed a Margin order "composes with `.duplicates = "keep"` with no diagnostic". That section is inherited by the nesting verbs, whose help page therefore named a policy they reject — the same defect in prose. It now names the policies the reading verb accepts. `man/` regenerated with `roxygen2::roxygenise()`.

No `NEWS.md` entry: 0.1.0 is unreleased, so this narrows behaviour that never shipped. Say the word if you would rather it were recorded.

## Verification

- `lintr::lint_package()` clean (after `pkgload::load_all()`, per `AGENTS.md`)
- `man/` and `NAMESPACE` regenerated; only the four `.sort`-section topics differ
- `spelling::spell_check_package()` clean
- No dependency metadata change: `DESCRIPTION` untouched, and the new tests use base R and `rlang` (an Import) only, so they need no optional backend
- Full `testthat` suite green under `NOT_CRAN=true`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2251`
- `Rscript .github/scripts/verify-suite-coverage.R`: all 368 tests execute in at least one single-backend configuration
- `R CMD check` on a built tarball: `Status: OK`
