### PR TITLE
Name the Parent share of a Grand total set row

### DIFF
--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -631,11 +631,11 @@ parent_report |>
   arrange(region, store)
 ```
 
-The root share is one. Missing numerators or denominators and zero
-denominators produce a missing double value. The helper requires a rollup and
-uses internal Grouping identity, so displayed Margin labels and source missing
-keys do not determine the parent. For multiple measures, complete source
-rules, and the supported `across()` form, see the
+A row of the Grand total set has a Parent share of one. Missing numerators or
+denominators and zero denominators produce a missing double value. The helper
+requires a rollup and uses internal Grouping identity, so displayed Margin
+labels and source missing keys do not determine the parent. For multiple
+measures, complete source rules, and the supported `across()` form, see the
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html).
 
 For several measures, use two ordered `across()` expressions: the first


### PR DESCRIPTION
`CONTEXT.md`'s Total share entry bans "root share". `vignettes/get_started.qmd`
used it anyway, and under `share_of_parent()`, where the concept is a Parent
share rather than a Total share — so the phrase was both a banned form and the
wrong entry's name for the row.

The sentence now reads "A row of the Grand total set has a Parent share of
one", the wording `CONTEXT.md`'s own Parent share entry uses, capitalized to
match how the vignette treats domain terms elsewhere ("Parent share" and
"Parent shares" a few lines below). The rest of the paragraph is rewrapped
around it.

Prose only; no result changes. fa8b42f cleared the Grand total set `_Avoid_`
violations and missed this one because it names a different entry's banned
term.

## Verification

- `grep` for "root share" now matches only `CONTEXT.md`'s own `_Avoid_` list.
- `spelling::spell_check_package()` reports no errors.
- `testthat::test_local()` passes in full.
- The rewrapped lines stay under 80 characters; the over-80 lines remaining in
  the file are pre-existing URLs and table rows.

Closes #121