### PR TITLE
Combine grouping-set branches without folding pairwise

### DIFF
--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -1,3 +1,96 @@
+# The `UNION ALL` composition every branch list ends in, and the one place the
+# package combines branches. `Reduce(dplyr::union_all, branches)` is
+# quadratic in the number of branches (#111): on an eager backend each step
+# re-copies the accumulated frame, and on a lazy one dbplyr re-aligns every
+# branch already folded in against the branch being added. The count is 2^n for
+# a cube over n dimensions, so a ten-dimension cube folds 1024 branches, and the
+# local backend has no `native_grouping_sets` capability, so it always folds.
+#
+# There is no single linear substitution, because a branch list is eager or
+# lazy depending on the input the verb was handed, and only the eager one can
+# be combined in one call. The two paths below are therefore chosen from the
+# branches rather than from the operation's backend: what is being combined is
+# what decides, and `build_lazy_parent_mapping()` in `R/share.R` reaches this
+# from every backend despite its name.
+combine_margin_branches <- function(branches) {
+  # An invariant, not a Package condition (ADR-0015): a plan holds at least one
+  # grouping set, and the share module gates its own call on a non-empty
+  # mapping list. `Reduce()` answered `NULL` here, which is not a result any
+  # caller could use.
+  stopifnot(is.list(branches), length(branches) > 0L)
+
+  if (length(branches) == 1L) {
+    return(branches[[1L]])
+  }
+  if (is.data.frame(branches[[1L]])) {
+    return(bind_margin_branches(branches))
+  }
+  union_margin_branches(branches)
+}
+
+# `dplyr::bind_rows()` combines the whole list in one pass, and it is the whole
+# of the eager path: `union_all.data.frame()` ends in a `dplyr_reconstruct()`
+# onto its first argument, but that call restores nothing `vec_rbind()` did not
+# already take from the same frame, so reproducing it would add the
+# reconstruction step ADR-0016 forbids an adapter and change no result.
+#
+# What does differ is strictness. `bind_rows()` fills a column a branch does not
+# have with `NA` where `union_all()` rejects the pair, so the check below
+# restores it explicitly: a branch of an unexpected shape is a defect in the
+# builders further down this file, and widening the result would hide it.
+bind_margin_branches <- function(branches) {
+  check_branch_columns(branches)
+  dplyr::bind_rows(branches)
+}
+
+# `names()` rather than `get_col_names()`: this runs on data frames only, where
+# it is exact and costs nothing per branch. Column *order* is not checked,
+# because `union_all()` accepts a reordered branch and matches by name.
+check_branch_columns <- function(branches) {
+  expected <- names(branches[[1L]])
+  for (i in seq_along(branches)[-1L]) {
+    actual <- names(branches[[i]])
+    if (length(actual) == length(expected) && setequal(actual, expected)) {
+      next
+    }
+    # Branch, not grouping-set branch: the share module's denominator mappings
+    # are combined here too, and they are one per set that has a coarser one
+    # rather than one per set.
+    stop(
+      "Union branch ", i, " does not have the columns of branch 1.\n",
+      "Only in branch ", i, ": ",
+      toString(setdiff(actual, expected)), "\n",
+      "Only in branch 1: ",
+      toString(setdiff(expected, actual)),
+      call. = FALSE
+    )
+  }
+  invisible(NULL)
+}
+
+# A lazy branch list has to be combined two at a time, since no backend here
+# exposes an n-ary `union_all()`. Pairing adjacent branches and halving makes
+# the work O(n log n) rather than quadratic and, just as importantly, bounds the
+# nesting depth at log2(n): dtplyr builds one step object per pair, and
+# collecting a left fold of 512 branches -- a cube over nine dimensions --
+# exhausts the C stack.
+#
+# Re-associating is safe because `UNION ALL` concatenates, so the row sequence
+# is the same however the pairs are bracketed. dbplyr flattens a union of
+# unions into one query, so the rendered SQL is a single `UNION ALL` over every
+# branch either way, with no subquery per pair.
+union_margin_branches <- function(branches) {
+  while (length(branches) > 1L) {
+    n <- length(branches)
+    pairs <- lapply(
+      seq_len(n %/% 2L),
+      function(i) dplyr::union_all(branches[[2L * i - 1L]], branches[[2L * i]])
+    )
+    branches <- if (n %% 2L == 1L) c(pairs, branches[n]) else pairs
+  }
+  branches[[1L]]
+}
+
 summarize_margin_branch <- function(.data,
                                     ...,
                                     .by) {
@@ -91,7 +184,7 @@ summarize_margin_union <- function(.data,
     plan$set_ids
   )
 
-  Reduce(dplyr::union_all, branches)
+  combine_margin_branches(branches)
 }
 
 expand_margin_union <- function(.data,
@@ -116,5 +209,5 @@ expand_margin_union <- function(.data,
     plan$set_ids
   )
 
-  Reduce(dplyr::union_all, branches)
+  combine_margin_branches(branches)
 }

--- a/R/share.R
+++ b/R/share.R
@@ -2345,7 +2345,7 @@ build_lazy_parent_mapping <- function(result,
       )
     }
   )
-  Reduce(dplyr::union_all, mappings)
+  combine_margin_branches(mappings)
 }
 
 add_lazy_parent_join_keys <- function(result,

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -288,6 +288,17 @@ keys, and labels omitted dimensions. Expansion emits one labelled input branch
 per grouping set; nesting builds on that expansion in its verb executor. Like
 the native adapter, it consumes derived inputs and does not own the lifecycle.
 
+`combine_margin_branches()` is the one place the package combines a branch
+list, and the contextual-share module calls it for its denominator mappings
+rather than folding its own. It chooses its strategy from the branches, not
+from the operation's backend: an eager list is combined in a single
+`bind_rows()` behind an explicit column check that keeps the strictness
+`union_all()` supplied, and a lazy one is paired and halved. That makes the
+eager path one pass over the branches and the lazy path `O(n log n)` with
+nesting depth `log2(n)`, in place of the quadratic pairwise fold both used to
+take. It matters because a cube over ten dimensions is 1024 branches and the
+local backend has no native grouping-sets capability to avoid them.
+
 ## Opaque Margin operation seam
 
 The class name, fields, and constructor of a prepared Margin operation are

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -1,0 +1,226 @@
+# The fold these tests replaced is what every assertion here is written
+# against: `combine_margin_branches()` is a performance change, so the value it
+# has to keep is that its answer is the answer `Reduce(dplyr::union_all, ...)`
+# gave, column classes and attributes included.
+fold_branches_pairwise <- function(branches) {
+  Reduce(dplyr::union_all, branches)
+}
+
+# A cube over nine dimensions, which is 512 branches -- the count at which a
+# left fold of dtplyr steps exhausted the C stack. Both scale tests below want
+# the same frame, and the count is the premise of each.
+nine_dimension_frame <- function() {
+  data <- as.data.frame(lapply(
+    seq_len(9),
+    function(i) rep(c("x", "y"), length.out = 4L)
+  ))
+  names(data) <- paste0("d", seq_len(9))
+  data$value <- seq_len(4)
+  data
+}
+
+# `UNION ALL` occurrences that no parenthesis encloses, which is the number of
+# branches a rendered query unions at its top level, less one. dbplyr renders a
+# subquery inside `FROM (...)`, so paren depth is what tells a widened union
+# from a nested one; identifiers are backquoted and string literals here hold no
+# parentheses, so scanning the text is exact for these queries.
+count_top_level_unions <- function(sql) {
+  characters <- strsplit(sql, "", fixed = TRUE)[[1L]]
+  depth <- cumsum((characters == "(") - (characters == ")"))
+  starts <- gregexpr("UNION ALL", sql, fixed = TRUE)[[1L]]
+  starts <- starts[starts > 0L]
+  sum(depth[starts] == 0L)
+}
+
+test_that("combining branches reproduces a pairwise `union_all()` fold", {
+  cases <- list(
+    "plain data frame" = data.frame(a = 1:3, b = letters[1:3]),
+    "factor and ordered columns" = data.frame(
+      f = factor(c("a", "b", "c"), levels = c("c", "b", "a")),
+      o = ordered(c("l", "m", "h"), levels = c("l", "m", "h"))
+    ),
+    "classed columns" = data.frame(
+      d = as.Date("2024-01-01") + 0:2,
+      p = as.POSIXct("2024-01-01", tz = "UTC") + 0:2
+    ),
+    "list column" = data.frame(a = 1:2, l = I(list(1, "x")))
+  )
+
+  for (label in names(cases)) {
+    branches <- rep(list(cases[[label]]), 4L)
+    expect_identical(
+      combine_margin_branches(branches),
+      fold_branches_pairwise(branches),
+      info = label
+    )
+  }
+})
+
+test_that("combining branches matches the fold on a reordered branch", {
+  first <- data.frame(a = 1:2, b = c("x", "y"))
+  branches <- list(first, first[, c("b", "a")])
+
+  expect_identical(
+    combine_margin_branches(branches),
+    fold_branches_pairwise(branches)
+  )
+})
+
+test_that("a lone branch is returned untouched", {
+  branch <- data.frame(a = 1:2, b = c("x", "y"))
+
+  expect_identical(combine_margin_branches(list(branch)), branch)
+  expect_error(combine_margin_branches(list()))
+})
+
+# `dplyr::bind_rows()` fills a column a branch does not have with `NA`, which
+# would turn a defect in the branch builders into a wider result nobody asked
+# for. The fold rejected that pair, and so does this.
+test_that("a branch of an unexpected shape is rejected, not filled", {
+  branches <- list(
+    data.frame(a = 1:2, b = c("x", "y")),
+    data.frame(a = 3:4)
+  )
+
+  expect_error(combine_margin_branches(branches), "branch 2")
+  expect_error(combine_margin_branches(branches), "Only in branch 1: b")
+  expect_error(combine_margin_branches(rev(branches)), "Only in branch 2: b")
+  # What the guard exists to prevent, stated as the thing that would otherwise
+  # happen.
+  expect_identical(nrow(dplyr::bind_rows(branches)), 4L)
+})
+
+# The eager path has to combine the whole list in one pass, which is the
+# property that makes it linear. Withdrawing `union_all()` is how that is
+# asserted without timing anything: a fold of any shape fails, a single
+# `bind_rows()` does not.
+test_that("eager branches are combined without folding pairwise", {
+  branches <- lapply(1:4, function(i) data.frame(a = 1:2, b = i))
+
+  testthat::local_mocked_bindings(
+    union_all = function(...) stop("pairwise fold on the eager path"),
+    .package = "dplyr"
+  )
+
+  expect_identical(
+    combine_margin_branches(branches),
+    data.frame(a = rep(1:2, 4L), b = rep(1:4, each = 2L))
+  )
+})
+
+test_that("an eager expansion over 512 branches keeps one branch per set", {
+  data <- nine_dimension_frame()
+  spec <- grouping_spec(cube(dplyr::starts_with("d")))
+
+  dimensions <- names(data)[names(data) != "value"]
+  expanded <- expand_with_margins(data, .grouping = spec)
+
+  expect_identical(length(compile_grouping_spec(spec, names(data))$sets), 512L)
+  expect_identical(nrow(expanded), 512L * nrow(data))
+  # One branch labels every dimension, and no other branch can.
+  all_total <- rowSums(expanded[dimensions] == "Total") == length(dimensions)
+  expect_identical(sum(all_total), nrow(data))
+  expect_identical(expanded$value[all_total], data$value)
+  expect_identical(class(expanded), class(data))
+})
+
+test_that("lazy branches nest logarithmically rather than linearly", {
+  skip_if_backend_absent("dtplyr")
+
+  # Folding 512 branches from the left builds 512 nested dtplyr steps, and
+  # collecting that exhausts the C stack; pairing and halving bounds the depth
+  # at nine.
+  data <- nine_dimension_frame()
+  spec <- grouping_spec(cube(dplyr::starts_with("d")))
+  expanded <- expand_with_margins(dtplyr::lazy_dt(data), .grouping = spec)
+
+  expect_identical(nrow(dplyr::collect(expanded)), 2048L)
+})
+
+test_that("a union-path query is one flat `UNION ALL` over every branch", {
+  skip_if_backend_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  data <- data.frame(
+    a = c("x", "x", "y"),
+    b = c("u", "v", "u"),
+    c = c("p", "q", "p"),
+    value = 1:3
+  )
+  dplyr::copy_to(con, data, "branch_union", temporary = TRUE)
+  remote <- dplyr::tbl(con, "branch_union")
+  spec <- grouping_spec(cube(a, b, c))
+
+  query <- summarize_with_margins(
+    remote,
+    total = sum(value, na.rm = TRUE),
+    .grouping = spec
+  )
+  sql <- as.character(dbplyr::sql_render(query))
+
+  # Every branch joins the same top-level `UNION ALL`, with none bracketed into
+  # a subquery of its own. Counting alone would not say that -- a nested union
+  # renders the same number of `UNION ALL`s, just inside a `FROM (...)` -- so
+  # what is counted is the ones outside every parenthesis.
+  #
+  # dbplyr flattens a union of unions, so this holds whichever way the branches
+  # are bracketed on the way in, and it is the property rather than the
+  # bracketing that is pinned here.
+  set_count <- length(compile_grouping_spec(spec, names(data))$sets)
+  expect_identical(set_count, 8L)
+  expect_identical(count_top_level_unions(sql), set_count - 1L)
+
+  remote_result <- query |>
+    dplyr::collect() |>
+    dplyr::arrange(a, b, c)
+  local_result <- summarize_with_margins(
+    data,
+    total = sum(value, na.rm = TRUE),
+    .grouping = spec
+  ) |>
+    dplyr::as_tibble() |>
+    dplyr::arrange(a, b, c)
+
+  expect_equal(remote_result, local_result)
+})
+
+# The third fold site: `build_lazy_parent_mapping()` unions one denominator
+# mapping per grouping set that has a coarser one. A Parent share needs a pure
+# `rollup()`, so that site never sees the branch counts the other two do -- it
+# is converted for one mechanism rather than for its own cost.
+test_that("Parent shares combine their denominator mappings the same way", {
+  data <- data.frame(
+    region = rep(c("north", "south"), each = 4L),
+    channel = rep(c("web", "store"), times = 4L),
+    sku = rep(c("a", "b"), each = 2L),
+    value = seq_len(8)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    total = sum(value),
+    parent = share_of_parent(total),
+    .grouping = rollup(region, channel, sku)
+  )
+
+  grand_total <- sum(data$value)
+  is_grand_total <- result$region == "Total"
+  expect_identical(result$total[is_grand_total], grand_total)
+  expect_identical(result$parent[is_grand_total], 1)
+
+  # The set one dimension finer than the Grand total divides by it, and the
+  # one below that divides by its own region.
+  by_region <- result[
+    result$channel == "Total" & result$sku == "Total" & !is_grand_total,
+  ]
+  expect_equal(by_region$parent, by_region$total / grand_total)
+
+  by_channel <- result[result$sku == "Total" & result$channel != "Total", ]
+  region_totals <- stats::setNames(by_region$total, by_region$region)
+  expect_equal(
+    by_channel$parent,
+    by_channel$total / unname(region_totals[by_channel$region])
+  )
+})


### PR DESCRIPTION
`Reduce(dplyr::union_all, branches)` was how all three branch lists ended: the summary and expansion paths in the portable adapter, and the Parent-share denominator mappings in `R/share.R`. A left fold is quadratic in the number of branches, and the number of branches is 2^n for a cube over n dimensions — 1024 for a ten-dimension cube, which the default local backend always takes because `local` has no `native_grouping_sets` capability.

`combine_margin_branches()` replaces all three. The fix is not one substitution, because a branch list is eager or lazy depending on the input the verb was handed, so the strategy is chosen from the branches rather than from the operation's backend — `build_lazy_parent_mapping()` reaches this from every backend despite its name.

## Changes

- **Eager**: one `dplyr::bind_rows()`, which is the whole of that path. `union_all.data.frame()` ends in a `dplyr_reconstruct()` onto its first argument, but that call restores nothing `vec_rbind()` did not already take from the same frame — measured identical for plain, subclassed, attribute-carrying, tibble, and `data.table` branches — so reproducing it would add the reconstruction step ADR 0016 forbids an adapter and change no result.
- **Strictness is restored explicitly.** `bind_rows()` fills a column a branch does not have with `NA` where `union_all()` rejects the pair, so `check_branch_columns()` rejects it instead. A branch of an unexpected shape is a defect in the builders above it, and widening the result would hide it. Bare `stop()` per ADR 0015: no rewrite of a public call reaches it.
- **Lazy**: no backend here exposes an n-ary `union_all()`, so branches are paired and halved. `O(n log n)` rather than quadratic, with nesting depth `log2(n)`.
- The share site is converted for one mechanism rather than for its own cost. A Parent share requires a pure `rollup()`, so its mapping list is one entry per dimension and was never large.
- `design/architecture.md` records `combine_margin_branches()` as the one place the package combines a branch list, and that the contextual-share module calls it rather than folding its own.

## Two corrections to the issue

**The SQL nesting does not reproduce on the required dbplyr.** `DESCRIPTION` pins `dbplyr (>= 2.6.0)`, whose `add_union()` already flattens a union of unions, so the left fold rendered a flat `UNION ALL` too. The quadratic cost there was R-side query-tree re-alignment, not nesting: the rendered SQL for a SQLite cube is byte-identical before and after this change. The acceptance criterion is still pinned, but by counting the `UNION ALL`s no parenthesis encloses — a raw count is the same for a nested union, so it could not have failed for the reason its name gives.

**Bounding the nesting depth fixes a crash, not just a cost.** Under dtplyr a left fold builds one step object per pair, and collecting 512 of them exhausts the C stack — so a cube over nine dimensions could not be expanded at all, on any input size. That is the one lazy regression the balanced pairing is load-bearing for, and it has a test.

## Measurements

| | fold | now |
|---|---:|---:|
| Eager, 1024 branches × 500 rows | 0.247 s | 0.011 s |
| SQLite, 1024 branches (query construction) | 11.6 s | 0.42 s |
| Local ten-dimension cube, end to end | 4.86 s | 2.91 s |
| dtplyr, nine-dimension cube expansion | C stack overflow | 1.33 s |

The end-to-end figure is the honest one: the per-branch `summarize()` calls are the rest of it, and are out of scope per the brief.

## Tests

`tests/testthat/test-branch-union.R`. Equivalence against `Reduce(dplyr::union_all, ...)` is what most of them assert, since this is a performance change: plain, factor and ordered, `Date`/`POSIXct`, list-column, and reordered-column branches.

Confirmed failing before passing, by restoring the fold:

- *eager branches are combined without folding pairwise* — withdraws `dplyr::union_all()` with `local_mocked_bindings()`, so a fold of any shape fails and one `bind_rows()` does not. This is how the linearity is asserted without timing anything.
- *lazy branches nest logarithmically rather than linearly* — the dtplyr C-stack case above.
- *a branch of an unexpected shape is rejected, not filled*, and the empty-list guard.

Per `AGENTS.md`, no test requires more than one member of `optional_backends()`: the dtplyr test takes `skip_if_backend_absent("dtplyr")` and the SQL test `skip_if_backend_absent("RSQLite", "DBI")`, where `DBI` is `asserted = FALSE`.

## Checks

- `lintr::lint_package()` after `pkgload::load_all()`: no lints
- `roxygen2::roxygenise()`: no diff
- `testthat::test_local()`: 2295 pass, 0 fail, 0 warn, 0 skip
- `.github/scripts/verify-suite-coverage.R`: 378/378 tests execute in at least one single-backend configuration
- `spelling::spell_check_package()`: clean
- `R CMD check` on a built tarball: **OK**, and again under `_R_CHECK_DEPENDS_ONLY_=true`: **OK**

Closes #111
