### PR TITLE
Reach a call's parts by subscript, so an empty argument falls through

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2592,11 +2592,9 @@ share_expression_kind <- function(expr) {
   if (!is.null(kind)) {
     return(kind)
   }
-  # By subscript rather than over the arguments themselves, for the reason
-  # `static_call_args()` gives: an empty argument bound to a loop variable
-  # raises on the first read of it. An empty argument holds no share helper, so
-  # it answers `NULL` like any other unrecognized shape and the walk carries on
-  # to the arguments after it.
+  # By subscript for the reason `static_call_args()` gives. An empty argument
+  # holds no share helper, so it answers `NULL` like any other unrecognized
+  # shape and the walk carries on to the arguments after it.
   arguments <- static_call_args(expr)
   for (index in seq_along(arguments)) {
     kind <- share_expression_kind(arguments[[index]])

--- a/R/share.R
+++ b/R/share.R
@@ -2592,8 +2592,14 @@ share_expression_kind <- function(expr) {
   if (!is.null(kind)) {
     return(kind)
   }
-  for (argument in static_call_args(expr)) {
-    kind <- share_expression_kind(argument)
+  # By subscript rather than over the arguments themselves, for the reason
+  # `static_call_args()` gives: an empty argument bound to a loop variable
+  # raises on the first read of it. An empty argument holds no share helper, so
+  # it answers `NULL` like any other unrecognized shape and the walk carries on
+  # to the arguments after it.
+  arguments <- static_call_args(expr)
+  for (index in seq_along(arguments)) {
+    kind <- share_expression_kind(arguments[[index]])
     if (!is.null(kind)) {
       return(kind)
     }
@@ -3041,8 +3047,12 @@ is_binding_statement <- function(call_name, expr) {
 # took this for one of those would pass a list to `intersect()`.
 block_reads_and_bound <- function(expr, bound) {
   reads <- character()
-  for (statement in static_call_args(expr)) {
-    step <- statement_reads_and_bound(statement, bound)
+  # By subscript for the reason `static_call_args()` gives. A `{` block cannot
+  # hold an empty statement -- the parser produces none -- so this is written
+  # the way the rule asks rather than to repair anything reachable here.
+  statements <- static_call_args(expr)
+  for (index in seq_along(statements)) {
+    step <- statement_reads_and_bound(statements[[index]], bound)
     reads <- c(reads, step$reads)
     bound <- step$bound
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -207,6 +207,15 @@ static_call_head <- function(expr) {
   expr[[1L]]
 }
 
+# An element of what this returns can be R's empty argument, so a caller reads
+# the parts by subscript -- `lapply()`, `vapply()`, or `parts[[i]]` under a
+# `seq_along()` loop -- and never as `for (part in static_call_args(expr))`.
+# All three of the first form pass the empty symbol as a value, which forces
+# without error; `for` binds the missing marker to a variable instead, and the
+# first read of that variable raises base R's untyped `missingArgError` naming
+# the loop variable rather than anything the caller wrote (#168). This is not a
+# contrived shape: every empty-index spelling has one, and `x[, "col"]` is
+# everyday R that `dplyr::summarise()` accepts.
 static_call_args <- function(expr) {
   if (rlang::is_quosure(expr)) {
     return(list(rlang::quo_get_expr(expr)))

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -1633,6 +1633,103 @@ test_that("`across()` argument numbering holds without a mix of names", {
   expect_match(conditionMessage(all_named), "`na.rm`.", fixed = TRUE)
 })
 
+test_that("an empty argument in a summary expression evaluates, not aborts", {
+  # Every empty-index spelling carries R's missing marker as an argument, and
+  # `x[, "col"]` is everyday R rather than a contrived shape, so these are
+  # written as the four spellings a caller writes rather than as a synthetic
+  # `rlang::missing_arg()` (#168). An empty argument holds no share helper and
+  # nothing else the analysis recognizes, so ADR-0015 asks each to fall through
+  # and evaluate exactly as `dplyr::summarise()` evaluates it.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    subset = sum(value[]),
+    picked = sum(dplyr::pick(value)[, "value"]),
+    row = sum(matrix(value, nrow = 1)[1, ]),
+    trailing = mean(value, ),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expected <- data |>
+    dplyr::group_by(region) |>
+    dplyr::summarise(
+      subset = sum(value[]),
+      picked = sum(dplyr::pick(value)[, "value"]),
+      row = sum(matrix(value, nrow = 1)[1, ]),
+      trailing = mean(value, ),
+      .groups = "drop"
+    )
+
+  expect_equal(
+    dplyr::arrange(result[!is.na(result$region), ], region),
+    as.data.frame(expected),
+    ignore_attr = "row.names"
+  )
+})
+
+test_that("a function rejecting an empty argument raises the caller's error", {
+  # `sum(value, )` is the fourth spelling from #168, and it is the one whose
+  # empty argument the called function itself refuses -- `mean()` accepts a
+  # trailing empty argument and `sum()` does not. Falling through is still the
+  # right answer: nothing is wrong with the analysis, so the call evaluates and
+  # the condition `dplyr::summarise()` produces for the same expression is the
+  # one that reaches the caller.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  baseline <- expect_error(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(trailing = sum(value, ), .groups = "drop")
+  )
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      trailing = sum(value, ),
+      .grouping = rollup(region)
+    )
+  )
+
+  expect_identical(class(error), class(baseline))
+  expect_identical(class(error$parent), class(baseline$parent))
+  expect_match(
+    conditionMessage(error$parent),
+    "argument 2 is empty",
+    fixed = TRUE
+  )
+  expect_false(inherits(error, "marginplyr_error"))
+})
+
+test_that("an empty argument does not hide a share helper beside it", {
+  # Answering `NULL` for the empty argument is a fall-through, not a stop: the
+  # walk has to carry on to the arguments after it, or a share helper written
+  # beside an empty index would reach the backend as an ordinary summary
+  # instead of the diagnostic that names it.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      derived = sum(c(total[], share_of_total(total))),
+      .grouping = rollup(region)
+    ),
+    "`share_of_total()`",
+    fixed = TRUE
+  )
+  expect_s3_class(error, "marginplyr_error")
+})
+
 test_that("no analysed shape reaches the caller as an untyped condition", {
   # The classes below are what each site raised before #100. Asserting their
   # absence together keeps a future rewrite that reintroduces one of them from

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -1731,9 +1731,9 @@ test_that("an empty argument does not hide a share helper beside it", {
 })
 
 test_that("no analysed shape reaches the caller as an untyped condition", {
-  # The classes below are what each site raised before #100. Asserting their
-  # absence together keeps a future rewrite that reintroduces one of them from
-  # passing on the message alone.
+  # The classes below are what each site raised before #100, and before #168 in
+  # `missingArgError`'s case. Asserting their absence together keeps a future
+  # rewrite that reintroduces one of them from passing on the message alone.
   data <- data.frame(
     region = c("East", "East", "West"),
     units = c(1, 3, 6)
@@ -1764,13 +1764,23 @@ test_that("no analysed shape reaches the caller as an untyped condition", {
         .grouping = rollup(region)
       ),
       error = function(cnd) cnd
+    ),
+    empty_argument = tryCatch(
+      summarize_with_margins(
+        data,
+        total = sum(units[]),
+        .grouping = rollup(region)
+      ),
+      error = function(cnd) cnd
     )
   )
 
   expect_s3_class(errors$call_head, "data.frame")
+  expect_s3_class(errors$empty_argument, "data.frame")
   for (error in errors[c("missing_get_name", "across_names")]) {
     expect_s3_class(error, "condition")
     expect_false(inherits(error, "simpleError"))
     expect_false(inherits(error, "subscriptOutOfBoundsError"))
+    expect_false(inherits(error, "missingArgError"))
   }
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -89,6 +89,104 @@ test_that("shared argument assertions use the package condition seam", {
   expect_s3_class(nest_error, "marginplyr_error")
 })
 
+# The rule `static_call_args()` states: its elements can be R's empty argument,
+# so a walk reads them by subscript and never binds one with `for`. #168 is what
+# happens when a walk forgets -- an untyped `missingArgError` naming the loop
+# variable, from a summary expression as ordinary as `sum(value[])`.
+#
+# Scanned rather than listed, for the reason every other gate here derives: a
+# list of walks is a list the next walk is not on. It reads the namespace rather
+# than `R/`, so it holds under `R CMD check` too, where the sources sit beside
+# the `.Rcheck` directory rather than inside it -- and so it needs no
+# `skip_if()` that `verify-backend.R` would then read as a job skipping for a
+# reason other than a withheld backend.
+package_functions <- function() {
+  namespace <- asNamespace("marginplyr")
+  names <- ls(namespace, all.names = TRUE)
+  objects <- lapply(names, get, envir = namespace)
+  keep <- vapply(objects, is.function, logical(1))
+  stats::setNames(objects[keep], names[keep])
+}
+
+# By subscript throughout, since the code being scanned is exactly the code that
+# may hold an empty argument.
+binds_call_parts_with_for <- function(expr) {
+  if (!is.call(expr)) {
+    return(FALSE)
+  }
+  sequence <- if (identical(expr[[1L]], quote(`for`)) && length(expr) >= 3L) {
+    expr[[3L]]
+  }
+  if (
+    is.call(sequence) && identical(sequence[[1L]], quote(static_call_args))
+  ) {
+    return(TRUE)
+  }
+  for (index in seq_along(expr)) {
+    if (binds_call_parts_with_for(expr[[index]])) {
+      return(TRUE)
+    }
+  }
+  FALSE
+}
+
+test_that("no walk binds a call's parts with `for`", {
+  functions <- package_functions()
+  # The scan iterates over this set, so a set that arrived empty is a set that
+  # passes. `static_call_args()` itself is the cheapest witness that the
+  # namespace was read.
+  expect_true("static_call_args" %in% names(functions))
+
+  offenders <- vapply(
+    functions,
+    function(f) binds_call_parts_with_for(body(f)),
+    logical(1)
+  )
+
+  # Named rather than counted, so the failure says which walk to rewrite.
+  expect_equal(
+    names(functions)[offenders],
+    character(),
+    info = paste(
+      "Read the parts by subscript instead --",
+      "`parts <- static_call_args(expr)`, then `parts[[index]]`."
+    )
+  )
+})
+
+test_that("the walk scan detects the shape it is written to forbid", {
+  # Asserted before the scan's verdict means anything, for the reason
+  # `verify-suite-coverage.R` asserts its own mechanism: a scan that stopped
+  # matching reports exactly what a clean package reports.
+  offending <- function(expr) {
+    for (part in static_call_args(expr)) {
+      part
+    }
+  }
+  nested <- function(expr) {
+    if (TRUE) {
+      lapply(seq_len(2L), function(i) {
+        for (part in static_call_args(expr)) {
+          part
+        }
+      })
+    }
+  }
+  compliant <- function(expr) {
+    parts <- static_call_args(expr)
+    for (index in seq_along(parts)) {
+      parts[[index]]
+    }
+  }
+
+  expect_true(binds_call_parts_with_for(body(offending)))
+  expect_true(binds_call_parts_with_for(body(nested)))
+  expect_false(binds_call_parts_with_for(body(compliant)))
+  # An empty argument in the scanned code must not abort the scan, which is the
+  # bug one level up.
+  expect_false(binds_call_parts_with_for(quote(sum(value[]))))
+})
+
 test_that("lazy-table assertions use the package condition seam", {
   skip_if_backend_absent("arrow")
 


### PR DESCRIPTION
Closes #168.

## The bug

`share_expression_kind()` (`R/share.R`) read a node's arguments with
`for (argument in static_call_args(expr))`. R's empty argument is the missing
marker, so binding one to a loop variable and then reading it raises base R's
`missingArgError` — untyped as far as ADR-0015 is concerned, and quoting the
walk's own loop variable rather than anything the caller wrote. Any summary
expression holding an empty argument therefore aborted inside the analysis,
before the expression was ever staged:

```r
summarize_with_margins(d, u = sum(value[]), .grouping = rollup(region))
#> Error: argument "argument" is missing, with no default
```

`x[, "col"]` is everyday R that `dplyr::summarise()` accepts, so the reachable
surface was wide. The five other walks over the same expression were unaffected
because they reach their parts through `lapply()`/`vapply()`, which pass the
empty symbol as a *value* — that forces without error, where `for` binds it as
a variable and does not.

## The semantic decision, confirmed against ADR-0015

The ticket asked for this to be decided rather than inferred from the existing
implementation. Confirmed in
[#168 (comment)](https://github.com/sayuks/marginplyr/issues/168#issuecomment-5245336271):

An empty argument is not a shape the analysis recognizes and cannot hold a
share helper, so it falls through and evaluates — the walk answers `NULL` for
it. The alternative reading, a typed diagnostic for an empty argument inside a
share expression, is rejected: the caller cannot be asked to rewrite valid
code, so no Package condition is owed. `NULL` means fall through, not stop:
the walk carries on to the arguments after the empty one, or a share helper
written beside an empty index would reach the backend as an ordinary summary
instead of the diagnostic that names it.

Where the called function itself refuses the empty argument — `sum(value, )`,
which `mean(value, )` accepts — falling through is still the answer, and the
caller sees the condition `summarise()` produces for the same expression with
its own class intact.

## What each change is

**The fix** — `share_expression_kind()` reads its arguments by subscript. This
is the behavioural change, and the only one.

**Behaviour-neutral consistency** — `block_reads_and_bound()` is the one other
`for` over `static_call_args()`, and it cannot reach an empty argument: it
walks the statements of a `{` block, and the parser produces no empty
statement. It is rewritten to match the rule below, not to repair anything
reachable.

**Structural guard** — the rule is stated on `static_call_args()` itself, since
it is a property of what that function returns rather than of one walk: parts
are read by subscript, never bound by `for`. A rule that holds only because
each walk remembered it is what this bug is a report of, so `test-utils.R`
scans the package namespace for the forbidden shape and names any walk written
the old way. It derives rather than lists, for the reason every other gate in
this repository does — a list of walks is a list the next walk is not on. It
reads the namespace rather than `R/`, which is what lets it hold under
`R CMD check`, where the sources sit beside the `.Rcheck` directory rather than
inside it, and so it needs no `skip_if()` that `verify-backend.R` would read as
a job skipping for a reason other than a withheld backend. A second test
asserts the scan still matches the shape before its verdict means anything.

## Tests

The regression tests use the spellings a caller writes rather than a synthetic
`rlang::missing_arg()`, since what makes this worth fixing is that
`pick(...)[, "col"]` is code people write. The three spellings that evaluate
are checked against `dplyr::summarise()`'s own result; `sum(value, )` is
asserted against the `summarise()` baseline by class. A further test pins that
an empty argument does not hide a share helper beside it, and the
untyped-condition registry test in `test-static-expression-analysis.R` gains
the empty argument and `missingArgError`, so the condition this was filed for
is asserted absent beside the three from #100 rather than only where it was
fixed.

Verified against `main`'s `R/share.R`: the new scan names both walks, and the
regression tests fail.

## Verification

- `lintr::lint_package()` after `pkgload::load_all(".")` — no lints found.
- Full suite with `NOT_CRAN=true` — green, no failures and no skips.
- No roxygen comments changed, so `man/` and `NAMESPACE` are unaffected.
- No new test requires an optional backend, so the one-backend-per-test policy
  and the `backend` matrix are untouched.
