### PR TITLE
Dispatch reconstruct_factor() tests through the generic

### DIFF
--- a/tests/testthat/test-factor.R
+++ b/tests/testthat/test-factor.R
@@ -29,7 +29,7 @@ test_that("reconstruct_factor() works with data.frame", {
 
   actual <- Reduce(
     function(df, info) {
-      reconstruct_factor.data.frame(df, info, "aaa")
+      reconstruct_factor(df, info, "aaa")
     },
     x = l_info,
     init = data_chr
@@ -101,7 +101,7 @@ test_that("reconstruct_factor() works with duckdb", {
 
   actual <- Reduce(
     function(df, info) {
-      reconstruct_factor.tbl_duckdb_connection(df, info, "aaa")
+      reconstruct_factor(df, info, "aaa")
     },
     x = l_info,
     init = data_chr
@@ -156,7 +156,7 @@ test_that("reconstruct_factor() works with dtplyr_step", {
 
   actual <- Reduce(
     function(df, info) {
-      reconstruct_factor.dtplyr_step(df, info, "aaa")
+      reconstruct_factor(df, info, "aaa")
     },
     x = l_info,
     init = data_chr


### PR DESCRIPTION
Closes #118.

Each of the three factor-reconstruction tests called its method by dotted name (`reconstruct_factor.data.frame()`, `reconstruct_factor.tbl_duckdb_connection()`, `reconstruct_factor.dtplyr_step()`), which exercises the method body but never `UseMethod("reconstruct_factor")`, so a lost or misspelled `@exportS3Method` registration would not fail these tests. Each test now calls the generic `reconstruct_factor()` instead, so both dispatch and registration are covered.

## Verification

- For each of the three methods, removing its `@exportS3Method` tag and regenerating `NAMESPACE` makes the suite fail naming the missing dispatch, and the suite passes again once restored.
- Results are unchanged (`expect_identical()` assertions untouched).
- Optional-backend tests still skip through `skip_if_backend_absent()`, and each still requires at most one member of `optional_backends()`.
- `Rscript .github/scripts/verify-suite-coverage.R` passes.
- `lintr::lint_package()` reports no lints; full local test suite passes.

## Out of scope

`reconstruct_factor` is the only package-defined internal generic (`UseMethod` call) in `R/`, so there was no other generic to audit for the same gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)