### PR TITLE
Bind the names `<-`, `for`, and a block introduce

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2800,9 +2800,12 @@ expression_alias_dependencies <- function(expr, aliases) {
 # `(function(share) .data$share)(value)` reads the column through a pronoun no
 # local binding shadows. Filtering the output collapses both, silently (#130).
 #
-# Only a function definition populates it today. `<-`, `for`, and `local()`
-# bind names the walk still reports as reads, which is a false positive rather
-# than the silence this argument exists for, and is tracked in #162.
+# A function definition populates it, and so do the statement-level binding
+# constructs: `<-` and `=` bind their target, `for` binds its index, and both
+# assign into the bottom of the data mask, so the name is a new binding rather
+# than a column read. `local()` needs no case of its own -- it binds nothing
+# itself, and the bindings its body makes are confined by the `{` walk below
+# (#162).
 expression_data_symbols <- function(expr, bound = character()) {
   if (rlang::is_symbol(expr)) {
     name <- rlang::as_name(expr)
@@ -2841,6 +2844,22 @@ expression_data_symbols <- function(expr, bound = character()) {
   # the one direction this walk is not allowed to be wrong in.
   if (identical(call_name, "function") && length(expr) >= 3L) {
     return(definition_data_symbols(expr, bound))
+  }
+  # `{` is where a binding becomes visible to anything other than itself: it
+  # opens no scope, so a name bound by one statement is bound for the ones
+  # after it and for nothing before them. Walking the statements in order is
+  # what tells `{ tmp <- share; tmp }`, which reads only the share, from
+  # `{ tmp + share; tmp <- 1 }`, which reads the column `tmp` before anything
+  # binds it. Collecting the block's bindings first and filtering the whole
+  # block with them would answer the second one silently wrong (#162).
+  if (identical(call_name, "{")) {
+    return(block_data_symbols(expr, bound)$reads)
+  }
+  # The same constructs reached outside a block -- `for (i in v) i + share` as
+  # a whole summary expression -- bind for their own operands alone, so only
+  # the reads are wanted here.
+  if (is_binding_statement(call_name, expr)) {
+    return(statement_data_symbols(expr, bound)$reads)
   }
   if (identical(call_name, "get") && length(expr) >= 2L) {
     if (get_has_external_env(expr)) {
@@ -2983,6 +3002,95 @@ definition_data_symbols <- function(expr, bound) {
     ),
     use.names = FALSE
   ))
+}
+
+# Whether this node binds a name into the environment holding it. The length is
+# part of the answer for the reason it is at the `function` node: a call built
+# by hand rather than parsed can carry one of these heads without the operands
+# the grammar guarantees, and it must fall through to the general walk, which
+# reports whatever its parts hold, rather than be read for an operand it does
+# not have.
+#
+# `<<-` is deliberately absent. It assigns past the environment it runs in, so
+# what it binds is not decidable from the expression, and reporting its target
+# as a read leaves the error on the diagnostic side rather than the silent one.
+is_binding_statement <- function(call_name, expr) {
+  if (is.null(call_name)) {
+    return(FALSE)
+  }
+  (call_name %in% c("<-", "=") && length(expr) >= 3L) ||
+    (identical(call_name, "for") && length(expr) >= 4L)
+}
+
+# A block's statements, walked in source order with the bound set growing as
+# they bind, and the set the statement after the block would see. Only a
+# statement that always runs grows it: an assignment nested inside anything
+# conditional -- `if (p) tmp <- 1`, a loop body over a sequence that may be
+# empty -- may not, so the name it would bind stays a read, which over-reports
+# rather than missing the read of a column that really did reach the mask
+# (#162).
+block_data_symbols <- function(expr, bound) {
+  reads <- character()
+  for (statement in as.list(expr)[-1L]) {
+    step <- statement_data_symbols(statement, bound)
+    reads <- c(reads, step$reads)
+    bound <- step$bound
+  }
+  list(reads = unique(reads), bound = bound)
+}
+
+# One statement's reads together with the bound set the statement after it
+# sees. A node that binds nothing returns the set it was given.
+statement_data_symbols <- function(expr, bound) {
+  call_name <- static_call_name(expr)
+  # A nested block and a redundant parenthesis are transparent here for the
+  # reason the enclosing block is: neither opens a scope, and both always run,
+  # so `{ { tmp <- share }; tmp }` and `{ (tmp <- share); tmp }` bind `tmp` for
+  # what follows exactly as the unwrapped statement does.
+  if (identical(call_name, "{")) {
+    return(block_data_symbols(expr, bound))
+  }
+  if (identical(call_name, "(") && length(expr) >= 2L) {
+    return(statement_data_symbols(expr[[2L]], bound))
+  }
+  if (!is_binding_statement(call_name, expr)) {
+    return(list(reads = expression_data_symbols(expr, bound), bound = bound))
+  }
+  if (identical(call_name, "for")) {
+    # The index survives the loop: R binds it in the enclosing environment, and
+    # binds it even when the sequence is empty, so `{ for (i in v) NULL; i }`
+    # reads no column `i`. The sequence is read before the index is bound, the
+    # body after.
+    inner <- bound
+    index <- expr[[2L]]
+    if (rlang::is_symbol(index)) {
+      inner <- unique(c(bound, rlang::as_name(index)))
+    }
+    return(list(
+      reads = unique(c(
+        expression_data_symbols(expr[[3L]], bound),
+        expression_data_symbols(expr[[4L]], inner)
+      )),
+      bound = inner
+    ))
+  }
+  target <- expr[[2L]]
+  value <- expression_data_symbols(expr[[3L]], bound)
+  if (rlang::is_symbol(target)) {
+    return(list(
+      reads = value,
+      bound = unique(c(bound, rlang::as_name(target)))
+    ))
+  }
+  # A replacement form -- `names(x) <- v` -- reads its target before it rebuilds
+  # it, so the target is walked and reported, in source order ahead of the
+  # value. It rebinds the object too, but the walk does not record that: which
+  # name a replacement call rebinds depends on the shape it is nested in, and
+  # leaving it unbound over-reports.
+  list(
+    reads = unique(c(expression_data_symbols(target, bound), value)),
+    bound = bound
+  )
 }
 
 get_has_external_env <- function(expr) {

--- a/R/share.R
+++ b/R/share.R
@@ -2801,11 +2801,11 @@ expression_alias_dependencies <- function(expr, aliases) {
 # local binding shadows. Filtering the output collapses both, silently (#130).
 #
 # A function definition populates it, and so do the statement-level binding
-# constructs: `<-` and `=` bind their target, `for` binds its index, and both
-# assign into the bottom of the data mask, so the name is a new binding rather
-# than a column read. `local()` needs no case of its own -- it binds nothing
-# itself, and the bindings its body makes are confined by the `{` walk below
-# (#162).
+# constructs. `<-` and `=` bind their target and `for` binds its index, each
+# into the bottom of the data mask, so the name is a new binding rather than a
+# column read; `{` binds nothing of its own but carries what its statements
+# bind to the statements after them. `local()` needs no case at all: it binds
+# nothing either, and whichever of these its argument is answers it (#162).
 expression_data_symbols <- function(expr, bound = character()) {
   if (rlang::is_symbol(expr)) {
     name <- rlang::as_name(expr)
@@ -2845,21 +2845,20 @@ expression_data_symbols <- function(expr, bound = character()) {
   if (identical(call_name, "function") && length(expr) >= 3L) {
     return(definition_data_symbols(expr, bound))
   }
-  # `{` is where a binding becomes visible to anything other than itself: it
-  # opens no scope, so a name bound by one statement is bound for the ones
-  # after it and for nothing before them. Walking the statements in order is
-  # what tells `{ tmp <- share; tmp }`, which reads only the share, from
+  # `statement_reads_and_bound()` is the one place that knows which nodes bind
+  # and what each of them binds. Here only its reads are wanted: an expression
+  # position has nothing after it for a binding to reach, which is what a bare
+  # `for (i in v) i + share` as a whole summary expression is. Inside a block
+  # the other half of its answer is what carries the binding along, and
+  # `is_binding_statement()` names `{` because a block opens no scope of its
+  # own: a name one statement binds is bound for the statements after it and
+  # for nothing before them. Walking them in order is what tells
+  # `{ tmp <- share; tmp }`, which reads only the share, from
   # `{ tmp + share; tmp <- 1 }`, which reads the column `tmp` before anything
-  # binds it. Collecting the block's bindings first and filtering the whole
-  # block with them would answer the second one silently wrong (#162).
-  if (identical(call_name, "{")) {
-    return(block_data_symbols(expr, bound)$reads)
-  }
-  # The same constructs reached outside a block -- `for (i in v) i + share` as
-  # a whole summary expression -- bind for their own operands alone, so only
-  # the reads are wanted here.
+  # binds it. Collecting a block's bindings first and filtering the whole block
+  # with them would answer the second one silently wrong (#162).
   if (is_binding_statement(call_name, expr)) {
-    return(statement_data_symbols(expr, bound)$reads)
+    return(statement_reads_and_bound(expr, bound)$reads)
   }
   if (identical(call_name, "get") && length(expr) >= 2L) {
     if (get_has_external_env(expr)) {
@@ -3004,12 +3003,17 @@ definition_data_symbols <- function(expr, bound) {
   ))
 }
 
-# Whether this node binds a name into the environment holding it. The length is
-# part of the answer for the reason it is at the `function` node: a call built
-# by hand rather than parsed can carry one of these heads without the operands
-# the grammar guarantees, and it must fall through to the general walk, which
-# reports whatever its parts hold, rather than be read for an operand it does
-# not have.
+# Whether this node changes what is bound around it: `<-` and `=` bind their
+# target, `for` binds its index, and `{` carries whatever its statements bind.
+# The length is part of the answer for the reason it is at the `function` node:
+# a call built by hand rather than parsed can carry one of these heads without
+# the operands the grammar guarantees, and it must fall through to the general
+# walk, which reports whatever its parts hold, rather than be read for an
+# operand it does not have.
+#
+# `call_name` is passed rather than read here because the caller has already
+# read it, and reading a node's name once is what the analysis sites in this
+# package were folded down to (#163).
 #
 # `<<-` is deliberately absent. It assigns past the environment it runs in, so
 # what it binds is not decidable from the expression, and reporting its target
@@ -3018,7 +3022,8 @@ is_binding_statement <- function(call_name, expr) {
   if (is.null(call_name)) {
     return(FALSE)
   }
-  (call_name %in% c("<-", "=") && length(expr) >= 3L) ||
+  identical(call_name, "{") ||
+    (call_name %in% c("<-", "=") && length(expr) >= 3L) ||
     (identical(call_name, "for") && length(expr) >= 4L)
 }
 
@@ -3029,10 +3034,14 @@ is_binding_statement <- function(call_name, expr) {
 # empty -- may not, so the name it would bind stays a read, which over-reports
 # rather than missing the read of a column that really did reach the mask
 # (#162).
-block_data_symbols <- function(expr, bound) {
+#
+# Named for both halves of what it answers rather than for the `_data_symbols`
+# family, whose members all return a character vector of reads. A reader who
+# took this for one of those would pass a list to `intersect()`.
+block_reads_and_bound <- function(expr, bound) {
   reads <- character()
   for (statement in as.list(expr)[-1L]) {
-    step <- statement_data_symbols(statement, bound)
+    step <- statement_reads_and_bound(statement, bound)
     reads <- c(reads, step$reads)
     bound <- step$bound
   }
@@ -3041,17 +3050,29 @@ block_data_symbols <- function(expr, bound) {
 
 # One statement's reads together with the bound set the statement after it
 # sees. A node that binds nothing returns the set it was given.
-statement_data_symbols <- function(expr, bound) {
+statement_reads_and_bound <- function(expr, bound) {
   call_name <- static_call_name(expr)
   # A nested block and a redundant parenthesis are transparent here for the
   # reason the enclosing block is: neither opens a scope, and both always run,
   # so `{ { tmp <- share }; tmp }` and `{ (tmp <- share); tmp }` bind `tmp` for
   # what follows exactly as the unwrapped statement does.
   if (identical(call_name, "{")) {
-    return(block_data_symbols(expr, bound))
+    return(block_reads_and_bound(expr, bound))
   }
   if (identical(call_name, "(") && length(expr) >= 2L) {
-    return(statement_data_symbols(expr[[2L]], bound))
+    return(statement_reads_and_bound(expr[[2L]], bound))
+  }
+  # `rm()` and its alias `remove()` are the only statements that take a name
+  # out of scope again, and losing one from the set is the direction this walk
+  # is not allowed to be wrong in: after `{ tmp <- 1; rm(tmp); tmp }` the last
+  # read reaches the column once more, so a share named `tmp` is read there and
+  # the guard owes the caller a diagnostic. Everything else the walk does not
+  # recognize can only add bindings, which over-reports and is safe to ignore.
+  if (!is.null(call_name) && call_name %in% c("rm", "remove")) {
+    return(list(
+      reads = expression_data_symbols(expr, bound),
+      bound = removal_retained_bound(expr, bound)
+    ))
   }
   if (!is_binding_statement(call_name, expr)) {
     return(list(reads = expression_data_symbols(expr, bound), bound = bound))
@@ -3091,6 +3112,37 @@ statement_data_symbols <- function(expr, bound) {
     reads = unique(c(expression_data_symbols(target, bound), value)),
     bound = bound
   )
+}
+
+# What survives an `rm()` of the bound set it is given. A name written
+# literally -- as a symbol or a string -- is the only removal readable here, so
+# anything else empties the set rather than being ignored: `rm(list = names)`
+# removes whatever that vector holds, and `rm(x, envir = e)` may remove nothing
+# at all. Both leave every later read reported, which is the over-reporting
+# side, while ignoring them would hide a read of a column that came back into
+# view (#162).
+removal_retained_bound <- function(expr, bound) {
+  args <- rlang::call_args(expr)
+  arg_names <- names(args)
+  if (is.null(arg_names)) {
+    arg_names <- rep("", length(args))
+  }
+  removed <- character()
+  for (i in seq_along(args)) {
+    arg <- args[[i]]
+    literal <- if (rlang::is_symbol(arg)) {
+      rlang::as_name(arg)
+    } else if (is.character(arg) && !anyNA(arg)) {
+      arg
+    } else {
+      NULL
+    }
+    if (nzchar(arg_names[[i]]) || is.null(literal)) {
+      return(character())
+    }
+    removed <- c(removed, literal)
+  }
+  setdiff(bound, removed)
 }
 
 get_has_external_env <- function(expr) {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -922,6 +922,24 @@ test_that("`rm()` puts a name back within reach of the column", {
   )
   expect_s3_class(from_removal, "marginplyr_error")
 
+  # A removal the walk cannot read has to reach the guard too, since emptying
+  # the set is only the safe answer if the reads it restores are reported.
+  from_dynamic_removal <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = {
+        share <- 1
+        rm(list = paste0("sh", "are"))
+        share
+      },
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_dynamic_removal, "marginplyr_error")
+
   expect_identical(
     expression_data_symbols(quote({
       tmp <- 1
@@ -942,14 +960,22 @@ test_that("`rm()` puts a name back within reach of the column", {
   )
   # A removal the walk cannot read empties the set rather than being ignored:
   # `rm(list = v)` removes whatever that vector holds, and `rm(x, envir = e)`
-  # may remove nothing at all.
+  # may remove nothing at all. The same holds under the other spelling.
   expect_identical(
     expression_data_symbols(quote({
       tmp <- 1
       rm(list = v)
-      tmp
+      tmp + share
     })),
-    c("v", "tmp")
+    c("v", "tmp", "share")
+  )
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- 1
+      remove(list = v)
+      tmp + share
+    })),
+    c("v", "tmp", "share")
   )
   # A name it does not remove stays bound, so the removal costs nothing beside
   # itself.
@@ -960,6 +986,69 @@ test_that("`rm()` puts a name back within reach of the column", {
       tmp
     })),
     "other"
+  )
+})
+
+test_that("a removal takes back only the names it names", {
+  # The transition `rm()` introduces runs the opposite way to every other one
+  # here -- bound to unbound -- so each place the bound set travels needs
+  # asserting in that direction too. Every expectation below was confirmed
+  # against R by evaluating the block in a child of an environment holding the
+  # removed names, and reading which binding the final read reached (#162).
+
+  # A removal beside an untouched binding: `a` reaches the enclosing value
+  # again, `b` is still the local one.
+  expect_identical(
+    expression_data_symbols(quote({
+      a <- 1
+      b <- 2
+      rm(a)
+      a + b
+    })),
+    "a"
+  )
+  # Several names removed at once, under both spellings of the call.
+  expect_identical(
+    expression_data_symbols(quote({
+      a <- 1
+      b <- 2
+      rm(a, b)
+      a + b
+    })),
+    c("a", "b")
+  )
+  expect_identical(
+    expression_data_symbols(quote({
+      a <- 1
+      b <- 2
+      remove(a, b)
+      a + b
+    })),
+    c("a", "b")
+  )
+  # Rebinding after a removal binds again: the set grows and shrinks along the
+  # block rather than being decided once for it.
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- 1
+      rm(tmp)
+      tmp <- 2
+      tmp
+    })),
+    character()
+  )
+  # A nested block and a redundant parenthesis carry a removal out of
+  # themselves exactly as they carry a binding: neither opens a scope, so
+  # `rm()` inside one removes the binding the statements after it would see.
+  # Both blocks are parsed from text because writing the inner braces out is
+  # the one shape `brace_linter` refuses.
+  expect_identical(
+    expression_data_symbols(str2lang("{ tmp <- 1; { rm(tmp) }; tmp }")),
+    "tmp"
+  )
+  expect_identical(
+    expression_data_symbols(str2lang("{ tmp <- 1; (rm(tmp)); tmp }")),
+    "tmp"
   )
 })
 

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -808,6 +808,20 @@ test_that("`<-`, `for`, and `local()` bind names rather than reading them", {
     .grouping = rollup(region)
   )
   expect_identical(unique(from_local$derived), 4)
+
+  # A binding statement reached outside a block, which is the other branch the
+  # walk answers: nothing follows it for the binding to reach, so only its
+  # reads count and it has none. A bare `for` cannot be asserted here because
+  # it evaluates to `NULL` and no summary can be one, so the walk-level table
+  # below is the layer that covers that spelling.
+  from_bare_assignment <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    derived = (share <- 2),
+    .grouping = rollup(region)
+  )
+  expect_identical(unique(from_bare_assignment$derived), 2)
 })
 
 test_that("a bound name does not hide a genuine read beside it", {
@@ -867,6 +881,86 @@ test_that("a bound name does not hide a genuine read beside it", {
     "`share`"
   )
   expect_s3_class(from_local_body, "marginplyr_error")
+
+  from_bare_assignment <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = (tmp <- share),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_bare_assignment, "marginplyr_error")
+})
+
+test_that("`rm()` puts a name back within reach of the column", {
+  # The bound set may only shrink where the walk can see the removal, and
+  # `rm()` is the one statement that shrinks it: after `rm(share)` the next
+  # read reaches the column again. Losing that read would be the silent class
+  # #130 removed rather than the loud class this issue owns, so it is the one
+  # direction growing a bound set is not allowed to be wrong in (#162).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  from_removal <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = {
+        share <- 1
+        rm(share)
+        share
+      },
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_removal, "marginplyr_error")
+
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- 1
+      rm(tmp)
+      tmp
+    })),
+    "tmp"
+  )
+  # `remove()` is the same function under its other name, and a string names
+  # the binding as directly as a symbol does.
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- 1
+      remove("tmp")
+      tmp
+    })),
+    "tmp"
+  )
+  # A removal the walk cannot read empties the set rather than being ignored:
+  # `rm(list = v)` removes whatever that vector holds, and `rm(x, envir = e)`
+  # may remove nothing at all.
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- 1
+      rm(list = v)
+      tmp
+    })),
+    c("v", "tmp")
+  )
+  # A name it does not remove stays bound, so the removal costs nothing beside
+  # itself.
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- 1
+      rm(other)
+      tmp
+    })),
+    "other"
+  )
 })
 
 test_that("a binding is visible to the statements after it and no others", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -758,6 +758,227 @@ test_that("a bound name shadows a symbol and a `get()`, but not a pronoun", {
   )
 })
 
+test_that("`<-`, `for`, and `local()` bind names rather than reading them", {
+  # `<-` inside a summary expression assigns into the bottom of the data mask,
+  # `for` binds its index the same way, and `local()` evaluates in a child
+  # environment of it. The walk collected every symbol it passed, so each bound
+  # name was reported as a column read, and where one collided with a preceding
+  # share the guard rejected legal code naming a share the expression never
+  # reads (#162).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  from_assignment <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    derived = {
+      share <- 2
+      share
+    },
+    .grouping = rollup(region)
+  )
+  expect_identical(unique(from_assignment$derived), 2)
+
+  from_loop <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    derived = {
+      out <- 0
+      for (share in c(1, 2)) {
+        out <- out + share
+      }
+      out
+    },
+    .grouping = rollup(region)
+  )
+  expect_identical(unique(from_loop$derived), 3)
+
+  from_local <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    derived = local({
+      share <- 4
+      share
+    }),
+    .grouping = rollup(region)
+  )
+  expect_identical(unique(from_local$derived), 4)
+})
+
+test_that("a bound name does not hide a genuine read beside it", {
+  # The other half of #162: dropping a name because something binds it must
+  # not drop the reads that reach the mask in the same expression. Each of
+  # these really does read the share, and the guard still owes the caller a
+  # `marginplyr_error`.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  from_value <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = {
+        tmp <- share
+        tmp
+      },
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_value, "marginplyr_error")
+
+  from_loop_body <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = {
+        out <- 0
+        for (i in c(1, 2)) {
+          out <- out + share
+        }
+        out
+      },
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_loop_body, "marginplyr_error")
+
+  from_local_body <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = local({
+        x <- 1
+        x + share
+      }),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  )
+  expect_s3_class(from_local_body, "marginplyr_error")
+})
+
+test_that("a binding is visible to the statements after it and no others", {
+  # A `{` opens no scope, so the bound set has to grow along the block rather
+  # than be collected from it and applied to the whole. The two spellings below
+  # differ only in the order of their statements, and a walk that filtered the
+  # block with its bindings would answer both `"share"` -- reporting no read of
+  # the column `tmp` that the second one really does make (#162).
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <- share
+      tmp
+    })),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp + share
+      tmp <- 1
+    })),
+    c("tmp", "share")
+  )
+  # An assignment that is not a statement of the block may not run, so the name
+  # it would bind stays a read. That over-reports, which is the side of this
+  # walk whose errors are diagnostics rather than silence.
+  expect_identical(
+    expression_data_symbols(quote({
+      if (p) tmp <- 1
+      tmp
+    })),
+    c("p", "tmp")
+  )
+  # A nested block and a redundant parenthesis are the other side of that: they
+  # open no scope either, and unlike an `if` they always run, so the binding
+  # inside one reaches the statements after it. Reading them as opaque would
+  # reject `{ { tmp <- 1 }; tmp }` naming a share it never reads, which is the
+  # false positive this issue removes rather than one to leave standing. The
+  # nested block is parsed from text because writing it out is the one brace
+  # shape `brace_linter` refuses, and the shape is the whole point of the case.
+  expect_identical(
+    expression_data_symbols(str2lang("{ { tmp <- share }; tmp }")),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote({
+      (tmp <- share)
+      tmp
+    })),
+    "share"
+  )
+  # `<<-` assigns past the environment it runs in, so what it binds is not
+  # decidable here and its target is left reported for the same reason.
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp <<- 1
+      tmp
+    })),
+    "tmp"
+  )
+  # `=` is the same node under another spelling.
+  expect_identical(
+    expression_data_symbols(quote({
+      tmp = share
+      tmp
+    })),
+    "share"
+  )
+})
+
+test_that("a loop reads its sequence and binds its index past the loop", {
+  expect_identical(
+    expression_data_symbols(quote(for (i in v) i + share)),
+    c("v", "share")
+  )
+  # R binds the index in the enclosing environment, and binds it even when the
+  # sequence is empty, so nothing after the loop reads a column of that name.
+  expect_identical(
+    expression_data_symbols(quote({
+      for (i in v) NULL
+      i
+    })),
+    "v"
+  )
+})
+
+test_that("an assignment still reads its value and a replacement target", {
+  # The target of `x <- ...` is not a read, but everything else about the
+  # statement is: the value always, and a replacement form's target, which is
+  # read before it is rebuilt.
+  expect_identical(expression_data_symbols(quote(x <- x + 1)), "x")
+  expect_identical(
+    expression_data_symbols(quote(names(x) <- share)),
+    c("x", "share")
+  )
+  # The bound set reaches a symbol and a `get()` and stops at a pronoun, the
+  # same three-way split a formal makes (#130).
+  expect_identical(
+    expression_data_symbols(quote({
+      share <- 1
+      get("share")
+    })),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote({
+      share <- 1
+      .data$share
+    })),
+    "share"
+  )
+})
+
 test_that("an ordinary `$` field name is not a data-mask read", {
   # `cfg$share` reads a field of a list. The name after `$` is fixed text
   # rather than a lookup, so collecting it made the guard against reading an


### PR DESCRIPTION
Closes #162.

`expression_data_symbols()` collected every symbol it walked past, so a name a
binding construct other than `function` introduced was reported as a data-mask
read. Where such a name matched a preceding share, the guard against an
ordinary summary using an earlier share rejected legal code naming a share the
expression never reads.

## The rule

`<-` and `=` assign into the bottom of the data mask and `for` binds its index
the same way, so each is a new binding rather than a column read. `{` is where
one becomes visible to anything other than itself: it opens no scope, so a name
bound by one statement is bound for the statements after it and for nothing
before them. The walk therefore threads the bound set along the block rather
than collecting the block's bindings and filtering the whole block with them,
which would report no read of the column in `{ tmp + share; tmp <- 1 }`.

`local()` needs no case of its own. It binds nothing itself, and whichever
construct its argument is answers it.

`rm()` and its alias `remove()` are the one statement running the other way,
and the bound set has to shrink for them: after `{ tmp <- 1; rm(tmp); tmp }`
the last read reaches the column again. A removal written literally is
subtracted from the set; one the walk cannot read — `rm(list = names)`, or any
named argument — empties it instead, since ignoring it would hide the same
read.

## What over-reports, deliberately

Per #130's contract, an undecidable case resolves toward reporting a read, so
the error lands on the diagnostic side rather than the silent one:

- an assignment under an `if`, or in a loop body over a sequence that may be
  empty, since neither is certain to run;
- `<<-`, which assigns past the environment it runs in;
- a replacement target — `names(x) <- v` reads `x` before rebuilding it, and is
  not recorded as rebinding it.

A nested `{` and a redundant `(` are transparent instead, because neither opens
a scope and both always run — so both a binding and a removal inside one reach
the statements after it.

## Verification

The primary assertions are at the guard, per #130: summaries that must now run
and return their value, and summaries that read the share through one of these
constructs and must still raise a `marginplyr_error`. Walk-level tables sit
beneath them, covering statement order, the transparent wrappers, loop index
scope, replacement targets, the `get()`/pronoun split, and every direction the
`rm()` transition travels. Each `rm()` expectation was confirmed against R
first, by evaluating the block in a child of an environment holding the removed
names and reading which binding the final read reached.

No snapshot tests and no derived enumeration of shapes, both for the reasons
#130 records. No new test requires an optional backend.

`lintr::lint_package()` is clean and the full suite passes under `NOT_CRAN=true`.
No roxygen or vignette changes, so the `document` and `altdoc` gates are
untouched.

## Review

Reviewed on two axes before this PR. Standards found no hard violations; its
findings on naming, a duplicated dispatch, and two loose comment sentences are
applied in b28cd70. Spec found a genuine defect — the `rm()` silent
under-report — which is fixed in the same commit, and a missing guard assertion
for a binding statement reached outside a block, which is now covered. A bare
`for` has no guard assertion because it evaluates to `NULL`, so no summary can
be one; the comment at the site says so.

## Follow-up

#162 blocks #65, which refreshes `cran-comments.md` now that this adds tests.