### PR TITLE
Name the DESCRIPTION copyright holder in the license files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2025
-COPYRIGHT HOLDER: marginplyr authors
+COPYRIGHT HOLDER: Yusuke Sasaki

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2025 marginplyr authors
+Copyright (c) 2025 Yusuke Sasaki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/testthat/test-package-metadata.R
+++ b/tests/testthat/test-package-metadata.R
@@ -1,0 +1,95 @@
+# `DESCRIPTION`'s `Authors@R` records who holds copyright in this package, and
+# both license files restate that name in their own format. Nothing compared the
+# three, which is how `LICENSE` and `LICENSE.md` came to name a holder
+# `Authors@R` never mentions (#115): each file reads as a settled statement on
+# its own, and only reading them together shows the package giving two answers
+# to one question. This test derives the expected name from `Authors@R` instead
+# of restating it, so the holder is recorded in one place and the license files
+# are checked against that record.
+
+# Prefer the repository copy, because `system.file()` reads whichever marginplyr
+# happens to be installed. `R CMD check` runs the tests from a directory holding
+# neither copy, and there the installed package is the only one -- `LICENSE` is
+# installed beside `DESCRIPTION` because the `License` field names it.
+metadata_path <- function(file) {
+  source_copy <- test_path("..", "..", file)
+  if (file.exists(source_copy)) {
+    return(source_copy)
+  }
+  installed <- system.file(file, package = "marginplyr")
+  if (!nzchar(installed)) {
+    stop(sprintf("No copy of %s is available to read.", file), call. = FALSE)
+  }
+  installed
+}
+
+# A field this cannot find is a failure rather than a pass, since a file that
+# states no holder is exactly the drift being guarded against.
+dcf_field <- function(path, field) {
+  # `read.dcf()` names the value after the field, which would otherwise turn a
+  # holder mismatch into a report about names.
+  value <- unname(read.dcf(path, fields = field)[1L, 1L])
+  if (is.na(value)) {
+    stop(
+      sprintf("%s states no %s field.", basename(path), field),
+      call. = FALSE
+    )
+  }
+  value
+}
+
+# `format()` renders a `person` the way a license notice names someone, so the
+# expectation comes from the metadata rather than from a second copy of the
+# name. Every `cph` is included, so adding a holder to `Authors@R` fails here
+# until the license files name them too.
+description_copyright_holders <- function() {
+  authors_r <- dcf_field(metadata_path("DESCRIPTION"), "Authors@R")
+  authors <- eval(parse(text = authors_r))
+  holders <- Filter(function(author) "cph" %in% author$role, authors)
+  if (length(holders) == 0L) {
+    stop("DESCRIPTION declares no author with the `cph` role.", call. = FALSE)
+  }
+  format(holders, include = c("given", "family"))
+}
+
+# `LICENSE` is a DCF file, which is what R itself reads it as when expanding the
+# `MIT + file LICENSE` template.
+license_copyright_holder <- function() {
+  dcf_field(metadata_path("LICENSE"), "COPYRIGHT HOLDER")
+}
+
+# `LICENSE.md` states the holder in prose, so match the line the MIT text puts
+# it on rather than the whole notice: the contract is the identity, not the
+# wording around it. The year is matched only to locate the line and is then
+# discarded, because copyright-year policy is a separate question.
+license_md_copyright_holder <- function(path) {
+  notice <- "^Copyright \\(c\\) [0-9]{4} (.+)$"
+  matched <- grep(notice, readLines(path, warn = FALSE), value = TRUE)
+  if (length(matched) != 1L) {
+    stop(
+      sprintf(
+        "%s states %d copyright notices; expected exactly one.",
+        basename(path),
+        length(matched)
+      ),
+      call. = FALSE
+    )
+  }
+  trimws(sub(notice, "\\1", matched))
+}
+
+test_that("the license files name the copyright holder DESCRIPTION declares", {
+  expected <- paste(description_copyright_holders(), collapse = ", ")
+
+  expect_equal(license_copyright_holder(), expected)
+
+  # `LICENSE.md` is `.Rbuildignore`d, so it is a repository file rather than a
+  # shipped one and is absent whenever the tests run from a built tarball.
+  # Reading it conditionally rather than skipping keeps `verify-backend.R`'s
+  # rule that every skip names a backend its job withheld, and the shipped
+  # `LICENSE` is asserted either way, so this test is never an empty one.
+  license_md <- test_path("..", "..", "LICENSE.md")
+  if (file.exists(license_md)) {
+    expect_equal(license_md_copyright_holder(license_md), expected)
+  }
+})


### PR DESCRIPTION
Closes #115.

`LICENSE` and `LICENSE.md` named "marginplyr authors" while `DESCRIPTION` gives the `cph` role to Yusuke Sasaki. CRAN reads both, so the package stated two answers to one question.

The premise was re-verified against `main` before editing; all three files still had the shape the issue describes.

## The direction

`Authors@R` is the authoritative record, so the license files restate the name it declares rather than the reverse. That is outcome 1 of the two the triage comment set out — the usual arrangement for a single-author package. The `cph` role, the `Authors@R` entry, and `License: MIT + file LICENSE` are unchanged, so `man/` and `NAMESPACE` are untouched.

`YEAR: 2025` is deliberately left alone. The issue concerns who holds copyright, not copyright-year policy; the year clause of its acceptance criteria is worth its own issue if the first release slips past 2025.

## The regression check

Two edited strings would leave the next drift just as undetectable, and a test asserting `"Yusuke Sasaki"` against each file would be a third independent copy of the value rather than a check on the relationship between them.

`tests/testthat/test-package-metadata.R` derives the expectation instead. It reads `Authors@R`, formats every person carrying `cph`, and checks that name against `LICENSE` — read as the DCF file R itself expands for the `MIT + file LICENSE` template — and against `LICENSE.md`'s notice line. Changing the holder is therefore an edit to `Authors@R` plus the two files it is checked against; changing one alone fails.

It is base R throughout and adds no dependency. A file that states no holder, or states two, fails rather than passes: the drift being guarded against includes a holder line that disappeared. The year is matched only to locate `LICENSE.md`'s line and is then discarded, so this test cannot start failing over year policy.

**`LICENSE.md` is read conditionally rather than skipped.** It is `.Rbuildignore`d, so the tarball ships only `LICENSE` and the repository copy is absent whenever the tests run from a built tarball. A `skip()` there would fail every `backend` job, since `verify-backend.R` rejects any skip that does not name a backend its job withheld. `LICENSE` is asserted in both environments, so the test is never an empty one either — which testthat 3e would itself report as a skip.

## Verification

- New test run against the unfixed files first: both assertions fail, naming `marginplyr authors` against `Yusuke Sasaki`. The malformed-input paths were probed separately — zero notices, two notices, and a missing DCF field each stop with a message naming the file and the problem.
- Full suite, `NOT_CRAN=true`: all pass, 0 fail, 0 skip.
- `pkgload::load_all(".")` then `lintr::lint_package()`: no lints.
- `Rscript .github/scripts/verify-suite-coverage.R`: 381 tests, none executing in zero configurations.
- `R CMD build` then `R CMD check --as-cran` on the tarball: `Status: OK` — no ERRORs, WARNINGs, or NOTEs, and no license NOTE. Its test run reports `FAIL 0 | WARN 0 | SKIP 0 | PASS 2305`, which is what exercises the installed-`LICENSE` fallback: the tarball ships `marginplyr/LICENSE` and no `LICENSE.md`.
- `git diff --check` clean. The diff is two holder lines and one new test file.