### PR TITLE
Read a name a summary reaches for reflectively as the read it is

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2789,11 +2789,27 @@ abort_share_predicate <- function(kind) {
   )
 }
 
+# A lookup the walk could not resolve is reported as a read of every alias in
+# scope. That is the over-reporting the contract asks for, applied where the
+# alias set is known: the walk itself cannot name what `get(name)` reads, and
+# a call with no alias to read is left alone, so an unresolvable lookup is
+# refused where it could hide a dependency and is legal everywhere else (#173).
+#
+# The messages downstream name `dependencies[[1L]]`, so an over-reported
+# refusal names an alias the caller may not have written. The remedy those
+# messages give is the one the caller needs either way -- move the derived
+# value into a following `mutate()`, or fold the alias into one expression --
+# and naming the marker instead would put a name no summary has into a message
+# about the caller's own summaries.
 expression_alias_dependencies <- function(expr, aliases) {
   if (length(aliases) == 0L) {
     return(character())
   }
-  intersect(unique(expression_data_symbols(expr)), aliases)
+  symbols <- unique(expression_data_symbols(expr))
+  if (unresolved_lookup_name() %in% symbols) {
+    return(aliases)
+  }
+  intersect(symbols, aliases)
 }
 
 # `bound` carries the names a construct inside the expression has bound, so a
@@ -2864,35 +2880,33 @@ expression_data_symbols <- function(expr, bound = character()) {
   if (is_binding_statement(call_name, expr)) {
     return(statement_reads_and_bound(expr, bound)$reads)
   }
-  if (identical(call_name, "get") && length(expr) >= 2L) {
-    if (get_has_external_env(expr)) {
-      return(character())
-    }
-    args <- rlang::call_args(expr)
-    arg_names <- names(args)
-    if (is.null(arg_names)) {
-      arg_names <- rep("", length(args))
-    }
-    name_index <- match("x", arg_names, nomatch = 0L)
-    if (name_index == 0L) {
-      name_index <- match("", arg_names, nomatch = 0L)
-    }
-    if (name_index > 0L) {
-      name <- args[[name_index]]
-      if (
-        is.character(name) &&
-          length(name) == 1L &&
-          !is.na(name)
-      ) {
-        # `get()` performs ordinary name resolution, so a local binding is
-        # what it finds. This is the branch the bound set applies to, unlike
-        # the pronoun below.
-        if (name %in% bound) {
-          return(character())
-        }
-        return(name)
-      }
-    }
+  # A name a summary expression reaches through one of the reflective
+  # primitives is the same read as the symbol would be, so it follows the same
+  # dependency rule: `get("share")` and `share` resolve one binding. Only
+  # `get()` was read that way, so `get0("share")`, `exists("share")`,
+  # `mget("share")` and every name built for `eval()` reached the staging
+  # placeholder instead -- silently for most of them (#173).
+  #
+  # Both branches add what the primitive resolves to the walk of the call's own
+  # parts rather than answering in its place, because a reflective call
+  # evaluates its arguments in the mask exactly as any other call does:
+  # `get(name)` really does read `name` there.
+  #
+  # `static_callee_name()` rather than the name read above, because a head
+  # wrapped in redundant parentheses invokes the same primitive while carrying
+  # no name of its own -- the shape #130 recorded defeating #100's fix.
+  callee_name <- static_callee_name(expr, call_name)
+  if (is_reflective_lookup(callee_name)) {
+    return(unique(c(
+      call_part_symbols(expr, bound),
+      reflective_lookup_symbols(expr, bound)
+    )))
+  }
+  if (is_reflective_evaluation(callee_name)) {
+    return(unique(c(
+      call_part_symbols(expr, bound),
+      evaluated_language_symbols(expr, bound)
+    )))
   }
   if (
     !is.null(call_name) &&
@@ -2967,6 +2981,14 @@ expression_data_symbols <- function(expr, bound = character()) {
   # miss a genuine read of a summary named `.x`, and suppressing it only under
   # `across()` would make the walk depend on its own call position, which is
   # what left function definitions behaving differently in a head (#130).
+  call_part_symbols(expr, bound)
+}
+
+# The reads of a call's own parts: its arguments, and its head when the head is
+# not a bare symbol. This is the general walk above, reached by name so that
+# the reflective branches can add their resolved names to it instead of
+# answering in its place.
+call_part_symbols <- function(expr, bound) {
   call_head <- static_call_head(expr)
   parts <- static_call_args(expr)
   if (!rlang::is_symbol(call_head)) {
@@ -3154,17 +3176,271 @@ removal_retained_bound <- function(expr, bound) {
   setdiff(bound, removed)
 }
 
-get_has_external_env <- function(expr) {
+lookup_has_external_env <- function(expr) {
   args <- rlang::call_args(expr)
   arg_names <- names(args)
   if (is.null(arg_names)) {
     arg_names <- rep("", length(args))
   }
-  if (any(arg_names %in% c("pos", "envir"))) {
+  if (any(arg_names %in% c("pos", "envir", "where", "frame"))) {
     return(TRUE)
   }
 
   unnamed_count <- sum(arg_names == "")
   x_is_named <- "x" %in% arg_names
   unnamed_count > as.integer(!x_is_named)
+}
+
+# The name of the function a call invokes, which is the name it was read for
+# unless the head is a call with no name of its own. Redundant parentheses are
+# the case that matters: `(get)("share")` invokes the same primitive as
+# `get("share")`, and #130 recorded the shape defeating #100's fix for the one
+# head shape that fix listed. A namespace qualifier under those parentheses is
+# unwrapped for the same reason `rlang::call_name()` unwraps one that is not
+# parenthesized -- `base::get` names `get`.
+#
+# What the parentheses do change is how the head is found: `(f)` is evaluated
+# in the mask as a value rather than through R's function lookup, so it is a
+# read. `call_part_symbols()` is what reports it, and every caller of this
+# unions the two.
+static_callee_name <- function(expr, call_name) {
+  if (!is.null(call_name)) {
+    return(call_name)
+  }
+  callee <- static_call_head(expr)
+  while (rlang::is_call(callee, "(") && length(callee) >= 2L) {
+    callee <- callee[[2L]]
+  }
+  if (rlang::is_symbol(callee)) {
+    return(rlang::as_name(callee))
+  }
+  if (
+    rlang::is_call(callee, c("::", ":::")) &&
+      length(callee) >= 3L &&
+      rlang::is_symbol(callee[[3L]])
+  ) {
+    return(rlang::as_name(callee[[3L]]))
+  }
+  NULL
+}
+
+# The primitives that resolve a name given as a string. Each searches ordinary
+# lexical scope from an environment that, under a data mask, is the mask, so a
+# name one of them is handed is a mask read exactly as the symbol is.
+#
+# `dynGet()` is deliberately absent: it searches the calling frames rather than
+# the lexical scope, so it does not reach the mask at all -- measured, not
+# assumed. `do.call()` and `match.fun()` are absent for the reason a bare
+# symbol in head position is excluded from the walk: both resolve a name
+# through function lookup, which skips a non-function binding, so a share
+# cannot shadow what either of them finds.
+is_reflective_lookup <- function(callee_name) {
+  !is.null(callee_name) &&
+    callee_name %in% c("get", "get0", "mget", "exists")
+}
+
+# The primitives that evaluate a language object. `evalq()` is absent because
+# it quotes its first argument, so the general walk already reports the symbols
+# under it -- adding it here would answer the same thing twice.
+is_reflective_evaluation <- function(callee_name) {
+  !is.null(callee_name) &&
+    callee_name %in% c("eval", "eval_tidy", "eval_bare")
+}
+
+# The names a reflective lookup resolves in the mask.
+#
+# An environment argument terminates the search: all four primitives require an
+# environment there -- `get("x", envir = list(x = 1))` is an error, not a
+# lookup in that list -- so a call supplying one reads no column, and code
+# reaching deliberately outside the mask keeps working beside a share of the
+# same name.
+#
+# The bound set applies here, unlike at the pronoun below: these perform
+# ordinary name resolution, so a local binding is what they find.
+#
+# A name that is not statically knowable is the undecidable shape #130's
+# contract resolves toward over-reporting, and the marker is how this walk says
+# so. Evaluating the argument to find out what it holds is the one thing this
+# analysis may not do -- it runs while the call is planned, on the caller's own
+# code.
+reflective_lookup_symbols <- function(expr, bound) {
+  if (lookup_has_external_env(expr)) {
+    return(character())
+  }
+  argument <- call_formal_argument(expr, "x")
+  if (length(argument) == 0L) {
+    # Nothing to look up, and nothing wrong with the walk: the call raises R's
+    # own condition for the missing argument when it runs.
+    return(character())
+  }
+  looked_up <- static_character_value(argument[[1L]])
+  if (is.null(looked_up)) {
+    return(unresolved_lookup_name())
+  }
+  setdiff(looked_up, bound)
+}
+
+# The names the language object handed to `eval()` reads.
+#
+# An `envir` argument is deliberately not an exemption here, unlike at the
+# lookup primitives above. `eval()`'s `enclos` defaults to `parent.frame()`,
+# which under a data mask is the mask, so a supplied `envir` that is a list or
+# a data frame leaves the mask on the lookup path -- `eval(as.name("share"),
+# list(a = 1))` reads the share. Which of the two an argument evaluates to is
+# not decidable here, so the node resolves toward over-reporting.
+evaluated_language_symbols <- function(expr, bound) {
+  argument <- call_formal_argument(expr, "expr")
+  if (length(argument) == 0L) {
+    return(character())
+  }
+  values <- static_language_values(argument[[1L]])
+  if (is.null(values)) {
+    return(unresolved_lookup_name())
+  }
+  unique(unlist(
+    lapply(values, expression_data_symbols, bound = bound),
+    use.names = FALSE
+  ))
+}
+
+# The language objects an expression is statically known to hand `eval()`, and
+# `NULL` where it is not knowable. An empty list is the third answer and is not
+# the same as `NULL`: a constant evaluates to itself and looks nothing up.
+#
+# Only the constructors that hide a name from the walk need a case. A name
+# written as a symbol -- `eval(quote(share))`, `evalq(share)` -- is already
+# reported by the walk of the call's parts; a name written as a string is not,
+# and that is the whole of what this recovers. `bquote()` is not among them
+# because `.()` substitutes an expression this walk cannot see, which leaves it
+# with the answer it gives any other unrecognized shape.
+static_language_values <- function(expr) {
+  if (rlang::is_symbol(expr)) {
+    # The symbol names a value, and which language object that value holds is
+    # not visible here.
+    return(NULL)
+  }
+  if (!rlang::is_call(expr)) {
+    return(list())
+  }
+  call_name <- static_call_name(expr)
+  if (is.null(call_name)) {
+    return(NULL)
+  }
+  if (identical(call_name, "quote")) {
+    return(call_formal_argument(expr, "expr"))
+  }
+  if (identical(call_name, "expression")) {
+    return(static_call_args(expr))
+  }
+  if (call_name %in% c("as.name", "as.symbol")) {
+    return(recovered_name_values(call_formal_argument(expr, "x")))
+  }
+  if (identical(call_name, "str2lang")) {
+    return(parsed_language_values(call_formal_argument(expr, "s")))
+  }
+  if (identical(call_name, "str2expression")) {
+    return(parsed_language_values(call_formal_argument(expr, "text")))
+  }
+  if (identical(call_name, "parse")) {
+    # Matched by name alone: `parse()`'s first positional argument is a
+    # connection, and what a connection holds is not knowable here.
+    return(parsed_language_values(
+      call_formal_argument(expr, "text", positional = FALSE)
+    ))
+  }
+  NULL
+}
+
+# The symbols a statically known string names. An empty string is dropped
+# rather than turned into a symbol, because `as.name("")` is an error in R and
+# the walk must raise none of its own.
+recovered_name_values <- function(argument) {
+  if (length(argument) == 0L) {
+    return(NULL)
+  }
+  text <- static_character_value(argument[[1L]])
+  if (is.null(text)) {
+    return(NULL)
+  }
+  lapply(text[nzchar(text)], as.name)
+}
+
+# The language a statically known string parses to. Parsing is not evaluation:
+# nothing the caller wrote runs here, which is what lets the recovery happen
+# during planning at all. Text that does not parse is reported as unknown
+# rather than raised, since the call itself raises R's own condition when it
+# runs.
+parsed_language_values <- function(argument) {
+  if (length(argument) == 0L) {
+    return(NULL)
+  }
+  text <- static_character_value(argument[[1L]])
+  if (is.null(text)) {
+    return(NULL)
+  }
+  parsed <- tryCatch(
+    str2expression(paste(text, collapse = "\n")),
+    error = function(cnd) NULL
+  )
+  if (is.null(parsed)) {
+    return(NULL)
+  }
+  as.list(parsed)
+}
+
+# The character vector an expression is statically known to be, and `NULL`
+# where it is not. A literal is one, and so is a `c()` of literals, which is
+# how a caller writes the vector `mget()` takes; anything else names a value
+# this walk cannot see without running it.
+static_character_value <- function(expr) {
+  if (is.character(expr)) {
+    if (anyNA(expr)) {
+      return(NULL)
+    }
+    return(expr)
+  }
+  if (!rlang::is_call(expr, "c")) {
+    return(NULL)
+  }
+  values <- lapply(rlang::call_args(expr), static_character_value)
+  if (any(vapply(values, is.null, logical(1)))) {
+    return(NULL)
+  }
+  recovered <- unlist(values, use.names = FALSE)
+  if (is.null(recovered)) {
+    # `c()` of nothing, which names nothing.
+    return(character())
+  }
+  recovered
+}
+
+# The argument a call gives one formal, matched by name and then by position,
+# which is how R matches the primitives above. Returned as a list of length one
+# or an empty list, so that an argument written as `NULL` is not read as an
+# absent one.
+call_formal_argument <- function(expr, formal, positional = TRUE) {
+  args <- rlang::call_args(expr)
+  arg_names <- names(args)
+  if (is.null(arg_names)) {
+    arg_names <- rep("", length(args))
+  }
+  index <- match(formal, arg_names, nomatch = 0L)
+  if (index == 0L && positional) {
+    index <- match("", arg_names, nomatch = 0L)
+  }
+  args[index]
+}
+
+# The name the walk reports for a read it could not resolve. It travels with
+# the names it is reported beside, because the walk's only channel to its
+# caller is the character vector it returns, and the alias analysis above is
+# the one place that reads it: a walk with no way to say "some name" would have
+# to answer either silently or by refusing the call, and #130 rules out both.
+#
+# The `..marginplyr` prefix is the one this package's internal names carry. A
+# column of this name would be read as unresolvable rather than as itself,
+# which is the over-reporting direction, so a collision costs a diagnostic and
+# never a silent miss.
+unresolved_lookup_name <- function() {
+  "..marginplyr_unresolved_lookup"
 }

--- a/R/share.R
+++ b/R/share.R
@@ -2892,10 +2892,15 @@ expression_data_symbols <- function(expr, bound = character()) {
   # evaluates its arguments in the mask exactly as any other call does:
   # `get(name)` really does read `name` there.
   #
-  # `static_callee_name()` rather than the name read above, because a head
-  # wrapped in redundant parentheses invokes the same primitive while carrying
-  # no name of its own -- the shape #130 recorded defeating #100's fix.
-  callee_name <- static_callee_name(expr, call_name)
+  # The callee name rather than the name read above, because a head that names
+  # one of these primitives without being a symbol carries no call name of its
+  # own. `(get)` is the redundant-parenthesis shape #130 recorded, and a head
+  # built by `match.fun()` or `getFunction()` names the same primitive through
+  # one whose whole purpose is to name a function.
+  callee_name <- call_name
+  if (is.null(callee_name)) {
+    callee_name <- static_callee_name(static_call_head(expr))
+  }
   if (is_reflective_lookup(callee_name)) {
     return(unique(c(
       call_part_symbols(expr, bound),
@@ -2906,6 +2911,12 @@ expression_data_symbols <- function(expr, bound = character()) {
     return(unique(c(
       call_part_symbols(expr, bound),
       evaluated_language_symbols(expr, bound)
+    )))
+  }
+  if (identical(callee_name, "do.call")) {
+    return(unique(c(
+      call_part_symbols(expr, bound),
+      deferred_call_symbols(expr)
     )))
   }
   if (
@@ -3154,10 +3165,7 @@ statement_reads_and_bound <- function(expr, bound) {
 # view (#162).
 removal_retained_bound <- function(expr, bound) {
   args <- rlang::call_args(expr)
-  arg_names <- names(args)
-  if (is.null(arg_names)) {
-    arg_names <- rep("", length(args))
-  }
+  arg_names <- argument_names(args)
   removed <- character()
   for (i in seq_along(args)) {
     arg <- args[[i]]
@@ -3178,10 +3186,7 @@ removal_retained_bound <- function(expr, bound) {
 
 lookup_has_external_env <- function(expr) {
   args <- rlang::call_args(expr)
-  arg_names <- names(args)
-  if (is.null(arg_names)) {
-    arg_names <- rep("", length(args))
-  }
+  arg_names <- argument_names(args)
   if (any(arg_names %in% c("pos", "envir", "where", "frame"))) {
     return(TRUE)
   }
@@ -3191,37 +3196,75 @@ lookup_has_external_env <- function(expr) {
   unnamed_count > as.integer(!x_is_named)
 }
 
-# The name of the function a call invokes, which is the name it was read for
-# unless the head is a call with no name of its own. Redundant parentheses are
-# the case that matters: `(get)("share")` invokes the same primitive as
-# `get("share")`, and #130 recorded the shape defeating #100's fix for the one
-# head shape that fix listed. A namespace qualifier under those parentheses is
-# unwrapped for the same reason `rlang::call_name()` unwraps one that is not
-# parenthesized -- `base::get` names `get`.
+# The function an expression statically names, however it spells it: a symbol,
+# a namespace qualifier, redundant parentheses, or a call to a primitive whose
+# purpose is to name a function. `get("get")("share")`,
+# `match.fun("get")("share")` and `getFunction("get")("share")` all invoke the
+# same primitive as `get("share")`, and a branch matching on the call's own
+# name sees none of them, because a call whose head is a call has no name.
 #
-# What the parentheses do change is how the head is found: `(f)` is evaluated
-# in the mask as a value rather than through R's function lookup, so it is a
-# read. `call_part_symbols()` is what reports it, and every caller of this
-# unions the two.
-static_callee_name <- function(expr, call_name) {
-  if (!is.null(call_name)) {
-    return(call_name)
-  }
-  callee <- static_call_head(expr)
-  while (rlang::is_call(callee, "(") && length(callee) >= 2L) {
-    callee <- callee[[2L]]
-  }
+# What none of those spellings change is that the head is a read: `(f)`,
+# `match.fun("f")` and the rest are evaluated in the mask as values rather than
+# through R's function lookup. `call_part_symbols()` reports that read, and
+# every caller of this unions the two answers.
+#
+# A literal string is here for `do.call()`, which takes its function that way.
+static_callee_name <- function(callee) {
   if (rlang::is_symbol(callee)) {
     return(rlang::as_name(callee))
   }
-  if (
-    rlang::is_call(callee, c("::", ":::")) &&
-      length(callee) >= 3L &&
-      rlang::is_symbol(callee[[3L]])
-  ) {
-    return(rlang::as_name(callee[[3L]]))
+  if (!rlang::is_call(callee)) {
+    named <- static_character_value(callee)
+    if (is.null(named) || length(named) != 1L) {
+      return(NULL)
+    }
+    return(named)
   }
-  NULL
+  if (rlang::is_call(callee, "(") && length(callee) >= 2L) {
+    return(static_callee_name(callee[[2L]]))
+  }
+  if (rlang::is_call(callee, c("::", ":::")) && length(callee) >= 3L) {
+    return(static_callee_name(callee[[3L]]))
+  }
+  call_name <- static_call_name(callee)
+  if (is.null(call_name)) {
+    return(NULL)
+  }
+  formal <- function_naming_formal(call_name)
+  if (is.null(formal)) {
+    return(NULL)
+  }
+  static_callee_name_from(callee, formal)
+}
+
+# The name a function-naming primitive was given, where that name is statically
+# knowable. One that is not leaves the head unnamed, which is the answer for
+# any other computed head: the walk reports the head's own reads and treats the
+# call as the ordinary call it cannot recognize.
+static_callee_name_from <- function(callee, formal) {
+  argument <- call_formal_argument(callee, formal)
+  if (length(argument) == 0L) {
+    return(NULL)
+  }
+  named <- static_character_value(argument[[1L]])
+  if (is.null(named) || length(named) != 1L) {
+    return(NULL)
+  }
+  named
+}
+
+# The formal each function-naming primitive takes its name in, and `NULL` for a
+# call that names no function. `mget()` and `exists()` are absent because
+# neither can answer a function to call: one answers a list and the other a
+# flag.
+function_naming_formal <- function(call_name) {
+  switch(call_name,
+    match.fun = "FUN",
+    getFunction = "name",
+    get = ,
+    get0 = "x",
+    NULL
+  )
 }
 
 # The primitives that resolve a name given as a string. Each searches ordinary
@@ -3229,11 +3272,15 @@ static_callee_name <- function(expr, call_name) {
 # name one of them is handed is a mask read exactly as the symbol is.
 #
 # `dynGet()` is deliberately absent: it searches the calling frames rather than
-# the lexical scope, so it does not reach the mask at all -- measured, not
-# assumed. `do.call()` and `match.fun()` are absent for the reason a bare
-# symbol in head position is excluded from the walk: both resolve a name
-# through function lookup, which skips a non-function binding, so a share
-# cannot shadow what either of them finds.
+# the lexical scope, so it does not reach the mask -- measured, not assumed.
+#
+# One of these reached as a *value* rather than as a callee is out of reach of
+# any static walk, and is safe for the same measured reason: in
+# `sapply(c("share"), get)` the environment `get()` searches from is the frame
+# that called it, inside `sapply()`, so the call raises rather than reading a
+# column. Which function a value holds is undecidable in general -- `f <- get`
+# is the smallest case -- so a walk answering it would have to over-report
+# every call it cannot name, and that is nearly all of them.
 is_reflective_lookup <- function(callee_name) {
   !is.null(callee_name) &&
     callee_name %in% c("get", "get0", "mget", "exists")
@@ -3278,6 +3325,28 @@ reflective_lookup_symbols <- function(expr, bound) {
     return(unresolved_lookup_name())
   }
   setdiff(looked_up, bound)
+}
+
+# What a `do.call()` reads beyond its own parts. It invokes the function it
+# names in an environment that defaults to the caller's, which under a data
+# mask is the mask, so `do.call("get", list("share"))` performs the lookup
+# `get("share")` performs. What that lookup is handed sits in a list built at
+# run time, which this walk cannot read, so a `do.call()` of a reflective
+# primitive is reported as a lookup it cannot resolve.
+#
+# A `do.call()` of anything else needs no answer here: its arguments are
+# values by the time it runs, and the walk has already reported the expressions
+# that produced them.
+deferred_call_symbols <- function(expr) {
+  argument <- call_formal_argument(expr, "what")
+  if (length(argument) == 0L) {
+    return(character())
+  }
+  named <- static_callee_name(argument[[1L]])
+  if (is_reflective_lookup(named) || is_reflective_evaluation(named)) {
+    return(unresolved_lookup_name())
+  }
+  character()
 }
 
 # The names the language object handed to `eval()` reads.
@@ -3414,16 +3483,24 @@ static_character_value <- function(expr) {
   recovered
 }
 
+# The name each of a call's arguments was given, empty where it was passed
+# positionally. An unnamed call carries no names at all rather than empty ones,
+# which is the case every site reading both name and position has to fill in.
+argument_names <- function(args) {
+  arg_names <- names(args)
+  if (is.null(arg_names)) {
+    return(rep("", length(args)))
+  }
+  arg_names
+}
+
 # The argument a call gives one formal, matched by name and then by position,
 # which is how R matches the primitives above. Returned as a list of length one
 # or an empty list, so that an argument written as `NULL` is not read as an
 # absent one.
 call_formal_argument <- function(expr, formal, positional = TRUE) {
   args <- rlang::call_args(expr)
-  arg_names <- names(args)
-  if (is.null(arg_names)) {
-    arg_names <- rep("", length(args))
-  }
+  arg_names <- argument_names(args)
   index <- match(formal, arg_names, nomatch = 0L)
   if (index == 0L && positional) {
     index <- match("", arg_names, nomatch = 0L)
@@ -3431,11 +3508,20 @@ call_formal_argument <- function(expr, formal, positional = TRUE) {
   args[index]
 }
 
-# The name the walk reports for a read it could not resolve. It travels with
-# the names it is reported beside, because the walk's only channel to its
-# caller is the character vector it returns, and the alias analysis above is
-# the one place that reads it: a walk with no way to say "some name" would have
-# to answer either silently or by refusing the call, and #130 rules out both.
+# The name the walk reports for a read it could not resolve.
+#
+# #130 fixed the walk as two-valued -- a name is read or it is not -- and this
+# keeps that shape rather than adding a third answer to it: the marker is a
+# name, carried in the vector every branch already unions, and the one site
+# that reads it is `expression_alias_dependencies()`, which turns it into a
+# read of every alias in scope. Returning a record instead, as
+# `statement_reads_and_bound()` does for the two answers a binding statement
+# has, would rewrite every branch of the walk to carry a second field that
+# only three of them can set.
+#
+# The alternatives are the two #130 rules out. Reporting nothing is the silence
+# the whole walk exists to prevent, and refusing the call outright would reject
+# `get(name)` wherever a summary precedes it, which is legal code.
 #
 # The `..marginplyr` prefix is the one this package's internal names carry. A
 # column of this name would be read as unresolvable rather than as itself,

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2007,6 +2007,102 @@ test_that("a parenthesized head is still the primitive it names", {
   expect_share_dependency_error(data, quote((get)("share") * 100))
 })
 
+test_that("a primitive named through another primitive is still itself", {
+  # `match.fun("get")`, `getFunction("get")` and `get("get")` each evaluate to
+  # the same primitive, so a head spelled any of those ways performs the same
+  # lookup as `get("share")` and owes the caller the same diagnostic. Each was
+  # silently `NA` while the branch matched on the call's own name, which a
+  # call whose head is a call does not have.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # The head is a read of its own wherever it is not a bare symbol, so the
+  # name it looks the function up under is reported beside the column.
+  expect_identical(
+    expression_data_symbols(quote(match.fun("get")("share"))),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(get("get")("share"))),
+    c("get", "share")
+  )
+
+  expect_share_dependency_error(data, quote(match.fun("get")("share") * 100))
+  expect_share_dependency_error(data, quote(getFunction("get")("share") * 100))
+  expect_share_dependency_error(data, quote(get("get")("share") * 100))
+  expect_share_dependency_error(data, quote(get0("get0")("share") * 100))
+})
+
+test_that("`do.call()` of a reflective primitive is an unresolved lookup", {
+  # `do.call()` runs the call it builds in the caller's environment, which
+  # under a data mask is the mask, so a primitive it names looks a column up
+  # there. What that primitive is handed is a list built at run time, so the
+  # name is not recoverable and the marker is the answer -- as it is for any
+  # lookup this walk cannot resolve.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(
+    expression_data_symbols(quote(do.call("get", list("share")))),
+    unresolved_lookup_name()
+  )
+  expect_identical(
+    expression_data_symbols(quote(do.call(get, list("share")))),
+    c("get", unresolved_lookup_name())
+  )
+  # A `do.call()` of anything else is left alone: its arguments are values by
+  # the time it runs, and the walk has reported the expressions that built
+  # them.
+  expect_identical(
+    expression_data_symbols(quote(do.call("sum", list(value)))),
+    "value"
+  )
+
+  expect_share_dependency_error(
+    data,
+    quote(do.call("get", list("share")) * 100)
+  )
+  expect_share_dependency_error(data, quote(do.call(get, list("share")) * 100))
+
+  legal <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    doubled = do.call("sum", list(value)) * 2,
+    .grouping = rollup(region)
+  )
+  expect_identical(legal$doubled, c(8, 12, 20))
+})
+
+test_that("a primitive reached as a value is out of the walk's reach", {
+  # `sapply(c("share"), get)` hands the primitive on as a value, and the
+  # environment it then searches from is the frame inside `sapply()` rather
+  # than the mask -- so it raises instead of reading the placeholder, and the
+  # walk owes it nothing. This is asserted rather than assumed because the
+  # comment at `is_reflective_lookup()` rests on it: were it to reach the
+  # mask, the shape would be a silent miss of exactly the kind #173 removes.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(value),
+      share = share_of_total(units),
+      derived = sapply(c("share"), get)[[1L]],
+      .grouping = rollup(region)
+    )
+  )
+  expect_false(inherits(error, "marginplyr_error"))
+  expect_match(conditionMessage(error), "'share' not found")
+})
+
 test_that("a reflective alias of an earlier summary is not a share source", {
   # The other direction of the same rule. A share source must be an ordinary
   # summary that depends on nothing earlier, and an alias built reflectively

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -1784,3 +1784,307 @@ test_that("no analysed shape reaches the caller as an untyped condition", {
     expect_false(inherits(error, "missingArgError"))
   }
 })
+
+# The tests below all build the rejected call by injection rather than by
+# writing each shape out, because the shapes are what varies and the call
+# around them is not. Injecting a plain language object splices it into the
+# quosure exactly as writing it there would, so the walk sees the expression
+# under test and nothing else (#165 covers the quosure case).
+reflective_summary <- function(data, expr) {
+  # nolint start: object_usage_linter.
+  # `value` and `region` are columns of the data mask the verb builds, which
+  # `codetools` cannot follow into.
+  rlang::inject(summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    derived = !!expr,
+    .grouping = rollup(region)
+  ))
+  # nolint end
+}
+
+expect_share_dependency_error <- function(data, expr) {
+  error <- expect_error(
+    reflective_summary(data, expr),
+    "Ordinary summaries cannot use an earlier Total share (`share`)",
+    fixed = TRUE
+  )
+  expect_s3_class(error, "marginplyr_error")
+}
+
+test_that("a reflective lookup reads the name it is given", {
+  # `get("share")` and `share` reach the same binding: the primitives below
+  # resolve a name through ordinary lexical scope, which under a data mask
+  # starts at the mask. A name handed to one as a string is therefore a mask
+  # read exactly as the symbol is, and the guard against an ordinary summary
+  # using an earlier share owes the caller the same diagnostic for both. Only
+  # `get()` was read that way, so the other three reached the placeholder --
+  # silently for two of them, and as an untyped base condition for `mget()`
+  # (#173).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(expression_data_symbols(quote(get0("share"))), "share")
+  expect_identical(expression_data_symbols(quote(exists("share"))), "share")
+  # `mget()` takes a vector, so its names are recovered from one rather than
+  # from a lone literal: a `c()` of literals is as statically known as a
+  # literal is.
+  expect_identical(
+    expression_data_symbols(quote(mget(c("share", "units")))),
+    c("share", "units")
+  )
+  # A bound name shadows all four for the reason it shadows `get()`: each
+  # performs ordinary name resolution, which finds the binding first.
+  expect_identical(
+    expression_data_symbols(quote(get0("share")), bound = "share"),
+    character()
+  )
+
+  expect_share_dependency_error(data, quote(get0("share") * 100))
+  expect_share_dependency_error(data, quote(exists("share")))
+  expect_share_dependency_error(data, quote(mget("share")[[1L]] * 100))
+})
+
+test_that("an evaluated language object is read where it is built", {
+  # A name reaches the mask as a string here rather than as a symbol, so the
+  # walk sees no symbol to report: `as.name("share")` builds the read that
+  # `eval()` then performs. Recovering the language object is what puts these
+  # under the same rule as `share`, and parsing a literal is the whole of the
+  # recovery -- nothing evaluates the caller's code to find out what it reads.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(
+    expression_data_symbols(quote(eval(as.name("share")))),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(as.symbol("share")))),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(str2lang("share * 2")))),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(parse(text = "share * 2")))),
+    "share"
+  )
+  # `quote()` needs no recovery of its own -- the general walk already reports
+  # the symbols under it -- but it reaches this branch too, so it is asserted
+  # beside the others rather than left to a walk the branch now shadows.
+  expect_identical(expression_data_symbols(quote(eval(quote(share)))), "share")
+  # A bound name shadows the recovered read as it shadows a symbol: what
+  # `eval()` resolves is the binding, not the column.
+  expect_identical(
+    expression_data_symbols(quote(eval(as.name("share"))), bound = "share"),
+    character()
+  )
+
+  expect_share_dependency_error(data, quote(eval(as.name("share")) * 100))
+  expect_share_dependency_error(data, quote(eval(as.symbol("share")) * 100))
+  expect_share_dependency_error(data, quote(eval(str2lang("share * 2"))))
+  expect_share_dependency_error(data, quote(eval(parse(text = "share * 2"))))
+})
+
+test_that("a lookup this walk cannot resolve reads every alias", {
+  # `get(name)` names whatever the string holds at run time, which is not
+  # decidable here and must not be found out by evaluating it. #130's contract
+  # resolves an undecidable shape toward over-reporting, so the walk reports a
+  # marker and the guard reads it as a read of every alias in scope: the call
+  # is refused wherever one exists, rather than silently computing against a
+  # staging placeholder.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # nolint start: object_usage_linter.
+  # Read from the summary expressions below, which the linter cannot follow
+  # into a data mask.
+  name <- "share"
+  existing <- "units"
+  # nolint end
+
+  # The argument is walked as well as recovered, because a reflective call
+  # evaluates its arguments in the mask like any other call does.
+  expect_identical(
+    expression_data_symbols(quote(get(name))),
+    c("name", unresolved_lookup_name())
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(built))),
+    c("built", unresolved_lookup_name())
+  )
+
+  expect_share_dependency_error(data, quote(get(name) * 100))
+  expect_share_dependency_error(data, quote(eval(as.name(name)) * 100))
+  expect_share_dependency_error(data, quote(eval(str2lang(name)) * 100))
+
+  # Over-reporting is a claim about the aliases in scope, so a call holding
+  # none is untouched: a lookup this walk cannot resolve is not a fault of its
+  # own, and refusing it outright would reject legal code.
+  resolved <- summarize_with_margins(
+    data,
+    units = sum(value),
+    derived = get(existing),
+    .grouping = rollup(region)
+  )
+  expect_identical(resolved$derived, resolved$units)
+})
+
+test_that("a lookup constrained to an external environment reads no column", {
+  # The environment argument terminates the search: these four require an
+  # environment there and never fall back to the mask, so a call supplying one
+  # reads no column and must keep working beside a share of that name. The
+  # environment expression itself is still a mask read -- it is evaluated
+  # there like any argument is.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # nolint start: object_usage_linter.
+  # Read from the summary expressions below, which the linter cannot follow
+  # into a data mask.
+  outside <- rlang::env(share = 2)
+  # nolint end
+
+  expect_identical(
+    expression_data_symbols(quote(get0("share", envir = outside))),
+    "outside"
+  )
+  expect_identical(
+    expression_data_symbols(quote(exists("share", where = outside))),
+    "outside"
+  )
+  # A second unnamed argument is the environment for each of them, whatever
+  # that argument is called in the primitive's own signature.
+  expect_identical(
+    expression_data_symbols(quote(mget("share", outside))),
+    "outside"
+  )
+
+  from_environment <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    got = get("share", envir = outside),
+    got0 = get0("share", envir = outside),
+    gotm = mget("share", envir = outside)[[1L]],
+    there = exists("share", where = outside),
+    .grouping = rollup(region)
+  )
+  expect_identical(unique(from_environment$got), 2)
+  expect_identical(unique(from_environment$got0), 2)
+  expect_identical(unique(from_environment$gotm), 2)
+  expect_identical(unique(from_environment$there), TRUE)
+})
+
+test_that("a parenthesized head is still the primitive it names", {
+  # `(get)("share")` calls the same primitive, and #130 recorded the shape it
+  # defeats: the head is a call to `(`, so a branch matching on the call's
+  # name does not see it. The parentheses are a mask read of their own --
+  # `(get)` is evaluated as a value rather than through function lookup -- so
+  # both answers are reported.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(
+    expression_data_symbols(quote((get)("share"))),
+    c("get", "share")
+  )
+  expect_identical(
+    expression_data_symbols(quote(((get))("share"))),
+    c("get", "share")
+  )
+
+  expect_share_dependency_error(data, quote((get)("share") * 100))
+})
+
+test_that("a reflective alias of an earlier summary is not a share source", {
+  # The other direction of the same rule. A share source must be an ordinary
+  # summary that depends on nothing earlier, and an alias built reflectively
+  # depends on exactly what the spelled-out alias does: the dependency is the
+  # read, however the name reached the mask.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # nolint start: object_usage_linter.
+  # Read from the summary expression below, which the linter cannot follow
+  # into a data mask.
+  name <- "units"
+  # nolint end
+  aliased <- function(expr) {
+    rlang::inject(summarize_with_margins(
+      data,
+      units = sum(value),
+      alias = !!expr,
+      share = share_of_total(alias),
+      .grouping = rollup(region)
+    ))
+  }
+
+  for (expr in list(
+    quote(get0("units")),
+    quote(mget("units")[[1L]]),
+    quote(eval(as.name("units"))),
+    quote(eval(parse(text = "units")))
+  )) {
+    error <- expect_error(
+      aliased(expr),
+      paste0(
+        "Total share `share` cannot use source summary `alias` because it ",
+        "depends on earlier summary alias `units`"
+      ),
+      fixed = TRUE
+    )
+    expect_s3_class(error, "marginplyr_error")
+  }
+
+  # An unresolvable lookup reaches the same refusal through the over-report:
+  # every alias in scope is a dependency, so the alias is no source.
+  unresolved <- expect_error(
+    aliased(quote(get(name))),
+    "cannot use source summary `alias`",
+    fixed = TRUE
+  )
+  expect_s3_class(unresolved, "marginplyr_error")
+})
+
+test_that("a lazy input is refused at planning like a local one", {
+  # The decision is made while the call is planned, before any backend sees a
+  # query, so the two paths owe the caller the same condition. A lazy frame
+  # that reached execution would raise whatever its backend makes of a
+  # placeholder instead, which is the difference this asserts away.
+  #
+  # No dialect is simulated and none is needed: nothing here renders SQL, so
+  # the test needs no optional driver package and runs in every configuration
+  # rather than skipping wherever one is absent.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  lazy <- dbplyr::tbl_lazy(data)
+
+  expect_share_dependency_error(lazy, quote(get0("share") * 100))
+
+  source <- expect_error(
+    rlang::inject(summarize_with_margins(
+      lazy,
+      units = sum(value),
+      alias = eval(as.name("units")),
+      share = share_of_total(alias),
+      .grouping = rollup(region)
+    )),
+    "cannot use source summary `alias`",
+    fixed = TRUE
+  )
+  expect_s3_class(source, "marginplyr_error")
+})

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2184,3 +2184,104 @@ test_that("a lazy input is refused at planning like a local one", {
   )
   expect_s3_class(source, "marginplyr_error")
 })
+
+test_that("a name the recovery cannot read fails closed, not through", {
+  # Each shape here is one the recovery does not read: a literal that is not a
+  # name, a vector holding something other than literals, text that does not
+  # parse, a constructor this walk does not recognize, a head with no name of
+  # its own. All of them resolve to the marker rather than to silence, which
+  # is the direction #130 fixed and the one the guard depends on.
+  expect_identical(
+    expression_data_symbols(quote(get(NA_character_))),
+    unresolved_lookup_name()
+  )
+  expect_identical(
+    expression_data_symbols(quote(mget(c("share", name)))),
+    c("name", unresolved_lookup_name())
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(str2lang("share +")))),
+    unresolved_lookup_name()
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(as.name()))),
+    unresolved_lookup_name()
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(str2lang()))),
+    unresolved_lookup_name()
+  )
+  # `bquote()` substitutes an expression through `.()`, which this walk cannot
+  # see, so it is unrecognized rather than recovered -- and the symbols under
+  # it are still reported by the walk of the parts.
+  expect_identical(
+    expression_data_symbols(quote(eval(bquote(share)))),
+    c("share", unresolved_lookup_name())
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(fns$build()))),
+    c("fns", unresolved_lookup_name())
+  )
+})
+
+test_that("a name the recovery can read is read, however it is spelled", {
+  # The other half of the same table: shapes that are statically knowable, and
+  # the two that are knowable to read nothing at all.
+  expect_identical(
+    expression_data_symbols(quote(eval(expression(share)))),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(str2expression("share * 2")))),
+    "share"
+  )
+  # A namespace qualifier under the parentheses names the same primitive, as
+  # it does without them.
+  expect_identical(
+    expression_data_symbols(quote((base::get)("share"))),
+    "share"
+  )
+  # A string is not a language object: `eval()` answers the string itself and
+  # looks nothing up.
+  expect_identical(expression_data_symbols(quote(eval("share"))), character())
+  # `c()` of nothing names nothing, so there is nothing to report and nothing
+  # unresolved either.
+  expect_identical(expression_data_symbols(quote(get(c()))), character())
+})
+
+test_that("a head that names no function leaves the call unrecognized", {
+  # A shape the analysis does not recognize falls through and evaluates, which
+  # is ADR-0015's answer wherever no fault of the analysis is involved: the
+  # walk reports the parts and claims nothing about what the call resolves.
+  expect_identical(
+    expression_data_symbols(quote(match.fun()("share"))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(match.fun(name)("share"))),
+    "name"
+  )
+  expect_identical(
+    expression_data_symbols(quote(do.call(1L, list("share")))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(do.call(args = list("share")))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(eval(envir = outside))),
+    "outside"
+  )
+})
+
+test_that("an unnamed argument list still answers one name per argument", {
+  # `rlang::call_args()` names every argument, empty where the caller passed
+  # one positionally, so the walk never reaches the fallback. It is what keeps
+  # the reading correct for a list that carries no names at all: `match("",
+  # NULL)` and `sum(NULL == "")` both answer 0 rather than failing, so a
+  # missing name vector would read as a call with no positional arguments and
+  # an environment argument beside a name would go unseen.
+  expect_identical(argument_names(list(1, 2)), c("", ""))
+  expect_identical(argument_names(list(a = 1, 2)), c("a", ""))
+})


### PR DESCRIPTION
Closes #173.

`expression_data_symbols()` decides which data-mask names a summary expression
reads, and #130 made it see through call heads and function scopes. It
recognized exactly one reflective spelling — `get("share")` — so every other
way of reaching a binding by name walked straight past the guard.

## What was reachable

Measured on `a473e5f`, with `units = sum(value)` and `share =
share_of_total(units)` preceding each `derived =`:

| Expression | Before |
|---|---|
| `get0("share")` | silently `NA` |
| `exists("share")` | silently `TRUE` — the placeholder exists |
| `eval(as.name("share"))`, `eval(as.symbol(…))` | silently `NA` |
| `eval(str2lang("share * 2"))`, `eval(parse(text = …))` | silently `NA` |
| `get(paste0("sha", "re"))` | silently `NA` |
| `(get)("share")` | silently `NA` |
| `mget("share")` | `value for 'share' not found` — a `simpleError` through dplyr |
| `alias = get0("units")`, then `share_of_total(alias)` | accepted a dependent source |

The last row is the other direction of the same rule: a spelled-out alias
records a dependency and is refused as a share source, and a reflective one
recorded none.

Review of the first commit found four more, all silent:
`do.call("get", list("share"))`, `match.fun("get")("share")`,
`getFunction("get")("share")`, `get("get")("share")`.

Most of these are the CRAN-blocking class #130 names: not a wrong diagnostic
but no diagnostic, and a column of `NA` where the caller reads 40 / 60 / 100.

## The rule now

**One branch for the four lookup primitives** — `get`, `get0`, `mget`,
`exists` — and one for the evaluation ones — `eval`, `eval_tidy`, `eval_bare`.
Each searches ordinary lexical scope from an environment that, under a data
mask, is the mask, so a name handed to one is the read the symbol is.

**Both add to the walk of the call's own parts rather than answering in its
place**, because a reflective call evaluates its arguments in the mask exactly
as any other call does: `get(name)` really does read `name` there. That is
`call_part_symbols()`, which is the general walk reached by name.

**The callee is recovered however it is spelled.** `static_callee_name()` sees
through a symbol, a namespace qualifier, redundant parentheses, and a call to a
primitive whose purpose is to name a function — `match.fun()`, `getFunction()`,
`get()`, `get0()`. `(get)("share")` is the redundant-parenthesis shape #130
recorded defeating #100's fix, and it defeated the `get()` branch the same way.
`do.call()` gets its own branch: what it hands the primitive is a list built at
run time, so a `do.call()` of a reflective primitive is a lookup this walk
cannot resolve, and is reported as one.

**A name written as a string is recovered by parsing, never by evaluating.**
`quote`, `expression`, `as.name`, `as.symbol`, `str2lang`, `str2expression`,
and `parse(text =)` are recovered from literals; the analysis runs while the
call is planned, on the caller's own code, so nothing of it may run.

**The bound set applies**, unlike at the `.data` pronoun: these perform
ordinary name resolution, so `(function(share) get("share"))(value)` finds the
formal.

## Failing closed without refusing legal code

`get(name)` names whatever the string holds at run time. #130's contract
resolves an undecidable shape toward over-reporting, so the walk reports a
marker and `expression_alias_dependencies()` reads it as a read of **every
alias in scope**. A call with no alias is untouched, so an unresolvable lookup
is refused where it could hide a dependency and stays legal everywhere else.

The two alternatives are the ones #130 rules out. Reporting nothing is the
silence the walk exists to prevent; refusing outright would reject
`derived = get(name)` wherever any summary precedes it, which is legal code.

The marker keeps the walk two-valued in the shape #130 fixed — it is a name,
carried in the vector every branch already unions, read by one site. A record
return, as `statement_reads_and_bound()` uses for the two answers a binding
statement has, would rewrite every branch to carry a field three of them can
set. The cost is that an over-reported refusal names an alias the caller may
not have written; the remedy those messages give — move it to a following
`mutate()`, or fold the alias into one expression — is the one the caller needs
either way.

## Where an environment argument is an exemption, and where it is not

`get()`, `get0()`, `mget()` and `exists()` require an environment in `envir` /
`pos` / `where` / `frame` and never fall back to the mask, so a call supplying
one reads no column and keeps working beside a share of that name (`get("x",
envir = list(x = 1))` is an error, not a lookup in that list).

`eval()` is deliberately **not** exempted. Its `enclos` defaults to
`parent.frame()`, which under a data mask is the mask, so a supplied `envir`
that is a list or a data frame leaves the mask on the lookup path — measured:
`eval(as.name("share"), list(a = 1))` reads the share. Which of the two an
argument evaluates to is not decidable here, so the node over-reports. The
consequence is that `eval(sym, envir = someEnv)` beside a share of that name is
now refused with a typed error. Recognizing a fixed set of certainly-external
environment expressions would narrow that, and every wrong entry in such a set
is a silent miss, so it is not done here.

## Where the line is drawn, and why that is asserted

A primitive reached as a **value** rather than as a callee —
`sapply(c("share"), get)` — is undecidable in general, `f <- get` being the
smallest case, so a walk answering it would have to over-report every call it
cannot name. It is also safe: the environment `get()` searches from there is
the frame inside `sapply()`, so the call raises rather than reading the
placeholder. A test asserts that rather than a comment claiming it — the first
commit excused `do.call()` and `match.fun()` in a comment, and both were live
silent misses.

`dynGet()` is excluded for the same measured reason: it searches the calling
frames rather than the lexical scope, and does not reach the mask.

## Tests

The primary assertions are at the **guard**, as #130's verification section
sets out: each shape is a `summarize_with_margins()` call asserting
`marginplyr_error`, with the walk-level table beneath it in
`test-static-expression-analysis.R`. Both directions are covered — an ordinary
summary reading an earlier share, and a share source whose alias was built
reflectively — together with the external-environment cases asserted by value,
and a legal `do.call("sum", …)` beside the refused ones.

The lazy path is asserted beside the local one and needs no dialect: nothing
there renders SQL, so `dbplyr::tbl_lazy()` alone shows both paths refuse the
call while it is planned, and the test runs in every configuration rather than
skipping wherever an optional driver is absent. No new test needs an optional
backend, so `AGENTS.md`'s one-backend-per-test policy holds by construction,
and no `skip_if()` or snapshot is added for `verify-backend.R` to read.

Every new assertion was confirmed red before the fix.

## Verification

- `testthat::test_local()` — green, no failures.
- `lintr::lint_package()` after `pkgload::load_all(".")` — no lints found.
- `R CMD check` on the built tarball with `NOT_CRAN=true` — tests, examples and
  spelling OK. (The two WARNINGs are the un-rendered vignettes of a
  `--no-build-vignettes` build.)
- `.github/scripts/verify-suite-coverage.R` — every test executes in at least
  one single-backend configuration.
- No roxygen comments changed, so `man/` and `NAMESPACE` are untouched; every
  function added is internal. The documented rule on the help page — a summary
  "cannot depend on an earlier summary alias", a later summary "cannot use a
  share" — is spelling-agnostic already, so no prose changed.

## Reviews applied

A two-axis review (Standards + Spec) ran against `205e0b2`. The Spec axis found
the four function-naming evasions above; the Standards axis found the
argument-name defaulting block standing in four copies — one of them added by
that commit beside the one it edited, now `argument_names()` — and a comment
claiming the character vector was the walk's only channel to its caller, which
`statement_reads_and_bound()` disproves two hundred lines above. All are fixed
in `94d61bf`.
