### PR TITLE
Shorten the test titles that forced reasonless `# nolint`s

### DIFF
--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -116,8 +116,8 @@ audit; nothing promoted to Imports.
 
 **Supported-backend claims are not backed by live execution** — #35, #38.
 `test-parent-share-backends.R` "RSQLite executes portable Parent shares end to
-end" and "DuckDB Parent shares agree across native, portable, and local
-paths", executed by the four `backend` jobs.
+end" and "DuckDB Parent shares agree across native, portable, local paths",
+executed by the four `backend` jobs.
 
 **Reference documentation duplicates contracts that can drift** — #36. All
 three tests in `test-documentation.R`.
@@ -162,8 +162,8 @@ its sole occurrence identifier" covers the `nest_by` one-row empty case.
 **Factor returns are defective** (Spec).
 **Rejected — no observable gap.** No factor-return defect reproduces at the
 public interface. `test-margin-label.R` "factor NA levels and missing values
-follow the eight-case contract" walks the whole ADR 0012 table; "NA factor
-levels stay structural when collision checks are disabled" covers the
+obey the eight-case contract" walks the whole ADR 0012 table; "NA factor
+levels stay structural when collision checks are off" covers the
 `.check_margin_label = FALSE` clause; "dtplyr applies mixed named labels
 lazily and restores factors" and "DuckDB uses typed missing for a missing
 factor Margin label" cover factor returns from lazy backends. Returned columns

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -334,7 +334,7 @@ register_inspect_proxy_methods <- function() {
   )
 }
 
-test_that("lazy inspection reads typed metadata once without executing margins", { # nolint: line_length_linter
+test_that("lazy inspection reads typed metadata once, executing no margins", {
   skip_if_backend_absent("dtplyr")
   register_inspect_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -36,7 +36,7 @@ factor_contract_data <- function(has_na_level, has_missing_value) {
   )
 }
 
-test_that("factor NA levels and missing values follow the eight-case contract", { # nolint: line_length_linter
+test_that("factor NA levels and missing values obey the eight-case contract", {
   cases <- data.frame(
     label = c(rep("NA", 4L), rep("NULL", 4L)),
     na_level = rep(c(TRUE, TRUE, FALSE, FALSE), 2L),
@@ -76,7 +76,7 @@ test_that("factor NA levels and missing values follow the eight-case contract", 
   }
 })
 
-test_that("NA factor levels stay structural when collision checks are disabled", { # nolint: line_length_linter
+test_that("NA factor levels stay structural when collision checks are off", {
   with_na_level <- factor_contract_data(
     has_na_level = TRUE,
     has_missing_value = FALSE
@@ -190,7 +190,7 @@ test_that("named Margin labels require exact dimension coverage", {
   )
 })
 
-test_that("factor collisions include unused levels and remain column-specific", { # nolint: line_length_linter
+test_that("factor collisions include unused levels and stay column-specific", {
   data <- data.frame(
     first = factor(c("a", "b"), levels = c("a", "b", "All first")),
     second = factor(c("x", "y"), levels = c("x", "y", "All second")),

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -592,7 +592,7 @@ parent_lazy_probe_counts <- function() {
   )
 }
 
-test_that("PostgreSQL renders one staged Parent-share mapping for all measures", { # nolint: line_length_linter
+test_that("PostgreSQL renders one staged Parent-share join for all measures", {
   data <- data.frame(
     region = "East",
     store = "A",
@@ -1122,7 +1122,7 @@ test_that("DuckDB rejects an ineligible share source like the local backend", {
   ))
 })
 
-test_that("DuckDB Parent shares agree across native, portable, and local paths", { # nolint: line_length_linter
+test_that("DuckDB Parent shares agree across native, portable, local paths", {
   skip_if_backend_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1536,7 +1536,7 @@ test_that("RSQLite executes portable Total shares end to end", {
   )
 })
 
-test_that("DuckDB Total shares agree across native, portable, and local paths", { # nolint: line_length_linter
+test_that("DuckDB Total shares agree across native, portable, local paths", {
   skip_if_backend_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)


### PR DESCRIPTION
Seven `test_that()` headers in `tests/` carried a bare `# nolint: line_length_linter`. `AGENTS.md` requires every `# nolint` in R code to sit next to a comment stating the expression-specific reason, and names the reasons it contemplates — a glue string or an NSE pronoun that `codetools` cannot follow, or a name fixed by another package's API.

None of the seven had one, and none could. The line was long because the test's *description string* was long, which nothing outside the file constrains — so there was no fact about the expression to record. `AGENTS.md` says what to do with a suppression that is not forced: "rewrite the line rather than suppress it". Each description is shortened instead.

## The rewrites

Every one was over the 80-column limit by one or two characters, so the cuts are small. Each still names the contract the test asserts, which is the constraint that made this more than a search-and-replace.

| File | Before | After |
|---|---|---|
| `test-margin-label.R:39` | factor NA levels and missing values **follow** the eight-case contract | …**obey**… |
| `test-margin-label.R:79` | NA factor levels stay structural when collision checks are **disabled** | …are **off** |
| `test-margin-label.R:193` | factor collisions include unused levels and **remain** column-specific | …and **stay**… |
| `test-inspect-grouping.R:337` | lazy inspection reads typed metadata once **without executing** margins | …once**, executing no** margins |
| `test-share-backends.R:595` | PostgreSQL renders one staged Parent-share **mapping** for all measures | …one staged Parent-share **join**… |
| `test-share-backends.R:1125` | DuckDB Parent shares agree across native, portable, **and** local paths | …native, portable, local paths |
| `test-share-backends.R:1539` | DuckDB Total shares agree across native, portable, **and** local paths | …native, portable, local paths |

No assertion, fixture, helper call, or skip guard changed. The diff is 11 lines, all strings.

Two of these keep a word the shortest available rewrite would have dropped, because the shorter one made a claim the body does not test:

- **`:595` stays "renders".** The test asserts over `dbplyr::sql_render()` output — it never executes anything — so "stages" would read as a runtime claim. It is also renamed for the one `LEFT JOIN` it counts rather than for the mapping that join carries, which is closer to `parent_sql_count(many_sql, "LEFT JOIN") == 1L` than the original was.
- **`:193` stays "include".** The contract is that the collision check considers a level *absent from the data*, which the unused `"All first"` level in its fixture establishes. A verb attributing the covering to the collisions themselves would have been vaguer than what it replaced.

I did not take a third suggestion, to drop "paths" from the two DuckDB titles so the Oxford "and" could stay. "Paths" is the load-bearing noun — these compare the native, portable, and local *code paths* — and "agree across native, portable, and local" leaves the adjectives dangling. The asyndetic list is the lesser cost.

## Two prose comments were left alone

`test-share-backends.R:1233` and `test-margin-order.R:534` contain the string `# nolint` inside comments *about* when a suppression is needed. They are not suppressions and are unchanged.

The four surviving `# nolint`s in `tests/` — `helper-unpredictable-summary-names.R:50` and `test-static-expression-analysis.R:86`, `:131`, `:269` — are `object_usage_linter` blocks that already carry their reason, each naming the data-mask or quosure resolution `codetools` cannot follow. They are compliant and untouched, as are the ones in `R/`.

## `design/review-dispositions.md`

That ledger quotes three of the seven titles as the evidence behind a rejected review finding, and its header states the premise: an entry must "point at something executable". A rename that left the quotations behind would have misnamed the evidence, so they move with the titles. No other file in the repo quotes any of the seven — checked across `design/`, `vignettes/`, `.github/`, `NEWS.md`, and `tests/testthat/_snaps/`.

Snapshots deserve a specific note, since a renamed `test_that()` silently orphans its snapshot block: `_snaps/` holds no heading for any of the seven. Only `share-backends.md` overlaps these files, and its two blocks belong to the Arrow tests, which are untouched.

## Verification

| Check | Result |
|---|---|
| `pkgload::load_all("."); lintr::lint_package()` | no lints |
| Full testthat suite, `NOT_CRAN=true` | passes, no skips |
| `.github/scripts/verify-suite-coverage.R` | all 378 tests execute in ≥1 of arrow, duckdb, dtplyr, RSQLite |
| No line in `tests/` over 80 columns | confirmed |
| Duplicate test titles across the suite | none |

`verify-suite-coverage.R` keys tests by file and name derived at runtime rather than from a hard-coded list, so a rename cannot uncover a test — but it is the gate that would notice if one did, which is why it is run here rather than assumed.

## Follow-up filed, not fixed

While updating those three quotations I found that `design/review-dispositions.md` has rotted more broadly: 19 citations name `test-parent-share.R` or `test-parent-share-backends.R`, neither of which has existed since those files were renamed, and three quoted test titles resolve to nothing under any name. That is pre-existing and out of scope for #120, so it is #150 rather than commits here.

Closes #120
