### PR TITLE
Honor the versions DESCRIPTION requires at every optional-dependency guard

### DIFF
--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -84,10 +84,16 @@ test_tally <- function(test_log) {
 #
 # `source()` evaluates top-level expressions only, and the helper's sole
 # testthat call sits inside `skip_if_backend_absent()`'s body, so this works
-# from a bare `Rscript` with testthat unattached. It also brings in
-# `backend_available()` and `required_suggests()`; nothing here calls them, and
-# separating the list into its own file would trade that for a file whose only
-# purpose is the separation.
+# from a bare `Rscript` with testthat unattached. Its reading of DESCRIPTION and
+# of `inst/suggests/guard.R` is inside function bodies for the same reason, one
+# step further on: `generate-backend-matrix.R` runs before marginplyr is
+# installed and asks only for the list, so resolving either at source time would
+# fail a script that has no version question to ask. `verify-suite-coverage.R`
+# does ask one, and runs from the repository root where both are present.
+#
+# The helper also brings in `backend_available()`, `suggest_status()`, and
+# `required_suggests()`; separating the list into its own file would trade that
+# for a file whose only purpose is the separation.
 source("tests/testthat/helper-optional-backends.R")
 
 # Reads a comma-separated list out of the environment, which is how a generated

--- a/.github/scripts/verify-suite-coverage.R
+++ b/.github/scripts/verify-suite-coverage.R
@@ -60,21 +60,28 @@ if (length(backends) == 0L) {
   stop(call. = FALSE, "`optional_backends()` is empty, so this proves nothing.")
 }
 
-# Half one of the mechanism. `requireNamespace()` directly rather than
-# `backend_available()`, because the question is what the library holds, not
-# what the guards report -- and the guards are the thing under test here.
-installed <- vapply(
-  backends,
-  function(package) requireNamespace(package, quietly = TRUE),
-  logical(1)
-)
-if (!all(installed)) {
+# Half one of the mechanism: this run's library holds every backend, at a
+# version DESCRIPTION accepts. Asked of the library rather than through
+# `backend_available()`, because the guards are the thing under test here --
+# `suggest_status()` reads DESCRIPTION and the installed version and knows
+# nothing of `MARGINPLYR_HIDE_SUGGESTS`, which is what the simulation drives.
+#
+# The version half matters as much as the presence half. A backend installed
+# below its constraint now reports unavailable, so it would skip in every
+# configuration and be reported below as requiring two backends -- a violation
+# invented entirely by the environment this ran in (#123).
+status <- lapply(backends, suggest_status)
+unusable <- Filter(function(one) !one$available, status)
+if (length(unusable) > 0L) {
   stop(call. = FALSE, sprintf(
     paste0(
       "This job simulates each backend's absence, so it needs all of them ",
-      "installed. These are not: %s."
+      "installed at the version DESCRIPTION requires. These are not: %s."
     ),
-    paste(backends[!installed], collapse = ", ")
+    paste(
+      vapply(unusable, function(one) one$reason, character(1)),
+      collapse = "; "
+    )
   ))
 }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,69 @@ The grep above is what finds an entry like this, because `R CMD check` does not
 — an unused Suggest raises no NOTE, which is why nothing flagged it for as long
 as it stood.
 
+### Optional-dependency guards
+
+Every guard deciding whether optional code runs goes through
+`marginplyr_suggest_available()` in `inst/suggests/guard.R`. Never
+`requireNamespace()` and never `rlang::is_installed()`, which answer "is it
+installed" and not "is it new enough" — the question DESCRIPTION actually asks,
+since several Suggests carry a version constraint. An installed-but-too-old
+package passes an installation check, the guarded code runs, and it fails at
+the feature instead of skipping (#123). `duckdb (>= 1.5.5)` is the case that
+showed it: under 1.5.4.x `duckdb::duckdb(shared_home = FALSE)` is a hard error
+rather than a degraded result.
+
+`R CMD check` is not the exposure. It stops at `checking package dependencies`
+with "required and available but unsuitable version" before any test, example,
+or vignette runs, so CRAN, the release matrix, and any local check were always
+safe. What the guard covers is everything that is not `R CMD check`:
+`devtools::test()`, `pkgload::load_all()` plus `testthat::test_local()`, an
+example run interactively, and the site build — whose `Config/Needs/website`
+entries carry no versions, so a site job can legitimately install a version the
+package's own Suggests entry rejects.
+
+DESCRIPTION states each constraint and the guard is the only thing that reads
+one, so there is no version written down twice and nothing to keep in step. The
+guard lives under `inst/` for the reason `must-error.R` does: the four
+vignettes, the four examples, and
+`tests/testthat/helper-optional-backends.R` each reach it in one `source()`
+call on a `system.file()` path, and a copy in `tests/` would be the copy the
+shipped sites drift from. Adding a backend still means editing the two places
+*Release matrix* names — a version is not a third place, because the guard
+reads it.
+
+`backend_available()` consults the guard, so a too-old backend skips rather
+than running, unless the job named it in `MARGINPLYR_REQUIRED_SUGGESTS` — then
+it errors, exactly as an absent required backend does, and a `backend` job
+holding a stale version reds as a failure rather than passing on a skipped
+suite. The skip says which case it is: `{duckdb} 1.5.4.3 is installed, but
+marginplyr requires >= 1.5.5`, deliberately not the `{pkg} is not installed`
+wording, which would send a reader looking for a package sitting in their
+library. A `backend` job cannot produce that skip — a backend it named errors
+and one it withheld is not installed — but the wording is still what stops
+`verify-backend.R` attributing a version failure to a withheld backend if one
+ever reached that path. A package hidden by `MARGINPLYR_HIDE_SUGGESTS` keeps
+the absent wording, because a simulated absence that announced a version is a
+skip neither `verify-suite-coverage.R` nor `verify-depends-only.R` could
+attribute.
+
+Guarding on a package DESCRIPTION does not suggest is an error, not an answer.
+`backend_available()` already refuses a backend `optional_suggests()` does not
+name, but a vignette and an example have no such registry, and a typo or a
+dependency that moved to `Config/Needs/website` would otherwise guard on
+installation alone while reading as protection.
+
+Two scans in `test-documentation.R` are what keep this from decaying, and they
+scan rather than list, for the reason every other gate here derives rather than
+lists. Each runs over the Rd topics and over the vignette sources: no page may
+name a version-blind guard, and a page using the guard must source it and vice
+versa. The Rd half reads `man/` when it is present and
+`tools::Rd_db("marginplyr")` otherwise, so it holds under `R CMD check` too;
+the vignette half is repository-only, because `R CMD check` unpacks the tarball
+beside the `.Rcheck` directory rather than inside it. Prose that needs to name
+a version-blind call has to spell it some other way — the scan is deliberately
+blunt.
+
 ### Release matrix
 
 `.github/workflows/release-matrix.yaml` checks one built tarball rather than
@@ -238,9 +301,10 @@ tests skip when their package is missing, which is correct for CRAN's minimal
 flavors but means a green job proves nothing about the backend. Every such
 test therefore goes through `skip_if_backend_absent()` or `backend_available()`
 from `tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
-or `rlang::is_installed()` directly, since those cannot be told to fail.
-(`skip_if_not_installed("dbplyr")` is not an exception: dbplyr is an Import, so
-it is never absent.)
+or `rlang::is_installed()` directly, since those cannot be told to fail — and
+never `requireNamespace()` either, for the separate reason in
+*Optional-dependency guards* above. (`skip_if_not_installed("dbplyr")` is not
+an exception: dbplyr is an Import, so it is never absent.)
 
 Snapshot expectations run only where `NOT_CRAN` is set: testthat skips them
 under CRAN semantics, so a snapshot never fails in a job that emulates CRAN.

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -66,8 +66,11 @@
 #' # SQLite has no native GROUPING SETS support in marginplyr, so a simulated
 #' # lazy table makes the portable UNION ALL translation visible. Rendering
 #' # SQLite SQL reads the driver version from the optional RSQLite package,
-#' # even though the simulator opens no connection.
-#' if (requireNamespace("RSQLite", quietly = TRUE)) {
+#' # even though the simulator opens no connection. Every optional-dependency
+#' # guard in this package's documentation goes through the guard shipped with
+#' # it, so none of them can be the one that forgot to read a version.
+#' source(system.file("suggests", "guard.R", package = "marginplyr"))
+#' if (marginplyr_suggest_available("RSQLite")) {
 #'   sqlite_sales <- dbplyr::tbl_lazy(
 #'     january_sales,
 #'     con = dbplyr::simulate_sqlite()

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -80,7 +80,11 @@
 #'
 #' # dtplyr performs the expansion and nesting lazily, then
 #' # nest_by_with_margins() collects it to create a local row-wise data frame.
-#' if (requireNamespace("dtplyr", quietly = TRUE)) {
+#' # The guard shipped with marginplyr reports dtplyr usable only at the
+#' # version DESCRIPTION requires, so an older one withholds this rather than
+#' # failing inside it.
+#' source(system.file("suggests", "guard.R", package = "marginplyr"))
+#' if (marginplyr_suggest_available("dtplyr")) {
 #'   lazy_nested <- january_sales |>
 #'     dtplyr::lazy_dt() |>
 #'     nest_with_margins(

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -121,8 +121,12 @@
 #'   )
 #' dplyr::group_vars(grouped_nested)
 #'
-#' # The same operation stays lazy for a dtplyr input until collect().
-#' if (requireNamespace("dtplyr", quietly = TRUE)) {
+#' # The same operation stays lazy for a dtplyr input until collect(). The
+#' # guard shipped with marginplyr reports dtplyr usable only at the version
+#' # DESCRIPTION requires, so an older one withholds this rather than failing
+#' # inside it.
+#' source(system.file("suggests", "guard.R", package = "marginplyr"))
+#' if (marginplyr_suggest_available("dtplyr")) {
 #'   nested_dt <- january_sales |>
 #'     dtplyr::lazy_dt() |>
 #'     nest_with_margins(

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -532,11 +532,15 @@
 #' ) |>
 #'   dplyr::arrange(year, region)
 #'
-#' # DuckDB executes a native GROUP BY GROUPING SETS query. The optional
-#' # dependency guard keeps this example runnable without DuckDB installed.
+#' # DuckDB executes a native GROUP BY GROUPING SETS query. The guard shipped
+#' # with marginplyr keeps this example runnable without DuckDB, and withholds
+#' # it just the same when the installed DuckDB is older than the version
+#' # DESCRIPTION requires -- `shared_home` below is an error there, not a
+#' # degraded result.
+#' source(system.file("suggests", "guard.R", package = "marginplyr"))
 #' if (
-#'   requireNamespace("DBI", quietly = TRUE) &&
-#'   requireNamespace("duckdb", quietly = TRUE)
+#'   marginplyr_suggest_available("DBI") &&
+#'   marginplyr_suggest_available("duckdb")
 #' ) {
 #'   # `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets
 #'   # inside the session's temporary directory instead of `~/.duckdb`.

--- a/inst/suggests/guard.R
+++ b/inst/suggests/guard.R
@@ -1,0 +1,208 @@
+# Whether an optional Suggested package can be used, which DESCRIPTION makes a
+# stronger question than whether it is installed.
+#
+# Several of this package's Suggests carry a version constraint, and
+# `requireNamespace()` cannot see one: it answers "installed" and returns TRUE
+# for a version whose API the guarded code then calls and does not find. The
+# case that motivated this is `duckdb (>= 1.5.5)`, where
+# `duckdb::duckdb(shared_home = FALSE)` is a hard error under 1.5.4.x rather
+# than a degraded result, so a guard that only asked "installed" turned a clean
+# skip into a confusing failure (#123).
+#
+# `R CMD check` is already safe: it stops at `checking package dependencies`
+# with "required and available but unsuitable version" before any test,
+# example, or vignette runs. What this file covers is every context that is not
+# `R CMD check` -- `devtools::test()`, `pkgload::load_all()` plus
+# `testthat::test_local()`, an example run interactively, and the altdoc site
+# build, whose `Config/Needs/website` entries carry no versions at all.
+#
+# DESCRIPTION states each constraint once and this file is the only thing that
+# reads one, so there is no second copy to drift. It is sourced rather than
+# exported, in the manner of `inst/vignette-hooks/must-error.R`: a vignette, an
+# example, and `tests/testthat/helper-optional-backends.R` each reach it in one
+# line -- a `source()` call on the `system.file()` path to this file -- and the
+# package's API gains nothing. A caller then guards on
+# `marginplyr_suggest_available()`, which is the only name here any of them
+# uses; the setup chunk of every vignette and the optional-backend section of
+# every example show the pair.
+#
+# `AGENTS.md` is authoritative for which guards must go through here and for
+# what asserts that they do.
+
+# DESCRIPTION's `Suggests` field, read from the installed package. Every caller
+# that can reach a repository DESCRIPTION passes it instead, which is why each
+# function below takes the field as an argument rather than reaching for it.
+marginplyr_declared_suggests <- function() {
+  suggests <- utils::packageDescription("marginplyr")$Suggests
+  if (is.null(suggests) || is.na(suggests)) {
+    stop(
+      "marginplyr's DESCRIPTION states no Suggests field to read a version ",
+      "constraint from.",
+      call. = FALSE
+    )
+  }
+  suggests
+}
+
+# One entry per Suggested package, split on the commas that separate entries
+# rather than on every comma: `pkg (>= 1.0, < 2.0)` is a legal single entry
+# whose constraint contains one, and splitting it would produce two entries
+# neither of which parses. Depth is counted rather than assumed, so the split
+# stays correct whichever form DESCRIPTION happens to use.
+marginplyr_suggest_entries <- function(suggests) {
+  characters <- strsplit(suggests, "", fixed = TRUE)[[1]]
+  depth <- cumsum(characters == "(") - cumsum(characters == ")")
+  breaks <- which(characters == "," & depth == 0L)
+  starts <- c(1L, breaks + 1L)
+  ends <- c(breaks - 1L, length(characters))
+  entries <- substring(suggests, starts, ends)
+  # A DESCRIPTION field wraps across lines, so an entry arrives with newlines
+  # and indentation inside it as readily as around it.
+  entries <- trimws(gsub("[[:space:]]+", " ", entries))
+  entries[nzchar(entries)]
+}
+
+# The shape of one entry, shared by the two functions below so that a package's
+# name is extracted the same way it is matched.
+marginplyr_entry_pattern <- paste0(
+  "^([[:alnum:]._]+)",
+  "[[:space:]]*(\\((.*)\\))?$"
+)
+
+# The packages DESCRIPTION suggests, in the order it lists them. An entry this
+# cannot read halts rather than being passed over: a constraint that stopped
+# being understood is one that silently stopped being honored, which is the
+# failure this file exists to prevent.
+marginplyr_suggest_names <- function(suggests) {
+  entries <- marginplyr_suggest_entries(suggests)
+  unreadable <- entries[!grepl(marginplyr_entry_pattern, entries)]
+  if (length(unreadable) > 0L) {
+    stop(
+      sprintf(
+        "These Suggests entries are not readable as `name (constraint)`: %s.",
+        paste(unreadable, collapse = "; ")
+      ),
+      call. = FALSE
+    )
+  }
+  sub(marginplyr_entry_pattern, "\\1", entries)
+}
+
+# The version constraint DESCRIPTION states for `package`, or NULL when it
+# states none.
+#
+# A package DESCRIPTION does not suggest at all is refused rather than answered.
+# Every guard reaching this file names a package the tarball declares, so a name
+# that is absent from `Suggests` is a typo or a dependency that moved -- and
+# answering it would answer the version-blind question this file exists to
+# replace, at exactly the call sites that have no other registry. The test
+# helpers refuse an unregistered backend for the same reason; a vignette and an
+# example have only this.
+marginplyr_suggest_requirement <- function(package,
+                                           suggests =
+                                             marginplyr_declared_suggests()) {
+  # Both derived from `marginplyr_suggest_entries()`, so the name at a position
+  # and the entry at it describe the same package.
+  entries <- marginplyr_suggest_entries(suggests)
+  named <- marginplyr_suggest_names(suggests)
+  matched <- which(named == package)
+  if (length(matched) == 0L) {
+    stop(
+      sprintf(
+        paste0(
+          "{%s} is not a Suggested package of marginplyr, so guarding on it ",
+          "would ask only whether it is installed. Suggested: %s."
+        ),
+        package,
+        paste(named, collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
+  text <- trimws(sub(
+    marginplyr_entry_pattern,
+    "\\3",
+    entries[matched[[1]]]
+  ))
+  if (!nzchar(text)) {
+    return(NULL)
+  }
+  comparison_pattern <- "^(<=|>=|==|!=|<|>)[[:space:]]*(.+)$"
+  parts <- trimws(strsplit(text, ",", fixed = TRUE)[[1]])
+  unreadable <- parts[!grepl(comparison_pattern, parts)]
+  if (length(unreadable) > 0L) {
+    stop(
+      sprintf(
+        "The version constraint on {%s} is not readable: %s.",
+        package,
+        paste(unreadable, collapse = "; ")
+      ),
+      call. = FALSE
+    )
+  }
+  list(
+    text = text,
+    comparisons = lapply(parts, function(part) {
+      list(
+        operator = sub(comparison_pattern, "\\1", part),
+        version = package_version(sub(comparison_pattern, "\\2", part))
+      )
+    })
+  )
+}
+
+# Everything a caller needs to decide whether to run guarded code and, when it
+# does not, to say why. The two unusable cases are worded apart on purpose: a
+# too-old package reported as "not installed" would send a reader looking for a
+# package that is sitting in their library.
+marginplyr_suggest_status <- function(package,
+                                      suggests =
+                                        marginplyr_declared_suggests()) {
+  requirement <- marginplyr_suggest_requirement(package, suggests = suggests)
+  if (!requireNamespace(package, quietly = TRUE)) {
+    return(list(
+      package = package,
+      available = FALSE,
+      installed = FALSE,
+      version = NULL,
+      requirement = requirement,
+      reason = sprintf("{%s} is not installed", package)
+    ))
+  }
+  version <- utils::packageVersion(package)
+  satisfied <- is.null(requirement) || all(vapply(
+    requirement$comparisons,
+    function(comparison) {
+      isTRUE(do.call(
+        comparison$operator,
+        list(version, comparison$version)
+      ))
+    },
+    logical(1)
+  ))
+  list(
+    package = package,
+    available = satisfied,
+    installed = TRUE,
+    version = version,
+    requirement = requirement,
+    reason = if (satisfied) {
+      ""
+    } else {
+      sprintf(
+        "{%s} %s is installed, but marginplyr requires %s",
+        package,
+        format(version),
+        requirement$text
+      )
+    }
+  )
+}
+
+# The guard itself. Reads as `requireNamespace()` did at the call sites it
+# replaced, and answers the question those call sites always meant to ask.
+marginplyr_suggest_available <- function(package,
+                                         suggests =
+                                           marginplyr_declared_suggests()) {
+  marginplyr_suggest_status(package, suggests = suggests)$available
+}

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -362,8 +362,11 @@ dplyr::group_vars(grouped_expansion)
 # SQLite has no native GROUPING SETS support in marginplyr, so a simulated
 # lazy table makes the portable UNION ALL translation visible. Rendering
 # SQLite SQL reads the driver version from the optional RSQLite package,
-# even though the simulator opens no connection.
-if (requireNamespace("RSQLite", quietly = TRUE)) {
+# even though the simulator opens no connection. Every optional-dependency
+# guard in this package's documentation goes through the guard shipped with
+# it, so none of them can be the one that forgot to read a version.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+if (marginplyr_suggest_available("RSQLite")) {
   sqlite_sales <- dbplyr::tbl_lazy(
     january_sales,
     con = dbplyr::simulate_sqlite()

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -410,7 +410,11 @@ nrow(nest_by_with_margins(.data = empty_sales))
 
 # dtplyr performs the expansion and nesting lazily, then
 # nest_by_with_margins() collects it to create a local row-wise data frame.
-if (requireNamespace("dtplyr", quietly = TRUE)) {
+# The guard shipped with marginplyr reports dtplyr usable only at the
+# version DESCRIPTION requires, so an older one withholds this rather than
+# failing inside it.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+if (marginplyr_suggest_available("dtplyr")) {
   lazy_nested <- january_sales |>
     dtplyr::lazy_dt() |>
     nest_with_margins(

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -401,8 +401,12 @@ grouped_nested <- retail_sales |>
   )
 dplyr::group_vars(grouped_nested)
 
-# The same operation stays lazy for a dtplyr input until collect().
-if (requireNamespace("dtplyr", quietly = TRUE)) {
+# The same operation stays lazy for a dtplyr input until collect(). The
+# guard shipped with marginplyr reports dtplyr usable only at the version
+# DESCRIPTION requires, so an older one withholds this rather than failing
+# inside it.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+if (marginplyr_suggest_available("dtplyr")) {
   nested_dt <- january_sales |>
     dtplyr::lazy_dt() |>
     nest_with_margins(

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -590,11 +590,15 @@ summarize_with_margins(
 ) |>
   dplyr::arrange(year, region)
 
-# DuckDB executes a native GROUP BY GROUPING SETS query. The optional
-# dependency guard keeps this example runnable without DuckDB installed.
+# DuckDB executes a native GROUP BY GROUPING SETS query. The guard shipped
+# with marginplyr keeps this example runnable without DuckDB, and withholds
+# it just the same when the installed DuckDB is older than the version
+# DESCRIPTION requires -- `shared_home` below is an error there, not a
+# degraded result.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
 if (
-  requireNamespace("DBI", quietly = TRUE) &&
-  requireNamespace("duckdb", quietly = TRUE)
+  marginplyr_suggest_available("DBI") &&
+  marginplyr_suggest_available("duckdb")
 ) {
   # `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets
   # inside the session's temporary directory instead of `~/.duckdb`.

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -38,6 +38,94 @@ hidden_suggests <- function() {
   suggests_env_list("MARGINPLYR_HIDE_SUGGESTS")
 }
 
+# Whether a package is usable is not the same question as whether it is
+# installed, because six of this package's Suggests carry a version constraint
+# (#123). `inst/suggests/guard.R` is what reads one, and these helpers source
+# that file rather than carrying a second reading of DESCRIPTION: no vignette
+# and no example can reach `tests/`, so a copy here would be the copy every one
+# of those sites drifts from.
+#
+# Repository copies are preferred over installed ones throughout, for the reason
+# `test-package-metadata.R` records: `system.file()` reads whichever marginplyr
+# happens to be installed, so a working tree that moved a version floor, or
+# changed the guard, would otherwise be tested against neither change. Under
+# `R CMD check` no repository copy is reachable and the installed package is the
+# only answer, which is the same package the tarball built.
+#
+# The lookup is a function rather than a value because `.github/scripts/`
+# sources this file from a bare `Rscript` before marginplyr is installed --
+# `generate-backend-matrix.R` needs only `optional_backend_spec()` -- so
+# resolving a path at source time would fail a script that never asks a version
+# question. Both candidate paths are relative, and both possible working
+# directories are covered: the repository root under those scripts, and
+# `tests/testthat` under testthat, from where the repository root is `../..`.
+#
+# The plain path is tried first because the `../..` form is the one that can
+# reach outside the repository: run from the root it names the parent of the
+# checkout, where a stray `DESCRIPTION` would quietly win. Neither
+# `tests/testthat/DESCRIPTION` nor `tests/testthat/inst/` exists, so trying the
+# plain path first costs nothing under testthat.
+repository_file <- function(path) {
+  candidates <- c(path, file.path("..", "..", path))
+  found <- candidates[file.exists(candidates)]
+  if (length(found) == 0L) {
+    return(NA_character_)
+  }
+  found[[1]]
+}
+
+# The `Suggests` field the guard reads its constraints out of.
+declared_suggests <- function() {
+  path <- repository_file("DESCRIPTION")
+  if (is.na(path)) {
+    path <- system.file("DESCRIPTION", package = "marginplyr")
+  }
+  if (!nzchar(path) || !file.exists(path)) {
+    stop("No DESCRIPTION is reachable to read Suggests versions from.")
+  }
+  suggests <- unname(read.dcf(path, fields = "Suggests")[1L, 1L])
+  # A DESCRIPTION stating no Suggests would make every guard below report every
+  # backend unconstrained, which reads exactly like a package whose constraints
+  # are all satisfied.
+  if (is.na(suggests)) {
+    stop(sprintf("%s states no Suggests field.", path))
+  }
+  suggests
+}
+
+# The shipped guard, sourced once into an environment of its own so that its
+# definitions cannot be mistaken for helpers defined here. Loaded on demand for
+# the reason above, and cached because every guarded test asks for it.
+suggest_guard <- local({
+  loaded <- NULL
+  function() {
+    if (!is.null(loaded)) {
+      return(loaded)
+    }
+    path <- repository_file(file.path("inst", "suggests", "guard.R"))
+    if (is.na(path)) {
+      path <- system.file("suggests", "guard.R", package = "marginplyr")
+    }
+    if (!nzchar(path) || !file.exists(path)) {
+      stop(
+        "`inst/suggests/guard.R` is not reachable, so no guard here can tell ",
+        "an installed backend from a usable one."
+      )
+    }
+    loaded <<- new.env(parent = globalenv())
+    sys.source(path, envir = loaded)
+    loaded
+  }
+})
+
+# What the guard reports about one Suggested package. `suggests` is a seam
+# rather than a convenience: it is how `test-optional-backends.R` drives the
+# too-old branch with a package that is certainly installed, which no real
+# constraint in DESCRIPTION would ever produce in a passing environment.
+suggest_status <- function(package, suggests = declared_suggests()) {
+  suggest_guard()$marginplyr_suggest_status(package, suggests = suggests)
+}
+
 # The one table describing the optional Suggests these helpers guard on, and the
 # only list the release matrix reads. Which side of the repository it lives on
 # is forced, not preferred: `R CMD check` runs these tests from the unpacked
@@ -103,19 +191,27 @@ backend_job_packages <- function(package) {
 # several backends use this directly, because dropping one from a list records
 # no skip at all and would otherwise be invisible.
 #
+# "Can be used" includes the version DESCRIPTION requires, which is what
+# `requireNamespace()` here could not say (#123). An installed-but-too-old
+# backend now reports FALSE and skips, where it used to report TRUE and let the
+# test call an API the installed version does not have.
+#
 # A package `known` does not name is an error rather than FALSE. Nothing in the
 # release matrix executes such a package and nothing asserts it absent, so a
 # guard on it would do nothing while reading as protection; erroring is what
 # makes this test suite the place a backend gets registered. The check runs
-# before `requireNamespace()` so that it fires the same way on a fully
+# before the guard is consulted so that it fires the same way on a fully
 # provisioned developer machine, where the package is installed and a check
 # placed after it would never be reached.
 #
-# `known` is a parameter only so that this helper's own tests can drive both
-# outcomes. They need a sentinel name no CRAN package uses and a base package
-# that is always installed, and neither belongs in `optional_suggests()`. Every
-# other call site takes the default.
-backend_available <- function(package, known = optional_suggests()) {
+# `known` and `suggests` are parameters only so that this helper's own tests can
+# drive every outcome. They need a sentinel name no CRAN package uses, a base
+# package that is always installed, and a constraint no installed version can
+# satisfy; none of the three belongs in `optional_suggests()` or in DESCRIPTION.
+# Every other call site takes the defaults.
+backend_available <- function(package,
+                              known = optional_suggests(),
+                              suggests = declared_suggests()) {
   if (!package %in% names(known)) {
     stop(sprintf(
       paste0(
@@ -146,30 +242,57 @@ backend_available <- function(package, known = optional_suggests()) {
       package
     ))
   }
-  if (!hidden && requireNamespace(package, quietly = TRUE)) {
+  status <- suggest_status(package, suggests = suggests)
+  if (!hidden && status$available) {
     return(TRUE)
   }
   if (package %in% required_suggests()) {
     stop(sprintf(
       paste0(
-        "{%s} is named in MARGINPLYR_REQUIRED_SUGGESTS but is not installed, ",
-        "so this job cannot prove its backend contract."
+        "%s, and it is named in MARGINPLYR_REQUIRED_SUGGESTS, so this job ",
+        "cannot prove its backend contract."
       ),
-      package
+      backend_absence_reason(package, suggests = suggests)
     ))
   }
   FALSE
 }
 
-# Skips unless every named backend is installed, keeping testthat's own wording
-# so the skip summary reads the same as it did under `skip_if_not_installed()`.
+# Why a backend is unusable, in the wording a skip carries.
 #
-# `known` sits after `...` and so can only be supplied by full name, which keeps
-# it from ever swallowing a backend argument.
-skip_if_backend_absent <- function(..., known = optional_suggests()) {
+# A hidden backend reports the absent wording rather than the guard's, because
+# `MARGINPLYR_HIDE_SUGGESTS` claims a package this process could otherwise see
+# is gone: `verify-suite-coverage.R` and `verify-depends-only.R` both attribute
+# a skip by matching `{pkg} is not installed`, and a simulated absence that
+# announced itself differently would be a skip neither could attribute.
+#
+# The too-old wording is deliberately not that phrase, and not because a
+# `backend` job needs it to be: a backend that job named is required, so
+# `backend_available()` above stops rather than skipping, and a backend it
+# withheld is not installed at all. What the distinction is for is the reader of
+# a skip -- "not installed" would send someone looking for a package sitting in
+# their library -- and for `verify-backend.R`, which fails a job on any skip it
+# cannot attribute. Sharing the absent wording would let a version failure pass
+# there as a withheld backend if one ever reached that path.
+backend_absence_reason <- function(package, suggests = declared_suggests()) {
+  if (package %in% hidden_suggests()) {
+    return(sprintf("{%s} is not installed", package))
+  }
+  suggest_status(package, suggests = suggests)$reason
+}
+
+# Skips unless every named backend is usable, keeping testthat's own wording for
+# an absent package so the skip summary reads the same as it did under
+# `skip_if_not_installed()`.
+#
+# `known` and `suggests` sit after `...` and so can only be supplied by full
+# name, which keeps them from ever swallowing a backend argument.
+skip_if_backend_absent <- function(...,
+                                   known = optional_suggests(),
+                                   suggests = declared_suggests()) {
   for (package in c(...)) {
-    if (!backend_available(package, known = known)) {
-      skip(sprintf("{%s} is not installed", package))
+    if (!backend_available(package, known = known, suggests = suggests)) {
+      skip(backend_absence_reason(package, suggests = suggests))
     }
   }
   invisible(NULL)

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -115,3 +115,89 @@ test_that("the Grouping-identity comparison has exactly one canonical home", {
 
   expect_equal(names(topics)[carries_table], "grouping_bit.Rd")
 })
+
+# Every guard in the shipped documentation decides whether optional code runs,
+# and `requireNamespace()` cannot make that decision correctly: it reports an
+# installed-but-too-old package usable, and the guarded code then calls an API
+# that version does not have (#123). `inst/suggests/guard.R` is what reads the
+# constraint DESCRIPTION states, and these scans are what keep a new guard from
+# quietly going back to the version-blind question.
+#
+# The scan is the gate rather than a list of guard sites, for the reason
+# `AGENTS.md` gives for deriving rather than listing elsewhere: a list has to be
+# edited when a guard is added, and the failure of the one left behind is
+# silence.
+#
+# Both names the *Release matrix* section forbids are scanned, not only the one
+# #123 found. The rlang spelling even takes a version argument of its own,
+# which makes it the likelier of the two to arrive looking correct.
+version_blind_guards <- c("requireNamespace", "is_installed")
+
+# Every shipped page whose guards this holds to, whatever it is written in.
+#
+# `.Rbuildignore` keeps no vignette out of the tarball, but `R CMD check`
+# unpacks it beside the `.Rcheck` directory rather than inside it, so a vignette
+# source is reachable from a repository run only. The Rd topics are reachable
+# either way -- from `man/` in a repository, from `tools::Rd_db()` otherwise --
+# so a run that finds no vignette still asserts these rules over the examples,
+# and adding the pages conditionally rather than skipping keeps
+# `verify-backend.R`'s rule that every skip names a backend its job withheld.
+documentation_sources <- function() {
+  pages <- rd_topics()
+  vignettes <- testthat::test_path("..", "..", "vignettes")
+  if (dir.exists(vignettes)) {
+    sources <- list.files(vignettes, pattern = "[.]qmd$", full.names = TRUE)
+    text <- lapply(sources, function(path) {
+      paste(readLines(path, warn = FALSE), collapse = "\n")
+    })
+    pages <- c(pages, stats::setNames(text, basename(sources)))
+  }
+  pages
+}
+
+test_that("no shipped page guards on installation alone", {
+  pages <- documentation_sources()
+  skip_if(length(pages) == 0L, "No documentation sources available")
+
+  blind <- vapply(
+    pages,
+    function(text) {
+      any(vapply(
+        version_blind_guards,
+        grepl,
+        logical(1),
+        x = text,
+        fixed = TRUE
+      ))
+    },
+    logical(1)
+  )
+
+  # Named rather than counted, so the failure says which page to fix and what
+  # to replace the call with.
+  expect_equal(
+    names(pages)[blind],
+    character(),
+    info = paste(
+      "Guard with `marginplyr_suggest_available()` from",
+      "`inst/suggests/guard.R` instead."
+    )
+  )
+})
+
+test_that("every shipped page using the guard also sources it", {
+  pages <- documentation_sources()
+  skip_if(length(pages) == 0L, "No documentation sources available")
+
+  # An example is evaluated with marginplyr attached but nothing sourced, and a
+  # vignette chunk is knitted the same way, so a guard call without the
+  # `source()` line above it is an object-not-found error rather than the
+  # withheld content it reads as.
+  uses <- grepl("marginplyr_suggest_available", pages, fixed = TRUE)
+  sources <- grepl("\"suggests\", \"guard.R\"", pages, fixed = TRUE)
+
+  expect_equal(names(pages)[uses & !sources], character())
+  # The other direction, so a `source()` left behind by a deleted guard is
+  # reported rather than shipped as an unexplained line.
+  expect_equal(names(pages)[sources & !uses], character())
+})

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -48,6 +48,19 @@ absent_package <- "marginplyrNoSuchBackend"
 known_absent <- stats::setNames(TRUE, absent_package)
 known_installed <- c(stats = TRUE)
 
+# The `Suggests` field each injected table is paired with. `suggests` has to
+# travel with `known`, because neither name is in DESCRIPTION and the guard
+# refuses a package DESCRIPTION does not suggest -- that refusal is what keeps a
+# vignette or an example from guarding on a name whose constraint could never be
+# read. A pretend table needs a pretend field for the same reason it needs a
+# pretend `known`.
+suggests_absent <- absent_package
+suggests_installed <- "stats"
+# What a constrained Suggest whose installed version is too old looks like. No
+# real constraint could produce this case in an environment where the suite
+# passes, so it is supplied rather than found.
+suggests_too_old <- "stats (>= 999.0.0)"
+
 test_that("required suggests are parsed from the environment variable", {
   with_required_suggests("", expect_identical(required_suggests(), character()))
   with_required_suggests(
@@ -58,12 +71,20 @@ test_that("required suggests are parsed from the environment variable", {
 
 test_that("an absent backend is skippable when no job promised it", {
   with_required_suggests("", {
-    expect_false(backend_available(absent_package, known = known_absent))
+    expect_false(backend_available(
+      absent_package,
+      known = known_absent,
+      suggests = suggests_absent
+    ))
     # Caught rather than asserted with `expect_error()`, because testthat lets
     # a skip condition escape an expectation and skip the whole test instead.
     skipped <- tryCatch(
       {
-        skip_if_backend_absent(absent_package, known = known_absent)
+        skip_if_backend_absent(
+          absent_package,
+          known = known_absent,
+          suggests = suggests_absent
+        )
         NULL
       },
       skip = function(condition) condition
@@ -76,11 +97,19 @@ test_that("an absent backend is skippable when no job promised it", {
 test_that("an absent backend fails when the job promised to prove it", {
   with_required_suggests(absent_package, {
     expect_error(
-      backend_available(absent_package, known = known_absent),
+      backend_available(
+        absent_package,
+        known = known_absent,
+        suggests = suggests_absent
+      ),
       "MARGINPLYR_REQUIRED_SUGGESTS"
     )
     expect_error(
-      skip_if_backend_absent(absent_package, known = known_absent),
+      skip_if_backend_absent(
+        absent_package,
+        known = known_absent,
+        suggests = suggests_absent
+      ),
       "MARGINPLYR_REQUIRED_SUGGESTS"
     )
   })
@@ -89,18 +118,31 @@ test_that("an absent backend fails when the job promised to prove it", {
 test_that("promising one backend does not make an unrelated one required", {
   with_required_suggests("duckdb", expect_false(backend_available(
     absent_package,
-    known = known_absent
+    known = known_absent,
+    suggests = suggests_absent
   )))
 })
 
 test_that("an installed backend is available whether or not it is required", {
   with_required_suggests(
     "",
-    expect_true(backend_available("stats", known = known_installed))
+    expect_true(backend_available(
+      "stats",
+      known = known_installed,
+      suggests = suggests_installed
+    ))
   )
   with_required_suggests("stats", {
-    expect_true(backend_available("stats", known = known_installed))
-    expect_no_error(skip_if_backend_absent("stats", known = known_installed))
+    expect_true(backend_available(
+      "stats",
+      known = known_installed,
+      suggests = suggests_installed
+    ))
+    expect_no_error(skip_if_backend_absent(
+      "stats",
+      known = known_installed,
+      suggests = suggests_installed
+    ))
   })
 })
 
@@ -135,10 +177,18 @@ test_that("a hidden backend reports absent even though it is installed", {
   # the simulation reports that every test runs in every configuration.
   with_required_suggests("", {
     with_hidden_suggests("stats", {
-      expect_false(backend_available("stats", known = known_installed))
+      expect_false(backend_available(
+        "stats",
+        known = known_installed,
+        suggests = suggests_installed
+      ))
       skipped <- tryCatch(
         {
-          skip_if_backend_absent("stats", known = known_installed)
+          skip_if_backend_absent(
+            "stats",
+            known = known_installed,
+            suggests = suggests_installed
+          )
           NULL
         },
         skip = function(condition) condition
@@ -155,11 +205,19 @@ test_that("hiding a backend a job promised to prove is refused", {
   with_required_suggests("stats", {
     with_hidden_suggests("stats", {
       expect_error(
-        backend_available("stats", known = known_installed),
+        backend_available(
+          "stats",
+          known = known_installed,
+          suggests = suggests_installed
+        ),
         "MARGINPLYR_HIDE_SUGGESTS"
       )
       expect_error(
-        skip_if_backend_absent("stats", known = known_installed),
+        skip_if_backend_absent(
+          "stats",
+          known = known_installed,
+          suggests = suggests_installed
+        ),
         "MARGINPLYR_REQUIRED_SUGGESTS"
       )
     })
@@ -173,8 +231,16 @@ test_that("hiding one backend leaves an unrelated promise alone", {
   # promise sentinel ones.
   with_required_suggests("stats", {
     with_hidden_suggests("arrow", {
-      expect_true(backend_available("stats", known = known_installed))
-      expect_false(backend_available(absent_package, known = known_absent))
+      expect_true(backend_available(
+        "stats",
+        known = known_installed,
+        suggests = suggests_installed
+      ))
+      expect_false(backend_available(
+        absent_package,
+        known = known_absent,
+        suggests = suggests_absent
+      ))
     })
   })
 })
@@ -220,8 +286,11 @@ test_that("every tracked Suggest is declared in DESCRIPTION", {
   # A typo in `optional_suggests()` would make `backend_available()` refuse the
   # real backend at every guard, which reads as a registration error rather
   # than as the typo it is.
-  declared <- strsplit(packageDescription("marginplyr")$Suggests, ",")[[1]]
-  declared <- trimws(sub("\\(.*", "", declared))
+  #
+  # Read through the shipped guard's own reading of the field rather than a
+  # second parse written here, so this test fails when that reading stops
+  # understanding DESCRIPTION instead of quietly agreeing with a broken one.
+  declared <- suggest_guard()$marginplyr_suggest_names(declared_suggests())
   expect_true(all(names(optional_suggests()) %in% declared))
 })
 
@@ -232,4 +301,219 @@ test_that("DBI is untrackable because dbplyr puts it in the hard closure", {
   # subset, and this test is what says so.
   expect_match(packageDescription("dbplyr")$Imports, "\\bDBI\\b")
   expect_false(optional_suggests()[["DBI"]])
+})
+
+# A guard that reports a backend usable now promises the version DESCRIPTION
+# requires, not only that the package is installed (#123). The two claims came
+# apart under `duckdb (>= 1.5.5)`, where the older `duckdb()` rejects the
+# `shared_home` argument outright: `requireNamespace()` answered TRUE, the
+# guarded code ran, and it failed at the feature instead of skipping.
+#
+# `suggests` is the seam these tests drive, through `suggests_too_old` above.
+test_that("a version constraint is read out of the Suggests field", {
+  requirement <- suggest_guard()$marginplyr_suggest_requirement
+  expect_null(requirement("DBI", suggests = "arrow (>= 1.0), DBI, tibble"))
+
+  read <- requirement("arrow", suggests = "arrow (>= 13.0.0), DBI")
+  expect_identical(read$text, ">= 13.0.0")
+  expect_identical(read$comparisons[[1]]$operator, ">=")
+  expect_identical(read$comparisons[[1]]$version, package_version("13.0.0"))
+})
+
+test_that("an entry survives the wrapping a DESCRIPTION field arrives with", {
+  # `read.dcf()` hands back the field with its newlines and indentation intact,
+  # so an entry can carry whitespace inside it as readily as around it.
+  requirement <- suggest_guard()$marginplyr_suggest_requirement
+  wrapped <- "\n    duckdb (>=\n    1.5.5),\n    knitr\n"
+  expect_identical(requirement("duckdb", suggests = wrapped)$text, ">= 1.5.5")
+  expect_null(requirement("knitr", suggests = wrapped))
+})
+
+test_that("a two-sided constraint is split on entries, not on every comma", {
+  # `pkg (>= 1.0, < 2.0)` is one legal entry whose constraint contains a comma.
+  # Splitting the field on every comma would make it two entries, neither of
+  # which parses, so this is the case a naive split turns into a hard error.
+  guard <- suggest_guard()
+  field <- "pkg (>= 1.0, < 2.0), other"
+  expect_identical(
+    guard$marginplyr_suggest_entries(field),
+    c("pkg (>= 1.0, < 2.0)", "other")
+  )
+  read <- guard$marginplyr_suggest_requirement("pkg", suggests = field)
+  expect_length(read$comparisons, 2L)
+  expect_identical(
+    vapply(read$comparisons, function(one) one$operator, character(1)),
+    c(">=", "<")
+  )
+})
+
+test_that("an unreadable constraint halts rather than being passed over", {
+  # A constraint this cannot read is one that silently stopped being honored,
+  # which is the whole failure the guard exists to prevent.
+  guard <- suggest_guard()
+  expect_error(
+    guard$marginplyr_suggest_requirement("pkg", suggests = "pkg >= 1.0"),
+    "not readable as"
+  )
+  expect_error(
+    guard$marginplyr_suggest_requirement("pkg", suggests = "pkg (1.0)"),
+    "constraint on \\{pkg\\} is not readable"
+  )
+})
+
+test_that("a package DESCRIPTION does not suggest is refused, not answered", {
+  # Returning "no constraint" for an unlisted name would answer the
+  # version-blind question at exactly the call sites with no other registry: a
+  # vignette or an example naming a typo, or a Suggest that moved to
+  # `Config/Needs/website`, would guard on installation alone and read as
+  # protection. `backend_available()` refuses an unregistered backend for the
+  # same reason, but nothing outside `tests/` reaches that refusal.
+  guard <- suggest_guard()
+  expect_error(
+    guard$marginplyr_suggest_available("dukcdb", suggests = "duckdb (>= 1.0)"),
+    "not a Suggested package of marginplyr"
+  )
+  # Named in DESCRIPTION without a constraint is a different answer from named
+  # nowhere, and the two must not collapse into each other.
+  expect_true(guard$marginplyr_suggest_available(
+    "stats",
+    suggests = suggests_installed
+  ))
+})
+
+test_that("an installed backend below its constraint is not available", {
+  with_required_suggests("", {
+    expect_true(backend_available(
+      "stats",
+      known = known_installed,
+      suggests = suggests_installed
+    ))
+    expect_false(backend_available(
+      "stats",
+      known = known_installed,
+      suggests = suggests_too_old
+    ))
+  })
+})
+
+test_that("a too-old backend skips with a reason that is not \"absent\"", {
+  # Reported as absent, this skip would send a reader looking for a package
+  # sitting in their library. It also has to stay distinguishable to
+  # `verify-backend.R`, which attributes a skip by matching the absent wording.
+  with_required_suggests("", {
+    skipped <- tryCatch(
+      {
+        skip_if_backend_absent(
+          "stats",
+          known = known_installed,
+          suggests = suggests_too_old
+        )
+        NULL
+      },
+      skip = function(condition) condition
+    )
+    expect_s3_class(skipped, "skip")
+    expect_no_match(conditionMessage(skipped), "is not installed")
+    expect_match(conditionMessage(skipped), "marginplyr requires >= 999.0.0")
+    expect_match(conditionMessage(skipped), "\\{stats\\}")
+  })
+})
+
+test_that("a too-old backend fails when the job promised to prove it", {
+  # A `backend` job installs the version DESCRIPTION asks for, so a job holding
+  # an older one has not proved its contract and must not report that it did.
+  with_required_suggests("stats", {
+    expect_error(
+      backend_available(
+        "stats",
+        known = known_installed,
+        suggests = suggests_too_old
+      ),
+      "MARGINPLYR_REQUIRED_SUGGESTS"
+    )
+    expect_error(
+      backend_available(
+        "stats",
+        known = known_installed,
+        suggests = suggests_too_old
+      ),
+      "marginplyr requires"
+    )
+  })
+})
+
+test_that("a hidden backend reports absent whatever its version says", {
+  # `MARGINPLYR_HIDE_SUGGESTS` claims a package is gone, and both
+  # `verify-suite-coverage.R` and `verify-depends-only.R` attribute the skip it
+  # produces by matching the absent wording. A simulated absence that announced
+  # a version instead would be a skip neither could attribute.
+  with_required_suggests("", {
+    with_hidden_suggests("stats", {
+      expect_identical(
+        backend_absence_reason("stats", suggests = suggests_too_old),
+        "{stats} is not installed"
+      )
+    })
+  })
+})
+
+test_that("the constraints the guard honors are the ones DESCRIPTION states", {
+  # The mechanism before the conclusion: every test above supplies its own
+  # `suggests`, so all of them would pass against a DESCRIPTION the guard reads
+  # nothing out of. This is the one that reads the real field, and it fails if
+  # a tracked backend's constraint stops being found.
+  requirement <- suggest_guard()$marginplyr_suggest_requirement
+  found <- Filter(
+    Negate(is.null),
+    lapply(names(optional_suggests()), requirement)
+  )
+  expect_gt(length(found), 0L)
+  expect_identical(
+    requirement("duckdb")$comparisons[[1]]$operator,
+    ">="
+  )
+  # Every tracked backend present in the checking environment satisfies what
+  # DESCRIPTION asks of it, which is what makes a skip elsewhere in the suite
+  # attributable to absence rather than to this run's own library.
+  for (package in names(optional_suggests())) {
+    status <- suggest_status(package)
+    expect_true(status$available || !status$installed)
+  }
+})
+
+test_that("the guard the tests read is the guard the vignettes source", {
+  # The vignettes and the `summarize_with_margins()` example cannot reach
+  # `tests/`, so they reach `inst/suggests/guard.R` through `system.file()`.
+  # These helpers source the same file, which is what makes one reading of
+  # DESCRIPTION serve all of them; a second copy here is exactly the drift
+  # `AGENTS.md` keeps `optional_backend_spec()` single to prevent.
+  expect_true(is.function(suggest_guard()$marginplyr_suggest_available))
+  installed <- system.file("suggests", "guard.R", package = "marginplyr")
+  expect_true(nzchar(installed))
+
+  # These helpers prefer the repository copies of the guard and of DESCRIPTION,
+  # so that a working tree is tested against its own changes. That preference is
+  # also how the two can differ: a stale install would leave the vignettes and
+  # examples enforcing floors the tests no longer do, and every assertion here
+  # would still pass. Comparing them is what makes the preference safe rather
+  # than merely convenient. Under `R CMD check` there is no repository copy to
+  # compare against and the installed package is the only reading, which is the
+  # package the tarball built.
+  repository <- repository_file(file.path("inst", "suggests", "guard.R"))
+  if (!is.na(repository)) {
+    expect_identical(
+      readLines(repository, warn = FALSE),
+      readLines(installed, warn = FALSE)
+    )
+  }
+  repository_description <- repository_file("DESCRIPTION")
+  if (!is.na(repository_description)) {
+    expect_identical(
+      declared_suggests(),
+      unname(read.dcf(
+        system.file("DESCRIPTION", package = "marginplyr"),
+        fields = "Suggests"
+      )[1L, 1L])
+    )
+  }
 })

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -28,15 +28,20 @@ library(dplyr)
 
 Only dplyr and dbplyr are required. The tidyr and SQLite sections below need
 optional packages, so their chunks evaluate only when those packages are
-installed. Where a package is missing the code is still shown, but its output
-is absent.
+installed at the versions marginplyr asks for. Where a package is missing or
+too old the code is still shown, but its output is absent.
 
 ```{r}
 #| include: false
 
-has_tidyr <- requireNamespace("tidyr", quietly = TRUE)
-has_sqlite <- requireNamespace("DBI", quietly = TRUE) &&
-  requireNamespace("RSQLite", quietly = TRUE)
+# `marginplyr_suggest_available()` answers what a bare installation check
+# could not: whether the installed package satisfies the version DESCRIPTION
+# requires. AGENTS.md is authoritative for which guards must go through it.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+
+has_tidyr <- marginplyr_suggest_available("tidyr")
+has_sqlite <- marginplyr_suggest_available("DBI") &&
+  marginplyr_suggest_available("RSQLite")
 ```
 
 ## Why completion is a separate operation

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -44,18 +44,23 @@ library(dplyr)
 
 Only dplyr and dbplyr are required. The DuckDB, SQLite, and dtplyr sections
 below need optional packages, so their chunks evaluate only when those
-packages are installed. Where a package is missing the code is still shown,
-but its output is absent.
+packages are installed at the versions marginplyr asks for. Where a package is
+missing or too old the code is still shown, but its output is absent.
 
 ```{r}
 #| include: false
 
-has_duckdb <- requireNamespace("DBI", quietly = TRUE) &&
-  requireNamespace("duckdb", quietly = TRUE)
+# `marginplyr_suggest_available()` answers what a bare installation check
+# could not: whether the installed package satisfies the version DESCRIPTION
+# requires. AGENTS.md is authoritative for which guards must go through it.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+
+has_duckdb <- marginplyr_suggest_available("DBI") &&
+  marginplyr_suggest_available("duckdb")
 # dbplyr's SQLite simulator opens no connection, but rendering its SQL reads
 # the installed driver version through RSQLite.
-has_sqlite_simulator <- requireNamespace("RSQLite", quietly = TRUE)
-has_dtplyr <- requireNamespace("dtplyr", quietly = TRUE)
+has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
+has_dtplyr <- marginplyr_suggest_available("dtplyr")
 ```
 
 ## One report, two execution locations

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -41,18 +41,24 @@ library(dplyr)
 ```
 
 Only dplyr and dbplyr are required. A few sections below illustrate optional
-tooling, so their chunks evaluate only when that tooling is installed. Where a
-package is missing the code is still shown, but its output is absent.
+tooling, so their chunks evaluate only when that tooling is installed at the
+version marginplyr asks for. Where a package is missing or too old the code is
+still shown, but its output is absent.
 
 ```{r}
 #| include: false
 
+# `marginplyr_suggest_available()` answers what a bare installation check
+# could not: whether the installed package satisfies the version DESCRIPTION
+# requires. AGENTS.md is authoritative for which guards must go through it.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+
 # dbplyr's SQLite simulator opens no connection, but rendering its SQL reads
 # the installed driver version through RSQLite.
-has_sqlite_simulator <- requireNamespace("RSQLite", quietly = TRUE)
-has_dtplyr <- requireNamespace("dtplyr", quietly = TRUE)
-has_tabsets <- requireNamespace("knitr", quietly = TRUE) &&
-  requireNamespace("quartabs", quietly = TRUE)
+has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
+has_dtplyr <- marginplyr_suggest_available("dtplyr")
+has_tabsets <- marginplyr_suggest_available("knitr") &&
+  marginplyr_suggest_available("quartabs")
 
 # Chunks marked with `must_error` show a call that is meant to fail, so the
 # reader sees the real diagnostic rather than a quotation of one. AGENTS.md is

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -46,16 +46,21 @@ library(dplyr)
 ```
 
 Only dplyr and dbplyr are required. Two recipes execute against DuckDB, so
-their chunks evaluate only when DuckDB is installed. Where a package is
-missing the code is still shown, but its output is absent. Everything else
-runs either locally or against `dbplyr::simulate_postgres()`, which needs no
-database and no optional package.
+their chunks evaluate only when DuckDB is installed at the version marginplyr
+asks for. Where a package is missing or too old the code is still shown, but
+its output is absent. Everything else runs either locally or against
+`dbplyr::simulate_postgres()`, which needs no database and no optional package.
 
 ```{r}
 #| include: false
 
-has_duckdb <- requireNamespace("DBI", quietly = TRUE) &&
-  requireNamespace("duckdb", quietly = TRUE)
+# `marginplyr_suggest_available()` answers what a bare installation check
+# could not: whether the installed package satisfies the version DESCRIPTION
+# requires. AGENTS.md is authoritative for which guards must go through it.
+source(system.file("suggests", "guard.R", package = "marginplyr"))
+
+has_duckdb <- marginplyr_suggest_available("DBI") &&
+  marginplyr_suggest_available("duckdb")
 
 # Chunks marked with `must_error` show a call that is meant to fail, so the
 # reader sees the real diagnostic rather than a quotation of one. AGENTS.md is


### PR DESCRIPTION
Closes #123.

The premise was re-verified against `main` before editing. Every guard still asked `requireNamespace()`, and the six sites the issue names had grown to eight: `R/nest_with_margins.R`, `R/nest_by_with_margins.R`, and `R/expand_with_margins.R` carry the same guard in their examples, and `vignettes/get_started.qmd` and `vignettes/completing_keys.qmd` carry it in their setup chunks.

`requireNamespace()` answers whether a package is installed and cannot answer whether it is new enough. An installed-but-too-old package therefore passed the guard, the guarded code ran, and it failed at the feature instead of skipping. `duckdb (>= 1.5.5)` is the case that showed it: under 1.5.4.x `duckdb::duckdb(shared_home = FALSE)` is a hard error rather than a degraded result.

`R CMD check` was never the exposure, as the issue establishes — it stops at `checking package dependencies` with "required and available but unsuitable version" before any test, example, or vignette runs. The exposure is everything that is not `R CMD check`: `devtools::test()`, `pkgload::load_all()` plus `testthat::test_local()`, an example run interactively, and the altdoc site build, whose `Config/Needs/website` entries carry no versions at all.

## The direction

The issue offered two shapes and asked for a deliberate choice: a version column on `optional_backend_spec()` that restates the constraint, or one that reads it. This reads it, so nothing restates a version and no gate is needed to keep two copies agreeing.

`inst/suggests/guard.R` is the only thing that reads a constraint. It lives under `inst/` for the reason `must-error.R` does: the four vignettes, the four examples, and `tests/testthat/helper-optional-backends.R` each reach it in one `source()` call on a `system.file()` path, and nothing is added to the package's API. That answers the question the issue left open — the shipped sites "cannot reach `tests/`, so whatever they use is a second implementation by construction" — by making it the *same* implementation instead. `optional_backend_spec()` gains no column, so adding a backend still means editing the two places `AGENTS.md` names; a version is not a third place, because the guard reads it.

The parser splits `Suggests` on the commas that separate entries rather than on every comma, since `pkg (>= 1.0, < 2.0)` is a legal single entry whose constraint contains one, and it halts on an entry or constraint it cannot read — a constraint that stopped being understood is one that silently stopped being honored.

## Skip wording, and the gates that read it

`backend_available()` consults the guard, so a too-old backend skips rather than running. It says which case it is — `{duckdb} 1.5.4.3 is installed, but marginplyr requires >= 1.5.5` — deliberately not the `{pkg} is not installed` wording, which would send a reader looking for a package sitting in their library.

A backend the job named in `MARGINPLYR_REQUIRED_SUGGESTS` errors instead, exactly as an absent required backend already did, so a `backend` job holding a stale version reds as a failure rather than passing on a skipped suite. A `backend` job cannot in fact produce the too-old skip — a backend it named errors and one it withheld is not installed — but the distinct wording is still what stops `verify-backend.R` attributing a version failure to a withheld backend if one ever reached that path.

A package hidden by `MARGINPLYR_HIDE_SUGGESTS` keeps the absent wording, because a simulated absence that announced a version is a skip neither `verify-suite-coverage.R` nor `verify-depends-only.R` could attribute.

`verify-suite-coverage.R`'s first mechanism assertion now checks the version as well as the presence of each backend. A backend installed below its constraint would skip in every configuration and be reported as requiring two backends — a policy violation invented entirely by the environment the script ran in.

## Guarding on a name DESCRIPTION does not suggest

Refused rather than answered. `backend_available()` already refuses a backend `optional_suggests()` does not name, but a vignette and an example have no such registry: a typo, or a Suggest that moved to `Config/Needs/website`, would otherwise collapse back to the version-blind question while reading as protection.

## The regression check

Two scans in `tests/testthat/test-documentation.R`, each running over the Rd topics and the vignette sources together: no shipped page may name a version-blind guard (`requireNamespace` or `is_installed`, both of which the *Release matrix* section forbids), and a page using the guard must source it and vice versa. They scan rather than list, so a new guard site needs no edit to be covered — a list would have to be edited when a guard is added, and the failure of the one left behind is silence.

The Rd half reads `man/` when present and `tools::Rd_db("marginplyr")` otherwise, so it holds under `R CMD check` too. The vignette half is repository-only, because `R CMD check` unpacks the tarball beside the `.Rcheck` directory rather than inside it; the pages are added conditionally rather than skipped, which keeps `verify-backend.R`'s rule that every skip names a backend its job withheld, and the Rd half asserts both rules unconditionally so neither test is ever an empty one.

The scan is deliberately blunt, so prose that needs to name a version-blind call has to spell it some other way. `AGENTS.md` records that.

## One decision worth a second opinion

The issue scopes out the unversioned Suggests (`DBI`, `RSQLite`, `knitr`, `tidyr`), which have no constraint to honor. Their guards are converted anyway, because uniformity is what lets the regression check be a derived scan rather than a list of exempt sites. The cost is a `source()` line in `expand_with_margins`'s help page for no behavior change. Exempting them is a one-line edit here plus an allowlist in the scan, if that trade reads the other way.

`Config/Needs/website` is left unversioned, as the issue permits. The guard is what makes that safe: a site job installing a version the Suggests entry rejects now withholds the DuckDB content instead of erroring.

## Verification

- `Rscript .github/scripts/verify-suite-coverage.R`: 394 tests, none executing in zero configurations, 107 in exactly one.
- `R CMD build` then `R CMD check` on the tarball: `Status: OK`.
- `_R_CHECK_DEPENDS_ONLY_=true R CMD check` on the same tarball: `Status: OK`. `verify-depends-only.R` against its output: `FAIL 0 | WARN 0 | SKIP 110 | PASS 1713`, with arrow, duckdb, dtplyr, and RSQLite all withheld — so every asserted backend still produced its `{pkg} is not installed` line.
- `Rscript .github/scripts/verify-must-error.R`: 8 fixtures, all OK.
- `altdoc::render_docs(parallel = FALSE, freeze = FALSE)` then `Rscript .github/scripts/verify-site.R`: 19 pages plus the search index.
- Full suite, `pkgload::load_all(".")` then `lintr::lint_package()`, `lintr::lint_dir(".github", ...)`, `spelling::spell_check_package()`, `roxygen2::roxygenise()`: all clean.
- End to end from the installed package: a simulated `duckdb (>= 99.0.0)` makes `marginplyr_suggest_available("duckdb")` return `FALSE` with the version-naming reason, and an unlisted name is refused by message.

**Not verified against a genuinely old duckdb.** 1.5.4.3 was not installed, matching the issue's own note. What is exercised instead is the same `has_duckdb <- FALSE` path the depends-only vignette rebuild takes, plus the guard's answer read directly.
