### PR TITLE
Ask no static analysis a formula for a call name

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -179,8 +179,8 @@ rewrite_grouping_expr <- function(expr,
 }
 
 grouping_helper_name <- function(expr) {
-  name <- rlang::call_name(expr)
-  namespace <- rlang::call_ns(expr)
+  name <- static_call_name(expr)
+  namespace <- static_call_ns(expr)
   if (
     !is.null(name) &&
       name %in% c("grouping_bit", "grouping_id") &&

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -276,9 +276,9 @@ is_name_only_expr <- function(expr, env, data_vars) {
     return(is.atomic(expr))
   }
 
-  # No `rlang::is_call()` guard: `static_call_name()` answers `NULL` for a
-  # language object that is no call, which is the answer the next line already
-  # gives.
+  # A language object that is no call -- an expression vector, a pairlist --
+  # answers `NULL` here, which the next line already turns into the `FALSE` a
+  # guard would have returned.
   call_name <- static_call_name(expr)
   if (is.null(call_name)) {
     return(FALSE)

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -275,10 +275,10 @@ is_name_only_expr <- function(expr, env, data_vars) {
   if (!is.language(expr)) {
     return(is.atomic(expr))
   }
-  if (!rlang::is_call(expr)) {
-    return(FALSE)
-  }
 
+  # No `rlang::is_call()` guard: `static_call_name()` answers `NULL` for a
+  # language object that is no call, which is the answer the next line already
+  # gives.
   call_name <- static_call_name(expr)
   if (is.null(call_name)) {
     return(FALSE)

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -279,7 +279,7 @@ is_name_only_expr <- function(expr, env, data_vars) {
     return(FALSE)
   }
 
-  call_name <- rlang::call_name(expr)
+  call_name <- static_call_name(expr)
   if (is.null(call_name)) {
     return(FALSE)
   }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -712,8 +712,8 @@ grouping_arg_spec <- function(arg, data_vars) {
   }
 
   constructors <- grouping_constructor_names()
-  call_name <- if (rlang::is_call(expr)) rlang::call_name(expr) else NULL
-  call_ns <- if (rlang::is_call(expr)) rlang::call_ns(expr) else NULL
+  call_name <- static_call_name(expr)
+  call_ns <- static_call_ns(expr)
   is_constructor_call <-
     !is.null(call_name) &&
     call_name %in% constructors &&

--- a/R/share.R
+++ b/R/share.R
@@ -2829,17 +2829,10 @@ expression_data_symbols <- function(expr, bound = character()) {
   if (rlang::is_call(expr, c("::", ":::"))) {
     return(character())
   }
-  # `rlang::call_name()` unwraps a one-sided formula to its right-hand side.
-  # That errors when the right-hand side is a bare symbol -- `~.x` -- and
-  # misreads the call when it is not: `~ .data$share` answers `$`, so the walk
-  # entered a branch written for a different shape and reached the right
-  # answer by accident. A formula is a call to `~`, and the general walk below
-  # already treats it as one, so it is never asked for a name.
-  call_name <- if (rlang::is_call(expr, "~")) {
-    NULL
-  } else {
-    rlang::call_name(expr)
-  }
+  # A formula is a call to `~`, and the general walk below already treats it as
+  # one, so it is never asked for a name. `static_call_name()` is why, and it
+  # is the same answer nine other analyses read (#163).
+  call_name <- static_call_name(expr)
   # The length is part of deciding whether this is a function definition at
   # all, not a precondition to check inside. A node built by hand rather than
   # parsed -- `rlang::call2("function")` arriving through injection -- can

--- a/R/share.R
+++ b/R/share.R
@@ -2541,11 +2541,11 @@ share_helper_call_kind <- function(expr) {
   if (!rlang::is_call(expr)) {
     return(NULL)
   }
-  name <- rlang::call_name(expr)
+  name <- static_call_name(expr)
   if (is.null(name)) {
     return(NULL)
   }
-  namespace <- rlang::call_ns(expr)
+  namespace <- static_call_ns(expr)
   if (!is.null(namespace) && !identical(namespace, "marginplyr")) {
     return(NULL)
   }
@@ -2624,9 +2624,9 @@ share_request_kinds <- function(requests) {
 
 is_across_call <- function(expr) {
   rlang::is_call(expr) &&
-    identical(rlang::call_name(expr), "across") &&
-    (is.null(rlang::call_ns(expr)) ||
-       identical(rlang::call_ns(expr), "dplyr"))
+    identical(static_call_name(expr), "across") &&
+    (is.null(static_call_ns(expr)) ||
+       identical(static_call_ns(expr), "dplyr"))
 }
 
 # `error_call` is the caller's own `across()` call rather than this frame,
@@ -2766,7 +2766,7 @@ contains_selection_predicate <- function(expr) {
   if (!rlang::is_call(expr)) {
     return(FALSE)
   }
-  if (identical(rlang::call_name(expr), "where")) {
+  if (identical(static_call_name(expr), "where")) {
     return(TRUE)
   }
   any(vapply(

--- a/R/share.R
+++ b/R/share.R
@@ -2538,8 +2538,8 @@ share_named_kind <- function(name) {
 }
 
 share_helper_call_kind <- function(expr) {
-  # No `rlang::is_call()` guard: `static_call_name()` answers `NULL` for a
-  # node that is no call, which is the answer the next line already gives.
+  # A node that is no call answers `NULL` here, which the next line already
+  # turns into the answer a guard would have returned.
   name <- static_call_name(expr)
   if (is.null(name)) {
     return(NULL)
@@ -2622,6 +2622,8 @@ share_request_kinds <- function(requests) {
 }
 
 is_across_call <- function(expr) {
+  # Asked of any expression, not only of a call: a node that is no call has no
+  # name, and no name matches.
   identical(static_call_name(expr), "across") &&
     (is.null(static_call_ns(expr)) ||
        identical(static_call_ns(expr), "dplyr"))
@@ -2758,9 +2760,8 @@ share_selection_missing_names <- function(cnd) {
 }
 
 contains_selection_predicate <- function(expr) {
-  if (rlang::is_symbol(expr)) {
-    return(FALSE)
-  }
+  # A symbol needs no test of its own: it is no call, so the walk below has
+  # nothing to descend into and the guard covers it.
   if (!rlang::is_call(expr)) {
     return(FALSE)
   }

--- a/R/share.R
+++ b/R/share.R
@@ -2538,9 +2538,8 @@ share_named_kind <- function(name) {
 }
 
 share_helper_call_kind <- function(expr) {
-  if (!rlang::is_call(expr)) {
-    return(NULL)
-  }
+  # No `rlang::is_call()` guard: `static_call_name()` answers `NULL` for a
+  # node that is no call, which is the answer the next line already gives.
   name <- static_call_name(expr)
   if (is.null(name)) {
     return(NULL)
@@ -2623,8 +2622,7 @@ share_request_kinds <- function(requests) {
 }
 
 is_across_call <- function(expr) {
-  rlang::is_call(expr) &&
-    identical(static_call_name(expr), "across") &&
+  identical(static_call_name(expr), "across") &&
     (is.null(static_call_ns(expr)) ||
        identical(static_call_ns(expr), "dplyr"))
 }
@@ -2831,7 +2829,7 @@ expression_data_symbols <- function(expr, bound = character()) {
   }
   # A formula is a call to `~`, and the general walk below already treats it as
   # one, so it is never asked for a name. `static_call_name()` is why, and it
-  # is the same answer nine other analyses read (#163).
+  # is the same answer every other analysis in this package reads (#163).
   call_name <- static_call_name(expr)
   # The length is part of deciding whether this is a function definition at
   # all, not a precondition to check inside. A node built by hand rather than

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -352,10 +352,11 @@ rewrite_summary_selections <- function(expr,
   expr
 }
 
-# `call_name` is the caller's answer rather than one asked again here: the only
-# caller reaches this after reading it, and asking a second time is the pairing
-# that made an unrecognized shape -- a formula -- answer as one of the three
-# names this handles (#163).
+# `call_name` is the caller's answer rather than one asked again here. Asking
+# again would answer the same, since the shared read answers a formula as no
+# name at all (#163); it would just be a second question about an expression
+# the only caller enters this function having already named, and the two
+# answers would then have to be kept in step by hand.
 rewrite_across_selection <- function(expr,
                                      env,
                                      data_proxy,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -250,8 +250,8 @@ find_summary_context_helpers <- function(expr) {
     return(character())
   }
 
-  call_name <- rlang::call_name(expr)
-  call_ns <- rlang::call_ns(expr)
+  call_name <- static_call_name(expr)
+  call_ns <- static_call_ns(expr)
   unsupported <- c(
     "cur_group",
     "cur_group_id",
@@ -329,8 +329,8 @@ rewrite_summary_selections <- function(expr,
   names(call_args) <- names(as.list(expr)[-1L])
   expr <- rlang::call2(expr[[1L]], !!!call_args)
 
-  call_name <- rlang::call_name(expr)
-  call_ns <- rlang::call_ns(expr)
+  call_name <- static_call_name(expr)
+  call_ns <- static_call_ns(expr)
   is_dplyr_call <- is.null(call_ns) || identical(call_ns, "dplyr")
   if (!is_dplyr_call) {
     return(expr)
@@ -341,7 +341,8 @@ rewrite_summary_selections <- function(expr,
       expr,
       env,
       data_proxy,
-      normalize_across_names = normalize_across_names
+      normalize_across_names = normalize_across_names,
+      call_name = call_name
     ))
   }
   if (identical(call_name, "pick")) {
@@ -351,11 +352,15 @@ rewrite_summary_selections <- function(expr,
   expr
 }
 
+# `call_name` is the caller's answer rather than one asked again here: the only
+# caller reaches this after reading it, and asking a second time is the pairing
+# that made an unrecognized shape -- a formula -- answer as one of the three
+# names this handles (#163).
 rewrite_across_selection <- function(expr,
                                      env,
                                      data_proxy,
-                                     normalize_across_names) {
-  call_name <- rlang::call_name(expr)
+                                     normalize_across_names,
+                                     call_name) {
   parsed <- parse_across_arguments(expr)
   call_args <- parsed$call_args
   selection_index <- parsed$cols_index
@@ -488,8 +493,8 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     return(character())
   }
 
-  call_name <- rlang::call_name(expr)
-  call_ns <- rlang::call_ns(expr)
+  call_name <- static_call_name(expr)
+  call_ns <- static_call_ns(expr)
   is_tibble_constructor <-
     !is.null(call_name) &&
     call_name %in% c("tibble", "data_frame") &&

--- a/R/utils.R
+++ b/R/utils.R
@@ -107,6 +107,39 @@ assert_lazy_table <- function(x) {
   }
 }
 
+# The name and namespace a static analysis reads from a call it has already
+# recognized as one with `rlang::is_call()`.
+#
+# `rlang::call_name()` and `rlang::call_ns()` do not answer a formula as the
+# call to `~` that it is: both unwrap a one-sided formula to its right-hand
+# side. When that side is a bare symbol they raise "`call` must be a defused
+# call, not a symbol" -- an untyped condition of the class ADR-0015
+# separates -- and when it is not they answer a different call, so
+# `~ .data$share` reads as a `$` call and the analysis enters a branch written
+# for another shape, carrying the formula as the expression that branch then
+# reads `[[2L]]` of. `rlang::call_args()` unwraps the same way, which is how a
+# formula reached the direct-share path and was computed as the share it is
+# not (#163).
+#
+# Every analysis in this package recognizes a call by its name, none of them
+# recognizes `~`, and each already has an answer for a name it does not know:
+# walk the call's parts, or report the shape as one it does not handle. A
+# formula is therefore a call with no name, and the analysis treats it as the
+# `~` call it is rather than as its right-hand side.
+static_call_name <- function(expr) {
+  if (rlang::is_call(expr, "~")) {
+    return(NULL)
+  }
+  rlang::call_name(expr)
+}
+
+static_call_ns <- function(expr) {
+  if (rlang::is_call(expr, "~")) {
+    return(NULL)
+  }
+  rlang::call_ns(expr)
+}
+
 # Required because dtplyr is an optional Suggest rather than an Import: it
 # brings data.table, which reads this flag from the calling namespace.
 # data.table fixes the spelling of this name, so it cannot follow the package's

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,7 +124,7 @@ assert_lazy_table <- function(x) {
 # is not -- measured on 5f078ea, and the one shape of this whose misread raised
 # nothing, which is what the ticket's severity note does not cover.
 #
-# Every analysis in this package recognizes a call by its name, none of them
+# Every analysis that reads a name recognizes a call by that name, none of them
 # recognizes `~`, and each already has an answer for a name it does not know:
 # walk the call's parts, or report the shape as one it does not handle. A
 # formula is therefore a call with no name, and the analysis treats it as the
@@ -157,8 +157,9 @@ static_call_ns <- function(expr) {
 
 # Whether `rlang::call_name()` and `rlang::call_ns()` may be asked about this
 # node at all: it is a call, and not a call to `~`. It does not promise a name
-# -- a call whose head is itself a call has none, and both answer `NULL` for it
-# (#100), which every site is already written to handle.
+# -- a call whose head is itself a call has none, and both answer `NULL` for
+# it, which every site is already written to handle since #100 made the name
+# read NULL-safe.
 is_nameable_call <- function(expr) {
   rlang::is_call(expr) && !rlang::is_call(expr, "~")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -108,8 +108,9 @@ assert_lazy_table <- function(x) {
 }
 
 # The name and namespace a static analysis reads from a call, and `NULL` when
-# there is no name to read -- which anything that is not a call also is, so a
-# site needs no `rlang::is_call()` guard of its own to ask.
+# there is none to read. Anything that is not a call answers `NULL` too, so a
+# site may ask without a guard of its own; the sites that keep one keep it for
+# a read it makes beside this, such as walking `as.list(expr)[-1L]`.
 #
 # `rlang::call_name()` and `rlang::call_ns()` do not answer a formula as the
 # call to `~` that it is: both unwrap a one-sided formula to its right-hand
@@ -118,9 +119,10 @@ assert_lazy_table <- function(x) {
 # separates -- and when it is not they answer a different call, so
 # `~ .data$share` reads as a `$` call and the analysis enters a branch written
 # for another shape, carrying the formula as the expression that branch then
-# reads `[[2L]]` of. `rlang::call_args()` unwraps the same way, which is how a
-# formula reached the direct-share path and was computed as the share it is
-# not (#163).
+# reads `[[2L]]` of (#163). `rlang::call_args()` unwraps the same way, which is
+# how a formula reached the direct-share path and was computed as the share it
+# is not -- measured on 5f078ea, and the one shape of this whose misread raised
+# nothing, which is what the ticket's severity note does not cover.
 #
 # Every analysis in this package recognizes a call by its name, none of them
 # recognizes `~`, and each already has an answer for a name it does not know:
@@ -140,26 +142,25 @@ assert_lazy_table <- function(x) {
 # that expression as a part and analyses it there, where the operands are its
 # own.
 static_call_name <- function(expr) {
-  if (is.null(static_call_expr(expr))) {
+  if (!is_nameable_call(expr)) {
     return(NULL)
   }
   rlang::call_name(expr)
 }
 
 static_call_ns <- function(expr) {
-  if (is.null(static_call_expr(expr))) {
+  if (!is_nameable_call(expr)) {
     return(NULL)
   }
   rlang::call_ns(expr)
 }
 
-# The call a name is read from, or `NULL` when there is none: anything that is
-# not a call, and any call to `~` -- a formula or a quosure.
-static_call_expr <- function(expr) {
-  if (!rlang::is_call(expr) || rlang::is_call(expr, "~")) {
-    return(NULL)
-  }
-  expr
+# Whether `rlang::call_name()` and `rlang::call_ns()` may be asked about this
+# node at all: it is a call, and not a call to `~`. It does not promise a name
+# -- a call whose head is itself a call has none, and both answer `NULL` for it
+# (#100), which every site is already written to handle.
+is_nameable_call <- function(expr) {
+  rlang::is_call(expr) && !rlang::is_call(expr, "~")
 }
 
 # Required because dtplyr is an optional Suggest rather than an Import: it

--- a/R/utils.R
+++ b/R/utils.R
@@ -107,8 +107,9 @@ assert_lazy_table <- function(x) {
   }
 }
 
-# The name and namespace a static analysis reads from a call it has already
-# recognized as one with `rlang::is_call()`.
+# The name and namespace a static analysis reads from a call, and `NULL` when
+# there is no name to read -- which anything that is not a call also is, so a
+# site needs no `rlang::is_call()` guard of its own to ask.
 #
 # `rlang::call_name()` and `rlang::call_ns()` do not answer a formula as the
 # call to `~` that it is: both unwrap a one-sided formula to its right-hand
@@ -126,18 +127,39 @@ assert_lazy_table <- function(x) {
 # walk the call's parts, or report the shape as one it does not handle. A
 # formula is therefore a call with no name, and the analysis treats it as the
 # `~` call it is rather than as its right-hand side.
+#
+# An injected quosure is a call to `~` as well, and gets the same answer for a
+# stronger reason. Every site reads operands from the node it has just named --
+# `expr[[2L]]`, `as.list(expr)[-1L]`, `length(expr)` -- and a quosure answers
+# none of those as the call it carries: `rlang::quo(.data$share)[[2L]]` is
+# `.data$share` rather than `.data`, and warns that subsetting a quosure is
+# deprecated, while `length()` of any quosure is 2. Naming a quosure for the
+# call inside it would split the name from the operands, which is the defect
+# this removes rather than a fix for it. Falling through costs nothing:
+# `as.list()` of a quosure yields the expression it carries, so a walk reaches
+# that expression as a part and analyses it there, where the operands are its
+# own.
 static_call_name <- function(expr) {
-  if (rlang::is_call(expr, "~")) {
+  if (is.null(static_call_expr(expr))) {
     return(NULL)
   }
   rlang::call_name(expr)
 }
 
 static_call_ns <- function(expr) {
-  if (rlang::is_call(expr, "~")) {
+  if (is.null(static_call_expr(expr))) {
     return(NULL)
   }
   rlang::call_ns(expr)
+}
+
+# The call a name is read from, or `NULL` when there is none: anything that is
+# not a call, and any call to `~` -- a formula or a quosure.
+static_call_expr <- function(expr) {
+  if (!rlang::is_call(expr) || rlang::is_call(expr, "~")) {
+    return(NULL)
+  }
+  expr
 }
 
 # Required because dtplyr is an optional Suggest rather than an Import: it

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -291,10 +291,10 @@ test_that("a formula is walked as the call to `~` that it is", {
   )
 
   # A formula written at the top of a summary expression -- `length(~value)`
-  # -- still aborts, from `find_summary_context_helpers()` rather than from
-  # here: the same `is_call()`-then-`call_name()` pairing appears at nine
-  # sites, and it fails there before this walk is reached. That predates #130
-  # and is tracked in #163, so it is deliberately not asserted here.
+  # -- used to abort from `find_summary_context_helpers()` before this walk was
+  # reached: the same `is_call()`-then-`call_name()` pairing appeared at nine
+  # further sites. That predated #130 and was fixed in #163, whose tests below
+  # cover the sites and the shapes this one does not.
 
   # A formula in the `.fns` position of `across()` is the one spelling of this
   # that users are documented to write (`R/share.R:307`), and it was the only
@@ -312,6 +312,137 @@ test_that("a formula is walked as the call to `~` that it is", {
     "`share`"
   )
   expect_s3_class(from_across, "marginplyr_error")
+})
+
+test_that("every analysis that names a call reads a formula as a `~` call", {
+  # Nine further analyses guarded with `rlang::is_call()` and then asked for a
+  # name, so each read a formula as whatever its right-hand side is (#163).
+  # Each is asserted at its own function rather than end to end, because only
+  # one half of the misread reports itself: a bare symbol on the right raises
+  # "`call` must be a defused call, not a symbol", while a call on the right
+  # silently sends the formula into a branch written for another shape,
+  # where `expr[[2L]]` is the formula's right-hand side and not the operand
+  # that branch means to read.
+  proxy <- data.frame(value = double(), other = double())
+  env <- rlang::current_env()
+
+  # The three reads #163 names, and the two-sided formula that is the one
+  # shape `call_name()` did answer as `~`.
+  expect_null(static_call_name(quote(~ .data$share)))
+  expect_null(static_call_name(quote(~ get("share"))))
+  expect_null(static_call_ns(quote(~ dplyr::n())))
+  expect_null(static_call_name(quote(a ~ b)))
+
+  # A walk still reaches what the formula holds: the helper inside is found
+  # once, from the parts, rather than twice -- once from the formula misread
+  # as the call it wraps, and once from that call itself.
+  expect_identical(
+    find_summary_context_helpers(quote(length(~ dplyr::cur_group()))),
+    "cur_group"
+  )
+  expect_identical(
+    find_summary_context_helpers(quote(length(~value))),
+    character()
+  )
+
+  # The rewrite belongs to the `across()` inside the formula, which the walk
+  # over the arguments already reaches. Rewriting the formula as that
+  # `across()` too turned a lambda into the two-sided formula
+  # `dplyr::all_of("value") ~ mean`.
+  expect_identical(
+    rewrite_summary_selections(
+      quote(~ dplyr::across(c(value), mean)),
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quote(~ dplyr::across(dplyr::all_of("value"), mean))
+  )
+  expect_identical(
+    rewrite_summary_selections(
+      quote(~.x),
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quote(~.x)
+  )
+
+  # A formula names no output columns, is no share helper call, no `across()`
+  # call, no name-only selection, and no grouping helper -- whatever sits on
+  # its right-hand side. Each of these answered for that right-hand side.
+  expect_identical(
+    known_data_frame_output_names(quote(~ dplyr::pick(value)), env, proxy),
+    character()
+  )
+  expect_null(share_helper_call_kind(quote(~ share_of_total(units))))
+  expect_false(is_across_call(quote(~ dplyr::across(value, mean))))
+  expect_false(
+    is_name_only_expr(quote(~c(region)), env = env, data_vars = "region")
+  )
+  expect_null(grouping_helper_name(quote(~ grouping_id(region))))
+
+  # The predicate search still finds `where()`, from the parts rather than
+  # from a misread name, and answers a bare-symbol right-hand side instead of
+  # aborting on it.
+  expect_true(contains_selection_predicate(quote(~ where(is.numeric))))
+  expect_false(contains_selection_predicate(quote(~.x)))
+})
+
+test_that("a formula in a summary expression evaluates instead of aborting", {
+  # `derived = purrr::map_dbl(v, ~.x)` is the realistic spelling of this;
+  # written against an Import it is `rlang::as_function()`, which is what
+  # `map_dbl()` applies the formula through. `length(~value)` is #163's
+  # contrived one, and it reaches further: the formula sits at the top of the
+  # summary expression rather than inside a call, so every analysis that reads
+  # a top-level expression sees it.
+  #
+  # Both are ordinary R that marginplyr has nothing to say about, so ADR-0015
+  # asks them to fall through and evaluate rather than to raise a condition of
+  # any class. A formula is a value, not a deferred read of the mask: the
+  # length of `~value` is 2 whatever the data holds.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    derived = length(~value),
+    lambda = rlang::as_function(~.x)(units),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expect_identical(result$derived, rep(2L, nrow(result)))
+  expect_identical(result$lambda, result$units)
+  expect_identical(result$share, result$units / sum(data$value))
+})
+
+test_that("a formula wrapping a share helper is refused, not computed", {
+  # The one shape whose misread raised nothing. `rlang::call_args()` unwraps a
+  # formula exactly as `call_name()` does, so `~ share_of_total(units)` was
+  # read as the direct share `share_of_total(units)` -- name, argument, and
+  # all. The formula the caller wrote was dropped and a share appeared under
+  # the name they gave it, which is the silently wrong result the raised
+  # conditions elsewhere in #163 were not.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      derived = ~ share_of_total(units),
+      .grouping = rollup(region)
+    ),
+    "must be the complete right-hand side"
+  )
+  expect_s3_class(error, "marginplyr_error")
 })
 
 test_that("the head is walked before the arguments, and the guard says so", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -315,14 +315,19 @@ test_that("a formula is walked as the call to `~` that it is", {
 })
 
 test_that("every analysis that names a call reads a formula as a `~` call", {
-  # Nine further analyses guarded with `rlang::is_call()` and then asked for a
-  # name, so each read a formula as whatever its right-hand side is (#163).
-  # Each is asserted at its own function rather than end to end, because only
-  # one half of the misread reports itself: a bare symbol on the right raises
-  # "`call` must be a defused call, not a symbol", while a call on the right
-  # silently sends the formula into a branch written for another shape,
-  # where `expr[[2L]]` is the formula's right-hand side and not the operand
-  # that branch means to read.
+  # The nine further analyses #163 lists guarded with `rlang::is_call()` and
+  # then asked for a name, so each read a formula as whatever its right-hand
+  # side is. Each is asserted at its own function rather than end to end,
+  # because only one half of the misread reports itself: a bare symbol on the
+  # right raises "`call` must be a defused call, not a symbol", while a call on
+  # the right silently sends the formula into a branch written for another
+  # shape, where `expr[[2L]]` is the formula's right-hand side and not the
+  # operand that branch means to read.
+  #
+  # `grouping_arg_spec()` is a tenth site, which #163 lists as unaffected on
+  # the grounds that it guards each read individually. That is NULL-safety for
+  # a non-call and no protection from a formula, which passes `is_call()`
+  # there like anywhere else; the test below covers it.
   proxy <- data.frame(value = double(), other = double())
   env <- rlang::current_env()
 
@@ -332,6 +337,23 @@ test_that("every analysis that names a call reads a formula as a `~` call", {
   expect_null(static_call_name(quote(~ get("share"))))
   expect_null(static_call_ns(quote(~ dplyr::n())))
   expect_null(static_call_name(quote(a ~ b)))
+
+  # An injected quosure is a `~` call as well, and gets the same answer for a
+  # stronger reason than a formula does: every site reads operands from the
+  # node it has just named, and a quosure answers none of those reads as the
+  # call it carries. Its length is 2 whatever it holds, so a name read through
+  # to the call inside would not describe the operands beside it -- which is
+  # this defect rather than a fix for it.
+  expect_null(static_call_name(rlang::quo(dplyr::across(value, mean))))
+  expect_null(static_call_ns(rlang::quo(dplyr::n())))
+  expect_identical(length(rlang::quo(dplyr::across(value, mean))), 2L)
+  # A quosure carrying no call is a name this cannot read, not an error: that
+  # is the shape `rlang::call_name()` aborts on.
+  expect_null(static_call_name(rlang::quo(value)))
+  # Anything that is not a call has no name to read either, so a site needs no
+  # `rlang::is_call()` guard of its own before asking.
+  expect_null(static_call_name(quote(value)))
+  expect_null(static_call_ns(1L))
 
   # A walk still reaches what the formula holds: the helper inside is found
   # once, from the parts, rather than twice -- once from the formula misread
@@ -419,6 +441,48 @@ test_that("a formula in a summary expression evaluates instead of aborting", {
   expect_identical(result$derived, rep(2L, nrow(result)))
   expect_identical(result$lambda, result$units)
   expect_identical(result$share, result$units / sum(data$value))
+})
+
+test_that("a formula in a grouping specification reaches tidyselect", {
+  # `grouping_arg_spec()` read a name to decide whether an argument is a
+  # Grouping constructor call or a selection to evaluate later. It guarded each
+  # read with `rlang::is_call()` separately, which #163 reads as protection --
+  # but that is NULL-safety for an argument that is no call at all, and a
+  # formula is a call. `rollup(~region)` passed both guards and aborted with
+  # the untyped condition, from a site the ticket lists as unaffected.
+  #
+  # A formula is no Grouping constructor, so the argument is a selection, and
+  # tidyselect is what has something to say about a formula in one. Its message
+  # names the rewrite; the internal abort named an rlang argument the caller
+  # never wrote.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      .grouping = rollup(~region)
+    ),
+    "Formula shorthand must be wrapped in `where\\(\\)`"
+  )
+  # The selection is the caller's own, so what tidyselect raises reaches them
+  # as tidyselect raised it -- neither re-typed as a Package condition nor
+  # replaced by one of this package's internal invariants (ADR-0015).
+  expect_s3_class(error, "rlang_error")
+  expect_false(inherits(error, "marginplyr_error"))
+
+  # A constructor argument is still recognized as one, and a bare column is
+  # still a name-only selection.
+  expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      .grouping = rollup(region)
+    )
+  )
 })
 
 test_that("a formula wrapping a share helper is refused, not computed", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -458,9 +458,11 @@ test_that("every analysis that names a call reads a formula as a `~` call", {
 })
 
 test_that("a formula in a summary expression evaluates instead of aborting", {
-  # `derived = purrr::map_dbl(v, ~.x)` is the realistic spelling of this;
-  # written against an Import it is `rlang::as_function()`, which is what
-  # `map_dbl()` applies the formula through. `length(~value)` is #163's
+  # `derived = purrr::map_dbl(v, ~.x)` is the realistic spelling of this. purrr
+  # is neither an Import nor a Suggest of this package, so it is written here
+  # against one that is: `rlang::as_function()` is what `map_dbl()` applies the
+  # formula through, and it is the same shape -- a lambda whose right-hand side
+  # is a bare symbol, in argument position. `length(~value)` is #163's
   # contrived one, and it reaches further: the formula sits at the top of the
   # summary expression rather than inside a call, so every analysis that reads
   # a top-level expression sees it.

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -314,6 +314,37 @@ test_that("a formula is walked as the call to `~` that it is", {
   expect_s3_class(from_across, "marginplyr_error")
 })
 
+test_that("a read inside an injected quosure is still reached", {
+  # A quosure is a call to `~`, so it is named as one -- no name -- and every
+  # walk descends into it instead. That answer is only safe if descending
+  # reaches what the quosure carries, which is what this asserts in the
+  # package's own terms rather than in rlang's: the guard against an ordinary
+  # summary reading an earlier share is the walk, so a read it stops seeing is
+  # a guard that stops firing, and the wrong number is returned in silence
+  # (#130).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # The walks subset the quosure node they descend into -- `expr[[1L]]`,
+  # `as.list(expr)[-1L]` -- and rlang soft-deprecated both spellings on a
+  # quosure, so walking one signals a lifecycle condition into whatever handler
+  # the caller has installed. That is #165, not this: the suppression comes out
+  # when the walks read a quosure with `rlang::quo_get_expr()` instead.
+  error <- expect_error(
+    suppressWarnings(summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = sum(!!rlang::quo(share)),
+      .grouping = rollup(region)
+    )),
+    "`share`"
+  )
+  expect_s3_class(error, "marginplyr_error")
+})
+
 test_that("every analysis that names a call reads a formula as a `~` call", {
   # The nine further analyses #163 lists guarded with `rlang::is_call()` and
   # then asked for a name, so each read a formula as whatever its right-hand
@@ -331,29 +362,44 @@ test_that("every analysis that names a call reads a formula as a `~` call", {
   proxy <- data.frame(value = double(), other = double())
   env <- rlang::current_env()
 
-  # The three reads #163 names, and the two-sided formula that is the one
-  # shape `call_name()` did answer as `~`.
+  # The three reads #163 names -- `"$"`, `"get"`, and `"+"` -- and the
+  # two-sided formula, which is the one shape `call_name()` did answer as `~`.
   expect_null(static_call_name(quote(~ .data$share)))
   expect_null(static_call_name(quote(~ get("share"))))
+  expect_null(static_call_name(quote(~ .x + share)))
   expect_null(static_call_ns(quote(~ dplyr::n())))
   expect_null(static_call_name(quote(a ~ b)))
 
   # An injected quosure is a `~` call as well, and gets the same answer for a
   # stronger reason than a formula does: every site reads operands from the
   # node it has just named, and a quosure answers none of those reads as the
-  # call it carries. Its length is 2 whatever it holds, so a name read through
-  # to the call inside would not describe the operands beside it -- which is
-  # this defect rather than a fix for it.
+  # call it carries, so a name read through to the call inside would not
+  # describe the operands beside it. That is this defect rather than a fix for
+  # it. What the answer must not cost is the read inside, which the walk
+  # reaches as a part -- asserted end to end below.
   expect_null(static_call_name(rlang::quo(dplyr::across(value, mean))))
   expect_null(static_call_ns(rlang::quo(dplyr::n())))
-  expect_identical(length(rlang::quo(dplyr::across(value, mean))), 2L)
   # A quosure carrying no call is a name this cannot read, not an error: that
   # is the shape `rlang::call_name()` aborts on.
   expect_null(static_call_name(rlang::quo(value)))
-  # Anything that is not a call has no name to read either, so a site needs no
-  # `rlang::is_call()` guard of its own before asking.
+
+  # Anything that is not a call has no name to read either. That is deliberate
+  # and load-bearing rather than incidental: it is what lets a site ask without
+  # a guard of its own, which `share_helper_call_kind()`, `is_across_call()`,
+  # `is_name_only_expr()`, and `grouping_arg_spec()` each rely on.
   expect_null(static_call_name(quote(value)))
+  expect_null(static_call_ns(quote(value)))
+  expect_null(static_call_name(1L))
   expect_null(static_call_ns(1L))
+  expect_false(is_share_helper_call(quote(value)))
+  expect_false(is_across_call(quote(value)))
+  # A language object that is no call, which is what the guard dropped from
+  # `is_name_only_expr()` used to answer. A literal takes the branch above it
+  # and is a name-only selection, as it was before.
+  expect_false(
+    is_name_only_expr(expression(x), env = env, data_vars = "region")
+  )
+  expect_true(is_name_only_expr(1L, env = env, data_vars = "region"))
 
   # A walk still reaches what the formula holds: the helper inside is found
   # once, from the parts, rather than twice -- once from the formula misread


### PR DESCRIPTION
Closes #163.

Ten static analyses guarded an expression with `rlang::is_call()` and then asked it for a name with `rlang::call_name()` or `rlang::call_ns()`. Both unwrap a one-sided formula to its right-hand side, so a formula was read as whatever that side is — raising an untyped condition when it is a bare symbol, and answering a *different call* when it is not.

`static_call_name()` and `static_call_ns()` in `R/utils.R` now hold that rule once. A formula is a call to `~`; no analysis here recognizes `~`; every one of them already has an answer for a name it does not know — walk the call's parts, or report the shape as one it does not handle. `rlang::call_name`/`call_ns` no longer appear anywhere in `R/` outside those two helpers.

## Ten sites, not nine

#163's table lists nine and marks `R/grouping-plan.R:715-716` unaffected "because it guards each call individually". That is NULL-safety for an argument that is **no call at all**, and a formula *is* a call. Measured on `main`:

```r
summarize_with_margins(d, units = sum(value), .grouping = rollup(~region))
#> Error: `call` must be a defused call, not a symbol.
```

The tenth site is fixed here rather than filed separately (maintainer's call). A formula is no Grouping constructor, so the argument is a selection and tidyselect answers it — ``Formula shorthand must be wrapped in `where()` `` — the caller's own selection error reaching them with its own class, which is the middle case ADR-0015 draws. The ticket's table is corrected in a comment on #163.

## The quiet half was louder than the ticket says

All measured on `main` (`5f078ea`):

| shape | before | after |
|---|---|---|
| `derived = ~ share_of_total(units)` | **silently computed the share** — `call_args()` unwraps a formula too, so the formula was dropped and a number returned under the caller's name | `marginplyr_error` |
| `~ dplyr::across(c(value), mean)` through `rewrite_summary_selections()` | rewritten into the two-sided formula `dplyr::all_of("value") ~ mean` | inner `across()` rewritten, formula intact |
| `length(~ dplyr::cur_group())` | `cur_group` reported **twice** | once, from the parts |
| `is_name_only_expr(~c(region))` | `TRUE` — a formula accepted as a name-only selection | `FALSE` |

The first one matters most: #163's severity note says "no result is silently wrong", and that turned out not to hold. Corrected on the ticket.

## `length(~value)` evaluates to 2

It no longer raises, and that is deliberate rather than a partial fix. A formula is an ordinary R value, not a deferred read of the data mask — `length(~value)` is 2 whatever the data holds, and plain dplyr answers the same. ADR-0015 asks a shape the analysis does not recognize to fall through and evaluate; it governs which *class* a raised condition carries, not whether ordinary R must be refused. The shape that does become an error is `~ share_of_total(units)` — the one a caller can avoid by rewriting the call — and it is typed.

## Quosures

An injected quosure is a call to `~` as well, and gets the same answer for a stronger reason: every site reads operands from the node it has just named, and a quosure answers none of those reads as the call it carries (`rlang::quo(.data$share)[[2L]]` is `.data$share`, not `.data`). Naming a quosure for the call inside it would split the name from the operands — this defect, not a fix for it. Falling through costs nothing, and a test asserts what it must buy: a read of an earlier share hidden inside `!!` is still refused.

A separate, older defect surfaced while checking this: `rewrite_summary_selections()` rebuilds every call node with `rlang::call2()`, which strips an injected quosure or formula object to a plain `~` call. It reproduces on `main` and is filed as **#165**, not fixed here.

## Verification

- `testthat::test_local()` — 414 tests, 0 failures
- `lintr::lint_package()` — 0 lints
- `.github/scripts/verify-suite-coverage.R` — all 414 execute in ≥1 backend configuration, 0 orphaned

New tests need no optional backend, so `AGENTS.md`'s one-backend-per-test policy holds by construction. Each was confirmed red on `5f078ea`. No roxygen changed, so `man/` and `NAMESPACE` are untouched; `cran-comments.md` is #65's job, as #163 specifies.

## Reviews applied

Two rounds of two-axis review (Standards + Spec) ran against this branch; every finding is fixed in the last two commits — a predicate written as an accessor, three inaccurate comments, a stale rationale at a touched site, two redundant guards, and four corrections to the #163/#165 records themselves.