### PR TITLE
Route every plan compilation through compile_grouping_spec()

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -113,28 +113,34 @@ prepare_grouping_plan <- function(.data,
       if (!is.null(validate_names)) {
         validate_names(data_vars)
       }
+      # Preflighted once and handed to both compilation passes. Preflight is
+      # not a free re-run: `grouping_arg_spec()` evaluates a symbol or a nested
+      # constructor argument, so preflighting per pass would evaluate a
+      # caller's quosure twice, and ADR-0008 holds the number and timing of
+      # evaluations fixed.
       preflight <- preflight_grouping_spec(grouping_spec, data_vars)
-      grouping_spec <- preflight$spec
       if (preflight$name_only) {
         # Reject name-only plan errors before acquiring typed metadata. The
         # canonical plan is compiled from the typed snapshot below.
-        compile_grouping_spec_impl(
+        compile_grouping_spec(
           grouping_spec,
           data_vars = data_vars,
           data_proxy = grouping_name_proxy(data_vars),
           .by = by,
           .duplicates = .duplicates,
-          duplicates_choices = duplicates_choices
+          duplicates_choices = duplicates_choices,
+          preflight = preflight
         )
       }
       data_proxy <- grouping_selection_proxy(data, backend = backend)
-      plan <- compile_grouping_spec_impl(
+      plan <- compile_grouping_spec(
         grouping_spec,
         data_vars = data_vars,
         data_proxy = data_proxy,
         .by = by,
         .duplicates = .duplicates,
-        duplicates_choices = duplicates_choices
+        duplicates_choices = duplicates_choices,
+        preflight = preflight
       )
 
       list(
@@ -296,24 +302,53 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   list(spec = grouping_spec, name_only = name_only)
 }
 
-compile_grouping_spec <- function(.grouping,
-                                  data_vars,
-                                  data_proxy = NULL,
-                                  .by = character(),
-                                  .duplicates = margin_duplicates_choices) {
+# The one way to turn a Grouping specification into a plan: preflight the
+# specification, then compile what the preflight resolved. Every call site is
+# here, `prepare_grouping_plan()`'s two compilation passes included, so a test
+# that compiles through this function runs the sequence production runs. It was
+# not always so — production reached `compile_grouping_spec_impl()` directly and
+# performed the preflight and the `.duplicates` matching for itself, leaving
+# this wrapper a second source of truth that only tests exercised (#119).
+# `test-grouping-plan.R` holds the namespace to a single caller of the
+# implementation so that cannot come back.
+#
+# `duplicates_choices` is the calling verb's own vocabulary, never the Margin
+# one: a verb that narrows it hands its list down rather than being re-checked
+# against the wider one (#110), and the hard-coded `margin_duplicates_choices`
+# this replaces is what put the nesting verbs' narrowing beyond a test's reach.
+# It has no default for the reason it has none in `normalize_margin_options()`
+# — a default here is what let the nesting verbs be validated against a list
+# their own formals exclude, and `compile_grouping_spec_impl()`'s membership
+# assert would not catch it, since the wider list admits the narrower one's
+# every value. `.duplicates` defaults to whichever list the caller stated,
+# which keeps `match_margin_choice()`'s "an untouched formal stands for its
+# first entry" idiom working for a narrowed vocabulary.
+#
+# `preflight` lets a caller running more than one pass over one specification
+# hand the same preflight to each, rather than paying a second evaluation of
+# the caller's quosures for a result that cannot differ (ADR-0008).
+compile_grouping_spec <- function(
+  .grouping,
+  data_vars,
+  data_proxy = NULL,
+  .by = character(),
+  .duplicates = duplicates_choices,
+  duplicates_choices,
+  preflight = preflight_grouping_spec(.grouping, data_vars)
+) {
   .duplicates <- match_margin_choice(
     .duplicates,
-    choices = margin_duplicates_choices,
+    choices = duplicates_choices,
     arg_name = ".duplicates"
   )
-  preflight <- preflight_grouping_spec(.grouping, data_vars)
+  stopifnot(identical(preflight$spec, .grouping))
   compile_grouping_spec_impl(
     preflight$spec,
     data_vars = data_vars,
     data_proxy = data_proxy,
     .by = .by,
     .duplicates = .duplicates,
-    duplicates_choices = margin_duplicates_choices
+    duplicates_choices = duplicates_choices
   )
 }
 

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -115,7 +115,12 @@ test_that("an eager expansion over 512 branches keeps one branch per set", {
   dimensions <- names(data)[names(data) != "value"]
   expanded <- expand_with_margins(data, .grouping = spec)
 
-  expect_identical(length(compile_grouping_spec(spec, names(data))$sets), 512L)
+  plan <- compile_grouping_spec(
+    spec,
+    names(data),
+    duplicates_choices = margin_duplicates_choices
+  )
+  expect_identical(length(plan$sets), 512L)
   expect_identical(nrow(expanded), 512L * nrow(data))
   # One branch labels every dimension, and no other branch can.
   all_total <- rowSums(expanded[dimensions] == "Total") == length(dimensions)
@@ -168,7 +173,12 @@ test_that("a union-path query is one flat `UNION ALL` over every branch", {
   # dbplyr flattens a union of unions, so this holds whichever way the branches
   # are bracketed on the way in, and it is the property rather than the
   # bracketing that is pinned here.
-  set_count <- length(compile_grouping_spec(spec, names(data))$sets)
+  plan <- compile_grouping_spec(
+    spec,
+    names(data),
+    duplicates_choices = margin_duplicates_choices
+  )
+  set_count <- length(plan$sets)
   expect_identical(set_count, 8L)
   expect_identical(count_top_level_unions(sql), set_count - 1L)
 

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -1466,7 +1466,11 @@ test_that("DuckDB native and UNION adapters agree", {
     dplyr::collect() |>
     dplyr::arrange(a, b, gid)
 
-  plan <- compile_grouping_spec(spec, names(data))
+  plan <- compile_grouping_spec(
+    spec,
+    names(data),
+    duplicates_choices = margin_duplicates_choices
+  )
   dots <- rlang::quos(total = sum(value), gid = grouping_id(a, b))
   fallback <- summarize_margin_union(
     remote,

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -1,7 +1,8 @@
 test_that("rollup and cube compile to concrete grouping sets", {
   rollup_plan <- compile_grouping_spec(
     rollup(a, b, c),
-    data_vars = c("a", "b", "c")
+    data_vars = c("a", "b", "c"),
+    duplicates_choices = margin_duplicates_choices
   )
   expect_equal(
     rollup_plan$sets,
@@ -18,7 +19,8 @@ test_that("rollup and cube compile to concrete grouping sets", {
 
   cube_plan <- compile_grouping_spec(
     cube(grouping_set(country, state), year),
-    data_vars = c("country", "state", "year")
+    data_vars = c("country", "state", "year"),
+    duplicates_choices = margin_duplicates_choices
   )
   expect_equal(
     cube_plan$sets,
@@ -36,7 +38,8 @@ test_that("grouping families support union, nesting, and Cartesian product", {
 
   product <- compile_grouping_spec(
     grouping_spec(rollup(a, b), cube(c)),
-    data_vars = vars
+    data_vars = vars,
+    duplicates_choices = margin_duplicates_choices
   )
   expect_equal(
     product$sets,
@@ -49,7 +52,8 @@ test_that("grouping families support union, nesting, and Cartesian product", {
   nested <- compile_grouping_spec(
     grouping_sets(rollup(a, b), cube(c, d)),
     data_vars = vars,
-    .duplicates = "drop"
+    .duplicates = "drop",
+    duplicates_choices = margin_duplicates_choices
   )
   expect_equal(
     nested$sets,
@@ -98,7 +102,12 @@ test_that("grouping specification kinds enforce the nesting grammar", {
     spec <- eval(
       rlang::call2(constructors[[parent]], nested_calls[[child]])
     )
-    compile_grouping_spec(spec, "a", .duplicates = "keep")
+    compile_grouping_spec(
+      spec,
+      "a",
+      .duplicates = "keep",
+      duplicates_choices = margin_duplicates_choices
+    )
   }
 
   for (parent in names(constructors)) {
@@ -117,27 +126,48 @@ test_that("grouping specification kinds enforce the nesting grammar", {
   for (constructor in constructors) {
     spec <- eval(rlang::call2(constructor, rlang::sym("a")))
     expect_no_error(
-      compile_grouping_spec(spec, "a", .duplicates = "keep")
+      compile_grouping_spec(
+        spec,
+        "a",
+        .duplicates = "keep",
+        duplicates_choices = margin_duplicates_choices
+      )
     )
   }
 })
 
 test_that("empty grouping rules preserve their phase and error precedence", {
   expect_equal(
-    compile_grouping_spec(grouping_set(a), "a")$sets,
+    compile_grouping_spec(
+      grouping_set(a),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    )$sets,
     list("a")
   )
   expect_equal(
-    compile_grouping_spec(grouping_set(), "a")$sets,
+    compile_grouping_spec(
+      grouping_set(),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    )$sets,
     list(character())
   )
   expect_equal(
-    compile_grouping_spec(grouping_spec(), "a")$sets,
+    compile_grouping_spec(
+      grouping_spec(),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    )$sets,
     list(character())
   )
 
   sets_error <- expect_error(
-    compile_grouping_spec(grouping_sets(), "a")
+    compile_grouping_spec(
+      grouping_sets(),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    )
   )
   expect_s3_class(sets_error, "marginplyr_error")
   expect_identical(
@@ -150,7 +180,11 @@ test_that("empty grouping rules preserve their phase and error precedence", {
 
   for (constructor in c("rollup", "cube")) {
     spec <- eval(rlang::call2(constructor))
-    error <- expect_error(compile_grouping_spec(spec, "a"))
+    error <- expect_error(compile_grouping_spec(
+      spec,
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    ))
     expect_s3_class(error, "marginplyr_error")
     expect_identical(
       conditionMessage(error),
@@ -164,7 +198,11 @@ test_that("empty grouping rules preserve their phase and error precedence", {
       quote(tidyselect::any_of("missing"))
     ))
     resolved_empty <- expect_error(
-      compile_grouping_spec(resolved_spec, "a")
+      compile_grouping_spec(
+        resolved_spec,
+        "a",
+        duplicates_choices = margin_duplicates_choices
+      )
     )
     expect_identical(
       conditionMessage(resolved_empty),
@@ -176,7 +214,11 @@ test_that("empty grouping rules preserve their phase and error precedence", {
       quote(grouping_set(tidyselect::any_of("missing")))
     ))
     empty_composite <- expect_error(
-      compile_grouping_spec(composite_spec, "a")
+      compile_grouping_spec(
+        composite_spec,
+        "a",
+        duplicates_choices = margin_duplicates_choices
+      )
     )
     expect_identical(
       conditionMessage(empty_composite),
@@ -185,13 +227,21 @@ test_that("empty grouping rules preserve their phase and error precedence", {
   }
 
   child_error <- expect_error(
-    compile_grouping_spec(rollup(grouping_sets()), "a")
+    compile_grouping_spec(
+      rollup(grouping_sets()),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    )
   )
   expect_identical(conditionMessage(child_error), conditionMessage(sets_error))
 })
 
 test_that("invalid grouping input lists every supported constructor", {
-  error <- expect_error(compile_grouping_spec(1, "a"))
+  error <- expect_error(compile_grouping_spec(
+    1,
+    "a",
+    duplicates_choices = margin_duplicates_choices
+  ))
   expect_s3_class(error, "marginplyr_error")
   expect_identical(
     conditionMessage(error),
@@ -207,7 +257,8 @@ test_that("selectors and fixed .by columns are resolved once", {
   plan <- compile_grouping_spec(
     rollup(tidyselect::all_of(selected)),
     data_vars = c("year", "a", "b", "value"),
-    .by = "year"
+    .by = "year",
+    duplicates_choices = margin_duplicates_choices
   )
 
   expect_equal(plan$by, "year")
@@ -239,7 +290,11 @@ test_that("a renaming grouping selection is refused by every constructor", {
   for (constructor in constructors) {
     for (selection in renaming_calls) {
       spec <- eval(rlang::call2(constructor, selection))
-      error <- expect_error(compile_grouping_spec(spec, data_vars))
+      error <- expect_error(compile_grouping_spec(
+        spec,
+        data_vars,
+        duplicates_choices = margin_duplicates_choices
+      ))
       expect_s3_class(error, "marginplyr_error")
       expect_identical(conditionMessage(error), renamed_message)
     }
@@ -248,7 +303,8 @@ test_that("a renaming grouping selection is refused by every constructor", {
   nested <- expect_error(
     compile_grouping_spec(
       rollup(grouping_set(tidyselect::all_of(c(area = "region")))),
-      data_vars
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
     )
   )
   expect_s3_class(nested, "marginplyr_error")
@@ -257,7 +313,8 @@ test_that("a renaming grouping selection is refused by every constructor", {
   several <- expect_error(
     compile_grouping_spec(
       rollup(tidyselect::all_of(c(area = "region", when = "year"))),
-      data_vars
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
     )
   )
   expect_s3_class(several, "marginplyr_error")
@@ -275,25 +332,35 @@ test_that("non-renaming grouping selections keep resolving", {
   selected <- c("region", "year")
 
   expect_equal(
-    compile_grouping_spec(rollup(region, year), data_vars)$dimensions,
+    compile_grouping_spec(
+      rollup(region, year),
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
+    )$dimensions,
     c("region", "year")
   )
   expect_equal(
     compile_grouping_spec(
       rollup(tidyselect::all_of(selected)),
-      data_vars
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
     )$dimensions,
     c("region", "year")
   )
   expect_equal(
     compile_grouping_spec(
       rollup(tidyselect::starts_with("region")),
-      data_vars
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
     )$dimensions,
     c("region", "region_code")
   )
   expect_equal(
-    compile_grouping_spec(rollup(-year), data_vars)$dimensions,
+    compile_grouping_spec(
+      rollup(-year),
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
+    )$dimensions,
     c("region", "region_code")
   )
   # A name that repeats the column it selects renames nothing, so the plan it
@@ -301,7 +368,8 @@ test_that("non-renaming grouping selections keep resolving", {
   expect_equal(
     compile_grouping_spec(
       rollup(tidyselect::all_of(c(region = "region"))),
-      data_vars
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
     )$dimensions,
     "region"
   )
@@ -311,11 +379,25 @@ test_that("duplicate grouping sets have explicit policies", {
   spec <- grouping_sets(grouping_set(a), grouping_set(a))
 
   expect_error(
-    compile_grouping_spec(spec, "a"),
+    compile_grouping_spec(
+      spec,
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    ),
     "Duplicate grouping sets"
   )
-  dropped <- compile_grouping_spec(spec, "a", .duplicates = "drop")
-  kept <- compile_grouping_spec(spec, "a", .duplicates = "keep")
+  dropped <- compile_grouping_spec(
+    spec,
+    "a",
+    .duplicates = "drop",
+    duplicates_choices = margin_duplicates_choices
+  )
+  kept <- compile_grouping_spec(
+    spec,
+    "a",
+    .duplicates = "keep",
+    duplicates_choices = margin_duplicates_choices
+  )
   expect_equal(dropped$sets, list("a"))
   expect_identical(dropped$set_ids, 1L)
   expect_equal(kept$sets, list("a", "a"))
@@ -324,19 +406,125 @@ test_that("duplicate grouping sets have explicit policies", {
 
 test_that("invalid or ambiguous specifications fail early", {
   expect_error(
-    compile_grouping_spec(rollup(a), "a", .by = "a"),
+    compile_grouping_spec(
+      rollup(a),
+      "a",
+      .by = "a",
+      duplicates_choices = margin_duplicates_choices
+    ),
     "both `.by` and `.grouping`"
   )
   expect_error(
-    compile_grouping_spec(rollup(cube(a)), "a"),
+    compile_grouping_spec(
+      rollup(cube(a)),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    ),
     "only accepts columns"
   )
   expect_error(
-    compile_grouping_spec(grouping_sets(), "a"),
+    compile_grouping_spec(
+      grouping_sets(),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    ),
     "requires at least one set"
   )
   expect_error(
-    compile_grouping_spec(rollup(floor(a)), "a"),
+    compile_grouping_spec(
+      rollup(floor(a)),
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    ),
     "object 'a' not found"
   )
+})
+
+# The plan compiler was reachable without going through
+# `compile_grouping_spec()`, so the preflight and the `.duplicates` matching
+# the wrapper performs were a second source of truth that production supplied
+# for itself (#119). A test that compiled through the wrapper therefore proved
+# nothing about the sequence production ran. This holds the two together: the
+# wrapper is the entry point, and a new call site that skips it fails here
+# rather than in whichever plan silently stopped being preflighted.
+test_that("compile_grouping_spec() is the only caller of the plan compiler", {
+  # Assembled rather than written out, so the source scan below does not
+  # report this file for holding the name it searches for.
+  impl <- paste0("compile_grouping_spec", "_impl")
+  ns <- asNamespace("marginplyr")
+  objects <- ls(ns, all.names = TRUE)
+  calls_impl <- vapply(
+    objects,
+    function(name) {
+      object <- get(name, envir = ns)
+      if (!is.function(object)) {
+        return(FALSE)
+      }
+      any(grepl(impl, deparse(body(object)), fixed = TRUE))
+    },
+    logical(1)
+  )
+  expect_identical(unname(objects[calls_impl]), "compile_grouping_spec")
+
+  # The namespace scan cannot see a test, and a test reaching the
+  # implementation with `:::` is the half of #119 that was actually there. The
+  # sources sit beside this file whenever the suite runs, so scanning them
+  # needs no installed copy; the assertion below refuses a scan that found no
+  # files rather than passing on one.
+  sources <- list.files(".", pattern = "^test-.*\\.R$", full.names = TRUE)
+  expect_gt(length(sources), 1L)
+  reached_by <- Filter(
+    function(path) {
+      any(grepl(paste0(impl, "("), readLines(path), fixed = TRUE))
+    },
+    sources
+  )
+  expect_identical(reached_by, character())
+})
+
+# The Margin vocabulary was hard-coded here, so the nesting verbs' narrower one
+# reached the compiler through `prepare_grouping_plan()` and through no test.
+test_that("compile_grouping_spec() reads a narrowed duplicates vocabulary", {
+  spec <- grouping_sets(grouping_set(a), grouping_set(a))
+
+  refused <- expect_error(
+    compile_grouping_spec(
+      spec,
+      "a",
+      .duplicates = "keep",
+      duplicates_choices = nest_duplicates_choices
+    )
+  )
+  expect_s3_class(refused, "marginplyr_error")
+  expect_identical(
+    conditionMessage(refused),
+    "`.duplicates` must be one of \"error\", \"drop\"."
+  )
+
+  # An untouched `.duplicates` stands for the first entry of the list the
+  # caller stated, not of the Margin one.
+  duplicated <- expect_error(
+    compile_grouping_spec(
+      spec,
+      "a",
+      duplicates_choices = nest_duplicates_choices
+    )
+  )
+  # The diagnostic offers the policies this caller could have asked for
+  # instead, so a narrowed vocabulary must not offer `"keep"` (#110).
+  expect_identical(
+    conditionMessage(duplicated),
+    paste0(
+      "Duplicate grouping sets were produced at positions 1, 2. ",
+      "Use `.duplicates = \"drop\"`."
+    )
+  )
+
+  dropped <- compile_grouping_spec(
+    spec,
+    "a",
+    .duplicates = "drop",
+    duplicates_choices = nest_duplicates_choices
+  )
+  expect_equal(dropped$sets, list("a"))
 })

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -392,7 +392,11 @@ test_that("DuckDB native and portable summaries agree on .id", {
     dplyr::collect() |>
     dplyr::arrange(set, group)
 
-  plan <- compile_grouping_spec(spec, names(data))
+  plan <- compile_grouping_spec(
+    spec,
+    names(data),
+    duplicates_choices = margin_duplicates_choices
+  )
   portable <- summarize_margin_union(
     remote,
     dots = rlang::quos(total = sum(value)),


### PR DESCRIPTION
Closes #119.

`compile_grouping_spec()` wrapped `compile_grouping_spec_impl()` with a preflight and a `.duplicates` match, but production never took it: `prepare_grouping_plan()` performed both steps for itself and called the implementation directly. The wrapper was referenced on 25 lines across three test files and by no production code, so the two could have diverged without a test noticing.

The issue asks first whether the wrapper supplies anything production supplies for itself. It does — the preflight, the `.duplicates` match, and a hard-coded vocabulary — so this consolidates rather than deletes.

## What changed

Production compiles through the wrapper for both of its passes, so the sequence the tests run is the sequence production runs.

`duplicates_choices` is a parameter instead of being hard-coded to `margin_duplicates_choices`. That hard-coding is why the nesting verbs' narrower `c("error", "drop")` reached the compiler through `prepare_grouping_plan()` and through no test at all — including the duplicate-set diagnostic's list of policies the caller could have asked for instead, which #110 is about. It has no default, for the reason it has none in `normalize_margin_options()`: a default is what let the nesting verbs be validated against a list their own formals exclude, and the membership assert in the implementation would not catch it, since the wider list admits every value of the narrower one. Callers state their list, tests included.

`preflight` is a new formal so a caller running more than one pass over one specification hands the same preflight to each. `prepare_grouping_plan()` does exactly that — see Evaluation counts below.

## Two scans, not one

The namespace scan holds the implementation to a single caller. It cannot see a test reaching the implementation with `:::`, which is the half of #119 that was actually there, so a second scan reads the test sources beside it. Both were confirmed to fail on a planted regression: reintroducing a direct call in `prepare_grouping_plan()` fails the first, and a temporary test file calling the implementation fails the second.

The scans assemble the name they search for rather than spelling it out, so the file holding them is not itself a hit, and the source scan asserts it found files rather than passing on an empty set.

## Evaluation counts

Compiling through the wrapper per pass meant preflighting per pass, and preflight is not a free re-run: `grouping_arg_spec()` calls `rlang::eval_tidy()` on a symbol or a nested constructor argument. ADR-0008 does not allow changing "the number and timing of evaluations without a separately accepted decision".

Measured with `rollup(cols)` where `cols` is an active binding that counts its own evaluations: `main` counts 3, an intermediate version of this branch counted 4. `prepare_grouping_plan()` now preflights once and hands the result to both passes, and the probe counts 3 again.

## Verification

- Removing the `preflight` argument from either call site raises the probe's count above 3; restoring it returns it to `main`'s 3.
- The name-only pass still runs before `grouping_selection_proxy()`, which is still called exactly once (ADR-0002, ADR-0005).
- Existing assertions are unchanged — the test diff adds the vocabulary argument at each call site and appends two tests; no expected plan, message, or class was edited.
- `lintr::lint_package()` reports no lints after `pkgload::load_all(".")`; `roxygen2::roxygenise()` leaves `man/` and `NAMESPACE` unchanged.
- Full local test suite passes; `Rscript .github/scripts/verify-suite-coverage.R` passes (380 tests, none executing in zero configurations).
- No test requires more than one member of `optional_backends()`; the new tests require none.

## Trade-off worth a second opinion

Requiring `duplicates_choices` means ~25 test call sites now spell out `duplicates_choices = margin_duplicates_choices`, which makes `test-grouping-plan.R` longer and pushes several one-line calls onto four lines. I followed the rule `R/margin-operation.R:132` documents for this parameter over the terser default. Reverting to a default is a one-line change if the readability cost is judged the larger one.

## Out of scope

How Grouping plans are compiled is unchanged. I did not audit other internal wrappers; none surfaced on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)