### PR TITLE
Refuse a renaming selection in `.by` (#134)

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -66,13 +66,42 @@ normalize_grouping_input <- function(.data, by_quo) {
   }
 
   .data <- dplyr::ungroup(.data)
-  by <- if (length(input_groups) > 0L) {
-    input_groups
-  } else {
-    rlang::inject(get_col_names(.data, !!by_quo))
-  }
 
-  list(data = .data, by = by)
+  list(data = .data, groups = input_groups)
+}
+
+# The fixed keys, wherever column names alone settle them: the grouping columns
+# of a grouped input, an absent `.by`, or a selection that names columns.
+# `NULL` says the selection carries a predicate, which no set of names can
+# answer; that one is resolved against the typed snapshot instead, exactly as a
+# Grouping dimension carrying a predicate is.
+resolve_fixed_keys <- function(by_quo, group_vars, data_vars) {
+  if (length(group_vars) > 0L) {
+    # Grouping columns are names dplyr resolved, so they name columns of the
+    # input and cannot rename one.
+    return(group_vars)
+  }
+  if (rlang::quo_is_null(by_quo)) {
+    return(character())
+  }
+  if (!is_name_only_selection(by_quo, data_vars)) {
+    return(NULL)
+  }
+  resolve_by_selection(by_quo, grouping_name_proxy(data_vars))
+}
+
+# A fixed key is a column of the input, exactly as a grouping dimension is, so
+# the rule #103 established for `.grouping` holds here too. `.by` was resolved
+# by selecting it and reading the names back with `get_col_names()`, which are
+# the names the caller wrote, so `.by = c(area = region)` was accepted two ways:
+# as a plan rejected for `area`, a column the caller never wrote, and — where
+# `area` is another column — as a plan silently fixed on that other column,
+# partitioning every verb's result by a column the selection did not name
+# (#134). Resolving through the selection is what keeps both names in hand;
+# `get_col_names()`'s other callers read back names dplyr assigned on purpose,
+# so the check belongs on this resolution rather than in that helper.
+resolve_by_selection <- function(by_quo, data_proxy) {
+  resolve_column_selection(by_quo, data_proxy, labels = by_rename_labels())
 }
 
 prepare_grouping_plan <- function(.data,
@@ -107,9 +136,9 @@ prepare_grouping_plan <- function(.data,
 
       input <- normalize_grouping_input(.data, by_quo)
       data <- input$data
-      by <- input$by
       backend <- grouping_backend(data)
       data_vars <- get_col_names(data, dplyr::everything())
+      by <- resolve_fixed_keys(by_quo, input$groups, data_vars)
       if (!is.null(validate_names)) {
         validate_names(data_vars)
       }
@@ -121,18 +150,27 @@ prepare_grouping_plan <- function(.data,
       preflight <- preflight_grouping_spec(grouping_spec, data_vars)
       if (preflight$name_only) {
         # Reject name-only plan errors before acquiring typed metadata. The
-        # canonical plan is compiled from the typed snapshot below.
+        # canonical plan is compiled from the typed snapshot below. Unresolved
+        # fixed keys stand in as none: a `.by` carrying a predicate is not known
+        # until that snapshot, and the two checks that read the keys — an
+        # unknown fixed key and one overlapping a dimension — are made again
+        # against the resolved keys below. Withholding the pass instead would
+        # make a `.grouping` error determinable from names alone wait for a
+        # backend read, which ADR-0005 forbids.
         compile_grouping_spec(
           grouping_spec,
           data_vars = data_vars,
           data_proxy = grouping_name_proxy(data_vars),
-          .by = by,
+          .by = if (is.null(by)) character() else by,
           .duplicates = .duplicates,
           duplicates_choices = duplicates_choices,
           preflight = preflight
         )
       }
       data_proxy <- grouping_selection_proxy(data, backend = backend)
+      if (is.null(by)) {
+        by <- resolve_by_selection(by_quo, data_proxy)
+      }
       plan <- compile_grouping_spec(
         grouping_spec,
         data_vars = data_vars,
@@ -696,15 +734,20 @@ grouping_arg_spec <- function(arg, data_vars) {
   NULL
 }
 
-# tidyselect reports a selection under the names the caller gave it, so
-# `all_of(c(area = "region"))` selects `region` and calls it `area`. A grouping
-# dimension is a column of the input, so a renamed selection would put a name
-# the data does not have into the plan. Renaming is refused here, the one place
-# that sees both names, rather than with `eval_select(allow_rename = FALSE)`,
-# whose diagnostic says only that renaming is disallowed and never names the
-# pair the caller has to fix. A name that repeats its own column renames
-# nothing and is left alone.
 resolve_grouping_selection <- function(arg, data_proxy) {
+  resolve_column_selection(arg, data_proxy, labels = grouping_rename_labels())
+}
+
+# tidyselect reports a selection under the names the caller gave it, so
+# `all_of(c(area = "region"))` selects `region` and calls it `area`. A column
+# a Margin verb selects — a grouping dimension or a fixed `.by` key alike — is
+# a column of the input, so a renamed selection would put a name the data does
+# not have into the plan. Renaming is refused here, the one place that sees
+# both names, rather than with `eval_select(allow_rename = FALSE)`, whose
+# diagnostic says only that renaming is disallowed and never names the pair the
+# caller has to fix. A name that repeats its own column renames nothing and is
+# left alone.
+resolve_column_selection <- function(arg, data_proxy, labels) {
   selected <- tidyselect::eval_select(
     arg,
     data = data_proxy,
@@ -717,21 +760,46 @@ resolve_grouping_selection <- function(arg, data_proxy) {
   source_names <- names(tidyselect::tidyselect_data_proxy(data_proxy))[selected]
   renamed <- selected_names != source_names
   if (any(renamed)) {
-    abort_grouping_rename(selected_names[renamed], source_names[renamed])
+    abort_selection_rename(
+      selected_names[renamed],
+      source_names[renamed],
+      labels = labels
+    )
   }
   selected_names
 }
 
-abort_grouping_rename <- function(selected_names, source_names) {
+# One caller mistake, one diagnostic: `.grouping` and `.by` refuse a renaming
+# selection for the same reason, and only the noun and the rule it states
+# differ.
+grouping_rename_labels <- function() {
+  list(
+    singular = "grouping dimension",
+    plural = "grouping dimensions",
+    rule = "Grouping dimensions must name existing columns."
+  )
+}
+
+by_rename_labels <- function() {
+  list(
+    singular = "`.by` column",
+    plural = "`.by` columns",
+    rule = "Fixed `.by` keys must name existing columns."
+  )
+}
+
+abort_selection_rename <- function(selected_names, source_names, labels) {
   abort_marginplyr(
     paste0(
-      "Can't rename grouping dimension",
-      if (length(selected_names) == 1L) " " else "s ",
+      "Can't rename ",
+      if (length(selected_names) == 1L) labels$singular else labels$plural,
+      " ",
       paste0(
         "`", selected_names, " = ", source_names, "`",
         collapse = ", "
       ),
-      ". Grouping dimensions must name existing columns."
+      ". ",
+      labels$rule
     )
   )
 }

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -7,7 +7,10 @@
 #' @param .data A data frame or lazy table.
 #' @param .by <[`tidy-select`][dplyr::dplyr_tidy_select]> Columns retained in
 #'   every grouping set. For grouped input, the existing grouping columns are
-#'   used and `.by` must be `NULL`.
+#'   used and `.by` must be `NULL`. A fixed key is a column of the input, so a
+#'   selection cannot rename it: `c(area = region)` is an error rather than a
+#'   fixed key named `area`. Rename the result afterwards with
+#'   [dplyr::rename()].
 #' @param .grouping A Grouping specification created by [grouping_set()],
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
 #'   represents the empty grouping set.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -15,7 +15,9 @@
 #' @param .by <[`tidy-select`][dplyr::dplyr_tidy_select]> Columns included in
 #'   every grouping set. These columns never receive `.margin_label`. When
 #'   `.data` is grouped and `.by` is `NULL`, its grouping columns are used as
-#'   implicit fixed keys.
+#'   implicit fixed keys. A fixed key is a column of the input, so a selection
+#'   cannot rename it: `c(area = region)` is an error rather than a fixed key
+#'   named `area`. Rename the result afterwards with [dplyr::rename()].
 #' @param .grouping A grouping specification made with [grouping_set()],
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
 #'   represents one empty grouping set.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -22,7 +22,9 @@ expand_with_margins(
 \item{.by}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns included in
 every grouping set. These columns never receive \code{.margin_label}. When
 \code{.data} is grouped and \code{.by} is \code{NULL}, its grouping columns are used as
-implicit fixed keys.}
+implicit fixed keys. A fixed key is a column of the input, so a selection
+cannot rename it: \code{c(area = region)} is an error rather than a fixed key
+named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -17,7 +17,10 @@ inspect_grouping(
 
 \item{.by}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns retained in
 every grouping set. For grouped input, the existing grouping columns are
-used and \code{.by} must be \code{NULL}.}
+used and \code{.by} must be \code{NULL}. A fixed key is a column of the input, so a
+selection cannot rename it: \code{c(area = region)} is an error rather than a
+fixed key named \code{area}. Rename the result afterwards with
+\code{\link[dplyr:rename]{dplyr::rename()}}.}
 
 \item{.grouping}{A Grouping specification created by \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -25,7 +25,9 @@ not supported because nesting creates list columns.}
 \item{.by}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns included in
 every grouping set. These columns never receive \code{.margin_label}. When
 \code{.data} is grouped and \code{.by} is \code{NULL}, its grouping columns are used as
-implicit fixed keys.}
+implicit fixed keys. A fixed key is a column of the input, so a selection
+cannot rename it: \code{c(area = region)} is an error rather than a fixed key
+named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -25,7 +25,9 @@ not supported because nesting creates list columns.}
 \item{.by}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns included in
 every grouping set. These columns never receive \code{.margin_label}. When
 \code{.data} is grouped and \code{.by} is \code{NULL}, its grouping columns are used as
-implicit fixed keys.}
+implicit fixed keys. A fixed key is a column of the input, so a selection
+cannot rename it: \code{c(area = region)} is an error rather than a fixed key
+named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -41,7 +41,9 @@ helpers \code{\link[=grouping_bit]{grouping_bit()}}, \code{\link[=grouping_id]{g
 \item{.by}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns included in
 every grouping set. These columns never receive \code{.margin_label}. When
 \code{.data} is grouped and \code{.by} is \code{NULL}, its grouping columns are used as
-implicit fixed keys.}
+implicit fixed keys. A fixed key is a column of the input, so a selection
+cannot rename it: \code{c(area = region)} is an error rather than a fixed key
+named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -380,6 +380,77 @@ test_that("a lazy selection proxy resolves renames against its columns", {
   )
 })
 
+backend_by_rename_message <- function() {
+  paste0(
+    "Can't rename `.by` column `area = region`. ",
+    "Fixed `.by` keys must name existing columns."
+  )
+}
+
+# A `.by` selection naming columns is settled from column names alone, so a
+# lazy input is never touched to resolve one. This source has no connection to
+# touch: a resolution that reached past the names would fail rather than report
+# what the caller has to fix.
+test_that("a lazy .by selection is settled before the table is read", {
+  source <- dbplyr::tbl_lazy(
+    data.frame(region = c("x", "y"), area = c("p", "q"), value = 1:2),
+    con = dbplyr::simulate_sqlite()
+  )
+
+  plan <- inspect_grouping(source, .by = region, .grouping = rollup(value))
+  expect_identical(plan$fixed, c("(region)", "(region)"))
+
+  error <- expect_error(
+    inspect_grouping(
+      source,
+      .by = tidyselect::all_of(c(area = "region")),
+      .grouping = rollup(value)
+    )
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(conditionMessage(error), backend_by_rename_message())
+})
+
+# A `.by` predicate is the one fixed-key selection column names cannot answer,
+# so it reads the typed snapshot — for Arrow, the schema the operation already
+# acquired. The schema reads are counted because a second one is what a
+# resolution of its own would look like, and it would still return the right
+# columns (ADR-0002).
+test_that("an Arrow .by predicate resolves against the typed snapshot", {
+  skip_if_backend_absent("arrow")
+
+  source <- arrow::Table$create(
+    data.frame(region = c("x", "y"), area = c("p", "q"), value = 1:2)
+  )
+  schema_reads <- 0L
+  infer_schema <- getFromNamespace("infer_schema", "arrow")
+  testthat::local_mocked_bindings(
+    infer_schema = function(x) {
+      schema_reads <<- schema_reads + 1L
+      infer_schema(x)
+    },
+    .package = "arrow"
+  )
+
+  plan <- inspect_grouping(
+    source,
+    .by = where(is.numeric),
+    .grouping = rollup(region)
+  )
+  expect_identical(plan$fixed, c("(value)", "(value)"))
+  expect_identical(schema_reads, 1L)
+
+  error <- expect_error(
+    inspect_grouping(
+      source,
+      .by = c(area = region, where(is.numeric)),
+      .grouping = grouping_set()
+    )
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(conditionMessage(error), backend_by_rename_message())
+})
+
 margin_label_check_data <- function() {
   data.frame(
     first = c("Total", "x"),

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -375,6 +375,112 @@ test_that("non-renaming grouping selections keep resolving", {
   )
 })
 
+by_rename_vars <- function() {
+  c("region", "area", "region_code", "value")
+}
+
+by_rename_message <- function() {
+  paste0(
+    "Can't rename `.by` column `area = region`. ",
+    "Fixed `.by` keys must name existing columns."
+  )
+}
+
+test_that("a renaming .by selection is refused", {
+  data_vars <- by_rename_vars()
+
+  # The renamed-to name is another column of the input, so a resolution that
+  # reports the name the caller wrote fixes the plan on `area` and never groups
+  # by the column the selection named (#134).
+  clashing <- expect_error(
+    resolve_fixed_keys(rlang::quo(c(area = region)), character(), data_vars)
+  )
+  expect_s3_class(clashing, "marginplyr_error")
+  expect_identical(conditionMessage(clashing), by_rename_message())
+
+  # The renamed-to name is no column at all, which used to be rejected as an
+  # unknown `.by` column the caller never wrote.
+  absent <- expect_error(
+    resolve_fixed_keys(
+      rlang::quo(c(area = region)),
+      character(),
+      c("region", "value")
+    )
+  )
+  expect_s3_class(absent, "marginplyr_error")
+  expect_identical(conditionMessage(absent), by_rename_message())
+
+  several <- expect_error(
+    resolve_fixed_keys(
+      rlang::quo(tidyselect::all_of(c(area = "region", size = "value"))),
+      character(),
+      data_vars
+    )
+  )
+  expect_s3_class(several, "marginplyr_error")
+  expect_identical(
+    conditionMessage(several),
+    paste0(
+      "Can't rename `.by` columns `area = region`, `size = value`. ",
+      "Fixed `.by` keys must name existing columns."
+    )
+  )
+})
+
+test_that("fixed keys settled by name alone need no typed metadata", {
+  data_vars <- by_rename_vars()
+  selected <- c("region", "value")
+
+  expect_identical(
+    resolve_fixed_keys(rlang::quo(region), character(), data_vars),
+    "region"
+  )
+  expect_identical(
+    resolve_fixed_keys(rlang::quo(c(region, area)), character(), data_vars),
+    c("region", "area")
+  )
+  expect_identical(
+    resolve_fixed_keys(
+      rlang::quo(tidyselect::all_of(selected)),
+      character(),
+      data_vars
+    ),
+    c("region", "value")
+  )
+  expect_identical(
+    resolve_fixed_keys(
+      rlang::quo(tidyselect::starts_with("region")),
+      character(),
+      data_vars
+    ),
+    c("region", "region_code")
+  )
+  expect_identical(
+    resolve_fixed_keys(rlang::quo(NULL), character(), data_vars),
+    character()
+  )
+  # A name that repeats the column it selects renames nothing.
+  expect_identical(
+    resolve_fixed_keys(
+      rlang::quo(tidyselect::all_of(c(region = "region"))),
+      character(),
+      data_vars
+    ),
+    "region"
+  )
+  # Grouping columns are names dplyr resolved, so a grouped input's keys are
+  # taken as they stand rather than selected again.
+  expect_identical(
+    resolve_fixed_keys(rlang::quo(NULL), "region", data_vars),
+    "region"
+  )
+  # A predicate is the one selection column names cannot answer, so it is left
+  # for the typed snapshot.
+  expect_null(
+    resolve_fixed_keys(rlang::quo(where(is.numeric)), character(), data_vars)
+  )
+})
+
 test_that("duplicate grouping sets have explicit policies", {
   spec <- grouping_sets(grouping_set(a), grouping_set(a))
 

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -306,6 +306,135 @@ test_that("a renaming selection resolved from typed metadata is refused", {
   expect_identical(conditionMessage(error), renaming_grouping_message())
 })
 
+renaming_by_data <- function() {
+  data.frame(region = c("x", "y"), area = c("p", "q"), revenue = 1:2)
+}
+
+renaming_by_message <- function() {
+  paste0(
+    "Can't rename `.by` column `area = region`. ",
+    "Fixed `.by` keys must name existing columns."
+  )
+}
+
+test_that("inspection and execution refuse a renaming .by alike", {
+  # `area` is a column too, so the resolution this replaces reported the name
+  # the caller wrote, fixed the plan on `area`, and partitioned every result by
+  # a column the selection never named (#134).
+  data <- renaming_by_data()
+
+  inspected <- expect_error(
+    inspect_grouping(data, .by = c(area = region), .grouping = rollup(revenue))
+  )
+  expect_s3_class(inspected, "marginplyr_error")
+  expect_identical(conditionMessage(inspected), renaming_by_message())
+  expect_identical(
+    rlang::call_name(conditionCall(inspected)),
+    "inspect_grouping"
+  )
+
+  # Every Margin verb resolves `.by` through the same helper, so each one
+  # reports what the inspection verb reported. The calls are written out rather
+  # than built from the verb names, so `codetools` can follow them.
+  summarized <- expect_error(
+    summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .by = c(area = region),
+      .grouping = rollup(revenue)
+    )
+  )
+  expect_identical(conditionMessage(summarized), renaming_by_message())
+
+  expanded <- expect_error(
+    expand_with_margins(
+      data,
+      .by = c(area = region),
+      .grouping = rollup(revenue)
+    )
+  )
+  expect_identical(conditionMessage(expanded), renaming_by_message())
+
+  nested <- expect_error(
+    nest_with_margins(
+      data,
+      .by = c(area = region),
+      .grouping = rollup(revenue)
+    )
+  )
+  expect_identical(conditionMessage(nested), renaming_by_message())
+
+  nested_by <- expect_error(
+    nest_by_with_margins(
+      data,
+      .by = c(area = region),
+      .grouping = rollup(revenue)
+    )
+  )
+  expect_identical(conditionMessage(nested_by), renaming_by_message())
+
+  for (error in list(summarized, expanded, nested, nested_by)) {
+    expect_s3_class(error, "marginplyr_error")
+  }
+})
+
+test_that("a renaming .by is refused whether or not the name is a column", {
+  # The renamed-to name is no column of this input, which used to be reported
+  # as an unknown `.by` column the caller never wrote.
+  error <- expect_error(
+    inspect_grouping(
+      data.frame(region = c("x", "y"), revenue = 1:2),
+      .by = c(area = region),
+      .grouping = rollup(revenue)
+    )
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(conditionMessage(error), renaming_by_message())
+})
+
+test_that("a renaming .by resolved from typed metadata is refused", {
+  # A selection carrying a predicate cannot be resolved from column names
+  # alone, so it reaches the typed selection proxy rather than the name proxy
+  # that rejects every other renaming `.by` before a backend is read.
+  error <- expect_error(
+    inspect_grouping(
+      renaming_by_data(),
+      .by = c(area = region, where(is.numeric)),
+      .grouping = grouping_set()
+    )
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(conditionMessage(error), renaming_by_message())
+})
+
+test_that("fixed .by keys still resolve without renaming", {
+  data <- renaming_by_data()
+
+  plan <- inspect_grouping(data, .by = region, .grouping = rollup(revenue))
+  expect_identical(plan$fixed, c("(region)", "(region)"))
+
+  # A grouped input supplies the same keys through `dplyr::group_vars()`.
+  grouped <- inspect_grouping(
+    dplyr::group_by(data, region),
+    .grouping = rollup(revenue)
+  )
+  expect_identical(grouped$fixed, c("(region)", "(region)"))
+
+  # A predicate resolves against the typed snapshot instead of the names.
+  typed <- inspect_grouping(
+    data,
+    .by = where(is.numeric),
+    .grouping = rollup(region)
+  )
+  expect_identical(typed$fixed, c("(revenue)", "(revenue)"))
+
+  # No `.by` at all fixes nothing.
+  expect_identical(
+    inspect_grouping(data, .grouping = rollup(region))$fixed,
+    c("()", "()")
+  )
+})
+
 inspect_proxy_capture <- new.env(parent = emptyenv())
 
 inspect_proxy_counter_head <- function(x, ...) {
@@ -353,6 +482,33 @@ test_that("lazy inspection reads typed metadata once, executing no margins", {
   expect_identical(class(result), c("tbl_df", "tbl", "data.frame"))
   expect_identical(result$included, c("(group)", "()"))
   expect_identical(result$grouping_id, c(0L, 1L))
+})
+
+test_that("a name-only grouping error precedes a .by predicate's read", {
+  # A `.by` predicate is resolved from typed metadata, but the Grouping
+  # specification beside it may still be resolvable from names — and ADR-0005
+  # puts its rejection before any backend read. Deferred fixed keys stand in as
+  # none for that pass, so the read a predicate needs cannot be pulled ahead of
+  # an error the names already decide.
+  skip_if_backend_absent("dtplyr")
+  register_inspect_proxy_methods()
+  source <- dtplyr::lazy_dt(data.frame(
+    group = c("x", "y"),
+    value = 1:2
+  ))
+  class(source) <- c("margin_inspect_proxy_counter", class(source))
+  inspect_proxy_capture$n <- 0L
+
+  error <- expect_error(
+    inspect_grouping(
+      source,
+      .by = where(is.numeric),
+      .grouping = rollup(tidyselect::all_of("absent"))
+    )
+  )
+
+  expect_identical(inspect_proxy_capture$n, 0L)
+  expect_match(conditionMessage(error), "absent")
 })
 
 test_that("dbplyr inspection returns local plan data without a source query", {


### PR DESCRIPTION
Closes #134.

## What was wrong

`.by` was resolved by selecting it and reading the names back with
`get_col_names()`, which reports the names the caller wrote. `.by = c(area =
region)` was therefore accepted two ways:

- where `area` is no column, the plan was rejected for a column the caller
  never wrote — ``Unknown `.by` column `area`.``;
- where `area` *is* another column, nothing was rejected at all: every verb
  partitioned its result by a column the selection did not name, and `region`
  was never grouped by.

Both now raise the same `marginplyr_error` from `inspect_grouping()` and from
all four executing verbs:

```
Can't rename `.by` column `area = region`. Fixed `.by` keys must name existing columns.
```

## How

A fixed key is a column of the input, exactly as a grouping dimension is, so
the rule #103 established for `.grouping` holds here too. The two arguments now
share one refusal, worded per argument, because one caller mistake should not
have two unrelated messages.

The resolution moved rather than the helper changing — `get_col_names()` has
seven other callers that read back names dplyr assigned on purpose:

- `resolve_fixed_keys()` settles the keys wherever column names suffice: a
  grouped input's `dplyr::group_vars()`, an absent `.by`, or a name-based
  selection resolved against the name proxy — before any backend read, as
  ADR-0005 requires.
- A `.by` carrying a predicate is the one selection names cannot answer, so it
  reads the typed snapshot the operation already holds rather than a second one
  (ADR-0002). That mirrors how a Grouping dimension carrying a predicate is
  resolved. The Arrow test counts `infer_schema()` calls to hold it at one.
- Deferred fixed keys stand in as none in the pre-snapshot rejection pass.
  Withholding that pass while `.by` is unresolved would make a `.grouping`
  error the column names already decide wait for a backend read; the two checks
  that read the keys — an unknown fixed key, and one overlapping a dimension —
  run again against the resolved keys afterwards. A dtplyr test counts
  collections to hold that at zero.

## One deliberate widening

A `.by` predicate on dtplyr or duckdb now resolves instead of erroring:
`dplyr::select()` on the lazy table rejected predicates, and the typed snapshot
answers them. `.grouping` has always resolved predicates on those backends, so
this makes the two arguments agree rather than differ by backend. Every `.by`
form that worked before still works: bare symbols, `c()` of symbols, `all_of()`
with unnamed character vectors, `starts_with()` and friends, negation, `NULL`,
`c(region = region)`, and a grouped input's keys.

## Docs

`@param .by` on `summarize_with_margins()` (inherited by the other verbs) and
on `inspect_grouping()` states the rule and points at `dplyr::rename()`; `man/`
regenerated.

## Verification

- Full suite green; `lintr::lint_package()` clean; `roxygen2::roxygenise()`
  reproduces `man/` and `NAMESPACE` unchanged.
- `.github/scripts/verify-suite-coverage.R`: 403 tests, each executing in at
  least one of arrow, duckdb, dtplyr, RSQLite — no test requires two backends.
- The ADR-0005 regression test was confirmed to fail against the guard it
  replaces.
- Not run locally: `R CMD check` on a tarball and `_R_CHECK_DEPENDS_ONLY_`;
  nothing here touches dependency metadata or vignettes, and CI gates both.

## Follow-up

#159 — the ``Unknown `.by` column`` branch in `compile_grouping_spec_impl()` is
unreachable from the public interface now that no resolution can invent a name.
Left alone here as out of scope.