### PR TITLE
Drop the altdoc Suggests entry the package never uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,31 @@ so it can change without a commit here. Keeping the Suggests entry is still
 right, because it records a direct use that would need declaring if the closure
 stopped supplying it.
 
+The audit runs in the other direction too, and a scanner is no more use there:
+a package the shipped sources never reference does not belong in Suggests,
+however real the tool that needs it. `att_amend_desc()` does prune, but by the
+same static reading that over-prunes above, so what it removes is not evidence
+either. `altdoc` was declared there while nothing outside `.Rbuildignore`d
+paths used it — `.github/workflows/altdoc.yaml` and the `altdoc::render_docs()`
+call in this file build the site, `altdoc/` configures it, and
+`.github/scripts/verify-site.R` reads its output — so the entry installed a
+dependency closure for a package the tarball never mentions (#113).
+
+`Config/Needs/website` is where such a dependency belongs, and it is not a
+weaker home: `setup-r-dependencies@v2` resolves that field through pak, which
+parses *and enforces* a version constraint written there, so a floor moved
+across loses nothing. That is worth re-checking rather than assuming, because
+nothing in this repository would fail if it stopped holding — a dropped
+constraint silently installs an older altdoc. Check it by putting an
+unsatisfiable constraint in the field of a throwaway package and resolving it:
+`pak::pkg_deps("local::<pkg>", dependencies = list(direct =
+"Config/Needs/website", indirect = "Config/Needs/website"))` must fail naming
+the constraint, not resolve.
+
+The grep above is what finds an entry like this, because `R CMD check` does not
+— an unused Suggest raises no NOTE, which is why nothing flagged it for as long
+as it stood.
+
 ### Release matrix
 
 `.github/workflows/release-matrix.yaml` checks one built tarball rather than

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     tidyselect (>= 1.2.0),
     utils
 Suggests:
-    altdoc (>= 0.7.3),
     arrow (>= 13.0.0),
     DBI,
     dtplyr (>= 1.3.2),
@@ -43,7 +42,7 @@ SystemRequirements: Quarto command line tool
     (<https://github.com/quarto-dev/quarto-cli>), needed to build the vignettes
     from their '.qmd' sources.
 Config/Needs/website:
-    altdoc,
+    altdoc (>= 0.7.3),
     DBI,
     dtplyr,
     duckdb,


### PR DESCRIPTION
`DESCRIPTION` declared `altdoc (>= 0.7.3)` under Suggests, but no file in `R/`, `tests/`, `vignettes/`, or `man/` references it. Everything that does use altdoc sits behind `.Rbuildignore` — `.github/workflows/altdoc.yaml` and the `altdoc::render_docs()` call in `AGENTS.md` build the site, `altdoc/` configures it, and `.github/scripts/verify-site.R` reads its output. So under `dependencies = TRUE` the entry installed a dependency closure for a package the tarball never mentions.

Nothing had to change to make the removal safe. `optional_backend_spec()` does not track altdoc, and `test-optional-backends.R:219` only requires *tracked* backends to appear in Suggests, so no gate was resting on the entry.

## The version floor moves rather than being dropped

The brief asked only that altdoc be "still present in `Config/Needs/website`", where it already was — unversioned. Deleting the Suggests line as written would therefore have silently lowered the floor to "any altdoc", which is a regression the acceptance criteria would not have caught. The constraint moves into `Config/Needs/website` instead.

That field is not a weaker home: `setup-r-dependencies@v2` resolves it through pak, which both parses and *enforces* a constraint written there. Checked rather than assumed, because a constraint that stopped being honored would install an older altdoc and fail nothing here — a throwaway package carrying `altdoc (>= 0.7.3)` in that field resolves to 0.7.3, and the same package carrying `altdoc (>= 99.0.0)` fails with `Can't install dependency altdoc (>= 99.0.0)` rather than resolving.

`AGENTS.md` records that reproduction alongside the rule, since it is the kind of behavior that can regress in another project's release without a commit here — the same reasoning its `packageDescription("<import>")$Imports` note already applies to the hard-dependency closure.

## `AGENTS.md`

The Dependency metadata section covered the audit in one direction only: a static scanner wrongly *promoting* a conditionally-used Suggest to Imports. This issue is the other direction, and the section had nothing to say about it. It now records that a package the shipped sources never reference does not belong in Suggests however real the tool that needs it, that `Config/Needs/website` is where a website-only dependency goes, and that the manual grep is what finds these — `R CMD check` raises no NOTE for an unused Suggest, which is why this stood for as long as it did.

## Verification

| Check | Result |
|---|---|
| `R CMD check --as-cran` (built tarball) | Status: OK, no NOTEs |
| `_R_CHECK_DEPENDS_ONLY_=true R CMD check` | Status: OK |
| Full testthat suite | passes, no skips |
| `lintr::lint_package()` | no lints |
| `altdoc::render_docs()` + `.github/scripts/verify-site.R` | 19 pages verified |
| `roxygen2::roxygenise()` | no drift |

The local site render is weaker evidence than it looks — it runs against an already-installed altdoc, so it never exercises the line that changed. The pak resolution above is what actually covers it.

## Suggests audit

Per the fourth acceptance criterion, every remaining Suggest was grepped for `pkg::` and bare-name use across `R/`, `tests/`, and `vignettes/`. All are used:

| Package | Used at |
|---|---|
| arrow | `R/backend-metadata.R:10`, `tests/testthat/test-get-col-names.R` |
| DBI | examples in `R/summarize_with_margins.R`, `tests/testthat/test-branch-union.R` |
| dtplyr | examples in `R/nest_by_with_margins.R`, `tests/testthat/test-get-col-names.R` |
| duckdb | examples, `tests/testthat/helper-duckdb.R`, `vignettes/database_backends.qmd` |
| knitr | `vignettes/recipes.qmd`'s `must_error` hook, `vignettes/get_started.qmd` |
| quartabs | `vignettes/get_started.qmd` |
| quarto | the `\VignetteEngine{quarto::html}` of all five vignettes |
| RSQLite | `tests/testthat/helper-sqlite-simulation.R`, `test-share-backends.R` |
| spelling | `tests/spelling.R` |
| testthat | throughout `tests/` |
| tibble | `tests/testthat/test-grouping-interface.R`, examples in `R/share.R` |
| tidyr | `vignettes/completing_keys.qmd:91` |

`attachment::att_amend_desc()` was not used, per the rule in `AGENTS.md`.

Closes #113
