### PR TITLE
Share the must_error chunk option and let it assert a condition class

### DIFF
--- a/.github/scripts/verify-must-error.R
+++ b/.github/scripts/verify-must-error.R
@@ -1,0 +1,362 @@
+# Verifies the `must_error` chunk option in `inst/vignette-hooks/must-error.R`.
+#
+# The option is what makes a vignette's claim that a call is rejected checkable:
+# the chunk runs the call, and the render halts if the call succeeds or fails
+# for the wrong reason. Nothing else in the repository can fail when the option
+# stops working -- a broken option reports nothing, which reads exactly like a
+# vignette whose rejected calls are all still rejected -- so the option needs a
+# gate of its own.
+#
+# It cannot be a testthat test. `release-matrix.yaml`'s `backend` jobs install
+# the hard dependencies plus one optional backend, so knitr is absent there, and
+# `verify-backend.R` fails a job for any skip that does not name a backend the
+# job withheld. A knitr-gated test would therefore turn every `backend` job red.
+# This script runs where knitr is provisioned instead: `altdoc.yaml`, alongside
+# `verify-site.R`, and locally with
+#
+#     Rscript .github/scripts/verify-must-error.R
+#
+# It knits fixture documents rather than calling the hooks directly, because
+# every property below is a property of a render: which chunks knitr evaluates,
+# what it puts in the result objects, and what it restores on the way out.
+
+source(".github/scripts/ci-helpers.R")
+
+definition <- "inst/vignette-hooks/must-error.R"
+if (!file.exists(definition)) {
+  stop(
+    call. = FALSE,
+    "Cannot find ", definition, ". Run this from the repository root."
+  )
+}
+
+# The fixtures raise their own conditions rather than calling marginplyr, so
+# this checks the option and not the package's error classes. `rlang` is an
+# Import, so it is present wherever the package is.
+setup_chunk <- c(
+  "```{r}",
+  "#| include: false",
+  sprintf("source(%s)", encodeString(normalizePath(definition), quote = "\"")),
+  "```",
+  ""
+)
+
+# Most fixtures are knitted with a sentinel `evaluate` hook already installed.
+# That serves two purposes: it is what the definition must put back, so the
+# restoration assertion is about the previous hook rather than about knitr's
+# default, and it makes `knit()` see non-default hooks on entry, which turns off
+# knitr's own hook restoration. What restores the hooks is then the definition
+# alone.
+#
+# A vignette render takes the other path -- default hooks on entry, where knitr
+# registers its own `knit_hooks$set(.default.hooks)` on exit ahead of the
+# `after.knit` call -- so one fixture below asks for `sentinel = FALSE` and
+# covers it. There the `evaluate` assertion is weak, because knitr would restore
+# that hook whatever the definition did; the `opts_hooks` entry is the one that
+# still means something, since knitr never restores those at all.
+baseline_evaluate <- knitr::knit_hooks$get("evaluate")
+sentinel_evaluate <- function(...) baseline_evaluate(...)
+
+# What the fixtures accumulate. An environment rather than a pair of variables
+# reached with `<<-`: every fixture below runs at top level, so a cascading
+# assignment here would be writing to the global environment.
+found <- new.env(parent = emptyenv())
+found$failures <- character()
+found$report <- character()
+
+fail <- function(...) {
+  found$failures <- c(found$failures, paste0(...))
+}
+
+# Renders one fixture and reports what the render did, without stopping: a
+# script that aborted on the first surprise would check one property per run.
+knit_fixture <- function(body, sentinel) {
+  input <- tempfile(fileext = ".Rmd")
+  output <- tempfile(fileext = ".md")
+  on.exit(unlink(c(input, output)), add = TRUE)
+  writeLines(c(setup_chunk, body), input)
+
+  knitr::knit_hooks$restore()
+  knitr::opts_hooks$restore()
+  if (sentinel) {
+    knitr::knit_hooks$set(evaluate = sentinel_evaluate)
+  }
+
+  error <- NULL
+  text <- tryCatch(
+    {
+      knitr::knit(input, output, quiet = TRUE)
+      paste(readLines(output, warn = FALSE), collapse = "\n")
+    },
+    error = function(cnd) {
+      error <<- cnd
+      NA_character_
+    }
+  )
+
+  state <- list(
+    must_error_hook = knitr::opts_hooks$get("must_error"),
+    evaluate_hook = knitr::knit_hooks$get("evaluate"),
+    after_knit_hook = knitr::knit_hooks$get("after.knit")
+  )
+
+  knitr::knit_hooks$restore()
+  knitr::opts_hooks$restore()
+
+  list(
+    halted = !is.null(error),
+    message = if (is.null(error)) "" else conditionMessage(error),
+    text = text,
+    state = state,
+    sentinel = sentinel
+  )
+}
+
+# Every fixture, whatever it asserts, has to leave knitr as it found it. A
+# render halted by the option is the case that matters most and the one an
+# `on.exit()`-free implementation gets wrong, so this runs for the failing
+# fixtures too.
+check_restored <- function(name, result) {
+  state <- result$state
+  if (!is.null(state$must_error_hook)) {
+    fail(name, ": the `must_error` entry in `opts_hooks` outlived the render.")
+  }
+  expected_evaluate <- if (result$sentinel) {
+    sentinel_evaluate
+  } else {
+    baseline_evaluate
+  }
+  if (!identical(state$evaluate_hook, expected_evaluate)) {
+    fail(name, ": the `evaluate` knit hook was not put back after the render.")
+  }
+  if (!is.null(state$after_knit_hook)) {
+    fail(name, ": the `after.knit` knit hook outlived the render.")
+  }
+}
+
+each_present <- function(text, needles) {
+  vapply(needles, grepl, logical(1), x = text, fixed = TRUE)
+}
+
+check <- function(name,
+                  body,
+                  halted,
+                  expect = character(),
+                  forbid = character(),
+                  sentinel = TRUE) {
+  result <- knit_fixture(body, sentinel = sentinel)
+  # The one text a fixture can assert against, whichever way the render went:
+  # the halt message when the option stopped it, the rendered page otherwise.
+  observed <- if (result$halted) result$message else result$text
+  subject <- if (halted) "the halt message" else "the rendered page"
+  if (result$halted != halted) {
+    fail(
+      name,
+      if (halted) {
+        ": the render completed, but it had to halt. Output: "
+      } else {
+        ": the render halted, but it had to complete. Error: "
+      },
+      observed
+    )
+  } else {
+    wrong <- list(
+      list(
+        strings = expect[!each_present(observed, expect)],
+        complaint = " is missing "
+      ),
+      list(
+        strings = forbid[each_present(observed, forbid)],
+        complaint = " must not hold "
+      )
+    )
+    for (one in wrong) {
+      if (length(one$strings) > 0L) {
+        fail(
+          name, ": ", subject, one$complaint,
+          paste(sprintf("\"%s\"", one$strings), collapse = ", "),
+          ". Got: ", observed
+        )
+      }
+    }
+  }
+  check_restored(name, result)
+  found$report <- c(found$report, sprintf(
+    "- %s %s",
+    if (name %in% sub(":.*$", "", found$failures)) "FAILED" else "OK",
+    name
+  ))
+  invisible(result)
+}
+
+# `must_error: true` keeps the meaning it had before class assertion existed.
+check(
+  "true accepts any error",
+  c(
+    "```{r}",
+    "#| label: any-error",
+    "#| must_error: true",
+    "stop(\"refused\")",
+    "```"
+  ),
+  halted = FALSE,
+  expect = "refused"
+)
+
+check(
+  "true halts when nothing is raised",
+  c(
+    "```{r}",
+    "#| label: quiet-chunk",
+    "#| must_error: true",
+    "1 + 1",
+    "```"
+  ),
+  halted = TRUE,
+  expect = c("quiet-chunk", "must_error: true", "without raising an error")
+)
+
+# The class form. The halt message has to name the chunk, what was expected, and
+# what was raised, because the first thing a reader of a failed render asks is
+# whether the prose or the call moved.
+check(
+  "a class halts on the wrong condition",
+  c(
+    "```{r}",
+    "#| label: wrong-class",
+    "#| must_error: fixture_error",
+    "rlang::abort(\"refused\", class = \"other_error\")",
+    "```"
+  ),
+  halted = TRUE,
+  expect = c(
+    "wrong-class",
+    "must_error: fixture_error",
+    "`fixture_error`",
+    "other_error"
+  )
+)
+
+check(
+  "a class accepts that condition",
+  c(
+    "```{r}",
+    "#| label: right-class",
+    "#| must_error: fixture_error",
+    "rlang::abort(\"refused\", class = \"fixture_error\")",
+    "```"
+  ),
+  halted = FALSE,
+  expect = "refused"
+)
+
+# The form a vignette actually needs: a Package condition is usually wrapped by
+# the verb the reader called, and it is the wrapped class the prose names.
+check(
+  "a class accepts a wrapped condition",
+  c(
+    "```{r}",
+    "#| label: wrapped-class",
+    "#| must_error: fixture_error",
+    "inner <- rlang::catch_cnd(",
+    "  rlang::abort(\"refused\", class = \"fixture_error\")",
+    ")",
+    "rlang::abort(\"in argument\", parent = inner)",
+    "```"
+  ),
+  halted = FALSE,
+  expect = "in argument"
+)
+
+# The property `_R_CHECK_DEPENDS_ONLY_` builds depend on. knitr never calls the
+# `evaluate` hook for a chunk it does not evaluate, so a chunk withheld because
+# its package is absent must pass through unreported -- not be counted as a
+# chunk that stopped failing.
+#
+# The guard is written the way `vignettes/recipes.qmd` writes it, on a name no
+# library holds, because what this fixture can vary is whether knitr evaluated
+# the chunk and not why. A genuinely withheld Suggest is checked where one can
+# be withheld: `release-matrix.yaml`'s `depends-only` job rebuilds the vignettes
+# with every Suggest absent, and `recipes.qmd`'s `nested-aggregate` chunk is a
+# `must_error` chunk behind `has_duckdb`. An option that reported it would fail
+# that job.
+check(
+  "a withheld chunk is not reported",
+  c(
+    "```{r}",
+    "#| include: false",
+    "has_backend <- requireNamespace(\"notapackage\", quietly = TRUE)",
+    "```",
+    "",
+    "```{r}",
+    "#| label: guarded",
+    "#| must_error: true",
+    "#| eval: !expr has_backend",
+    "1 + 1",
+    "```"
+  ),
+  halted = FALSE,
+  forbid = "guarded"
+)
+
+# The path a vignette render actually takes: default hooks when `knit()` starts,
+# so knitr registers its own `knit_hooks` reset ahead of the `after.knit` call
+# that undoes the option. `after.knit` is not among `.default.hooks`, so it
+# survives that reset and still runs -- and the `opts_hooks` entry, which knitr
+# never restores, is the one this fixture proves gone.
+check(
+  "the option undoes itself from default hooks",
+  c(
+    "```{r}",
+    "#| label: default-hooks",
+    "#| must_error: fixture_error",
+    "rlang::abort(\"refused\", class = \"fixture_error\")",
+    "```"
+  ),
+  halted = FALSE,
+  expect = "refused",
+  sentinel = FALSE
+)
+
+# A value that is neither `true` nor a class name is a mistake in the chunk
+# header, and a mistake that silently disabled the assertion would leave the
+# prose unchecked.
+check(
+  "a malformed value is refused",
+  c(
+    "```{r}",
+    "#| label: malformed",
+    "#| must_error: 3",
+    "stop(\"refused\")",
+    "```"
+  ),
+  halted = TRUE,
+  expect = "one condition class name"
+)
+
+write_step_summary(c(
+  "## `must_error` chunk option",
+  "",
+  sprintf(
+    "Verified `%s` against %d rendered fixture(s).",
+    definition,
+    length(found$report)
+  ),
+  "",
+  found$report
+))
+
+if (length(found$failures) > 0L) {
+  stop(
+    call. = FALSE,
+    sprintf(
+      "The `must_error` option is not behaving as documented:\n%s",
+      paste0("- ", found$failures, collapse = "\n")
+    )
+  )
+}
+
+message(sprintf(
+  "Verified the `must_error` option against %d rendered fixture(s).",
+  length(found$report)
+))

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -267,7 +267,14 @@ markers <- list(
     "Compare a summary with the whole",
     "original pre-margin",
     "funion(funion(",
-    "Total"
+    "Total",
+    # The guide's one `must_error` chunk, by the diagnostic it has to produce.
+    # It is marked with the class form, so this marker also stands for the
+    # assertion: prose survives a chunk that stopped running, and a chunk that
+    # started failing for some other reason halts the render rather than
+    # reaching this scan.
+    "Error in `summarize_with_margins()`",
+    "does not support `cur_group_id()`"
   ),
   "docs/vignettes/recipes.html" = c(
     "Put each subtotal with the rows it summarizes",
@@ -278,7 +285,7 @@ markers <- list(
     "Compute what the summary pass cannot express",
     "share_of_total",
     "expand_with_margins",
-    # The guide's `must_error: true` chunks, by the diagnostic each one has to
+    # The guide's `must_error` chunks, by the diagnostic each one has to
     # produce. Prose alone would still be there if every chunk stopped running;
     # a rendered error is proof the call was made and was refused. Only the
     # three that need no database are listed, so the markers hold wherever the

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -36,6 +36,12 @@ jobs:
           extra-packages: local::.
           needs: website
 
+      # Before the render rather than after it. A `must_error` option that
+      # stopped asserting anything reports nothing, so the site it produces
+      # looks exactly like a correct one; failing here says which half broke.
+      - name: Verify the must_error chunk option
+        run: Rscript .github/scripts/verify-must-error.R
+
       - name: Build site
         run: |
           altdoc::render_docs(parallel = FALSE, freeze = FALSE)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,21 +49,72 @@ prose that still claims a failure, and nothing reports it. knitr and Quarto
 offer no option for the other half, and no package supplies one
 (`investigation/requiring-a-documentation-chunk-to-fail.md`).
 
-`vignettes/recipes.qmd` therefore defines a `must_error: true` chunk option in
-a hidden setup chunk. It implies `error: true`, so the two are never set
-inconsistently, and it halts the render naming the chunk when a chunk marked
-with it completes without raising an error. Mark a chunk with it instead of
-`error: true` whenever the surrounding prose asserts that the call fails.
+`inst/vignette-hooks/must-error.R` therefore defines a `must_error` chunk
+option. It implies `error: true`, so the two are never set inconsistently, and
+it halts the render naming the chunk when a chunk marked with it completes
+without raising an error. Mark a chunk with it instead of `error: true`
+whenever the surrounding prose asserts that the call fails.
 
-Two properties are load-bearing and easy to lose in a rewrite. It is
+It takes two forms. `must_error: true` accepts any error, which is what the
+option has always meant. `must_error: marginplyr_error` additionally requires
+the error to carry that condition class. Prefer the class form wherever the
+prose names what refuses the call: a bare `true` passes when the call fails for
+an unrelated reason — a renamed argument, a typo, a changed column — and the
+reader is then shown a diagnostic the prose does not describe. The check reads
+the `parent` chain, because a Package condition usually reaches the reader
+wrapped by the dplyr verb that raised it, and it is the wrapped class the prose
+names. Any other value halts the render rather than being ignored, since a
+header this cannot read is one whose assertion silently stopped happening.
+
+The definition lives under `inst/` so that every vignette reaches it in one
+line rather than carrying a copy:
+
+```r
+source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
+```
+
+That works because vignettes are built against the *installed* package, which
+is also why a working tree whose hook file changed must be reinstalled before
+its vignettes are rendered. The call needs no availability guard even though
+knitr is a Suggest: `VignetteBuilder: quarto` is visible while vignettes are
+rebuilt even under `_R_CHECK_DEPENDS_ONLY_=true`, and quarto imports rmarkdown,
+which imports knitr — the `DBI = FALSE` case from *Dependency metadata*, so a
+guard on knitr in a vignette would never fire
+(`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
+
+Three properties are load-bearing and easy to lose in a rewrite. It is
 implemented as a wrapper around knitr's `evaluate` hook, which inspects the
 returned result objects; that keeps knitr's own error rendering, whereas
 catching the condition in a helper prints an `<error/rlang_error>` header and
-a backtrace through the helper, which no reader would see. And because knitr
+a backtrace through the helper, which no reader would see. Because knitr
 does not call that hook for a chunk it does not evaluate, a chunk withheld by
 an availability guard is skipped without a special case — a guarded chunk that
 never runs must not be reported as a chunk that stopped failing, or
-`_R_CHECK_DEPENDS_ONLY_` builds break.
+`_R_CHECK_DEPENDS_ONLY_` builds break. And the definition undoes itself from an
+`after.knit` hook, which `knit()` runs from `on.exit()` so that a render halted
+by the option restores as a completed one does; knitr restores neither the
+`opts_hooks` entry nor a `knit_hooks` entry installed while it runs, and the
+`document` hook — the obvious alternative — is not called on the halted path
+(`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
+
+`.github/scripts/verify-must-error.R` is the gate, run by `altdoc.yaml` and
+locally with `Rscript .github/scripts/verify-must-error.R`. It knits fixture
+documents covering each form, the guarded chunk, a malformed option value, and
+the restoration, because nothing else in the repository fails when the option
+stops working — an option that asserts nothing reports nothing, which reads
+exactly like a set of vignettes whose rejected calls are all still rejected.
+It is not a testthat test: `release-matrix.yaml`'s `backend` jobs install the
+hard dependencies plus one optional backend, so knitr is absent there — a
+vignette rebuild is what puts it in the closure, and those jobs pass
+`--ignore-vignettes` — and `verify-backend.R` fails a job for any skip that does
+not name a backend the job withheld.
+
+Its guarded-chunk fixture withholds a name no library holds, because what a
+fixture can vary is whether knitr evaluated a chunk and not why. A genuinely
+absent Suggest is covered where one is absent: `depends-only` rebuilds the
+vignettes with every Suggest withheld, and `recipes.qmd`'s `nested-aggregate`
+chunk is a `must_error` chunk behind `has_duckdb`, so an option that reported it
+fails that job.
 
 ### Site verification
 

--- a/inst/vignette-hooks/must-error.R
+++ b/inst/vignette-hooks/must-error.R
@@ -1,0 +1,182 @@
+# The `must_error` chunk option, shared by every vignette.
+#
+# A vignette showing a rejected call executes it rather than quoting its error,
+# so the reader sees the diagnostic their own session would produce. Mark such a
+# chunk with this option instead of Quarto's `error: true`, which only *permits*
+# an error and so renders a success underneath prose that still claims a
+# failure.
+#
+# A vignette reaches it in one line -- a `source()` call on the `system.file()`
+# path to this file -- which is why the definition lives here rather than in a
+# setup chunk. The hidden setup chunks of `vignettes/recipes.qmd` and
+# `vignettes/get_started.qmd` show the call.
+#
+# Two forms:
+#
+#     must_error: true               any error will do
+#     must_error: marginplyr_error   the error must carry that condition class
+#
+# `AGENTS.md` is authoritative for when to mark a chunk and for the three
+# properties of this implementation that are load-bearing: it wraps knitr's
+# `evaluate` hook and inspects the result objects, it does nothing for a chunk
+# knitr never evaluated, and it undoes itself from `after.knit`.
+
+local({
+  # Sourcing this twice -- two setup chunks in one document, or a second
+  # vignette rendered in a session that already rendered one -- must not stack a
+  # second wrapper on the first. Each wrapper saves the hook it replaced, so a
+  # stack of two would restore the other one and leave the option installed.
+  if (!is.null(knitr::opts_hooks$get("must_error"))) {
+    return(invisible(NULL))
+  }
+
+  # What a chunk's option value asks for. `NULL` means the chunk is not marked,
+  # so every hook below leaves it alone. `NA_character_` means any error will
+  # do, which is what `must_error: true` has always meant. A string names the
+  # condition class the raised error has to carry.
+  #
+  # A value that is neither is refused rather than ignored: a chunk header this
+  # cannot read is one whose assertion would silently stop happening, which is
+  # the failure the option exists to prevent.
+  expected_class <- function(value) {
+    if (is.null(value) || identical(value, FALSE)) {
+      return(NULL)
+    }
+    if (isTRUE(value)) {
+      return(NA_character_)
+    }
+    if (is.character(value) && length(value) == 1L && nzchar(value)) {
+      return(value)
+    }
+    stop(
+      "`must_error` must be `true` or one condition class name.",
+      call. = FALSE
+    )
+  }
+
+  # How the chunk header was written, so a diagnostic quotes the option the
+  # author set rather than paraphrasing it.
+  option_text <- function(expected) {
+    if (is.na(expected)) "true" else expected
+  }
+
+  # rlang chains a wrapped condition onto `parent`, and the errors a vignette
+  # shows are usually wrapped: a rejected summary helper reaches the reader as a
+  # dplyr error carrying the Package condition beneath it. Reading the chain is
+  # what lets `must_error: marginplyr_error` mean "marginplyr refused this call"
+  # for a call made through another verb.
+  chain <- function(cnd) {
+    out <- list()
+    while (inherits(cnd, "condition")) {
+      out[[length(out) + 1L]] <- cnd
+      cnd <- cnd$parent
+    }
+    out
+  }
+
+  carries <- function(cnd, expected) {
+    if (is.na(expected)) {
+      return(TRUE)
+    }
+    any(vapply(chain(cnd), inherits, logical(1), what = expected))
+  }
+
+  describe <- function(cnd) {
+    paste(
+      vapply(
+        chain(cnd),
+        function(one) paste(class(one), collapse = "/"),
+        character(1)
+      ),
+      collapse = " caused by "
+    )
+  }
+
+  # `must_error` implies `error: true`, so the two can never be set
+  # inconsistently on one chunk.
+  knitr::opts_hooks$set(must_error = function(options) {
+    if (!is.null(expected_class(options$must_error))) {
+      options$error <- TRUE
+    }
+    options
+  })
+
+  previous_evaluate <- knitr::knit_hooks$get("evaluate")
+
+  knitr::knit_hooks$set(evaluate = function(...) {
+    # knitr does not call this hook for a chunk it does not evaluate, so a chunk
+    # withheld by an availability guard -- `eval: !expr has_duckdb` -- is passed
+    # over here with no special case. Losing that would report a guarded chunk
+    # as a chunk that stopped failing, and break `_R_CHECK_DEPENDS_ONLY_`
+    # builds.
+    results <- previous_evaluate(...)
+    options <- knitr::opts_current$get()
+    expected <- expected_class(options$must_error)
+    if (is.null(expected)) {
+      return(results)
+    }
+    # Inspecting the result objects rather than catching the condition here:
+    # this leaves knitr's own error rendering in place, whereas catching it
+    # would print an `<error/rlang_error>` header and a backtrace through this
+    # function, which no reader would see in their own session.
+    raised <- Filter(function(one) inherits(one, "error"), results)
+    if (length(raised) == 0L) {
+      stop(
+        sprintf(
+          paste0(
+            "Chunk `%s` is marked `must_error: %s` but completed without ",
+            "raising an error."
+          ),
+          options$label,
+          option_text(expected)
+        ),
+        call. = FALSE
+      )
+    }
+    if (!any(vapply(raised, carries, logical(1), expected = expected))) {
+      stop(
+        sprintf(
+          paste0(
+            "Chunk `%s` is marked `must_error: %s` but raised no error ",
+            "carrying `%s`. Raised: %s."
+          ),
+          options$label,
+          option_text(expected),
+          expected,
+          paste(vapply(raised, describe, character(1)), collapse = "; ")
+        ),
+        call. = FALSE
+      )
+    }
+    results
+  })
+
+  # knitr restores neither of the two things above: `opts_hooks` it never
+  # restores, and `knit_hooks` only when the hooks were untouched at the moment
+  # `knit()` started, which says nothing about a hook installed while it runs.
+  # So the definition undoes itself.
+  #
+  # `after.knit` is where, because `knit()` runs it from `on.exit()`: a render
+  # halted by a chunk that failed the assertion above restores just as one that
+  # finished does. The child-mode guard is what keeps a child document's own
+  # `knit()` from restoring while the parent still has chunks to run; a hook
+  # this one displaced is still called there, because skipping the restoration
+  # is not a reason to swallow someone else's hook.
+  previous_after_knit <- knitr::knit_hooks$get("after.knit")
+
+  knitr::knit_hooks$set(after.knit = function(...) {
+    if (!isTRUE(knitr::opts_knit$get("child"))) {
+      knitr::opts_hooks$delete("must_error")
+      knitr::knit_hooks$set(evaluate = previous_evaluate)
+      if (is.null(previous_after_knit)) {
+        knitr::knit_hooks$delete("after.knit")
+      } else {
+        knitr::knit_hooks$set(after.knit = previous_after_knit)
+      }
+    }
+    if (!is.null(previous_after_knit)) {
+      previous_after_knit(...)
+    }
+    invisible(NULL)
+  })
+})

--- a/investigation/restoring-knitr-hooks-a-vignette-installs.md
+++ b/investigation/restoring-knitr-hooks-a-vignette-installs.md
@@ -1,0 +1,100 @@
+# Restoring knitr hooks a vignette installs
+
+Investigated: 2026-08-10
+
+Read while #116 moved the `must_error` chunk option out of
+`vignettes/recipes.qmd` into one definition every vignette can source. Two of
+that ticket's three defects were about state: the option left an `opts_hooks`
+entry and an `evaluate` wrapper installed, and it asserted only that some error
+occurred. The question here was which knitr mechanism can undo an installation
+made *during* a render, and where the raised condition can be read from.
+`requiring-a-documentation-chunk-to-fail.md` covers whether the assertion can
+be expressed at all, and is not superseded by anything below.
+
+## Environment
+
+| Component | Version |
+|---|---|
+| R | 4.6.1 |
+| knitr | 1.51 |
+| Quarto CLI | 1.9.38 |
+| rlang | 1.3.0 |
+
+## knitr restores neither of the two things such an option installs
+
+Read from `deparse(body(knitr::knit))` in knitr 1.51.
+
+`opts_hooks` appears in no `on.exit()` at all. The four settings objects knitr
+snapshots and restores are `opts_chunk`, `opts_current`, `knit_code`, and
+`opts_knit`; `opts_hooks` is not among them, so an entry added by a setup chunk
+outlives the render.
+
+`knit_hooks` is restored, but conditionally and only to knitr's defaults:
+
+```r
+if (identical(knit_hooks$get(names(.default.hooks)), .default.hooks) &&
+      !child_mode()) {
+  getFromNamespace(paste("render", out_format(), sep = "_"), "knitr")()
+  on.exit(knit_hooks$set(.default.hooks), add = TRUE)
+}
+```
+
+The condition is evaluated before any chunk runs, so it says something about
+the caller's state on entry and nothing about a hook installed while knitting.
+A render started from customised hooks gets no restoration, and one started
+from defaults gets the defaults back rather than whatever the definition
+replaced.
+
+## `after.knit` is the hook that runs on both paths
+
+`knit()` registers `on.exit(run_hook("after.knit"), add = TRUE)`, and
+`run_hook()` reads `knit_hooks$get(.name)` at exit time rather than at
+registration time. A hook installed mid-render is therefore still called, and
+called on the halted path as well as the completed one — which is what a render
+stopped by the assertion needs.
+
+Two orderings make this work, and both were checked rather than assumed:
+
+- `after.knit` is not among the twelve names in `.default.hooks` (`source`,
+  `output`, `warning`, `message`, `error`, `plot`, `inline`, `chunk`, `text`,
+  `evaluate.inline`, `evaluate`, `document`). The `knit_hooks$set(.default.hooks)`
+  exit handler above is registered first and so runs first, and it leaves
+  `after.knit` in place.
+- It also runs at the end of a *child* document's `knit()`, with
+  `opts_knit$get("child")` still `TRUE` there, because `knit_child()` clears
+  that flag from its own frame after `knit()` returns. A restoration that does
+  not test it uninstalls the option while the parent still has chunks to run.
+
+The `document` hook was the alternative considered. It is called at
+`res = one_string((knit_hooks$get("document"))(res))`, inside the body, so it
+does not run when a chunk halts the render — the case that matters most.
+
+## The condition object is already in the `evaluate` results
+
+`evaluate::evaluate()` returns the condition itself for a failing expression,
+not its rendered text, so the `evaluate` hook the option already wraps can read
+`class()` and rlang's `parent` chain from what it is handed. No second
+mechanism is needed to assert a class, and none of the rendering behaviour
+recorded in `requiring-a-documentation-chunk-to-fail.md` changes.
+
+The chain matters because the errors a vignette shows are usually wrapped.
+`retail_sales |> summarize_with_margins(...) |> filter(grouping_bit(channel) == 1L)`
+raised `rlang_error/error/condition` at the top with `marginplyr_error` on its
+`parent`; an assertion reading only the outermost class could say nothing about
+which package refused the call.
+
+## knitr is not optional during a vignette rebuild
+
+Relevant because a definition sourced from a vignette calls `knitr::` at
+top level, and `_R_CHECK_DEPENDS_ONLY_=true` is the authority on whether a
+Suggest is optional. It is not reachable here: `DESCRIPTION` declares
+`VignetteBuilder: quarto`, `R CMD check` makes the VignetteBuilder visible
+while rebuilding vignettes even in that mode, and
+`packageDescription("quarto")$Imports` names `rmarkdown`, whose `Imports` names
+`knitr (>= 1.43)`. So knitr sits in the hard dependency closure of the builder
+whenever a vignette is being built — the same shape as the `DBI = FALSE` entry
+in `tests/testthat/helper-optional-backends.R`, and a guard written against
+knitr in a vignette would never fire.
+
+`AGENTS.md` is authoritative for what the option now does and for the rule
+about when to mark a chunk.

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -53,6 +53,11 @@ has_sqlite_simulator <- requireNamespace("RSQLite", quietly = TRUE)
 has_dtplyr <- requireNamespace("dtplyr", quietly = TRUE)
 has_tabsets <- requireNamespace("knitr", quietly = TRUE) &&
   requireNamespace("quartabs", quietly = TRUE)
+
+# Chunks marked with `must_error` show a call that is meant to fail, so the
+# reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
+# authoritative for what the option does and why it exists.
+source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
 ```
 
 ## Start with the report question
@@ -574,7 +579,19 @@ complete grouping plan, not only the ones active in one branch. The
 `cur_group*()` family is rejected outright: a branch-local identifier, row
 position, or column set has no global meaning once several grouping sets are
 combined, so use `grouping_bit()` or `grouping_id()` to identify levels
-instead.
+instead. The refusal is a Package condition naming the replacement, not a
+silently different answer:
+
+```{r}
+#| label: cur-group-id-rejected
+#| must_error: marginplyr_error
+
+retail_sales |>
+  summarize_with_margins(
+    branch = cur_group_id(),
+    .grouping = cube(region, channel)
+  )
+```
 
 Two familiar conveniences also behave differently. Row order is unspecified
 for local and lazy results alike unless `.sort` asks for a Margin order, which

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -57,29 +57,10 @@ database and no optional package.
 has_duckdb <- requireNamespace("DBI", quietly = TRUE) &&
   requireNamespace("duckdb", quietly = TRUE)
 
-# Chunks marked `must_error: true` show a call that is meant to fail, so the
+# Chunks marked with `must_error` show a call that is meant to fail, so the
 # reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
 # authoritative for what the option does and why it exists.
-local({
-  knitr::opts_hooks$set(must_error = function(options) {
-    if (isTRUE(options$must_error)) options$error <- TRUE
-    options
-  })
-  default_evaluate <- knitr::knit_hooks$get("evaluate")
-  knitr::knit_hooks$set(evaluate = function(...) {
-    res <- default_evaluate(...)
-    opts <- knitr::opts_current$get()
-    if (isTRUE(opts$must_error) &&
-          !any(vapply(res, inherits, logical(1), "error"))) {
-      stop(
-        "Chunk `", opts$label, "` is marked `must_error: true` but ",
-        "completed without raising an error.",
-        call. = FALSE
-      )
-    }
-    res
-  })
-})
+source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
 ```
 
 ## Put each subtotal with the rows it summarizes
@@ -213,7 +194,7 @@ which only the summary knows, so calling one inside `filter()` is rejected:
 
 ```{r}
 #| label: grouping-bit-in-filter
-#| must_error: true
+#| must_error: marginplyr_error
 
 retail_sales |>
   summarize_with_margins(


### PR DESCRIPTION
Closes #116.

The `must_error` chunk option lived in `vignettes/recipes.qmd`'s hidden setup chunk. It asserted only that *some* error occurred, never restored the `evaluate` knit hook or the `opts_hooks` entry it installed, and could not be reached by the four other vignettes without copying the block.

Both properties `AGENTS.md` calls load-bearing are preserved: the option is still a wrapper around knitr's `evaluate` hook inspecting the returned result objects, and it still does nothing for a chunk knitr never evaluated.

## What changed

`inst/vignette-hooks/must-error.R` is the one definition. A vignette reaches it in one line:

```r
source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
```

`inst/` rather than a child document or a package-internal helper, because vignettes are built against the *installed* package, so `system.file()` resolves during `R CMD check`, during `altdoc::render_docs()`, and locally. It adds no dependency: knitr is already in the hard dependency closure of the declared `VignetteBuilder` (`quarto` → `rmarkdown` → `knitr (>= 1.43)`), and `R CMD check` makes the builder visible while rebuilding vignettes even under `_R_CHECK_DEPENDS_ONLY_=true`. That is the `DBI = FALSE` case from *Dependency metadata*, so a guard on knitr in a vignette could never fire.

**Class assertion.** `must_error: true` keeps its meaning exactly. `must_error: marginplyr_error` additionally requires the error to carry that class, and the halt message names the chunk, what was expected, and what was raised. Any other value halts the render rather than being ignored, since a header the option cannot read is one whose assertion silently stopped happening.

The check reads rlang's `parent` chain. Without it the class form would be useless for the case a vignette actually has: `recipes.qmd`'s `grouping-bit-in-filter` chunk raises `rlang_error/error/condition` at the top with `marginplyr_error` on its parent, because dplyr wraps what `filter()` raised.

**Restoration.** The definition undoes itself from an `after.knit` hook. `knit()` registers `on.exit(run_hook("after.knit"), add = TRUE)` and `run_hook()` reads the hook at exit time, so a hook installed mid-render still runs — including when a chunk that failed the assertion halted the render. The `document` hook, the obvious alternative, is called inside the body and so does not run on that path. A child-mode guard keeps a child document's own `knit()` from restoring while the parent still has chunks; a hook this one displaced is still called there.

**Second vignette.** `vignettes/get_started.qmd` gains a `must_error: marginplyr_error` chunk for the `cur_group_id()` rejection, where the prose already said the `cur_group*()` family is rejected outright and nothing executed it.

## The gate

`.github/scripts/verify-must-error.R`, run by `altdoc.yaml` before the render and locally with `Rscript .github/scripts/verify-must-error.R`. Nothing else in the repository fails when the option stops working — an option that asserts nothing reports nothing, which reads exactly like a set of vignettes whose rejected calls are all still rejected.

Eight fixtures, each a knitted document: both forms, a wrapped condition, a chunk that raises nothing, a chunk marked with the wrong class, a guarded chunk, a malformed value, and restoration after every one of them.

Two of those need explaining:

- **`the option undoes itself from default hooks`** covers the path a real vignette render takes. The other seven install a sentinel `evaluate` hook first, which makes the restoration assertion about the *previous* hook rather than knitr's default — and, as a side effect, makes `knit()` see non-default hooks on entry, which turns off knitr's own restoration. A vignette enters with default hooks, where knitr registers `knit_hooks$set(.default.hooks)` *ahead of* the `after.knit` call. `after.knit` is not among `.default.hooks`, so it survives that reset; this fixture is what holds that.
- **`a withheld chunk is not reported`** guards on a name no library holds, because what a fixture can vary is whether knitr evaluated a chunk, not why. A genuinely absent Suggest is covered where one is absent: `depends-only` rebuilds the vignettes with every Suggest withheld, and `recipes.qmd`'s `nested-aggregate` chunk is a `must_error` chunk behind `has_duckdb`, so an option that reported it fails that job.

It is a CI script rather than a testthat test because `release-matrix.yaml`'s `backend` jobs install the hard dependencies plus one optional backend and pass `--ignore-vignettes`, so knitr is absent there — and `verify-backend.R` fails a job for any skip that does not name a backend the job withheld. A knitr-gated test would turn every `backend` job red.

## Verification

- `Rscript .github/scripts/verify-must-error.R`: 8/8. Mutation-tested three ways — deleting the `after.knit` registration, neutering the class check, and dropping the `opts_hooks` cleanup each turn it red, and each fails naming the property that broke.
- Site render plus `Rscript .github/scripts/verify-site.R` pass. `verify-site.R` gains two markers on `get_started.html` for the new chunk's rendered diagnostic.
- `pkgload::load_all(".")` then `lintr::lint_package()`: no lints. `lintr::lint_dir(".github", ...)`: no lints. `spelling::spell_check_package()`: clean.
- Full suite: 2304 pass, 0 fail, 0 skip.
- `R CMD build` then `R CMD check` on the tarball: no ERRORs, WARNINGs, or NOTEs. The tarball ships `inst/vignette-hooks/must-error.R`.
- No roxygen comments changed, so `man/` and `NAMESPACE` are untouched.

## Review dispositions

Two findings from `/code-review` that changed the shape of the work, recorded because the reasoning is not visible in the diff:

- **The list form `must_error: [a, b]` was cut.** It was in the first draft and no vignette used it. The issue asks for "the class of the expected condition"; a future need is a one-line change.
- **The investigation note was left untouched.** The first draft added a `## Revisions` section to `investigation/requiring-a-documentation-chunk-to-fail.md` with a `Revised:` header line pointing at an implementation file. `investigation/README.md` reserves that mechanism for supersession, and nothing in that note was overturned. The new knitr readings went into `investigation/restoring-knitr-hooks-a-vignette-installs.md` instead, as their own dated note.

A third finding — that `get_started.qmd` guards knitr for tabsets and then sources a knitr-using file unguarded — I checked rather than accepted; it is the dependency-closure case described above. `AGENTS.md` now records it so nobody adds a guard that cannot fire.

## Out of scope

Converting the remaining prose claims of failure across the vignettes into marked chunks, which #116 deferred. Inventoried as #155 — ten sites across two vignettes.

The option is not public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)