### PR TITLE
Scope function definitions and walk call heads in the data-symbol walk

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2819,7 +2819,27 @@ expression_data_symbols <- function(expr, bound = character()) {
   # has no name, so `call_name()` returns `NULL`. Every comparison below is
   # written to be NULL-safe, since such a call is simply not the shape this
   # analysis recognizes and must fall through to its parts (#100).
-  call_name <- rlang::call_name(expr)
+  # `pkg::fun` is the one head shape the data mask does not evaluate. `::` and
+  # `:::` take both operands literally -- neither is a lookup -- so a call to
+  # one reads nothing, in a head or anywhere else. Walking every non-symbol
+  # head is what brought this node into the walk's reach, and reporting its
+  # parts rejects `dplyr::n()` in any call holding a summary named `n`, which
+  # is how the vignettes here write it. The same over-report already reached
+  # argument position, so answering it once at the node covers both.
+  if (rlang::is_call(expr, c("::", ":::"))) {
+    return(character())
+  }
+  # `rlang::call_name()` unwraps a one-sided formula to its right-hand side.
+  # That errors when the right-hand side is a bare symbol -- `~.x` -- and
+  # misreads the call when it is not: `~ .data$share` answers `$`, so the walk
+  # entered a branch written for a different shape and reached the right
+  # answer by accident. A formula is a call to `~`, and the general walk below
+  # already treats it as one, so it is never asked for a name.
+  call_name <- if (rlang::is_call(expr, "~")) {
+    NULL
+  } else {
+    rlang::call_name(expr)
+  }
   if (identical(call_name, "function") && length(expr) >= 3L) {
     return(function_definition_symbols(expr, bound))
   }

--- a/R/share.R
+++ b/R/share.R
@@ -2869,17 +2869,19 @@ expression_data_symbols <- function(expr) {
   ) {
     return(expression_data_symbols(expr[[2L]]))
   }
-  # Element 1 is the function position, dropped because a symbol there names a
-  # function rather than a column -- that is what keeps `sum` out of every
-  # result. A `[[` there is the one head shape whose parts are all evaluated
-  # in the data mask, so `fns[[bucket]](x)` reads `bucket` and the walk has to
-  # see it (#100). The other head shapes are left alone: a function definition
-  # binds its own formals, so walking one would report a read that is not one
-  # and reject a call dplyr accepts. A `$` head is no longer that case now
-  # that its field name contributes nothing, and the read of its object is
-  # missed here -- #130 owns the head, and this line is not its fix.
+  # Element 1 is the function position. A bare symbol there is dropped, and it
+  # is the only head shape that can be: R resolves a symbol in that position
+  # through function lookup, which skips non-function bindings, so a share
+  # named `sum` cannot shadow `sum(x)`. Every other head is evaluated in the
+  # data mask exactly like an argument, so a read hidden in one bypasses the
+  # guard against an ordinary summary using an earlier share (#130).
+  #
+  # This names the one shape that is excluded rather than listing the shapes
+  # that are walked. #100 could justify only `[[` at the time and listed it,
+  # which left `(fns[[bucket]])(x)` -- a head that is a call to `(`, not to
+  # `[[` -- slipping past, together with `$`, `if`/`else`, and computed heads.
   parts <- as.list(expr)[-1L]
-  if (rlang::is_call(expr[[1L]], "[[")) {
+  if (!rlang::is_symbol(expr[[1L]])) {
     parts <- c(list(expr[[1L]]), parts)
   }
   unique(unlist(

--- a/R/share.R
+++ b/R/share.R
@@ -2793,9 +2793,24 @@ expression_alias_dependencies <- function(expr, aliases) {
   intersect(unique(expression_data_symbols(expr)), aliases)
 }
 
-expression_data_symbols <- function(expr) {
+# `bound` carries the names a construct inside the expression has bound, so a
+# symbol matching one is a read of that binding rather than of a column. It is
+# threaded through the recursion rather than applied to the result, because the
+# two are not the same answer: `(function(share) share)(share)` reads the
+# column in argument position while the body reads the formal, and
+# `(function(share) .data$share)(value)` reads the column through a pronoun no
+# local binding shadows. Filtering the output collapses both, silently (#130).
+#
+# Only a function definition populates it today. `<-`, `for`, and `local()`
+# bind names the walk still reports as reads, which is a false positive rather
+# than the silence this argument exists for, and is tracked in #162.
+expression_data_symbols <- function(expr, bound = character()) {
   if (rlang::is_symbol(expr)) {
-    return(rlang::as_name(expr))
+    name <- rlang::as_name(expr)
+    if (name %in% bound) {
+      return(character())
+    }
+    return(name)
   }
   if (!rlang::is_call(expr)) {
     return(character())
@@ -2805,6 +2820,9 @@ expression_data_symbols <- function(expr) {
   # written to be NULL-safe, since such a call is simply not the shape this
   # analysis recognizes and must fall through to its parts (#100).
   call_name <- rlang::call_name(expr)
+  if (identical(call_name, "function") && length(expr) >= 3L) {
+    return(function_definition_symbols(expr, bound))
+  }
   if (identical(call_name, "get") && length(expr) >= 2L) {
     if (get_has_external_env(expr)) {
       return(character())
@@ -2825,6 +2843,12 @@ expression_data_symbols <- function(expr) {
           length(name) == 1L &&
           !is.na(name)
       ) {
+        # `get()` performs ordinary name resolution, so a local binding is
+        # what it finds. This is the branch the bound set applies to, unlike
+        # the pronoun below.
+        if (name %in% bound) {
+          return(character())
+        }
         return(name)
       }
     }
@@ -2835,6 +2859,15 @@ expression_data_symbols <- function(expr) {
       length(expr) >= 3L &&
       rlang::is_symbol(expr[[2L]])
   ) {
+    # The bound set is deliberately not consulted here. `.data` is dplyr's
+    # contract for reaching a column whatever else is in scope, so a local
+    # binding of that column's name does not shadow it and
+    # `(function(share) .data$share)(value)` really does read the column.
+    # Applying the bound set to a pronoun-resolved name is the silent miss
+    # this whole walk exists to prevent. `.data` bound as a formal is left
+    # alone for the same reason, in the over-reporting direction: a caller who
+    # does that has already left the contract, and a diagnostic is the safe
+    # side to be wrong on.
     pronoun <- rlang::as_name(expr[[2L]])
     if (identical(pronoun, ".env")) {
       return(character())
@@ -2867,7 +2900,7 @@ expression_data_symbols <- function(expr) {
       call_name %in% c("$", "@") &&
       length(expr) >= 2L
   ) {
-    return(expression_data_symbols(expr[[2L]]))
+    return(expression_data_symbols(expr[[2L]], bound))
   }
   # Element 1 is the function position. A bare symbol there is dropped, and it
   # is the only head shape that can be: R resolves a symbol in that position
@@ -2880,12 +2913,55 @@ expression_data_symbols <- function(expr) {
   # that are walked. #100 could justify only `[[` at the time and listed it,
   # which left `(fns[[bucket]])(x)` -- a head that is a call to `(`, not to
   # `[[` -- slipping past, together with `$`, `if`/`else`, and computed heads.
+  #
+  # The head comes first so that the walk returns symbols in source order,
+  # which is user-visible: the guard names `share_dependency[[1L]]`, so this
+  # decides which share an expression reading two of them is reported against.
+  #
+  # A formula falls through here like any other call, so `~ .x + share`
+  # reports `.x`. That is deliberate. A formula is not intrinsically a lambda
+  # -- it becomes one only where something calls `as_function()` on it, which
+  # this walk cannot see -- so `.x` is over-reported, in the direction whose
+  # errors are diagnostics rather than silence. Suppressing it outright would
+  # miss a genuine read of a summary named `.x`, and suppressing it only under
+  # `across()` would make the walk depend on its own call position, which is
+  # what left function definitions behaving differently in a head (#130).
   parts <- as.list(expr)[-1L]
   if (!rlang::is_symbol(expr[[1L]])) {
     parts <- c(list(expr[[1L]]), parts)
   }
   unique(unlist(
-    lapply(parts, expression_data_symbols),
+    lapply(parts, expression_data_symbols, bound = bound),
+    use.names = FALSE
+  ))
+}
+
+# A function definition binds its formals, so its body reads the mask only
+# through the names they do not cover. The formals' default values are mask
+# reads too: a default is evaluated in the function's own frame, whose
+# enclosure is the definition environment -- the mask -- so
+# `(function(y = share) y)()` reads the share. The walk collected nothing from
+# the formals pairlist at all, which is why that one was silent (#130).
+#
+# Defaults are scoped against every formal rather than the ones written before
+# them. R evaluates them lazily in a frame that already holds all the formals,
+# so `(function(a = b, b = 1) a)()` is 1, and `k` in `function(share, k =
+# share)` names the formal rather than the column.
+#
+# The srcref at element 4 is deliberately not walked: it is not code the mask
+# ever evaluates.
+function_definition_symbols <- function(expr, bound) {
+  formals_list <- as.list(expr[[2L]])
+  inner <- unique(c(bound, names(formals_list)))
+  defaults <- formals_list[
+    !vapply(formals_list, rlang::is_missing, logical(1))
+  ]
+  unique(unlist(
+    lapply(
+      c(defaults, list(expr[[3L]])),
+      expression_data_symbols,
+      bound = inner
+    ),
     use.names = FALSE
   ))
 }

--- a/R/share.R
+++ b/R/share.R
@@ -2840,8 +2840,15 @@ expression_data_symbols <- function(expr, bound = character()) {
   } else {
     rlang::call_name(expr)
   }
+  # The length is part of deciding whether this is a function definition at
+  # all, not a precondition to check inside. A node built by hand rather than
+  # parsed -- `rlang::call2("function")` arriving through injection -- can
+  # carry a head named `function` without formals or a body, and it falls
+  # through to the general walk below, which reports whatever its parts hold.
+  # Answering `character()` for it instead would be a silent miss, which is
+  # the one direction this walk is not allowed to be wrong in.
   if (identical(call_name, "function") && length(expr) >= 3L) {
-    return(function_definition_symbols(expr, bound))
+    return(definition_data_symbols(expr, bound))
   }
   if (identical(call_name, "get") && length(expr) >= 2L) {
     if (get_has_external_env(expr)) {
@@ -2970,7 +2977,7 @@ expression_data_symbols <- function(expr, bound = character()) {
 #
 # The srcref at element 4 is deliberately not walked: it is not code the mask
 # ever evaluates.
-function_definition_symbols <- function(expr, bound) {
+definition_data_symbols <- function(expr, bound) {
   formals_list <- as.list(expr[[2L]])
   inner <- unique(c(bound, names(formals_list)))
   defaults <- formals_list[

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -202,6 +202,101 @@ test_that("every call head that is not a bare symbol is walked", {
   )
 })
 
+test_that("a namespaced call reads neither of its operands", {
+  # `pkg::fun` is the head shape the mask does not evaluate: `::` takes both
+  # operands literally, so neither names a column. Walking every non-symbol
+  # head brings it into scope of the walk for the first time, and reporting
+  # its parts rejects `dplyr::n()` wherever a summary is named `n` -- which is
+  # how this package's own vignettes write it.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(expression_data_symbols(quote(dplyr::n())), character())
+  expect_identical(
+    expression_data_symbols(quote(stats::median(value))),
+    "value"
+  )
+  # Argument position reaches the same node, so one branch answers both.
+  expect_identical(
+    expression_data_symbols(quote(list(m = stats::median))),
+    character()
+  )
+  expect_identical(expression_data_symbols(quote(pkg:::fun(x))), "x")
+
+  # A share source depending on an alias named after the function it calls.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      records = dplyr::n(),
+      share = share_of_total(records),
+      .grouping = rollup(region)
+    )
+  )
+
+  # An ordinary summary written after a share of the same name.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      n = share_of_total(units),
+      rows = dplyr::n(),
+      .grouping = rollup(region)
+    )
+  )
+
+  # `base::get()` still reaches the `get()` branch: the namespace qualifier
+  # names the function, and the literal it is given is still a mask read.
+  expect_identical(
+    expression_data_symbols(quote(base::get("share"))),
+    "share"
+  )
+})
+
+test_that("a formula is walked as the call to `~` that it is", {
+  # `rlang::call_name()` unwraps a one-sided formula to its right-hand side.
+  # That errors outright when the right-hand side is a bare symbol, and
+  # misreads the call otherwise -- `~ .data$share` answers `$`, so the walk
+  # entered a branch written for a different shape and got the right answer by
+  # accident. Asking a formula for a call name is the mistake; it is a call to
+  # `~` and the general walk already handles it.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(expression_data_symbols(quote(~.x)), ".x")
+  expect_identical(expression_data_symbols(quote(~value)), "value")
+  expect_identical(
+    expression_data_symbols(quote(~ .x + share)),
+    c(".x", "share")
+  )
+  expect_identical(expression_data_symbols(quote(~ .data$share)), "share")
+  expect_identical(expression_data_symbols(quote(~ get("share"))), "share")
+
+  # A formal's default is a new entry point into a formula: defaults were not
+  # walked at all before, so this shape could not reach the walk until now.
+  # It is asserted end to end because this walk is the only analysis that
+  # descends into a default.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (function(f = ~.x) length(f))(),
+      .grouping = rollup(region)
+    )
+  )
+
+  # A formula written at the top of a summary expression -- `length(~value)`
+  # -- still aborts, from `find_summary_context_helpers()` rather than from
+  # here: the same `is_call()`-then-`call_name()` pairing appears at nine
+  # sites, and it fails there before this walk is reached. That predates #130
+  # and is tracked in #163, so it is deliberately not asserted here.
+})
+
 test_that("a function definition binds its formals", {
   # The walk used to collect every symbol in a function body, so a lambda
   # binding a name equal to a preceding share was rejected while a lambda

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -295,6 +295,70 @@ test_that("a formula is walked as the call to `~` that it is", {
   # here: the same `is_call()`-then-`call_name()` pairing appears at nine
   # sites, and it fails there before this walk is reached. That predates #130
   # and is tracked in #163, so it is deliberately not asserted here.
+
+  # A formula in the `.fns` position of `across()` is the one spelling of this
+  # that users are documented to write (`R/share.R:307`), and it was the only
+  # shape in #130's tables asserted at the walk alone. The guard is where the
+  # caller meets it, so it is asserted there too: `.x` is over-reported by
+  # design, and the read of `share` beside it must still be refused.
+  from_across <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = across(value, ~ .x + share),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_across, "marginplyr_error")
+})
+
+test_that("the head is walked before the arguments, and the guard says so", {
+  # The walk returns symbols in source order, and the head is syntactically
+  # first. That is not an internal detail: the guard names
+  # `share_dependency[[1L]]` (`R/share.R:786`), so this order decides which
+  # share an expression reading two of them is reported against. Asserting it
+  # through the message is what makes it a property of the diagnostic the
+  # caller reads rather than of the vector the walk happens to build.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  from_head <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      a = share_of_total(units),
+      b = share_of_total(units),
+      derived = (if (a > 0) sum else prod)(b),
+      .grouping = rollup(region)
+    ),
+    "`a`"
+  )
+  expect_s3_class(from_head, "marginplyr_error")
+
+  # The same two shares with neither in a head: the first one written is the
+  # one named, so the case above is reporting the head rather than reporting
+  # whichever share happens to sort first.
+  from_argument <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      a = share_of_total(units),
+      b = share_of_total(units),
+      derived = b + a,
+      .grouping = rollup(region)
+    ),
+    "`b`"
+  )
+  expect_s3_class(from_argument, "marginplyr_error")
+
+  expect_identical(
+    expression_data_symbols(quote((if (a > 0) sum else prod)(b))),
+    c("a", "sum", "prod", "b")
+  )
 })
 
 test_that("a function definition binds its formals", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -71,14 +71,22 @@ test_that("falling through a call head still sees its arguments", {
   expect_s3_class(error, "marginplyr_error")
 })
 
-test_that("a `[[` call head is walked, and other head shapes are not", {
-  # The function position is dropped so `sum` never counts as a column, which
-  # leaves a read inside a call-valued head unseen. `[[` is the one head shape
-  # whose parts are all mask reads, so it is walked; a function definition is
-  # not, because it binds its own formals and walking it would report a read
-  # that is not one. A `$` head is not walked either, so the object it reads
-  # is missed -- #130 carries that, and these are the two halves that must not
-  # drift into each other.
+test_that("every call head that is not a bare symbol is walked", {
+  # A bare symbol in the function position is the one head that cannot read a
+  # column: R resolves it through function lookup, which skips non-function
+  # bindings, so a share named `sum` does not shadow `sum(x)`. Every other head
+  # is evaluated in the data mask exactly like an argument, so a read hidden
+  # there bypasses the guard against an ordinary summary using an earlier share
+  # (#130).
+  #
+  # The exclusion is written as that one shape rather than as a list of walked
+  # shapes. #100 could justify only `[[` at the time and enumerated it, which
+  # is why a redundant pair of parentheses -- making the head a call to `(`
+  # rather than to `[[` -- slipped past that fix. The cases below are the head
+  # shapes that were reaching the caller as `attempt to apply non-function`,
+  # `$ operator is invalid for atomic vectors`, and `missing value where
+  # TRUE/FALSE needed`: untyped conditions naming nothing the caller can act
+  # on, which is the class ADR-0015 separates.
   data <- data.frame(
     region = c("East", "East", "West"),
     value = c(1, 3, 6)
@@ -92,7 +100,7 @@ test_that("a `[[` call head is walked, and other head shapes are not", {
   )
   # nolint end
 
-  from_head <- expect_error(
+  from_index <- expect_error(
     summarize_with_margins(
       data,
       units = sum(value),
@@ -102,17 +110,92 @@ test_that("a `[[` call head is walked, and other head shapes are not", {
     ),
     "`share`"
   )
-  expect_s3_class(from_head, "marginplyr_error")
+  expect_s3_class(from_index, "marginplyr_error")
+
+  # The same `[[` head wrapped in redundant parentheses. The head is now a call
+  # to `(`, so an enumeration of walked head shapes misses it.
+  from_parenthesized <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (fns[[share]])(value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_parenthesized, "marginplyr_error")
+
+  # The object of a `$` head. #101 stopped the field name counting as a read,
+  # which is what makes walking this head safe; the object was still missed.
+  from_dollar_object <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = share$total(value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_dollar_object, "marginplyr_error")
+
+  from_condition <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (if (share > 0) sum else prod)(value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_condition, "marginplyr_error")
+
+  # A head that is an ordinary call returning a function. Nothing about this
+  # shape is special; it is here because an enumeration would have to name it.
+  from_computed <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (function(s) function(v) s * v)(share)(value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_computed, "marginplyr_error")
 
   # `total` in `fns$total` names a field of `fns` rather than reading the
   # share of that name, so this call must execute. Rejecting it is the defect
-  # #100 was filed against, reached from the other direction.
+  # #100 was filed against, reached from the other direction, and walking the
+  # head must not bring it back.
   expect_no_error(
     summarize_with_margins(
       data,
       units = sum(value),
       total = share_of_total(units),
       derived = fns$total(value, TRUE),
+      .grouping = rollup(region)
+    )
+  )
+
+  # A bare symbol head stays excluded, which is what the exclusion is for.
+  # `doubled` here names both a share and a function, and R's function lookup
+  # skips the non-function binding: the call reaches the function even though
+  # the mask holds a share of that name, so reporting the head as a read would
+  # reject a call that runs correctly.
+  # nolint start: object_usage_linter.
+  # `doubled` is called from the summary expression below, through the data
+  # mask, which codetools cannot follow.
+  doubled <- function(x) sum(x) * 2
+  # nolint end
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      doubled = share_of_total(units),
+      derived = doubled(value),
       .grouping = rollup(region)
     )
   )

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -80,9 +80,10 @@ test_that("every call head that is not a bare symbol is walked", {
   # (#130).
   #
   # The exclusion is written as that one shape rather than as a list of walked
-  # shapes. #100 could justify only `[[` at the time and enumerated it, which
-  # is why a redundant pair of parentheses -- making the head a call to `(`
-  # rather than to `[[` -- slipped past that fix. The cases below are the head
+  # shapes. #100 could justify only the double-bracket head at the time and
+  # enumerated it, which is why a redundant pair of parentheses -- making the
+  # head a call to the paren function -- slipped past that fix. The cases
+  # below are the head
   # shapes that were reaching the caller as `attempt to apply non-function`,
   # `$ operator is invalid for atomic vectors`, and `missing value where
   # TRUE/FALSE needed`: untyped conditions naming nothing the caller can act
@@ -198,6 +199,160 @@ test_that("every call head that is not a bare symbol is walked", {
       derived = doubled(value),
       .grouping = rollup(region)
     )
+  )
+})
+
+test_that("a function definition binds its formals", {
+  # The walk used to collect every symbol in a function body, so a lambda
+  # binding a name equal to a preceding share was rejected while a lambda
+  # genuinely reading that share was accepted only when it sat in argument
+  # position. Both halves are asserted here, because a fix that suppresses
+  # formal names by filtering the walk's output passes the first and breaks
+  # the second (#130).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # A read the guard owes the caller. In head position this returned a silent
+  # `NA` column rather than any condition, which is what made #130 a blocker.
+  from_lambda_head <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (function(y) share * 100)(value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_lambda_head, "marginplyr_error")
+
+  from_backslash_head <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (\(y) share * 100)(value),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_backslash_head, "marginplyr_error")
+
+  # The same read in argument position was already rejected, and must stay so.
+  from_argument <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = sum(vapply(value, function(z) z + share, numeric(1))),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_argument, "marginplyr_error")
+
+  # A formal shadowing the share. The lambda never reads the column, so
+  # rejecting this is the #101 defect reached through a different construct.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = sum(vapply(value, function(share) share + 1, numeric(1))),
+      .grouping = rollup(region)
+    )
+  )
+
+  # Formals reach the body and the defaults, and nothing else. The argument
+  # here is evaluated in the mask, so it reads the share even though the
+  # function it is passed to binds that name.
+  from_sibling_argument <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (function(share) share)(share),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_sibling_argument, "marginplyr_error")
+
+  # Nesting stacks: the inner formal shadows only inside the inner body.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = sum(
+        vapply(value, function(z) (function(share) share)(z), numeric(1))
+      ),
+      .grouping = rollup(region)
+    )
+  )
+})
+
+test_that("a formal's default value is a data-mask read", {
+  # A default is evaluated in the function's own frame, whose enclosure is the
+  # data mask, so it reads the mask like any other expression. The walk
+  # collected nothing from the formals pairlist, so this was silent in every
+  # position -- the same failure as a lambda head, reached without one (#130).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  from_default <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (function(y = share) y)(),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_default, "marginplyr_error")
+
+  # A default is scoped against every formal, not only the ones written before
+  # it: R evaluates defaults lazily in a frame that already holds them all, so
+  # `(function(a = b, b = 1) a)()` is 1. `k` here therefore names the formal
+  # `share` rather than the column, and the call must run.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (function(share, k = share) sum(k))(value),
+      .grouping = rollup(region)
+    )
+  )
+})
+
+test_that("a bound name shadows a symbol and a `get()`, but not a pronoun", {
+  # The bound set has to be threaded through the recursion as a scope rather
+  # than applied to the walk's output, and these are the three cases that tell
+  # the two implementations apart. `.data$share` reads the column whatever is
+  # bound locally, because the pronoun is dplyr's contract; `get("share")`
+  # goes through ordinary name resolution and finds the binding (#130).
+  expect_identical(
+    expression_data_symbols(quote(share), bound = "share"),
+    character()
+  )
+  expect_identical(expression_data_symbols(quote(share)), "share")
+  expect_identical(
+    expression_data_symbols(quote(.data$share), bound = "share"),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(.data[["share"]]), bound = "share"),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(get("share")), bound = "share"),
+    character()
   )
 })
 


### PR DESCRIPTION
Closes #130.

`expression_data_symbols()` decides which data symbols a summary expression reads, and the guard against an ordinary summary using an earlier share is that same walk. Two things it did not do: scope function definitions, and walk call heads. A read it missed is a guard that does not fire, and with one row per group the result was a silently `NA` column rather than any condition.

## Commits

**`8435dac` — walk every call head that is not a bare symbol.** #100 added `[[` as the one head it could justify, written as a list of shapes to walk. Listing them is what left the rest out: a redundant pair of parentheses makes `(fns[[bucket]])(x)` a call to `(` rather than to `[[`, and `$`, `if`/`else`, and computed heads were never covered. The exclusion is now the one shape derivable from R's semantics — a bare symbol in function position goes through function lookup, which skips non-function bindings, so a share named `sum` cannot shadow `sum(x)`.

**`204bccb` — scope function definitions.** A bound-name set threaded through the recursion. Formal names are not reads; body and defaults are walked with them in scope; nesting stacks. Defaults are scoped against *every* formal, not the preceding ones, because R evaluates them lazily in a frame that already holds them all — `(function(a = b, b = 1) a)()` is `1`.

The set is threaded rather than applied to the walk's output. Filtering is the shorter implementation and cannot tell `(function(share) share)(share)` — whose argument reads the column while its body reads the formal — from an expression reading neither, and it would suppress `(function(share) .data$share)(value)`, where the pronoun reaches the column past any local binding. Both would be silent misses introduced by the fix for a silent miss, so both are asserted.

**`6c7d901` — fixes from review of the first two.** See below.

## Behaviour change

Measured on `97327f3` before, and on this branch after. `units = sum(value)` and `share = share_of_total(units)` precede each `derived =`.

| Expression | Before | After |
|---|---|---|
| `(function(y) share * 100)(value)` | no condition, `NA` | `marginplyr_error` |
| `(\(y) share * 100)(value)` | no condition, `NA` | `marginplyr_error` |
| `(function(y = share) y)()` | no condition, `NA` | `marginplyr_error` |
| `share$total(value)` | `$ operator is invalid for atomic vectors` | `marginplyr_error` |
| `(fns[[share]])(value)` | `attempt to apply non-function` | `marginplyr_error` |
| `(function(s) function(v) s * v)(share)(value)` | `` `derived` must be size 1, not 2 `` | `marginplyr_error` |
| `(if (share > 0) sum else prod)(value)` | `missing value where TRUE/FALSE needed` | `marginplyr_error` |
| `sum(vapply(value, function(share) share + 1, numeric(1)))` | `marginplyr_error` (wrong) | runs, `5 / 7 / 12` |
| `fns[[bucket]](value)`, `across(value, ~ .x + share)` | `marginplyr_error` | unchanged |

The three silent rows are what made this a CRAN blocker. Four more were loud with untyped base-R conditions — the class ADR-0015 separates and #100 removed from three other sites. One was a false positive of #101's class, reached through a different construct.

## Fixed after review

Both verified before acting on them, and both regressions of the head walk rather than of the scoping:

- **`::` and `:::` read neither operand.** "Every non-symbol head is evaluated in the mask" is false for exactly this shape, which takes both operands literally. `dplyr::n()` began reporting `dplyr` and `n`, so any call holding a summary named `n` was rejected — and that is how the vignettes here write it (`grouping_identity.qmd:257`, `get_started.qmd:517`). Answered at the `::` node, which also clears the same over-report in argument position, where it predates this branch (`list(m = stats::median)` reports `stats` and `median` on `main`).
- **`rlang::call_name()` unwraps a one-sided formula to its right-hand side.** It errors on `~.x`, and where the right-hand side is a call it answers a different question — `~ .data$share` reads as a `$` call, so the walk entered a branch written for another shape and was right by accident. A formula is a call to `~` and is no longer asked for a name.

## Scope held

- `<-`, `for`, and `local()` still report their bound names. That is #101-class (a raised condition, not silence) and is **#162**, blocked by this.
- The formula/`call_name` pairing appears at nine other sites, where `length(~value)` still aborts before this walk is reached. Confirmed identical on `main` against a worktree at `97327f3`, so it is not this issue's: **#163**.

The `::` fix deliberately covers argument position as well as heads. A branch applying only to heads would reintroduce the position-dependent behaviour this design rejected, which is what left function definitions behaving one way in a head and another in an argument.

## Verification

Assertions are primarily at the **guard** — a `summarize_with_margins()` call per shape asserting `marginplyr_error`, or its absence for the false-positive row — so a refactor losing a shape fails at the user-visible contract rather than only in a unit table. The walk-level table sits beneath it, and `bound` is passed directly to assert scoping.

No snapshots: they skip under CRAN semantics, so a silent failure would stay silent in the flavors that matter. No derived enumeration of head shapes: nothing in the repository can source one, so it would be a hand-written list wearing a derivation's clothes.

Full suite green, `lintr::lint_package()` clean, `roxygen2::roxygenise()` produces no diff in `man/` or `NAMESPACE`.
