### PR TITLE
Print the constructor a Grouping specification was made with

### DIFF
--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -182,6 +182,14 @@ new_grouping_spec <- function(type, args) {
 #' @exportS3Method
 #' @noRd
 print.margin_grouping_spec <- function(x, ...) {
-  cat("<marginplyr grouping specification: ", x$type, ">\n", sep = "")
+  # The kind stored on the object is internal; three of the five kinds are not
+  # the name of any function a caller can write. The kind rules already carry
+  # each kind's public constructor, so a new kind names itself correctly here
+  # without an edit. A kind with no rule is not constructible through the
+  # package, and printing one falls back to what it stores rather than
+  # reporting no name at all.
+  rule <- find_grouping_kind_rule(x$type)
+  name <- if (is.null(rule)) x$type else rule$constructor
+  cat("<marginplyr grouping specification: ", name, ">\n", sep = "")
   invisible(x)
 }

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1047,3 +1047,30 @@ test_that("documented option formals match the shared choice vocabularies", {
     grouping_format_choices
   )
 })
+
+test_that("a printed Grouping specification names the constructor called", {
+  exports <- getNamespaceExports("marginplyr")
+
+  for (kind in names(grouping_kind_rules())) {
+    constructor <- find_grouping_kind_rule(kind)$constructor
+    expect_true(constructor %in% exports, info = kind)
+
+    spec <- eval(rlang::call2(constructor, rlang::sym("a")))
+    # The printed name is read from the kind stored on the object, so a rule
+    # naming a constructor that produces some other kind would print the wrong
+    # name for both of them.
+    expect_identical(spec$type, kind, info = kind)
+    expect_identical(
+      utils::capture.output(print(spec)),
+      paste0("<marginplyr grouping specification: ", constructor, ">"),
+      info = kind
+    )
+  }
+
+  # No constructor makes a kind the rules do not know, and the verbs reject
+  # one. Printing it still names something rather than nothing.
+  expect_identical(
+    utils::capture.output(print(new_grouping_spec("nonesuch", list()))),
+    "<marginplyr grouping specification: nonesuch>"
+  )
+})


### PR DESCRIPTION
Closes #117.

## Fix

`print.margin_grouping_spec()` interpolated the internal kind string the object stores, and three of the five kinds — `set`, `sets`, `product` — are not the name of any function a caller can write. Someone who typed `grouping_set(a)` was answered `<marginplyr grouping specification: set>`, naming a function that does not exist. `rollup` and `cube` printed a callable name only because their kind and their constructor happen to coincide.

```r
print(grouping_set(a))    #> <marginplyr grouping specification: grouping_set>
print(grouping_sets(a))   #> <marginplyr grouping specification: grouping_sets>
print(rollup(a))          #> <marginplyr grouping specification: rollup>
print(cube(a))            #> <marginplyr grouping specification: cube>
print(grouping_spec(a))   #> <marginplyr grouping specification: grouping_spec>
```

The method reads the name from `find_grouping_kind_rule(x$type)$constructor`. ADR 0008 already makes the kind rules authoritative for every per-kind fact and gives each rule its public constructor, which `grouping_constructor_names()` reads when a verb lists the valid constructors — so there is no second mapping, and a kind added to the rules prints its own constructor with no edit to the print method. Nothing else in the tree consumed the old text: no vignette, help page, or snapshot mentions it.

## The ADR wording

This is the first reader of the rules outside compilation, which widens ADR 0008's "The registry is a compilation-only detail" — but not its decision. The ADR gives each rule its constructor name precisely so that one place answers what a kind is called, and the sentence's own subject is what the *plan* stores: the rules are still neither stored in the Grouping plan nor consulted after one is built. Raising it rather than leaving it silent.

## The unknown kind

`find_grouping_kind_rule()` answers `NULL` for a kind it does not know, and `cat()` would then print `<marginplyr grouping specification: >`. No constructor produces such an object — every `new_grouping_spec()` call site passes a literal kind, and the verbs reject an unknown one before anything else — but printing is not a verb, and answering a hand-built object with an empty name is worse than answering it with what it stores. It falls back to the kind, and a test covers that line.

This is behaviour the ticket did not ask for. Say the word if you would rather the branch were unreachable and untested, or the object refused.

## Tests

One test in `test-grouping-interface.R`, next to the other assertions about what the public grouping surface presents. It walks `names(grouping_kind_rules())` rather than a list of five names, so a sixth kind is covered without an edit, and asserts of each rule:

1. its `constructor` is in `getNamespaceExports("marginplyr")` — the criterion that the printed name is a function that exists and is exported;
2. calling that constructor produces *that rule's own kind*;
3. the printed line names the constructor.

Assertion 2 is the one that is not redundant. Printing derives the name from the kind stored on the object, so a rule whose `constructor` field names another kind's constructor still prints a callable name for both — swapping `set` and `sets` is invisible to 1 and 3 together. Checked by mutating the registry in the namespace and re-running the test body: baseline passes; `set$constructor <- "cube"` fails on 2; the `set`/`sets` swap fails on 2; an unexported or misspelled name fails on 1.

The added test fails on `main` for `grouping_set`, `grouping_sets`, and `grouping_spec`, and passes there for `rollup` and `cube` — which is the defect, stated as a test.

No `NEWS.md` entry: 0.1.0 is unreleased and no bullet describes printing, so there is nothing to amend and no shipped behaviour to record a fix against.

## Verification

- `lintr::lint_package()` after `pkgload::load_all(".")` — no lints. No `# nolint` added.
- `roxygen2::roxygenise()` — `man/` and `NAMESPACE` unchanged; the method is `@exportS3Method` `@noRd` and stays that way, which the ticket's "Out of scope" asks for.
- Full suite under `NOT_CRAN=true` — every file passes, no failures and no skips.
- The new test requires no optional backend, so it executes in every `backend` job and does not touch the one-backend-per-test policy.