### PR TITLE
Answer an empty across() argument as the omitted one R says it is

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -983,18 +983,26 @@ wrap_dtplyr_share_across <- function(expr, checks, call) {
     recognized_positions[recognized_positions > 0L]
   )
   forwarded_args <- call_args[forwarded_positions]
-  if (fns_index == 0L) {
+  # `parsed$fns` is `NULL` for a `.fns` the caller omitted, which is the
+  # identity lambda `across()` applies in its place. It answers the same for a
+  # `.fns` left empty, but no share reaches here with one:
+  # `preflight_share_across_syntax()` requires the helper itself in that
+  # position and refuses anything else, an empty argument included. Asking the
+  # value rather than the index is still what this is written on, because the
+  # index is a position and the position is a separate question -- the one the
+  # write-back below asks, where an empty `.fns` would be replaced in place and
+  # an absent one appended (#174).
+  if (is.null(parsed$fns)) {
     functions <- list(rlang::expr(~.x))
     function_names <- ""
     fns_is_list <- FALSE
   } else {
-    fns <- call_args[[fns_index]]
-    fns_is_list <- rlang::is_call(fns, "list")
+    fns_is_list <- rlang::is_call(parsed$fns, "list")
     if (fns_is_list) {
-      functions <- static_call_args(fns)
+      functions <- static_call_args(parsed$fns)
       function_names <- names(functions)
     } else {
-      functions <- list(fns)
+      functions <- list(parsed$fns)
       function_names <- ""
     }
   }
@@ -2827,7 +2835,12 @@ expression_alias_dependencies <- function(expr, aliases) {
 # bind to the statements after them. `local()` needs no case at all: it binds
 # nothing either, and whichever of these its argument is answers it (#162).
 expression_data_symbols <- function(expr, bound = character()) {
-  if (rlang::is_symbol(expr)) {
+  # `is_name_part()` rather than `rlang::is_symbol()`, because the walk
+  # descends into every part of a call and an empty argument is a symbol whose
+  # name is `""`: the read of a column by that name was reported to every
+  # caller of this list. An empty part is no call either, so it falls to the
+  # line below and names nothing, which is the answer (#174).
+  if (is_name_part(expr)) {
     name <- rlang::as_name(expr)
     if (name %in% bound) {
       return(character())
@@ -2939,16 +2952,19 @@ expression_data_symbols <- function(expr, bound = character()) {
       return(character())
     }
     if (identical(pronoun, ".data")) {
-      column <- expr[[3L]]
-      if (rlang::is_symbol(column)) {
-        return(rlang::as_name(column))
+      # By subscript, because `.data[[, 1]]` puts an empty argument in the
+      # index position: `column <- expr[[3L]]` binds R's missing marker there
+      # and raises `missingArgError` on the first read of that name (#174). It
+      # names no column, which is what an unreadable index already answers.
+      if (is_name_part(expr[[3L]])) {
+        return(rlang::as_name(expr[[3L]]))
       }
       if (
-        is.character(column) &&
-          length(column) == 1L &&
-          !is.na(column)
+        is.character(expr[[3L]]) &&
+          length(expr[[3L]]) == 1L &&
+          !is.na(expr[[3L]])
       ) {
-        return(column)
+        return(expr[[3L]])
       }
       return(character())
     }
@@ -3125,9 +3141,8 @@ statement_reads_and_bound <- function(expr, bound) {
     # reads no column `i`. The sequence is read before the index is bound, the
     # body after.
     inner <- bound
-    index <- expr[[2L]]
-    if (rlang::is_symbol(index)) {
-      inner <- unique(c(bound, rlang::as_name(index)))
+    if (is_name_part(expr[[2L]])) {
+      inner <- unique(c(bound, rlang::as_name(expr[[2L]])))
     }
     return(list(
       reads = unique(c(
@@ -3137,12 +3152,11 @@ statement_reads_and_bound <- function(expr, bound) {
       bound = inner
     ))
   }
-  target <- expr[[2L]]
   value <- expression_data_symbols(expr[[3L]], bound)
-  if (rlang::is_symbol(target)) {
+  if (is_name_part(expr[[2L]])) {
     return(list(
       reads = value,
-      bound = unique(c(bound, rlang::as_name(target)))
+      bound = unique(c(bound, rlang::as_name(expr[[2L]])))
     ))
   }
   # A replacement form -- `names(x) <- v` -- reads its target before it rebuilds
@@ -3151,7 +3165,7 @@ statement_reads_and_bound <- function(expr, bound) {
   # name a replacement call rebinds depends on the shape it is nested in, and
   # leaving it unbound over-reports.
   list(
-    reads = unique(c(expression_data_symbols(target, bound), value)),
+    reads = unique(c(expression_data_symbols(expr[[2L]], bound), value)),
     bound = bound
   )
 }
@@ -3168,11 +3182,16 @@ removal_retained_bound <- function(expr, bound) {
   arg_names <- argument_names(args)
   removed <- character()
   for (i in seq_along(args)) {
-    arg <- args[[i]]
-    literal <- if (rlang::is_symbol(arg)) {
-      rlang::as_name(arg)
-    } else if (is.character(arg) && !anyNA(arg)) {
-      arg
+    # By subscript throughout, and never `arg <- args[[i]]`: an argument the
+    # caller left empty is bound to that name as R's missing marker, and the
+    # first read of it raises `missingArgError` naming this frame's variable
+    # (#168, #174). Such an argument is no literal, so it empties the bound set
+    # like any other unreadable removal and the expression evaluates -- `rm(x,
+    # )` is refused by `rm()` itself, and that is the error the caller sees.
+    literal <- if (is_name_part(args[[i]])) {
+      rlang::as_name(args[[i]])
+    } else if (is.character(args[[i]]) && !anyNA(args[[i]])) {
+      args[[i]]
     } else {
       NULL
     }

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -374,38 +374,38 @@ rewrite_across_selection <- function(expr,
   call_args <- parsed$call_args
   selection_index <- parsed$cols_index
 
-  if (selection_index == 0L || is.na(selection_index)) {
-    selected <- resolve_summary_selection(
-      rlang::expr(dplyr::everything()),
-      env = env,
-      data_proxy = data_proxy
-    )
+  # One resolution, whichever way the selection was written: `parsed$cols` is
+  # already the `dplyr::everything()` that an omitted `.cols` selects, and an
+  # argument the caller left empty is omitted in exactly that sense. What the
+  # branch decides is only where the resolved selection goes -- prepended when
+  # no argument occupies `.cols`, and written back over the argument that does,
+  # so an empty one keeps its position instead of being dropped from the
+  # middle of the call (#174).
+  selected <- resolve_summary_selection(
+    parsed$cols,
+    env = env,
+    data_proxy = data_proxy
+  )
+  if (selection_index == 0L) {
     call_args <- append(
       list(.cols = summary_all_of_expr(selected, data_proxy)),
       call_args
     )
     selection_index <- 1L
   } else {
-    selected <- resolve_summary_selection(
-      call_args[[selection_index]],
-      env = env,
-      data_proxy = data_proxy
-    )
     call_args[[selection_index]] <- summary_all_of_expr(selected, data_proxy)
   }
 
   if (identical(call_name, "across") && normalize_across_names) {
     parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
-    names_index <- parsed$names_index
-    unpack_index <- parsed$unpack_index
-    unpack_is_false <- unpack_index == 0L || isFALSE(tryCatch(
-      rlang::eval_tidy(call_args[[unpack_index]], env = env),
+    unpack_is_false <- is.null(parsed$unpack) || isFALSE(tryCatch(
+      rlang::eval_tidy(parsed$unpack, env = env),
       error = function(cnd) NULL
     ))
     function_names <- known_across_function_names(parsed)
 
     if (
-      names_index > 0L &&
+      !is.null(parsed$names) &&
         unpack_is_false &&
         length(function_names) == 1L
     ) {
@@ -417,24 +417,22 @@ rewrite_across_selection <- function(expr,
           data_proxy
         )
 
-        fns_index <- parsed$fns_index
         if (
-          fns_index > 0L &&
-            rlang::is_call(call_args[[fns_index]], "list") &&
-            length(call_args[[fns_index]]) == 2L
+          rlang::is_call(parsed$fns, "list") &&
+            length(parsed$fns) == 2L
         ) {
-          call_args[[fns_index]] <- call_args[[fns_index]][[2L]]
+          call_args[[parsed$fns_index]] <- parsed$fns[[2L]]
         }
-        call_args <- call_args[-names_index]
+        call_args <- call_args[-parsed$names_index]
       }
     }
   }
 
   if (identical(call_name, "across")) {
     parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
-    if (parsed$names_index > 0L) {
+    if (!is.null(parsed$names)) {
       call_args[[parsed$names_index]] <- rlang::eval_tidy(
-        call_args[[parsed$names_index]],
+        parsed$names,
         env = env
       )
     }
@@ -553,29 +551,30 @@ known_injected_argument_name <- function(expr) {
     return("")
   }
 
-  lhs <- expr[[2L]]
-  if (is.character(lhs) && length(lhs) == 1L && !is.na(lhs)) {
-    return(lhs)
+  # By subscript, because a name-position argument the caller left empty is R's
+  # missing marker: `lhs <- expr[[2L]]` binds it and raises `missingArgError`
+  # on the first read of that name (#174). It names no output, which is what
+  # the fall-through below already says.
+  if (
+    is.character(expr[[2L]]) &&
+      length(expr[[2L]]) == 1L &&
+      !is.na(expr[[2L]])
+  ) {
+    return(expr[[2L]])
   }
-  if (rlang::is_symbol(lhs)) {
-    return(rlang::as_name(lhs))
+  if (is_name_part(expr[[2L]])) {
+    return(rlang::as_name(expr[[2L]]))
   }
   ""
 }
 
 known_across_output_names <- function(expr, env, data_proxy) {
   parsed <- parse_across_arguments(expr)
-  call_args <- parsed$call_args
   cols_expr <- parsed$cols
   column_names <- names(resolve_summary_selection(cols_expr, env, data_proxy))
 
-  names_index <- parsed$names_index
-  if (names_index == 0L) {
-    fns_index <- parsed$fns_index
-    if (
-      fns_index > 0L &&
-        rlang::is_call(call_args[[fns_index]], "list")
-    ) {
+  if (is.null(parsed$names)) {
+    if (rlang::is_call(parsed$fns, "list")) {
       function_names <- known_across_function_names(parsed)
       return(unlist(
         lapply(
@@ -590,7 +589,7 @@ known_across_output_names <- function(expr, env, data_proxy) {
     return(column_names)
   }
   names_template <- tryCatch(
-    rlang::eval_tidy(call_args[[names_index]], env = env),
+    rlang::eval_tidy(parsed$names, env = env),
     error = function(cnd) NULL
   )
   if (
@@ -660,17 +659,15 @@ known_across_source_names <- function(expr, env, data_proxy) {
   get_col_names(data_proxy, dplyr::everything())[unname(selected)]
 }
 
+# `"1"` is what `{.fn}` expands to for a `.fns` that is one function, and for
+# one that was never supplied: dplyr numbers a single function by its position
+# whether the caller wrote it or took the identity default.
 known_across_function_names <- function(parsed) {
-  fns_index <- parsed$fns_index
-  if (fns_index == 0L) {
+  if (!rlang::is_call(parsed$fns, "list")) {
     return("1")
   }
 
-  fns_expr <- parsed$call_args[[fns_index]]
-  if (!rlang::is_call(fns_expr, "list")) {
-    return("1")
-  }
-  fns <- static_call_args(fns_expr)
+  fns <- static_call_args(parsed$fns)
   fns_names <- names(fns)
   if (is.null(fns_names)) {
     fns_names <- rep("", length(fns))
@@ -692,6 +689,22 @@ name_unnamed_by_position <- function(arg_names, prefix) {
   arg_names
 }
 
+# The one place that knows an `across()` argument can be empty, so that no
+# caller has to. R's empty argument is what a caller leaves in a position they
+# omitted, and R answers it as an omission: `across(v, )` takes `.fns`'s
+# default exactly as `across(v)` does, which is why `dplyr::across()` treats
+# the two alike down to the `{.fn}` expansion and the `.cols` deprecation. The
+# value fields below therefore answer for an empty argument what they answer
+# for an absent one, and the index fields keep naming the position it occupies:
+# a rewrite puts its replacement back where the caller wrote it rather than
+# dropping an argument, which would slide every positional argument after it
+# into a formal that is not its own (#174).
+#
+# Reading a value here rather than out of `call_args` is also what keeps the
+# empty argument from being bound to a name downstream. `parts[[index]]` is
+# safe, and passing what it returns straight to a function is safe, but binding
+# it -- `for (part in parts)` as in #168, or `part <- parts[[index]]` as here --
+# raises base R's untyped `missingArgError` on the first read of that name.
 parse_across_arguments <- function(expr) {
   call_args <- rlang::call_args(expr)
   arg_names <- names(call_args)
@@ -715,6 +728,9 @@ parse_across_arguments <- function(expr) {
   used <- c(cols_index, fns_index, names_index, unpack_index)
   additional <- setdiff(seq_along(call_args), used[used > 0L])
   additional_names <- name_unnamed_by_position(arg_names[additional], "..")
+  supplied <- function(index) {
+    index > 0L && !rlang::is_missing(call_args[[index]])
+  }
 
   list(
     call_args = call_args,
@@ -722,14 +738,14 @@ parse_across_arguments <- function(expr) {
     fns_index = fns_index,
     names_index = names_index,
     unpack_index = unpack_index,
-    cols = if (cols_index == 0L) {
-      rlang::expr(dplyr::everything())
-    } else {
+    cols = if (supplied(cols_index)) {
       call_args[[cols_index]]
+    } else {
+      rlang::expr(dplyr::everything())
     },
-    fns = if (fns_index == 0L) NULL else call_args[[fns_index]],
-    names = if (names_index == 0L) NULL else call_args[[names_index]],
-    unpack = if (unpack_index == 0L) NULL else call_args[[unpack_index]],
+    fns = if (supplied(fns_index)) call_args[[fns_index]] else NULL,
+    names = if (supplied(names_index)) call_args[[names_index]] else NULL,
+    unpack = if (supplied(unpack_index)) call_args[[unpack_index]] else NULL,
     additional = additional_names
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -216,11 +216,29 @@ static_call_head <- function(expr) {
 # the loop variable rather than anything the caller wrote (#168). This is not a
 # contrived shape: every empty-index spelling has one, and `x[, "col"]` is
 # everyday R that `dplyr::summarise()` accepts.
+#
+# What `for` does is bind, so `part <- parts[[index]]` does it too: the rule is
+# about the binding rather than about the loop, and lifting one part into a
+# local is how the same condition reached an `across()` rebuild (#174). Read
+# the part where it is used, and ask `is_name_part()` below what it is.
+#
+# `test-utils.R` scans the namespace for both spellings.
 static_call_args <- function(expr) {
   if (rlang::is_quosure(expr)) {
     return(list(rlang::quo_get_expr(expr)))
   }
   as.list(expr)[-1L]
+}
+
+# Whether a call part names something: a symbol, and not the empty argument.
+# The second half is what `rlang::is_symbol()` cannot answer on its own, and
+# every site that reads a name out of a part needs it -- the empty argument is
+# a symbol whose name is `""`, so a bare symbol test reports a column, a
+# binding, or an output called `""`, which nothing the caller wrote can be
+# (#174). Asked of a part read by subscript, never of one bound to a name,
+# which is the rule above.
+is_name_part <- function(part) {
+  !rlang::is_missing(part) && rlang::is_symbol(part)
 }
 
 rebuild_static_call <- function(expr, args) {

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -312,6 +312,44 @@ test_that("dtplyr preserves across arguments for unreferenced functions", {
   )
 })
 
+test_that("dtplyr preserves an omitted across selection", {
+  skip_if_backend_absent("dtplyr")
+  # dtplyr takes the share `across()` apart and rebuilds it a second time, to
+  # wrap each function in the validation the lazy backend needs, so an argument
+  # the caller omitted has one more rebuild to survive (#174). Compared against
+  # the local result, which needs no optional backend and cannot agree with a
+  # wrong rebuild by making the same mistake.
+  data <- data.frame(
+    group = c("x", "x", "y"),
+    value = c(1, 3, 6),
+    other = c(2, 4, 8)
+  )
+  summarize <- function(source) {
+    summarize_with_margins(
+      source,
+      total = sum(value),
+      rest = sum(other),
+      dplyr::across(, share_of_parent, .names = "{.col}_share"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    ) |>
+      dplyr::arrange(group)
+  }
+
+  expected <- summarize(data)
+  query <- summarize(dtplyr::lazy_dt(data))
+  expect_s3_class(query, "dtplyr_step")
+  expect_equal(
+    as.data.frame(dplyr::collect(query)),
+    as.data.frame(expected)
+  )
+  # The omission selected both eligible summaries, as `everything()` does.
+  expect_named(
+    expected,
+    c("group", "total", "rest", "total_share", "rest_share")
+  )
+})
+
 test_that("Arrow rejects Parent shares before constructing a query", {
   skip_if_backend_absent("arrow")
   source <- arrow::Table$create(data.frame(

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -1730,6 +1730,431 @@ test_that("an empty argument does not hide a share helper beside it", {
   expect_s3_class(error, "marginplyr_error")
 })
 
+# The tests below cover the second place an empty argument reaches, and the
+# reason it needed one of its own (#174). #168's walk only reads a summary
+# expression; an `across()` call is taken apart and rebuilt, so an argument the
+# caller omitted has to come back out in the position they left it, still
+# omitted. R decides what "omitted" means and dplyr follows it: `f(a = )` takes
+# the default exactly as `f()` does, so `dplyr::summarise()` is the oracle for
+# every shape here rather than a rule restated in this package.
+#
+# One difference from dplyr is deliberate and is not a shape omitted below.
+# dplyr deprecated an omitted `.cols` and warns about it, while a summary
+# staged here reaches dplyr with its selection already resolved to an
+# `all_of()` literal -- the invariant `native_summary_output_names()` depends
+# on -- so the call dplyr finally sees omits nothing and its lifecycle warning
+# does not fire. That is what the omitted spelling `across(.fns = sum)` has
+# always done here, and the empty spelling now matches it. The columns and the
+# values are dplyr's either way, which is what these assert.
+
+test_that("an omitted `across()` selection keeps the columns dplyr selects", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    dplyr::across(, sum),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  # Named and positional spellings of the same omission. R matches `.cols` by
+  # name here and finds it empty, which is the same missing argument the
+  # positional spelling leaves in the first position.
+  named <- summarize_with_margins(
+    data,
+    dplyr::across(.cols = , .fns = sum),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expected <- suppressWarnings(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(dplyr::across(, sum), .groups = "drop")
+  )
+
+  expect_equal(
+    dplyr::arrange(result[!is.na(result$region), ], region),
+    as.data.frame(expected),
+    ignore_attr = "row.names"
+  )
+  expect_equal(named, result)
+
+  # The one difference from dplyr, asserted rather than left to the comment
+  # above. Raising the deprecation is what makes it visible: dplyr refuses
+  # `across(, sum)` outright there, while the summary staged here reaches
+  # dplyr with `.cols` resolved to an `all_of()` literal, so nothing about the
+  # call it finally sees is deprecated. A change that let the signal through
+  # fails here and sends its author to that comment rather than passing
+  # silently in either direction.
+  with_deprecation_errors({
+    expect_error(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(dplyr::across(, sum), .groups = "drop"),
+      "across()",
+      fixed = TRUE
+    )
+    expect_equal(
+      summarize_with_margins(
+        data,
+        dplyr::across(, sum),
+        .grouping = rollup(region),
+        .margin_label = NULL
+      ),
+      result
+    )
+  })
+})
+
+test_that("an omitted `across()` function keeps the columns dplyr returns", {
+  # An omitted `.fns` is the identity, so every group must hold one row for the
+  # result to be a summary at all -- which is dplyr's rule, not this package's,
+  # and the reason the plan below carries a single grouping set.
+  data <- data.frame(
+    region = c("East", "West"),
+    units = c(1, 3),
+    revenue = c(2, 4)
+  )
+  plan <- grouping_sets(grouping_set(region))
+
+  result <- summarize_with_margins(
+    data,
+    dplyr::across(units, ),
+    .grouping = plan
+  )
+  # `{.fn}` expands to `"1"` for an omitted `.fns`, exactly as it does for a
+  # `.fns` that is a single unnamed function.
+  templated <- summarize_with_margins(
+    data,
+    dplyr::across(c(units, revenue), , .names = "{.col}_{.fn}"),
+    .grouping = plan
+  )
+
+  expected <- data |>
+    dplyr::group_by(region) |>
+    dplyr::summarise(dplyr::across(units, ), .groups = "drop")
+  expected_templated <- data |>
+    dplyr::group_by(region) |>
+    dplyr::summarise(
+      dplyr::across(c(units, revenue), , .names = "{.col}_{.fn}"),
+      .groups = "drop"
+    )
+
+  expect_equal(result, as.data.frame(expected), ignore_attr = "row.names")
+  expect_equal(
+    templated,
+    as.data.frame(expected_templated),
+    ignore_attr = "row.names"
+  )
+})
+
+test_that("an omitted `across()` argument leaves the positions around it", {
+  # The surrounding arguments are what a rebuild that drops or appends gets
+  # wrong: an argument removed from the middle moves every positional argument
+  # after it into a formal that is not its own.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+  summarize <- function(...) {
+    summarize_with_margins(
+      data,
+      ...,
+      .grouping = rollup(region),
+      .margin_label = NULL
+    )
+  }
+  expected <- function(...) {
+    as.data.frame(suppressWarnings(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(..., .groups = "drop")
+    ))
+  }
+  without_margins <- function(result) {
+    dplyr::arrange(result[!is.na(result$region), ], region)
+  }
+
+  # An omitted `.cols` before a `.names` template that names what follows it.
+  expect_equal(
+    without_margins(summarize(dplyr::across(, sum, .names = "{.col}_total"))),
+    expected(dplyr::across(, sum, .names = "{.col}_total")),
+    ignore_attr = "row.names"
+  )
+  # An omitted `.names` after a selection and a function, both positional.
+  expect_equal(
+    without_margins(summarize(dplyr::across(c(units), sum, .names = ))),
+    expected(dplyr::across(c(units), sum, .names = )),
+    ignore_attr = "row.names"
+  )
+  # An omitted `.unpack`, whose default this package also reads.
+  expect_equal(
+    without_margins(summarize(dplyr::across(units, sum, .unpack = ))),
+    expected(dplyr::across(units, sum, .unpack = )),
+    ignore_attr = "row.names"
+  )
+  # Partially named: an omitted `.cols`, a positional `.fns`, and a named
+  # argument that `across()` forwards to it. The forwarded argument has to
+  # stay forwarded, which it does not if the omission is closed by inserting
+  # an argument ahead of it. dplyr deprecated forwarding through `...`, and
+  # that its warning still reaches the caller is the evidence the argument is
+  # in that position after the rebuild rather than in a formal of its own.
+  expect_equal(
+    suppressWarnings(
+      without_margins(summarize(dplyr::across(, mean, na.rm = TRUE)))
+    ),
+    expected(dplyr::across(, mean, na.rm = TRUE)),
+    ignore_attr = "row.names"
+  )
+  # Collected rather than expected one at a time, since a plan of this shape
+  # runs one branch per grouping set and each raises the warning of its own.
+  signalled <- character()
+  withCallingHandlers(
+    summarize(dplyr::across(, mean, na.rm = TRUE)),
+    warning = function(condition) {
+      signalled <<- c(signalled, conditionMessage(condition))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_true(any(grepl(
+    "argument of `across()` is deprecated",
+    signalled,
+    fixed = TRUE
+  )))
+  # And with the function list named, where `{.fn}` names each output.
+  expect_equal(
+    without_margins(summarize(dplyr::across(, list(total = sum, m = mean)))),
+    expected(dplyr::across(, list(total = sum, m = mean))),
+    ignore_attr = "row.names"
+  )
+})
+
+test_that("an invalid omitted `across()` argument raises dplyr's own error", {
+  # An omitted `.fns` over a group of more than one row is a size error dplyr
+  # itself raises, and the analysis has no fault to report: the caller must see
+  # the condition their own expression produces, not a missing-argument lookup
+  # from inside the rebuild (ADR-0015).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+
+  baseline <- expect_error(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(dplyr::across(units, ), .groups = "drop")
+  )
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(units, ),
+      .grouping = rollup(region)
+    )
+  )
+
+  expect_identical(class(error), class(baseline))
+  expect_false(inherits(error, "missingArgError"))
+  expect_false(inherits(error, "marginplyr_error"))
+  expect_match(conditionMessage(error), "must be size 1", fixed = TRUE)
+})
+
+test_that("an omitted selection in a share `across()` selects every source", {
+  # The share planner reads the selection from the same parse, so an omitted
+  # one has to reach it as the `everything()` dplyr would have applied --
+  # over the eligible preceding summaries, which is what an `across()` share
+  # selects from.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+  summarize <- function(selection) {
+    rlang::inject(summarize_with_margins(
+      data,
+      units = sum(units),
+      revenue = sum(revenue),
+      dplyr::across(!!!selection, share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    ))
+  }
+
+  expect_equal(
+    summarize(list(rlang::missing_arg())),
+    summarize(list(quote(dplyr::everything())))
+  )
+})
+
+test_that("an omitted share `.fns` is refused by name, not by lookup", {
+  # A share helper written past an omitted `.fns` is not a `.fns` at all, and
+  # the diagnostic that says so is the one the caller can act on.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      units = sum(units),
+      dplyr::across(units, , share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(region)
+    ),
+    "`.fns` must be",
+    fixed = TRUE
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_false(inherits(error, "missingArgError"))
+})
+
+test_that("an empty argument answers as omitted wherever the walk reads one", {
+  # `across()` was the reconstruction path #174 was filed for, and the audit
+  # that fixed it found the same read in four more places, each reached by an
+  # expression R and dplyr both accept: a name position (`rm(x, )`), an
+  # injected output name, the `.data` pronoun's index, and the target of a
+  # binding written as a call. All five bound a part of the caller's call to a
+  # name, which is `missingArgError` on the first read of it (#168), and the
+  # empty argument passes `rlang::is_symbol()` besides, so the name `""` was
+  # what the two survivors reported.
+  #
+  # Each expression is read into a variable before it is asserted on, because
+  # `expect_identical()` quotes its own first argument and rlang's quotation
+  # walks what it finds there -- an expression carrying an empty argument
+  # aborts in the expectation rather than in what it is testing.
+  read <- function(expr) expression_data_symbols(expr)
+
+  subset <- read(quote(sum(value[])))
+  pronoun <- read(quote(sum(.data[[, 1]])))
+  # `` `for`(, seq, body) `` and `` `<-`(, value) `` are calls R evaluates
+  # without complaint, so the walk has to answer them: neither binds a name,
+  # and the parts around the empty target are read as they always were.
+  looped <- read(quote({
+    `for`(, share, NULL)
+    1
+  }))
+  assigned <- read(quote({
+    `<-`(, share)
+    2
+  }))
+  # An `rm()` whose argument is empty removes nothing readable, so the bound
+  # set empties and the read after it is reported -- the over-reporting side
+  # this walk is required to be wrong on (#162).
+  removed <- read(quote({
+    x <- share
+    rm(x, )
+    x
+  }))
+  injected <- known_injected_argument_name(quote(`:=`(, 1)))
+
+  expect_identical(subset, "value")
+  expect_identical(pronoun, character())
+  expect_identical(looped, "share")
+  expect_identical(assigned, "share")
+  expect_identical(removed, c("share", "x"))
+  expect_identical(injected, "")
+})
+
+test_that("an empty argument outside `across()` evaluates as dplyr evaluates", {
+  # The end-to-end half of the same audit, with dplyr as the oracle: whatever
+  # each expression does in `dplyr::summarise()` is what it must do here,
+  # whether that is a result or the error the caller's own code produces.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # A name a `tibble()` builds from an empty argument is a name dplyr accepts,
+  # so a result is what both sides must return.
+  injected <- summarize_with_margins(
+    data,
+    tibble::tibble(`:=`(, 1)),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expected <- data |>
+    dplyr::group_by(region) |>
+    dplyr::summarise(tibble::tibble(`:=`(, 1)), .groups = "drop")
+  expect_equal(
+    dplyr::arrange(injected[!is.na(injected$region), ], region),
+    as.data.frame(expected),
+    ignore_attr = "row.names"
+  )
+
+  # `rm(x, )` is refused by `rm()` itself, so the caller must see that refusal
+  # rather than a missing-argument lookup from inside the walk.
+  baseline <- expect_error(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(
+        derived = {
+          x <- 2
+          rm(x, )
+          5
+        },
+        .groups = "drop"
+      )
+  )
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      derived = {
+        x <- 2
+        rm(x, )
+        5
+      },
+      .grouping = rollup(region)
+    )
+  )
+  expect_identical(class(error), class(baseline))
+  expect_identical(class(error$parent), class(baseline$parent))
+  expect_false(inherits(error, "missingArgError"))
+  expect_match(
+    conditionMessage(error$parent),
+    "zero-length variable name",
+    fixed = TRUE
+  )
+})
+
+test_that("`parse_across_arguments()` answers an empty argument as omitted", {
+  # The seam every `across()` path reads, and the one place that has to know
+  # about the empty argument: each field below answers what it answers for an
+  # argument that is absent, so no caller binds R's missing marker to a name
+  # -- the read that raises `missingArgError` whether it is spelled `for` or
+  # `<-` (#168).
+  empty <- parse_across_arguments(quote(across(, , .names = , .unpack = )))
+  absent <- parse_across_arguments(quote(across()))
+
+  expect_identical(empty$cols, absent$cols)
+  expect_identical(empty$fns, absent$fns)
+  expect_identical(empty$names, absent$names)
+  expect_identical(empty$unpack, absent$unpack)
+  expect_identical(empty$additional, absent$additional)
+
+  # The positions are the half that is not the same. An empty argument
+  # occupies the formal it was written in, so the indices name it and a
+  # rewrite puts its replacement back where the caller left it.
+  expect_identical(empty$cols_index, 1L)
+  expect_identical(empty$fns_index, 2L)
+  expect_identical(empty$names_index, 3L)
+  expect_identical(empty$unpack_index, 4L)
+  expect_true(rlang::is_missing(empty$call_args[[1L]]))
+  expect_true(rlang::is_missing(empty$call_args[[3L]]))
+
+  # A supplied argument is unchanged by the same reading.
+  supplied <- parse_across_arguments(
+    quote(across(units, sum, .names = "{.col}", .unpack = FALSE))
+  )
+  expect_identical(supplied$cols, quote(units))
+  expect_identical(supplied$fns, quote(sum))
+  expect_identical(supplied$names, "{.col}")
+  expect_identical(supplied$unpack, FALSE)
+})
+
 test_that("no analysed shape reaches the caller as an untyped condition", {
   # The classes below are what each site raised before #100, and before #168 in
   # `missingArgError`'s case. Asserting their absence together keeps a future

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2050,6 +2050,11 @@ test_that("an empty argument answers as omitted wherever the walk reads one", {
     x
   }))
   injected <- known_injected_argument_name(quote(`:=`(, 1)))
+  # The contrast, in both spellings of a name this can read: the empty
+  # argument has to fall through the same branch a readable name is taken by,
+  # rather than the branch taking it under the name `""`.
+  injected_symbol <- known_injected_argument_name(quote(x := 1))
+  injected_string <- known_injected_argument_name(quote("x" := 1))
 
   expect_identical(subset, "value")
   expect_identical(pronoun, character())
@@ -2057,6 +2062,8 @@ test_that("an empty argument answers as omitted wherever the walk reads one", {
   expect_identical(assigned, "share")
   expect_identical(removed, c("share", "x"))
   expect_identical(injected, "")
+  expect_identical(injected_symbol, "x")
+  expect_identical(injected_string, "x")
 })
 
 test_that("an empty argument outside `across()` evaluates as dplyr evaluates", {

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -229,6 +229,41 @@ test_that("dtplyr summary reuses one typed snapshot across selections", {
   expect_setequal(result$total_value, c(10, 20, 30))
 })
 
+test_that("dtplyr unwraps a `.fns` list of one into the function it holds", {
+  skip_if_backend_absent("dtplyr")
+  # dtplyr is the only backend whose `across()` output names are normalized
+  # before staging: the `.names` template is expanded into the selection, and
+  # a `.fns` list holding one function is unwrapped to that function, since a
+  # list would otherwise name the outputs a second time. The rebuild reads
+  # that list off the parse rather than out of the argument list it is
+  # rewriting (#174), so the unwrapping is asserted here. Compared against the
+  # local result, which needs no optional backend.
+  data <- data.frame(
+    group = c("x", "x", "y"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+  summarize <- function(source) {
+    summarize_with_margins(
+      source,
+      dplyr::across(c(units, revenue), list(sum), .names = "{.col}_total"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    ) |>
+      dplyr::arrange(group)
+  }
+
+  expected <- summarize(data)
+  query <- summarize(dtplyr::lazy_dt(data))
+  expect_s3_class(query, "dtplyr_step")
+  expect_equal(
+    as.data.frame(dplyr::collect(query)),
+    as.data.frame(expected)
+  )
+  # The template named each output once, rather than the list naming it again.
+  expect_named(expected, c("group", "units_total", "revenue_total"))
+})
+
 test_that("summary selection errors use the package condition seam", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   summary_options <- list(.groups = "drop")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -90,9 +90,14 @@ test_that("shared argument assertions use the package condition seam", {
 })
 
 # The rule `static_call_args()` states: its elements can be R's empty argument,
-# so a walk reads them by subscript and never binds one with `for`. #168 is what
+# so a walk reads them by subscript and never binds one to a name. #168 is what
 # happens when a walk forgets -- an untyped `missingArgError` naming the loop
 # variable, from a summary expression as ordinary as `sum(value[])`.
+#
+# `for` is one spelling of that binding and `<-` is the other, which is how the
+# same condition reached an `across()` rebuild (#174): a local bound to one
+# element of a parsed call's arguments raises it on the first read of that
+# local. Both spellings are scanned below.
 #
 # Scanned rather than listed, for the reason every other gate here derives: a
 # list of walks is a list the next walk is not on. It reads the namespace rather
@@ -108,26 +113,82 @@ package_functions <- function() {
   stats::setNames(objects[keep], names[keep])
 }
 
-# By subscript throughout, since the code being scanned is exactly the code that
-# may hold an empty argument.
-binds_call_parts_with_for <- function(expr) {
+# Where a list of a call's arguments comes from: the shared reader, the rlang
+# function it wraps, or the `call_args` element of a parse this package builds
+# out of one, in either spelling of the element read.
+#
+# One matcher serves both scans below, because the hazard is one hazard: a list
+# reached this way holds elements that may be empty, whichever construct then
+# binds one. Written separately, the `for` scan matched a direct
+# `static_call_args()` call alone, so the same loop over a local -- the shape
+# `removal_retained_bound()` sits one line away from -- passed both gates while
+# the prose above claimed otherwise.
+reads_call_arguments <- function(expr) {
   if (!is.call(expr)) {
     return(FALSE)
   }
-  sequence <- if (identical(expr[[1L]], quote(`for`)) && length(expr) >= 3L) {
-    expr[[3L]]
-  }
-  if (
-    is.call(sequence) && identical(sequence[[1L]], quote(static_call_args))
-  ) {
+  head <- expr[[1L]]
+  named_reader <-
+    identical(head, quote(static_call_args)) ||
+    identical(head, quote(rlang::call_args))
+  if (named_reader) {
     return(TRUE)
   }
+  element <- identical(head, quote(`$`)) || identical(head, quote(`[[`))
+  element &&
+    length(expr) == 3L &&
+    (identical(expr[[3L]], quote(call_args)) ||
+       identical(expr[[3L]], "call_args"))
+}
+
+# The names a body binds to such a list, so that a loop over one, or a
+# subscript of one, is read as reaching the arguments themselves.
+call_argument_locals <- function(expr, found = character()) {
+  if (!is.call(expr)) {
+    return(found)
+  }
+  if (
+    identical(expr[[1L]], quote(`<-`)) &&
+      length(expr) == 3L &&
+      is.symbol(expr[[2L]]) &&
+      reads_call_arguments(expr[[3L]])
+  ) {
+    found <- unique(c(found, as.character(expr[[2L]])))
+  }
   for (index in seq_along(expr)) {
-    if (binds_call_parts_with_for(expr[[index]])) {
+    found <- call_argument_locals(expr[[index]], found)
+  }
+  found
+}
+
+is_call_arguments <- function(expr, locals) {
+  reads_call_arguments(expr) ||
+    (is.symbol(expr) && as.character(expr) %in% locals)
+}
+
+# By subscript throughout, since the code being scanned is exactly the code that
+# may hold an empty argument.
+binds_call_parts_with_for <- function(body) {
+  locals <- call_argument_locals(body)
+  scan <- function(expr) {
+    if (!is.call(expr)) {
+      return(FALSE)
+    }
+    if (
+      identical(expr[[1L]], quote(`for`)) &&
+        length(expr) >= 3L &&
+        is_call_arguments(expr[[3L]], locals)
+    ) {
       return(TRUE)
     }
+    for (index in seq_along(expr)) {
+      if (scan(expr[[index]])) {
+        return(TRUE)
+      }
+    }
+    FALSE
   }
-  FALSE
+  scan(body)
 }
 
 test_that("no walk binds a call's parts with `for`", {
@@ -172,6 +233,20 @@ test_that("the walk scan detects the shape it is written to forbid", {
       })
     }
   }
+  # The same loop over a local, and over the rlang function the reader wraps:
+  # a scan that matched only a direct `static_call_args()` call passed both,
+  # which is the shape half this package's argument walks are written in.
+  through_local <- function(expr) {
+    args <- rlang::call_args(expr)
+    for (arg in args) {
+      arg
+    }
+  }
+  through_parsed <- function(expr) {
+    for (part in parse_across_arguments(expr)$call_args) {
+      part
+    }
+  }
   compliant <- function(expr) {
     parts <- static_call_args(expr)
     for (index in seq_along(parts)) {
@@ -181,10 +256,117 @@ test_that("the walk scan detects the shape it is written to forbid", {
 
   expect_true(binds_call_parts_with_for(body(offending)))
   expect_true(binds_call_parts_with_for(body(nested)))
+  expect_true(binds_call_parts_with_for(body(through_local)))
+  expect_true(binds_call_parts_with_for(body(through_parsed)))
   expect_false(binds_call_parts_with_for(body(compliant)))
   # An empty argument in the scanned code must not abort the scan, which is the
   # bug one level up.
   expect_false(binds_call_parts_with_for(quote(sum(value[]))))
+})
+
+# The `<-` spelling, over the same matcher: `name <- arguments[[index]]` binds
+# one element of the list the `for` scan above binds every element of.
+#
+# What this cannot see is a part read straight off the call node --
+# `column <- expr[[3L]]` -- because the scan would then have to flag every
+# `x <- y[[i]]` in the package, most of which read an ordinary list. Those sites
+# are covered by behaviour instead, in `test-static-expression-analysis.R`,
+# where each shape is compared against what `dplyr::summarise()` does with it.
+binds_call_parts_by_assign <- function(body) {
+  locals <- call_argument_locals(body)
+  scan <- function(expr) {
+    if (!is.call(expr)) {
+      return(FALSE)
+    }
+    if (
+      identical(expr[[1L]], quote(`<-`)) &&
+        length(expr) == 3L &&
+        is.symbol(expr[[2L]]) &&
+        is.call(expr[[3L]]) &&
+        identical(expr[[3L]][[1L]], quote(`[[`)) &&
+        length(expr[[3L]]) >= 2L
+    ) {
+      if (is_call_arguments(expr[[3L]][[2L]], locals)) {
+        return(TRUE)
+      }
+    }
+    for (index in seq_along(expr)) {
+      if (scan(expr[[index]])) {
+        return(TRUE)
+      }
+    }
+    FALSE
+  }
+  scan(body)
+}
+
+test_that("no walk binds a call's parts with `<-`", {
+  functions <- package_functions()
+  expect_true("parse_across_arguments" %in% names(functions))
+
+  offenders <- vapply(
+    functions,
+    function(f) binds_call_parts_by_assign(body(f)),
+    logical(1)
+  )
+
+  expect_equal(
+    names(functions)[offenders],
+    character(),
+    info = paste(
+      "Read the argument at the point of use --",
+      "`parts[[index]]` rather than `part <- parts[[index]]`."
+    )
+  )
+})
+
+test_that("the assignment scan detects the shape it is written to forbid", {
+  # The two shapes #174 found, and the two the package uses instead. Asserted
+  # before the scan's verdict means anything, as above.
+  through_parse <- function(expr) {
+    parsed <- parse_across_arguments(expr)
+    fns_expr <- parsed$call_args[[parsed$fns_index]]
+    fns_expr
+  }
+  through_local <- function(expr) {
+    args <- rlang::call_args(expr)
+    arg <- args[[1L]]
+    arg
+  }
+  through_parsed_local <- function(expr) {
+    call_args <- parse_across_arguments(expr)$call_args
+    fns <- call_args[[1L]]
+    fns
+  }
+  # The element read by string rather than by name, which is one respelling
+  # away from the shape above and answers the same.
+  through_string_element <- function(expr) {
+    fns <- parse_across_arguments(expr)[["call_args"]][[1L]]
+    fns
+  }
+  through_reader <- function(expr) {
+    part <- static_call_args(expr)[[1L]]
+    part
+  }
+  compliant_local <- function(expr) {
+    parts <- static_call_args(expr)
+    rlang::is_symbol(parts[[1L]])
+  }
+  compliant_list <- function(labels) {
+    label <- labels[[1L]]
+    label
+  }
+
+  expect_true(binds_call_parts_by_assign(body(through_parse)))
+  expect_true(binds_call_parts_by_assign(body(through_local)))
+  expect_true(binds_call_parts_by_assign(body(through_parsed_local)))
+  expect_true(binds_call_parts_by_assign(body(through_string_element)))
+  expect_true(binds_call_parts_by_assign(body(through_reader)))
+  expect_false(binds_call_parts_by_assign(body(compliant_local)))
+  # An ordinary list read is not the shape, or the scan would name most of the
+  # package and mean nothing.
+  expect_false(binds_call_parts_by_assign(body(compliant_list)))
+  expect_false(binds_call_parts_by_assign(quote(sum(value[]))))
 })
 
 test_that("lazy-table assertions use the package condition seam", {


### PR DESCRIPTION
Closes #174.

## What this is

R's empty argument is what a caller leaves in a position they omitted, and R
answers it as an omission: `across(v, )` takes `.fns`'s default exactly as
`across(v)` does, and `dplyr::across()` follows that down to the `{.fn}`
expansion and the `.cols` deprecation. The `across()` planning here did not, in
either direction.

| expression | before | now |
| --- | --- | --- |
| `across(, sum)` | a summary with no columns at all, silently | dplyr's values |
| `across(v, )` | `argument "fns_expr" is missing, with no default` | dplyr's identity, or dplyr's size error |
| `across(, share_of_parent, .names = ...)` | ``refers to unknown summary `` `` `` | every eligible preceding summary |
| `across(v, , .names = "{.col}_{.fn}")` | the same internal lookup failure | `v_1`, as dplyr expands it |

## How

`parse_across_arguments()` is now the one place that knows an argument can be
empty. Its value fields answer for an empty argument what they answer for an
absent one; its index fields keep naming the position it occupies, so a rewrite
puts the replacement back where the caller wrote it. Dropping an argument from
the middle would slide every positional argument after it into a formal that is
not its own, which is what the ticket's fourth and fifth criteria are about.
Both rebuilds read those values rather than re-reading `call_args` by index:
the ordinary selection rewrite in `R/summary-selections.R`, and dtplyr's share
wrapper in `R/share.R`.

## Beyond the ticket's letter

The audit found the same read at four more sites, each reached by an expression
R and dplyr both accept: `rm(x, )`, an injected `:=` output name, the `.data`
pronoun's index, and the target of a binding written as a call. All four are
fixed here. All four also passed a bare `rlang::is_symbol()` — `TRUE` for the
empty argument, with `""` as its name — so two of them reported a read of a
column called `""`; `is_name_part()` in `R/utils.R` is the shared answer, and
the symbol branch of the walk itself now goes through it.

One neighbouring defect is **not** fixed here and has its own ticket: #181, an
empty argument to `grouping_id()` reported as a column named ` `` `. It fails
with a Package condition rather than an untyped one, so it is a diagnostic
defect in a different verb path rather than this invariant.

## The one deliberate difference from dplyr

dplyr deprecated an omitted `.cols` and warns about it. A summary staged here
reaches dplyr with its selection already resolved to an `all_of()` literal —
the invariant `native_summary_output_names()` depends on — so nothing about the
call dplyr finally sees is omitted, and the lifecycle warning does not fire.
That is what the omitted spelling `across(.fns = sum)` has always done here,
and the empty spelling now matches it rather than opening a new gap. The
divergence is pinned under `with_deprecation_errors()` instead of being left to
a comment: dplyr refuses `across(, sum)` outright there, and this package
returns the result.

So the ticket's first criterion is met for values and names, and deliberately
not for the lifecycle signal. Nothing user-facing documents the acceptance of a
spelling dplyr deprecates; say if that should change.

## Tests

dplyr is the oracle throughout, since what "omitted" means is R's answer rather
than this package's. The dtplyr case compares against the **local** result, per
the one-backend policy. The scan in `test-utils.R` gains the `<-` spelling of
the binding it already forbade with `for`, over one matcher shared by both —
written separately, the `for` scan matched a direct `static_call_args()` call
alone, so the same loop over a local passed a gate whose prose claimed
otherwise.

Locally: lint clean, `roxygenise()` a no-op, the full suite 2711 passing with 0
failures, 0 skips and 0 warnings, and `verify-suite-coverage.R` confirms every
test still executes in a single-backend configuration.
