### PR TITLE
Give back the node a walk descended into, not a rebuilt call

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -147,7 +147,7 @@ rewrite_grouping_expr <- function(expr,
 
   helper <- grouping_helper_name(expr)
   if (!is.null(helper)) {
-    args <- as.list(expr)[-1]
+    args <- static_call_args(expr)
     vars <- grouping_helper_vars(args, helper, plan)
 
     if (identical(helper, "grouping_bit")) {
@@ -174,7 +174,7 @@ rewrite_grouping_expr <- function(expr,
     sql = sql,
     con = con
   )
-  rebuild_call(expr, call_args)
+  rebuild_static_call(expr, call_args)
 }
 
 grouping_helper_name <- function(expr) {

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -166,16 +166,15 @@ rewrite_grouping_expr <- function(expr,
     return(as.integer(sum(bits * weights)))
   }
 
-  pieces <- as.list(expr)
-  pieces[-1] <- lapply(
-    pieces[-1],
+  call_args <- lapply(
+    static_call_args(expr),
     rewrite_grouping_expr,
     plan = plan,
     grouping_set = grouping_set,
     sql = sql,
     con = con
   )
-  as.call(pieces)
+  rebuild_call(expr, call_args)
 }
 
 grouping_helper_name <- function(expr) {

--- a/R/share.R
+++ b/R/share.R
@@ -991,7 +991,7 @@ wrap_dtplyr_share_across <- function(expr, checks, call) {
     fns <- call_args[[fns_index]]
     fns_is_list <- rlang::is_call(fns, "list")
     if (fns_is_list) {
-      functions <- as.list(fns)[-1L]
+      functions <- static_call_args(fns)
       function_names <- names(functions)
     } else {
       functions <- list(fns)
@@ -1080,7 +1080,7 @@ wrap_dtplyr_share_across <- function(expr, checks, call) {
   if (can_inline_forwarded && length(forwarded_positions) > 0L) {
     call_args <- call_args[-forwarded_positions]
   }
-  rebuild_call(expr, call_args)
+  rebuild_static_call(expr, call_args)
 }
 
 # The argument a dtplyr lambda binds to each column it is mapped over. Named
@@ -3041,7 +3041,7 @@ is_binding_statement <- function(call_name, expr) {
 # took this for one of those would pass a list to `intersect()`.
 block_reads_and_bound <- function(expr, bound) {
   reads <- character()
-  for (statement in as.list(expr)[-1L]) {
+  for (statement in static_call_args(expr)) {
     step <- statement_reads_and_bound(statement, bound)
     reads <- c(reads, step$reads)
     bound <- step$bound

--- a/R/share.R
+++ b/R/share.R
@@ -1080,7 +1080,7 @@ wrap_dtplyr_share_across <- function(expr, checks, call) {
   if (can_inline_forwarded && length(forwarded_positions) > 0L) {
     call_args <- call_args[-forwarded_positions]
   }
-  rlang::call2(expr[[1L]], !!!call_args)
+  rebuild_call(expr, call_args)
 }
 
 # The argument a dtplyr lambda binds to each column it is mapped over. Named
@@ -2592,7 +2592,7 @@ share_expression_kind <- function(expr) {
   if (!is.null(kind)) {
     return(kind)
   }
-  for (argument in as.list(expr)[-1L]) {
+  for (argument in static_call_args(expr)) {
     kind <- share_expression_kind(argument)
     if (!is.null(kind)) {
       return(kind)
@@ -2769,7 +2769,7 @@ contains_selection_predicate <- function(expr) {
     return(TRUE)
   }
   any(vapply(
-    as.list(expr)[-1L],
+    static_call_args(expr),
     contains_selection_predicate,
     logical(1)
   ))
@@ -2963,9 +2963,10 @@ expression_data_symbols <- function(expr, bound = character()) {
   # miss a genuine read of a summary named `.x`, and suppressing it only under
   # `across()` would make the walk depend on its own call position, which is
   # what left function definitions behaving differently in a head (#130).
-  parts <- as.list(expr)[-1L]
-  if (!rlang::is_symbol(expr[[1L]])) {
-    parts <- c(list(expr[[1L]]), parts)
+  call_head <- static_call_head(expr)
+  parts <- static_call_args(expr)
+  if (!rlang::is_symbol(call_head)) {
+    parts <- c(list(call_head), parts)
   }
   unique(unlist(
     lapply(parts, expression_data_symbols, bound = bound),

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -269,10 +269,12 @@ find_summary_context_helpers <- function(expr) {
     character()
   }
 
-  pieces <- as.list(expr)[-1L]
   c(
     found,
-    unlist(lapply(pieces, find_summary_context_helpers), use.names = FALSE)
+    unlist(
+      lapply(static_call_args(expr), find_summary_context_helpers),
+      use.names = FALSE
+    )
   )
 }
 
@@ -318,16 +320,22 @@ rewrite_summary_selections <- function(expr,
     return(expr)
   }
 
-  call_args <- as.list(expr)[-1L]
+  # An injected quosure carries an environment of its own, and that is what
+  # injecting one is for, so a selection inside it resolves there rather than
+  # in the environment of the dot that contains it. Reading the outer one would
+  # look up a name the caller never put in it.
+  if (rlang::is_quosure(expr)) {
+    env <- rlang::quo_get_env(expr)
+  }
+
   call_args <- lapply(
-    call_args,
+    static_call_args(expr),
     rewrite_summary_selections,
     env = env,
     data_proxy = data_proxy,
     normalize_across_names = normalize_across_names
   )
-  names(call_args) <- names(as.list(expr)[-1L])
-  expr <- rlang::call2(expr[[1L]], !!!call_args)
+  expr <- rebuild_call(expr, call_args)
 
   call_name <- static_call_name(expr)
   call_ns <- static_call_ns(expr)
@@ -387,7 +395,7 @@ rewrite_across_selection <- function(expr,
   }
 
   if (identical(call_name, "across") && normalize_across_names) {
-    parsed <- parse_across_arguments(rlang::call2(expr[[1L]], !!!call_args))
+    parsed <- parse_across_arguments(rebuild_call(expr, call_args))
     names_index <- parsed$names_index
     unpack_index <- parsed$unpack_index
     unpack_is_false <- unpack_index == 0L || isFALSE(tryCatch(
@@ -423,7 +431,7 @@ rewrite_across_selection <- function(expr,
   }
 
   if (identical(call_name, "across")) {
-    parsed <- parse_across_arguments(rlang::call2(expr[[1L]], !!!call_args))
+    parsed <- parse_across_arguments(rebuild_call(expr, call_args))
     if (parsed$names_index > 0L) {
       call_args[[parsed$names_index]] <- rlang::eval_tidy(
         call_args[[parsed$names_index]],
@@ -432,7 +440,7 @@ rewrite_across_selection <- function(expr,
     }
   }
 
-  rlang::call2(expr[[1L]], !!!call_args)
+  rebuild_call(expr, call_args)
 }
 
 rewrite_pick_selection <- function(expr, env, data_proxy) {
@@ -448,10 +456,7 @@ rewrite_pick_selection <- function(expr, env, data_proxy) {
     data_proxy = data_proxy
   )
 
-  rlang::call2(
-    expr[[1L]],
-    summary_all_of_expr(selected, data_proxy)
-  )
+  rebuild_call(expr, list(summary_all_of_expr(selected, data_proxy)))
 }
 
 resolve_summary_selection <- function(expr, env, data_proxy) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -335,7 +335,7 @@ rewrite_summary_selections <- function(expr,
     data_proxy = data_proxy,
     normalize_across_names = normalize_across_names
   )
-  expr <- rebuild_call(expr, call_args)
+  expr <- rebuild_static_call(expr, call_args)
 
   call_name <- static_call_name(expr)
   call_ns <- static_call_ns(expr)
@@ -395,7 +395,7 @@ rewrite_across_selection <- function(expr,
   }
 
   if (identical(call_name, "across") && normalize_across_names) {
-    parsed <- parse_across_arguments(rebuild_call(expr, call_args))
+    parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
     names_index <- parsed$names_index
     unpack_index <- parsed$unpack_index
     unpack_is_false <- unpack_index == 0L || isFALSE(tryCatch(
@@ -431,7 +431,7 @@ rewrite_across_selection <- function(expr,
   }
 
   if (identical(call_name, "across")) {
-    parsed <- parse_across_arguments(rebuild_call(expr, call_args))
+    parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
     if (parsed$names_index > 0L) {
       call_args[[parsed$names_index]] <- rlang::eval_tidy(
         call_args[[parsed$names_index]],
@@ -440,11 +440,11 @@ rewrite_across_selection <- function(expr,
     }
   }
 
-  rebuild_call(expr, call_args)
+  rebuild_static_call(expr, call_args)
 }
 
 rewrite_pick_selection <- function(expr, env, data_proxy) {
-  call_args <- as.list(expr)[-1L]
+  call_args <- static_call_args(expr)
   selection <- if (length(call_args) == 0L) {
     rlang::expr(dplyr::everything())
   } else {
@@ -456,7 +456,7 @@ rewrite_pick_selection <- function(expr, env, data_proxy) {
     data_proxy = data_proxy
   )
 
-  rebuild_call(expr, list(summary_all_of_expr(selected, data_proxy)))
+  rebuild_static_call(expr, list(summary_all_of_expr(selected, data_proxy)))
 }
 
 resolve_summary_selection <- function(expr, env, data_proxy) {
@@ -509,7 +509,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     identical(call_name, "data.frame") &&
     (is.null(call_ns) || identical(call_ns, "base"))
   if (is_tibble_constructor || is_data_frame_constructor) {
-    call_args <- as.list(expr)[-1L]
+    call_args <- static_call_args(expr)
     arg_names <- names(call_args)
     if (is.null(arg_names)) {
       arg_names <- rep("", length(call_args))
@@ -529,7 +529,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     identical(call_name, "pick") &&
       (is.null(call_ns) || identical(call_ns, "dplyr"))
   ) {
-    call_args <- as.list(expr)[-1L]
+    call_args <- static_call_args(expr)
     selection <- if (length(call_args) == 0L) {
       rlang::expr(dplyr::everything())
     } else {
@@ -670,7 +670,7 @@ known_across_function_names <- function(parsed) {
   if (!rlang::is_call(fns_expr, "list")) {
     return("1")
   }
-  fns <- as.list(fns_expr)[-1L]
+  fns <- static_call_args(fns_expr)
   fns_names <- names(fns)
   if (is.null(fns_names)) {
     fns_names <- rep("", length(fns))

--- a/R/utils.R
+++ b/R/utils.R
@@ -164,6 +164,56 @@ is_nameable_call <- function(expr) {
   rlang::is_call(expr) && !rlang::is_call(expr, "~")
 }
 
+# The head and the arguments of a call a walk descends into, and the node
+# rebuilt around rewritten arguments. `static_call_name()` above answers what a
+# walk asks of a node it does not descend into; these three are what it asks of
+# one it does.
+#
+# All three exist for the same node the name read exists for. A quosure is a
+# call to `~`, so a walk descends into it, and the spellings a walk reaches for
+# -- `expr[[1L]]`, `as.list(expr)[-1L]` -- are the two rlang soft-deprecated on
+# a quosure in 0.4.0. Walking one therefore signals a lifecycle condition into
+# whatever handler the caller has installed, which is the class of signal
+# `margin_column_pronoun()` above exists to avoid producing. `as.list()` is the
+# subtler half: it keeps the quosure's class on the list it returns, so it is
+# the `[-1L]` after it that dispatches to rlang's deprecated method (#165).
+#
+# The rebuild is the half that changed an answer rather than only a signal.
+# `rlang::call2()` and `as.call()` build a plain call, so the environment and
+# the class a quosure carries were dropped and dplyr was handed a one-sided
+# formula where the caller injected a quosure: `sum(!!rlang::quo(dplyr::n()))`
+# reached the summary as `sum(~dplyr::n())` and `sum()` was given a language
+# object. A formula object a caller injects loses the same two attributes, and
+# nothing tests for it -- `rlang::is_formula()` reads the call's shape rather
+# than its class -- so a lambda came out resolving against whatever mask it
+# landed in rather than where it was written. Carrying the attributes across
+# covers both, and covers a plain call for free, which has none.
+#
+# A `~` written in source is untouched by any of this: the verb captures it
+# unevaluated, so the node is a bare call with no attributes to lose. The
+# exposure is injection, for a quosure and a formula alike.
+static_call_head <- function(expr) {
+  if (rlang::is_quosure(expr)) {
+    return(quote(`~`))
+  }
+  expr[[1L]]
+}
+
+static_call_args <- function(expr) {
+  if (rlang::is_quosure(expr)) {
+    return(list(rlang::quo_get_expr(expr)))
+  }
+  as.list(expr)[-1L]
+}
+
+rebuild_call <- function(expr, args) {
+  rebuilt <- rlang::call2(static_call_head(expr), !!!args)
+  # Argument names live in the call's own pairlist tags rather than in an
+  # attribute, so this replaces nothing `call2()` just set.
+  attributes(rebuilt) <- attributes(expr)
+  rebuilt
+}
+
 # Required because dtplyr is an optional Suggest rather than an Import: it
 # brings data.table, which reads this flag from the calling namespace.
 # data.table fixes the spelling of this name, so it cannot follow the package's

--- a/R/utils.R
+++ b/R/utils.R
@@ -192,6 +192,14 @@ is_nameable_call <- function(expr) {
 # A `~` written in source is untouched by any of this: the verb captures it
 # unevaluated, so the node is a bare call with no attributes to lose. The
 # exposure is injection, for a quosure and a formula alike.
+#
+# Every site reading a node's parts goes through these, including the many a
+# name match has already told cannot hold a quosure -- a `list()` of `.fns`, a
+# `{` block, a `pick()` call. Those sites are safe as they stand, and routing
+# them here anyway is what makes the rule checkable rather than remembered:
+# neither deprecated spelling survives anywhere in `R/` outside this block, so
+# a walk written the old way is one grep away rather than a signal nobody sees
+# until a caller installs a handler.
 static_call_head <- function(expr) {
   if (rlang::is_quosure(expr)) {
     return(quote(`~`))
@@ -206,7 +214,15 @@ static_call_args <- function(expr) {
   as.list(expr)[-1L]
 }
 
-rebuild_call <- function(expr, args) {
+rebuild_static_call <- function(expr, args) {
+  # An invariant, not a Package condition (ADR-0015): a quosure carries exactly
+  # one expression, so rebuilding one around any other number of arguments
+  # would attach its class to a `~` call that is not a quosure at all -- an
+  # object rlang's own accessors would then misread. No rewrite of a public
+  # call reaches this: the two walks that hand a quosure here map the
+  # arguments `static_call_args()` gave them one to one, and the ones that
+  # change an argument count are named `across()` and `pick()` calls.
+  stopifnot(!rlang::is_quosure(expr) || length(args) == 1L)
   rebuilt <- rlang::call2(static_call_head(expr), !!!args)
   # Argument names live in the call's own pairlist tags rather than in an
   # attribute, so this replaces nothing `call2()` just set.

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -432,26 +432,28 @@ test_that("a selection inside a quosure resolves in the quosure's own env", {
   expect_identical(result$rows, c(2L, 1L, 3L))
 })
 
+# Runs `code` with rlang's soft deprecations raised as errors, restoring
+# whatever the checking environment had before. Written with `on.exit()` rather
+# than withr so the tests add no dependency beyond the ones DESCRIPTION
+# declares, as `with_required_suggests()` in `test-optional-backends.R` is, and
+# at file level so the next test asserting a signal-free walk reaches it.
+with_deprecation_errors <- function(code) {
+  previous <- options(lifecycle_verbosity = "error")
+  on.exit(options(previous), add = TRUE)
+  force(code)
+}
+
 test_that("no walk subsets a quosure", {
   # rlang soft-deprecated `[` and `[[` on a quosure, so a walk spelling its
   # reads that way signals a lifecycle condition into whatever handler the
   # caller has installed -- the class of signal `margin_column_pronoun()`
-  # exists to avoid producing. The verbosity option turns the soft deprecation
-  # into an error, because the warning itself is shown only once every eight
-  # hours and would otherwise pass unnoticed here.
+  # exists to avoid producing. Raising the soft deprecation is what makes the
+  # assertion hold: the warning itself is shown only once every eight hours,
+  # so a test reading for one would pass on a walk that still subsets.
   data <- data.frame(
     region = c("East", "East", "West"),
     value = c(1, 3, 6)
   )
-
-  # Written with `on.exit()` rather than withr so the tests add no dependency
-  # beyond the ones DESCRIPTION declares, as `with_required_suggests()` in
-  # `test-optional-backends.R` is.
-  with_deprecation_errors <- function(code) {
-    previous <- options(lifecycle_verbosity = "error")
-    on.exit(options(previous), add = TRUE)
-    force(code)
-  }
 
   # Each walk in turn: the share analysis that reads a summary for an earlier
   # share, the two rewrites, and the context-helper search.

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -327,22 +327,160 @@ test_that("a read inside an injected quosure is still reached", {
     value = c(1, 3, 6)
   )
 
-  # The walks subset the quosure node they descend into -- `expr[[1L]]`,
-  # `as.list(expr)[-1L]` -- and rlang soft-deprecated both spellings on a
-  # quosure, so walking one signals a lifecycle condition into whatever handler
-  # the caller has installed. That is #165, not this: the suppression comes out
-  # when the walks read a quosure with `rlang::quo_get_expr()` instead.
   error <- expect_error(
-    suppressWarnings(summarize_with_margins(
+    summarize_with_margins(
       data,
       units = sum(value),
       share = share_of_total(units),
       derived = sum(!!rlang::quo(share)),
       .grouping = rollup(region)
-    )),
+    ),
     "`share`"
   )
   expect_s3_class(error, "marginplyr_error")
+})
+
+test_that("a rewritten expression gives back the quosure it walked into", {
+  # Every walk that rewrites a node rebuilds it, and `rlang::call2()` and
+  # `as.call()` build a plain call. A quosure is a call to `~` carrying an
+  # environment and a class, so a walk that descended into one handed dplyr a
+  # one-sided formula in its place and the summary was given a language object
+  # instead of the value the caller injected (#165).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # `rewrite_summary_selections()` is the walk that flattened this one. The
+  # quosure carries no selection to rewrite, so what it must give back is the
+  # node it was handed.
+  counted <- summarize_with_margins(
+    data,
+    units = sum(!!rlang::quo(dplyr::n())),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(counted$units, c(2L, 1L, 3L))
+
+  # `rewrite_grouping_expr()` is the second walk, and it substitutes a constant
+  # into the quosure rather than leaving it untouched, so this asserts the
+  # rebuild rather than a walk that happened to change nothing. On `main` the
+  # flattening reached the caller as `sum(~0L)` (#165), and before #163 as a
+  # `grouping_id()` diagnostic naming a fault the caller did not have.
+  identified <- summarize_with_margins(
+    data,
+    units = sum(value),
+    level = sum(!!rlang::quo(grouping_id(region))),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(identified$level, c(0L, 0L, 1L))
+})
+
+test_that("a rewritten expression gives back the formula object it walked", {
+  # A formula object is a call to `~` carrying attributes exactly as a quosure
+  # is, so the same rebuild drops its class and its `.Environment`. Nothing
+  # written in source is exposed -- a `~` typed inside a summary expression is
+  # a bare call with no attributes at rewrite time -- so the shape is an
+  # injected formula the caller holds.
+  #
+  # `rlang::is_formula()` still answers `TRUE` for the flattened node, because
+  # it tests the call's shape. The loss shows only where the class is used, and
+  # `~` is one such place: R returns a classed call unevaluated and rebuilds an
+  # unclassed one against whatever environment it is evaluated in, so a
+  # flattened lambda resolves in the data mask rather than where it was
+  # written.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  written_in <- rlang::env(offset = 100)
+  lambda <- rlang::new_formula(NULL, quote(.x + offset), env = written_in)
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(value),
+    kept = identical(attr(!!lambda, ".Environment"), !!written_in),
+    applied = rlang::as_function(!!lambda)(units),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_true(all(result$kept))
+  expect_identical(result$applied, result$units + 100)
+})
+
+test_that("a selection inside a quosure resolves in the quosure's own env", {
+  # The rewrite evaluates a selection in the environment of the dot it is
+  # walking. A quosure carries an environment of its own, and that is the point
+  # of injecting one, so a selection inside it resolves there instead. Reading
+  # the outer environment would look up a name the caller never put in it.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  held <- local({
+    selected <- "value"
+    rlang::quo(dplyr::pick(dplyr::all_of(selected)))
+  })
+
+  result <- summarize_with_margins(
+    data,
+    rows = nrow(!!held),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(result$rows, c(2L, 1L, 3L))
+})
+
+test_that("no walk subsets a quosure", {
+  # rlang soft-deprecated `[` and `[[` on a quosure, so a walk spelling its
+  # reads that way signals a lifecycle condition into whatever handler the
+  # caller has installed -- the class of signal `margin_column_pronoun()`
+  # exists to avoid producing. The verbosity option turns the soft deprecation
+  # into an error, because the warning itself is shown only once every eight
+  # hours and would otherwise pass unnoticed here.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # Written with `on.exit()` rather than withr so the tests add no dependency
+  # beyond the ones DESCRIPTION declares, as `with_required_suggests()` in
+  # `test-optional-backends.R` is.
+  with_deprecation_errors <- function(code) {
+    previous <- options(lifecycle_verbosity = "error")
+    on.exit(options(previous), add = TRUE)
+    force(code)
+  }
+
+  # Each walk in turn: the share analysis that reads a summary for an earlier
+  # share, the two rewrites, and the context-helper search.
+  with_deprecation_errors(expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = sum(!!rlang::quo(share)),
+      .grouping = rollup(region)
+    ),
+    "`share`"
+  ))
+  with_deprecation_errors(expect_no_error(
+    summarize_with_margins(
+      data,
+      units = sum(!!rlang::quo(dplyr::n())),
+      level = sum(!!rlang::quo(grouping_id(region))),
+      .grouping = rollup(region)
+    )
+  ))
+  with_deprecation_errors(expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(!!rlang::quo(dplyr::cur_group_id())),
+      .grouping = rollup(region)
+    ),
+    "does not support"
+  ))
 })
 
 test_that("every analysis that names a call reads a formula as a `~` call", {


### PR DESCRIPTION
Closes #165.

Every walk that rewrites a summary expression rebuilt each node it visited with `rlang::call2()` or `as.call()`. A quosure and a formula object are both calls to `~` carrying a `class` and a `.Environment`, so a walk that descended into one handed back a plain one-sided formula in its place — the environment that is the whole point of the object, dropped in silence.

`static_call_head()`, `static_call_args()`, and `rebuild_static_call()` in `R/utils.R` now hold that rule once, beside the `static_call_name()` pair #163 put there. A node's parts are read without subsetting it, and a rebuilt node carries what the original carried.

## Two symptoms, one rebuild

Measured on `main` (`b178763`):

| shape | before | after |
|---|---|---|
| `sum(!!rlang::quo(dplyr::n()))` | `sum()` given a language object — the argument dplyr quotes back is `sum(~dplyr::n())`, which the caller never wrote | counts |
| `sum(!!rlang::quo(grouping_id(region)))` | `sum(~0L)`, same failure | the Grouping identifier |
| an injected formula object | `class` and `.Environment` dropped; **no error at all** | intact |
| any walk over a quosure | `Subsetting quosures with `[` is deprecated` into the caller's handler | no signal |

The formula row is the one worth pausing on, because it is the half that raises nothing. `rlang::is_formula()` still answers `TRUE` for the flattened node — it tests the call's shape, not its class — so the loss is invisible to the usual predicate. It shows where the class is used, and `~` is itself such a place: R returns a *classed* `~` call unevaluated and rebuilds an unclassed one against whatever environment it is evaluated in. A flattened lambda therefore resolves in the data mask rather than where it was written, which is a wrong answer rather than a refused call.

## The open question, answered

#165 asks whether the carried expression should be rewritten at all — "the environment is the point of a quosure, and rewriting a selection inside one may be wrong rather than merely unimplemented."

It is rewritten, **in the quosure's own environment**. `rewrite_summary_selections()` already threads an `env` for resolving selections; descending into a quosure now switches it to `rlang::quo_get_env()`. That is what injecting a quosure means, and the alternative would have split the rewrite walks from the analysis walks, which have descended into quosures since #163. A test holds it by construction — the name the selection needs exists only in the quosure's environment, so reading the outer one fails:

```r
held <- local({
  selected <- "value"
  rlang::quo(dplyr::pick(dplyr::all_of(selected)))
})
summarize_with_margins(d, rows = nrow(!!held), .grouping = rollup(region))
```

## Neither deprecated spelling survives

`as.list(expr)[-1L]` and `expr[[1L]]` now appear nowhere in `R/` outside the block defining the helpers — including at the many sites a name match had already proved cannot hold a quosure (a `list()` of `.fns`, a `{` block, a `pick()` call). Those were safe as they stood; routing them here anyway is what makes the rule checkable by grep rather than remembered by each walk. `rebuild_static_call()` also asserts the invariant it had been trusting its callers to keep: a quosure carries exactly one expression, and attaching its class to a `~` call holding any other number builds an object rlang's own accessors misread (an internal invariant, ADR-0015).

`as.list()` is the subtler half of the deprecation and is recorded as such: it keeps the quosure's class on the list it returns, so it is the `[-1L]` *after* it that dispatches to rlang's deprecated method.

## Asserting a signal that is shown once every eight hours

The lifecycle warning is throttled, so a test reading for one would pass against a walk that still subsets. `with_deprecation_errors()` raises rlang's soft deprecations instead, written with `on.exit()` rather than withr so the tests add no dependency beyond what DESCRIPTION declares — the precedent is `with_required_suggests()` in `test-optional-backends.R`.

## Not fixed here

Two adjacent defects surfaced during review. Both reproduce unchanged on `main`, and neither is this ticket:

- **#168** — `share_expression_kind()` binds an empty argument to a `for` variable, so `sum(pick(value)[, "col"])`, `sum(value[])`, and `sum(value, )` all abort with an untyped `argument "argument" is missing`. dplyr accepts all three. Wider and arguably more severe than #165; filed `ready-for-agent` with the single site identified.
- **#169** — the four helpers taking bare column names reject an injected quosure, so the standard `enquo()` wrapper fails with a message describing a mistake the caller did not make. Filed `needs-triage`: which injected forms to accept is one decision across all four, not a mechanical unwrap.

## Verification

- `testthat::test_local()` — 425 tests, 0 failures, 0 warnings
- `lintr::lint_package()` — 0 lints
- `R CMD check` on the **built tarball** (`--ignore-vignettes`) — Status: OK
- `.github/scripts/verify-suite-coverage.R` — all 425 execute in ≥1 backend configuration, 0 orphaned

The four new tests need no optional backend, so `AGENTS.md`'s one-backend-per-test policy holds by construction; they add no `skip_if()` and no snapshot, so `verify-backend.R` is unaffected. Each was confirmed red before the fix. No roxygen changed, so `man/` and `NAMESPACE` are untouched.

## Reviews applied

A two-axis review (Standards + Spec) ran against `fe95bfd`. Spec found nothing missing. Every Standards finding is fixed in `cfc048c` — the incomplete conversion of the remaining read sites, `rebuild_call()` renamed so the four-function family is one grep, the missing internal invariant, and the test helper moved to file level.