### PR TITLE
Document the collision check by what it accepts

### DIFF
--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -31,10 +31,11 @@
 #'   `NA_character_` or `NULL`.
 #' @param .check_margin_label A logical scalar. If `TRUE`, check each Margin
 #'   dimension independently for a value or factor level that collides with its
-#'   display label. `NULL` bypasses collision checks. See *Display labels and
-#'   grouping identity* for the factor missing-value contract. Every Margin
-#'   verb uses the same default: `TRUE` for local data frames and `FALSE` for
-#'   lazy inputs, where checking would require an additional query.
+#'   display label. `.margin_label = NULL` opts out of these checks. See
+#'   *Display labels and grouping identity* for the factor missing-value
+#'   contract. Every Margin verb uses the same default: `TRUE` for local data
+#'   frames and `FALSE` for lazy inputs, where checking would require an
+#'   additional query.
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
 #'   duplicate grouping sets after expansion.
 #' @param .sort One of `"none"` (the default), `"last"`, or `"first"`. `"none"`

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -42,10 +42,11 @@ ordered-factor levels. It does not sort result rows and has no effect for
 
 \item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
 dimension independently for a value or factor level that collides with its
-display label. \code{NULL} bypasses collision checks. See \emph{Display labels and
-grouping identity} for the factor missing-value contract. Every Margin
-verb uses the same default: \code{TRUE} for local data frames and \code{FALSE} for
-lazy inputs, where checking would require an additional query.}
+display label. \code{.margin_label = NULL} opts out of these checks. See
+\emph{Display labels and grouping identity} for the factor missing-value
+contract. Every Margin verb uses the same default: \code{TRUE} for local data
+frames and \code{FALSE} for lazy inputs, where checking would require an
+additional query.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
 duplicate grouping sets after expansion.}

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -45,10 +45,11 @@ ordered-factor levels. It does not sort result rows and has no effect for
 
 \item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
 dimension independently for a value or factor level that collides with its
-display label. \code{NULL} bypasses collision checks. See \emph{Display labels and
-grouping identity} for the factor missing-value contract. Every Margin
-verb uses the same default: \code{TRUE} for local data frames and \code{FALSE} for
-lazy inputs, where checking would require an additional query.}
+display label. \code{.margin_label = NULL} opts out of these checks. See
+\emph{Display labels and grouping identity} for the factor missing-value
+contract. Every Margin verb uses the same default: \code{TRUE} for local data
+frames and \code{FALSE} for lazy inputs, where checking would require an
+additional query.}
 
 \item{.duplicates}{\code{"error"} or \code{"drop"}. Nesting does not support the
 \code{"keep"} policy available in \code{\link[=summarize_with_margins]{summarize_with_margins()}} and

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -45,10 +45,11 @@ ordered-factor levels. It does not sort result rows and has no effect for
 
 \item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
 dimension independently for a value or factor level that collides with its
-display label. \code{NULL} bypasses collision checks. See \emph{Display labels and
-grouping identity} for the factor missing-value contract. Every Margin
-verb uses the same default: \code{TRUE} for local data frames and \code{FALSE} for
-lazy inputs, where checking would require an additional query.}
+display label. \code{.margin_label = NULL} opts out of these checks. See
+\emph{Display labels and grouping identity} for the factor missing-value
+contract. Every Margin verb uses the same default: \code{TRUE} for local data
+frames and \code{FALSE} for lazy inputs, where checking would require an
+additional query.}
 
 \item{.duplicates}{\code{"error"} or \code{"drop"}. Nesting does not support the
 \code{"keep"} policy available in \code{\link[=summarize_with_margins]{summarize_with_margins()}} and

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -61,10 +61,11 @@ ordered-factor levels. It does not sort result rows and has no effect for
 
 \item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
 dimension independently for a value or factor level that collides with its
-display label. \code{NULL} bypasses collision checks. See \emph{Display labels and
-grouping identity} for the factor missing-value contract. Every Margin
-verb uses the same default: \code{TRUE} for local data frames and \code{FALSE} for
-lazy inputs, where checking would require an additional query.}
+display label. \code{.margin_label = NULL} opts out of these checks. See
+\emph{Display labels and grouping identity} for the factor missing-value
+contract. Every Margin verb uses the same default: \code{TRUE} for local data
+frames and \code{FALSE} for lazy inputs, where checking would require an
+additional query.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
 duplicate grouping sets after expansion.}

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -94,6 +94,15 @@ test_that("shared lifecycle options use package conditions", {
       )),
       message = "`\\.check_margin_label` must be a logical scalar"
     ),
+    check_margin_label_null = list(
+      expr = quote(summarize_with_margins(
+        data,
+        id = dplyr::cur_group_id(),
+        .grouping = rollup(group),
+        .check_margin_label = NULL
+      )),
+      message = "`\\.check_margin_label` must be a logical scalar"
+    ),
     margin_label_position = list(
       expr = quote(summarize_with_margins(
         data,

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -464,9 +464,9 @@ retail_sales |>
   dplyr::as_tibble()
 ```
 
-`NULL` bypasses collision checks. `NA_character_` requests the same typed
-missing output but still checks for source missing values and factor NA
-levels when `.check_margin_label = TRUE`.
+`.margin_label = NULL` bypasses collision checks. `NA_character_` requests
+the same typed missing output but still checks for source missing values and
+factor NA levels when `.check_margin_label = TRUE`.
 
 A factor NA level and a missing factor code are different even though both
 can print as `<NA>`. Here the second value uses the NA level and the third is


### PR DESCRIPTION
`.check_margin_label`'s `@param` claimed `NULL` bypasses collision checks, but the argument is validated with `assert_logical_scalar()`, so `NULL` has never been accepted — it raises the same `marginplyr_error` any other non-logical value gets. Through `@inheritParams` the wrong sentence reached `summarize_with_margins()`, `expand_with_margins()`, `nest_with_margins()`, and `nest_by_with_margins()`.

The documentation is what is wrong, not the guard. `NULL` already means something else one argument over: on `.margin_label` it selects typed missing Margin values, which is where the sentence most likely came from — the *Display labels and grouping identity* section states the opt-out correctly and attributes it to `.margin_label`. Giving `NULL` a second, unrelated meaning on the check argument would be a worse API than the one that exists, and disabling the check already spells itself `FALSE`.

## Changes

- The `@param` names the argument that actually opts out, and `man/` is regenerated for all four inheriting pages.
- The `vignettes/get_started.qmd` sentence sits under a `.margin_label = NULL` example, so it was true in context but was the ambiguous form that got copied; it now names its argument too.
- A case in the shared lifecycle-option test pins `NULL` to the existing error, so a future widening of the guard has to be a deliberate change rather than a way to make the old sentence true again.

The guard, its error message, and `.margin_label`'s documented `NULL` behavior are untouched.

## Checks

- `testthat::test_local()` with `NOT_CRAN=true`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 2270 ]`
- `lintr::lint_package()` after `pkgload::load_all()`: no lints
- `spelling::spell_check_package()`: clean

Closes #109