### PR TITLE
Execute the rejections the vignette prose asserts (#155)

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -268,13 +268,21 @@ markers <- list(
     "original pre-margin",
     "funion(funion(",
     "Total",
-    # The guide's one `must_error` chunk, by the diagnostic it has to produce.
-    # It is marked with the class form, so this marker also stands for the
-    # assertion: prose survives a chunk that stopped running, and a chunk that
-    # started failing for some other reason halts the render rather than
-    # reaching this scan.
+    # The guide's `must_error` chunks, by the diagnostic each one has to
+    # produce. Every one is marked with the class form, so these markers also
+    # stand for the assertions: prose survives a chunk that stopped running,
+    # and a chunk that started failing for some other reason halts the render
+    # rather than reaching this scan. None of them needs an optional Suggest,
+    # so all of them hold wherever the page is built.
     "Error in `summarize_with_margins()`",
-    "does not support `cur_group_id()`"
+    "Error in `nest_with_margins()`",
+    "does not support `cur_group_id()`",
+    "Duplicate grouping sets were produced at positions",
+    "Can't supply `.by` when `.data` is grouped",
+    "Grouped input created with `.drop = FALSE` is not supported",
+    "do not define one unambiguous parent",
+    "Add an empty `grouping_set()` to the `grouping_sets()` specification",
+    "`.duplicates` must be one of \"error\", \"drop\""
   ),
   "docs/vignettes/recipes.html" = c(
     "Put each subtotal with the rows it summarizes",
@@ -325,7 +333,14 @@ markers <- list(
     "Only DuckDB and SQLite are exercised as live SQL databases",
     "DuckDB covers native SQL end to end",
     "dozen-plus fallback dialects",
-    "Arrow and dtplyr are tested for the lazy"
+    "Arrow and dtplyr are tested for the lazy",
+    # The one `must_error` chunk on this page that needs no optional Suggest:
+    # nesting a SQL table, refused through the dbplyr simulator. The guide's
+    # DuckDB, dtplyr, and Arrow refusals are behind availability guards, so
+    # they render nothing where their package is absent and can carry no
+    # marker — the same reason only three of `recipes.qmd`'s are listed above.
+    "Error in `nest_with_margins()`",
+    "which can be nested: data.frame, dtplyr_step"
   ),
   "docs/man/summarize_with_margins.html" = c(
     "summarise_with_margins",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ SystemRequirements: Quarto command line tool
     from their '.qmd' sources.
 Config/Needs/website:
     altdoc (>= 0.7.3),
+    arrow,
     DBI,
     dtplyr,
     duckdb,

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -32,7 +32,7 @@ install.packages("pak")
 pak::pkg_install("sayuks/marginplyr")
 
 # Used for the optional backend sections of this guide.
-install.packages(c("DBI", "duckdb", "RSQLite", "dtplyr"))
+install.packages(c("DBI", "duckdb", "RSQLite", "dtplyr", "arrow"))
 ```
 
 ```{r setup}
@@ -42,8 +42,8 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. The DuckDB, SQLite, and dtplyr sections
-below need optional packages, so their chunks evaluate only when those
+Only dplyr and dbplyr are required. The DuckDB, SQLite, dtplyr, and Arrow
+sections below need optional packages, so their chunks evaluate only when those
 packages are installed at the versions marginplyr asks for. Where a package is
 missing or too old the code is still shown, but its output is absent.
 
@@ -61,6 +61,12 @@ has_duckdb <- marginplyr_suggest_available("DBI") &&
 # the installed driver version through RSQLite.
 has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
 has_dtplyr <- marginplyr_suggest_available("dtplyr")
+has_arrow <- marginplyr_suggest_available("arrow")
+
+# Chunks marked with `must_error` show a call that is meant to fail, so the
+# reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
+# authoritative for what the option does and why it exists.
+source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
 ```
 
 ## One report, two execution locations
@@ -294,10 +300,47 @@ arbitrary aggregate's result type, so marginplyr reads the summaries a share
 reads over a single input row and rejects an ineligible source before
 returning the query. That read is bounded in the rows it asks for and gets
 back, not in the work the input may have to do to produce one row — the staged
-query above is still not executed, and `show_query()` runs nothing. A source
-the sample cannot type is left alone rather than rejected, so a runtime-only
-incompatibility, and any non-scalar summary, can still surface from the
-database when the staged query executes.
+query above is still not executed, and `show_query()` runs nothing.
+
+Sampling one row needs a connection that can execute one, so this refusal is
+shown against a live DuckDB table rather than the simulator used above:
+
+```{r}
+#| eval: !expr has_duckdb
+
+sample_con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+sample_sales <- copy_to(
+  sample_con,
+  january_sales,
+  name = "january_sales",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+```
+
+```{r}
+#| label: duckdb-ineligible-share-source
+#| eval: !expr has_duckdb
+#| must_error: marginplyr_error
+
+sample_sales |>
+  summarize_with_margins(
+    last_channel = max(channel),
+    last_channel_share = share_of_parent(last_channel),
+    .grouping = rollup(region, store)
+  )
+```
+
+```{r}
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(sample_con)
+```
+
+A source the sample cannot type is left alone rather than rejected — which is
+what the simulator above falls under, since it executes nothing at all. So a
+runtime-only incompatibility, and any non-scalar summary, can still surface
+from the database when the staged query executes.
 
 The portable value contract covers finite numbers, missing values, and zero
 denominators. Backend-specific non-finite representations are outside that
@@ -337,17 +380,70 @@ collect(dt_query)
 
 `nest_with_margins()` also supports dtplyr and remains lazy until collection.
 SQL database and Arrow tables cannot use the nesting verbs because their
-result contains a list column.
+result contains a list column, and the refusal names the classes that can:
+
+```{r}
+#| label: nesting-a-sql-table
+#| must_error: marginplyr_error
+
+postgres_sales |>
+  nest_with_margins(
+    .grouping = rollup(region, store)
+  )
+```
 
 dtplyr also enforces the contextual-share source rules, for both denominators.
 A valid request stays a native lazy query, and an ineligible source type or a
 non-scalar summary raises a Package condition at explicit execution, before an
-invalid grouping row is emitted.
+invalid grouping row is emitted:
+
+```{r}
+#| label: dtplyr-ineligible-share-source
+#| eval: !expr has_dtplyr
+#| must_error: marginplyr_error
+
+january_sales |>
+  dtplyr::lazy_dt() |>
+  summarize_with_margins(
+    last_channel = max(channel),
+    last_channel_share = share_of_parent(last_channel),
+    .grouping = rollup(region, store)
+  ) |>
+  collect()
+```
 
 Arrow summaries and expansions are supported and lazy, but `share_of_parent()`
 and `share_of_total()` are both rejected outright, before any Arrow query is
 constructed: the reason is the source summary they share. Collect the Arrow
-table first when you need either. The
+table first when you need either.
+
+```{r}
+#| label: arrow-parent-share
+#| eval: !expr has_arrow
+#| must_error: marginplyr_error
+
+arrow::arrow_table(january_sales) |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    revenue_share = share_of_parent(revenue),
+    .grouping = rollup(region, store)
+  )
+```
+
+```{r}
+#| label: arrow-total-share
+#| eval: !expr has_arrow
+#| must_error: marginplyr_error
+
+arrow::arrow_table(january_sales) |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    revenue_of_total = share_of_total(revenue),
+    .grouping = rollup(region, store)
+  )
+```
+
+The
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 states where each backend reports these errors.
 

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -267,9 +267,26 @@ This is a union of:
 (year, month), (year), (), (region, store), (region)
 ```
 
-Both rollups contain `()`. The default `.duplicates = "error"` catches this
-overlap. `"drop"` retains one copy; `"keep"` retains both copies when repeated
-totals are intentionally meaningful:
+Both rollups contain `()`, which is why the call above asks for `"drop"`.
+Without it, the default `.duplicates = "error"` catches the overlap and names
+the positions that collide:
+
+```{r}
+#| label: duplicate-grouping-sets
+#| must_error: marginplyr_error
+
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .grouping = grouping_sets(
+      rollup(year, month),
+      rollup(region, store)
+    )
+  )
+```
+
+`"drop"` retains one copy; `"keep"` retains both copies when repeated totals
+are intentionally meaningful:
 
 ```{r}
 retail_sales |>
@@ -553,11 +570,40 @@ group_vars(grouped_monthly_report)
 ```
 
 The calculation is equivalent to the earlier `.by = c(year, month)` call.
-Do not combine grouped input with `.by`. A fixed grouping column also cannot
-appear in `.grouping`; call `ungroup()` first if that column should be rolled
-up instead. Row-wise inputs must likewise be ungrouped explicitly. Local
-groups created with `.drop = FALSE` are rejected because empty factor groups
-do not have a consistent SQL or lazy-backend equivalent.
+Grouped input and `.by` name the fixed keys twice over, so supplying both is
+refused rather than resolved in one direction:
+
+```{r}
+#| label: grouped-input-with-by
+#| must_error: marginplyr_error
+
+retail_sales |>
+  group_by(year) |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .by = month,
+    .grouping = rollup(region, store)
+  )
+```
+
+A fixed grouping column also cannot appear in `.grouping`; call `ungroup()`
+first if that column should be rolled up instead. Row-wise inputs must
+likewise be ungrouped explicitly. Local groups created with `.drop = FALSE`
+are rejected because empty factor groups do not have a consistent SQL or
+lazy-backend equivalent:
+
+```{r}
+#| label: drop-false-groups
+#| must_error: marginplyr_error
+
+retail_sales |>
+  mutate(region = factor(region)) |>
+  group_by(region, .drop = FALSE) |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .grouping = rollup(store)
+  )
+```
 
 Input groups affect the calculation but, except for the explicitly row-wise
 nesting verb, do not persist on the result. `summarize_with_margins()`,
@@ -707,9 +753,24 @@ retail_sales |>
 ```
 
 A parent is ambiguous outside a rollup, but a grand total is not: a plan
-either contains one or it does not. So `share_of_total()` accepts any
-Grouping specification that produces one, including the `cube()` and
-`grouping_sets()` forms `share_of_parent()` rejects:
+either contains one or it does not. A `cube()` therefore has no Parent share,
+and asking for one names the rewrite instead of choosing a parent:
+
+```{r}
+#| label: parent-share-outside-rollup
+#| must_error: marginplyr_error
+
+retail_sales |>
+  filter(year == 2026L, month == "Jan") |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    revenue_share = share_of_parent(revenue),
+    .grouping = cube(region, store)
+  )
+```
+
+`share_of_total()` accepts any Grouping specification that produces a Grand
+total set, that same `cube()` included:
 
 ```{r}
 retail_sales |>
@@ -723,9 +784,26 @@ retail_sales |>
 ```
 
 A `grouping_sets()` specification qualifies only when it includes an empty
-`grouping_set()`; one without it is rejected naming that fix. Everything else
-is shared with `share_of_parent()` — eligible sources, the `across()` form,
-and the value rules — and the
+`grouping_set()`; one without it is rejected naming that fix:
+
+```{r}
+#| label: total-share-without-grand-total
+#| must_error: marginplyr_error
+
+retail_sales |>
+  filter(year == 2026L, month == "Jan") |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    revenue_of_total = share_of_total(revenue),
+    .grouping = grouping_sets(
+      grouping_set(region, store),
+      grouping_set(region)
+    )
+  )
+```
+
+Everything else is shared with `share_of_parent()` — eligible sources, the
+`across()` form, and the value rules — and the
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 documents both helpers.
 
@@ -955,9 +1033,22 @@ subtotal, and total rows.
 
 Nesting accepts `.duplicates = "error"` or `"drop"`, but rejects `"keep"`.
 Unlike a summary or row expansion, two duplicate nested groups have no
-visible set identifier and would therefore be indistinguishable. Internal set
-identifiers and `.keep` copies use collision-free temporary names, so no input
-column name is reserved.
+visible set identifier and would therefore be indistinguishable, so the value
+is refused where it is written rather than where a duplicate first appears:
+
+```{r}
+#| label: nesting-duplicates-keep
+#| must_error: marginplyr_error
+
+january_sales |>
+  nest_with_margins(
+    .grouping = rollup(region, store),
+    .duplicates = "keep"
+  )
+```
+
+Internal set identifiers and `.keep` copies use collision-free temporary
+names, so no input column name is reserved.
 
 The list column is a regular list of data frames; a
 `vctrs::list_of` subclass is not promised. On an empty ungrouped input,


### PR DESCRIPTION
Closes #155.

## What was wrong

Ten places across two vignettes asserted that a call is rejected and showed no
chunk making it. `AGENTS.md` states the rule under *Chunks that must fail* —
mark a chunk with `must_error` "whenever the surrounding prose asserts that
the call fails" — and each of these claims was unchecked: a relaxed
validation, a renamed argument, or a changed column would leave the prose
saying a call is refused with nothing reporting that it no longer is.

This is the sweep #116 deferred. The mechanism it waited on now exists in
`inst/vignette-hooks/must-error.R` and is proven from `recipes.qmd`.

## Dispositions

Nine chunks now execute the call, every one with the class form. The full
table, site by site, is [in the issue][dispositions]; the summary is:

- **`vignettes/get_started.qmd`** — 6 converted: the duplicate-grouping-sets
  overlap, grouped input plus `.by`, `.drop = FALSE` groups,
  `share_of_parent()` outside a rollup, `share_of_total()` without a Grand
  total set, and nesting's `.duplicates = "keep"`.
- **`vignettes/database_backends.qmd`** — 3 sites, 4 chunks: nesting a SQL
  table (unguarded), the dtplyr and DuckDB ineligible share sources, and both
  Arrow denominators.
- **Left as prose (2)**, both in `get_started.qmd`: the `.by` clause in the
  `.margin_label` paragraph and "a fixed grouping column cannot appear in
  `.grouping`". Each is a subordinate clause whose own sentence already names
  the fix the diagnostic would, and each sits beside a section that gains a
  rendered refusal anyway. The issue records the reasoning, as its acceptance
  criteria ask.

[dispositions]: https://github.com/sayuks/marginplyr/issues/155#issuecomment-5235014553

## Two corrections to the inventory

**The guard column is wrong for `database_backends.qmd` line 289.** It reads
"none — `dbplyr::simulate_postgres()`", but the simulator does not reject an
ineligible share source. Typing the source is a single-row read; a simulated
connection executes nothing, so it falls under the paragraph's *next*
sentence — "A source the sample cannot type is left alone rather than
rejected" — and hands back the query without complaint. The refusal is only
visible against a live table, so the chunk sits behind `has_duckdb`, and the
prose now says which case the simulator is.

**Arrow needed two chunks.** Converting only `share_of_parent()` would have
left `share_of_total()` as a newly written unexecuted refusal claim on the
line below — the defect this issue opens with, reintroduced by the change
meant to remove it. Both denominators are executed.

## Site verification

Seven markers added: six on `get_started.html`, one on
`database_backends.html`. The DuckDB, dtplyr, and Arrow refusals stay
unmarked, on the `recipes.qmd` precedent — a guarded chunk renders nothing
where its package is absent, so a marker on one would fail a local
`verify-site.R` run for anyone lacking that backend.

`arrow` joins `Config/Needs/website`. Every other optional package a vignette
executes was already there; without it the site renders the two Arrow chunks
as code with no output, which reads exactly like a chunk that broke.

## Gates

- `Rscript .github/scripts/verify-must-error.R` — 8 fixtures, OK
- `altdoc::render_docs(parallel = FALSE, freeze = FALSE)` then
  `Rscript .github/scripts/verify-site.R` — OK
- `pkgload::load_all()` + `lintr::lint_package()` — no lints
- full test suite with `NOT_CRAN` — no failures
- `_R_CHECK_DEPENDS_ONLY_=true R CMD check` on the built tarball — **Status:
  OK**, which is what proves the guarded chunks skip rather than being
  reported as chunks that stopped failing
