### PR TITLE
Count the rows a nested cell stands for when no column can

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,7 +75,9 @@
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because
-  their visible outer keys would be indistinguishable. A nesting that leaves
-  no payload column still nests one inner row per source row, on detail
-  groups, subtotals, and the Grand total set alike, and local and `dtplyr`
-  results agree once collected.
+  their visible outer keys would be indistinguishable.
+* A nesting that leaves no payload column now nests one inner row per source
+  row, on detail groups, subtotals, and the Grand total set alike, as
+  `dplyr::nest_by()` does. Local and `dtplyr` results agree once collected.
+  Such a cell is a tibble on both backends, because a `data.table` cannot hold
+  rows without columns.

--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,8 @@
   their visible outer keys would be indistinguishable.
 * A nesting that leaves no payload column now nests one inner row per source
   row, on detail groups, subtotals, and the Grand total set alike, as
-  `dplyr::nest_by()` does. Local and `dtplyr` results agree once collected.
-  Such a cell is a tibble on both backends, because a `data.table` cannot hold
-  rows without columns.
+  `dplyr::nest_by()` does, and local and `dtplyr` results agree once collected.
+  An input with no columns at all is outside that agreement, because a
+  `data.table` cannot represent one. The class of such a cell is described
+  rather than promised, as every nested element class is: on both backends it
+  is what `dplyr::tibble()` produced.

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,4 +75,7 @@
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because
-  their visible outer keys would be indistinguishable.
+  their visible outer keys would be indistinguishable. A nesting that leaves
+  no payload column still nests one inner row per source row, on detail
+  groups, subtotals, and the Grand total set alike, and local and `dtplyr`
+  results agree once collected.

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -147,7 +147,9 @@ nest_by_with_margins <- function(.data,
     )
     result <- dplyr::summarize(
       empty_data,
-      "{.key}" := list(!!nest_cell_expr(ncol(empty_data) == 0L))
+      "{.key}" := list(
+        !!nest_cell_expr(empty_payload = ncol(empty_data) == 0L)
+      )
     )
     if (!is.null(.id)) {
       result <- dplyr::mutate(result, "{.id}" := 1L)

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -147,7 +147,7 @@ nest_by_with_margins <- function(.data,
     )
     result <- dplyr::summarize(
       empty_data,
-      "{.key}" := list(dplyr::pick(dplyr::everything()))
+      "{.key}" := list(!!nest_cell_expr(ncol(empty_data) == 0L))
     )
     if (!is.null(.id)) {
       result <- dplyr::mutate(result, "{.id}" := 1L)

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -66,6 +66,13 @@
 #' [dplyr::tibble()] produced, because a `data.table` cannot hold rows without
 #' columns at all.
 #'
+#' That last point is also a limit on what an input can carry into `dtplyr`,
+#' rather than anything nesting does: a data frame with rows and no columns
+#' loses its rows on the way in, so `dtplyr::lazy_dt(data.frame(row.names =
+#' 1:3))` is already empty before marginplyr reads it and no behavior here can
+#' restore the three rows. Nest an input that has no columns at all locally
+#' when its row count matters.
+#'
 #' No input column name is reserved for internal bookkeeping. Temporary
 #' grouping-set and `.keep` columns are generated collision-free and removed
 #' before the result is returned.

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -58,6 +58,12 @@
 #' [nest_by_with_margins()] follows [dplyr::nest_by()] and returns one row
 #' containing the empty input when there are no grouping keys.
 #'
+#' When nesting leaves no payload column — every input column is a fixed key or
+#' a grouping dimension, and `.keep` does not put them back — each nested data
+#' frame still has one row per source row it stands for, as [dplyr::nest_by()]
+#' does. Such a cell is a tibble whatever the backend, since a `data.table`
+#' cannot hold rows without columns.
+#'
 #' No input column name is reserved for internal bookkeeping. Temporary
 #' grouping-set and `.keep` columns are generated collision-free and removed
 #' before the result is returned.
@@ -323,6 +329,24 @@ execute_margin_nest <- function(operation, .key, .keep) {
   )
 }
 
+# A nesting that removes every payload column still stands for a known number
+# of source rows per cell, and once the columns are gone the count is the only
+# thing left to carry it. `pick()` cannot: with an empty selection it answers a
+# one-row frame locally and an empty `data.table` under dtplyr, so each cell
+# reports a cardinality no source row produced, and the two backends disagree
+# besides. `n()` is that count, and dtplyr translates it to `.N`, so one
+# expression serves both. The cell is a tibble on either backend, because a
+# `data.table` cannot hold rows without columns — `dim()` reads its row count
+# from its first column, so a column-less one is always empty — and the element
+# class is documented as whatever the backend produced rather than promised.
+nest_cell_expr <- function(empty_payload) {
+  if (empty_payload) {
+    quote(dplyr::tibble(.rows = dplyr::n()))
+  } else {
+    quote(dplyr::pick(dplyr::everything()))
+  }
+}
+
 nest_expanded_margins <- function(.data,
                                   group_cols,
                                   set_col,
@@ -330,6 +354,8 @@ nest_expanded_margins <- function(.data,
                                   .key,
                                   .keep,
                                   drop_set_col = TRUE) {
+  # `.keep = TRUE` with grouping columns nests them, so that branch always has
+  # a payload column and needs no count of its own.
   if (.keep && length(group_cols) > 0L) {
     # `rename()` and `relocate()` run inside a data-masked summary expression,
     # so their tidyselect resolves `keep_cols` and `group_cols` against the
@@ -351,10 +377,19 @@ nest_expanded_margins <- function(.data,
       .by = dplyr::all_of(!!c(group_cols, set_col))
     ))
   } else {
+    outer_cols <- c(group_cols, set_col)
+    # `get_col_names()` rather than `colnames()`, which reads `dimnames()` and
+    # so answers `NULL` for a `dtplyr` step — every payload column would then
+    # look absent and be dropped from every cell.
+    payload_cols <- setdiff(
+      get_col_names(.data, dplyr::everything()),
+      outer_cols
+    )
+    cell <- nest_cell_expr(length(payload_cols) == 0L)
     result <- dplyr::summarize(
       .data,
-      "{.key}" := list(dplyr::pick(dplyr::everything())),
-      .by = dplyr::all_of(c(group_cols, set_col))
+      "{.key}" := list(!!cell),
+      .by = dplyr::all_of(outer_cols)
     )
   }
 

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -61,8 +61,10 @@
 #' When nesting leaves no payload column — every input column is a fixed key or
 #' a grouping dimension, and `.keep` does not put them back — each nested data
 #' frame still has one row per source row it stands for, as [dplyr::nest_by()]
-#' does. Such a cell is a tibble whatever the backend, since a `data.table`
-#' cannot hold rows without columns.
+#' does. That row count is promised. The class of such a cell is described
+#' rather than promised, as every element class is: on both backends it is what
+#' [dplyr::tibble()] produced, because a `data.table` cannot hold rows without
+#' columns at all.
 #'
 #' No input column name is reserved for internal bookkeeping. Temporary
 #' grouping-set and `.keep` columns are generated collision-free and removed
@@ -339,6 +341,10 @@ execute_margin_nest <- function(operation, .key, .keep) {
 # `data.table` cannot hold rows without columns — `dim()` reads its row count
 # from its first column, so a column-less one is always empty — and the element
 # class is documented as whatever the backend produced rather than promised.
+#
+# Both call sites spell `empty_payload` out, because the two expressions this
+# returns differ in what they read rather than in degree, and a bare `TRUE` at
+# a call site would not say which one it asked for.
 nest_cell_expr <- function(empty_payload) {
   if (empty_payload) {
     quote(dplyr::tibble(.rows = dplyr::n()))
@@ -385,7 +391,7 @@ nest_expanded_margins <- function(.data,
       get_col_names(.data, dplyr::everything()),
       outer_cols
     )
-    cell <- nest_cell_expr(length(payload_cols) == 0L)
+    cell <- nest_cell_expr(empty_payload = length(payload_cols) == 0L)
     result <- dplyr::summarize(
       .data,
       "{.key}" := list(!!cell),

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -359,6 +359,12 @@ class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margi
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.
 
+When nesting leaves no payload column — every input column is a fixed key or
+a grouping dimension, and \code{.keep} does not put them back — each nested data
+frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
+does. Such a cell is a tibble whatever the backend, since a \code{data.table}
+cannot hold rows without columns.
+
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed
 before the result is returned.

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -362,8 +362,10 @@ containing the empty input when there are no grouping keys.
 When nesting leaves no payload column — every input column is a fixed key or
 a grouping dimension, and \code{.keep} does not put them back — each nested data
 frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
-does. Such a cell is a tibble whatever the backend, since a \code{data.table}
-cannot hold rows without columns.
+does. That row count is promised. The class of such a cell is described
+rather than promised, as every element class is: on both backends it is what
+\code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
+columns at all.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -367,6 +367,12 @@ rather than promised, as every element class is: on both backends it is what
 \code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
 columns at all.
 
+That last point is also a limit on what an input can carry into \code{dtplyr},
+rather than anything nesting does: a data frame with rows and no columns
+loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
+restore the three rows. Nest an input that has no columns at all locally
+when its row count matters.
+
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed
 before the result is returned.

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -139,6 +139,12 @@ rather than promised, as every element class is: on both backends it is what
 \code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
 columns at all.
 
+That last point is also a limit on what an input can carry into \code{dtplyr},
+rather than anything nesting does: a data frame with rows and no columns
+loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
+restore the three rows. Nest an input that has no columns at all locally
+when its row count matters.
+
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed
 before the result is returned.

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -134,8 +134,10 @@ containing the empty input when there are no grouping keys.
 When nesting leaves no payload column — every input column is a fixed key or
 a grouping dimension, and \code{.keep} does not put them back — each nested data
 frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
-does. Such a cell is a tibble whatever the backend, since a \code{data.table}
-cannot hold rows without columns.
+does. That row count is promised. The class of such a cell is described
+rather than promised, as every element class is: on both backends it is what
+\code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
+columns at all.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -131,6 +131,12 @@ class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margi
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.
 
+When nesting leaves no payload column — every input column is a fixed key or
+a grouping dimension, and \code{.keep} does not put them back — each nested data
+frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
+does. Such a cell is a tibble whatever the backend, since a \code{data.table}
+cannot hold rows without columns.
+
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed
 before the result is returned.

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -259,6 +259,233 @@ test_that("nesting drops duplicate grouping sets", {
   expect_identical(dplyr::mutate(by_result, n = nrow(data))$n, c(1L, 1L, 2L))
 })
 
+# A nesting whose payload has no columns still stands for a known number of
+# source rows, and the count is the only thing left to carry. Every case below
+# pins it, because a cell that lost it is still a data frame and still nests
+# under the right key — the loss shows up only as a row count no source row
+# produced.
+keys_only_sales <- function() {
+  data.frame(
+    region = c("East", "East", "West"),
+    store = c("A", "A", "B"),
+    stringsAsFactors = FALSE
+  )
+}
+
+# The same keys carrying one payload column, so the branch that keeps
+# `pick()` is exercised beside the branch that counts rows.
+payload_sales <- function() {
+  cbind(keys_only_sales(), units = c(10L, 20L, 30L))
+}
+
+# Sorted by the outer keys rather than by `.sort`, so the expectation reads the
+# same for both verbs and both backends whatever Margin order they return.
+keys_only_expected <- function() {
+  list(
+    region = c("East", "East", "Total", "West", "West"),
+    store = c("A", "Total", "Total", "B", "Total"),
+    rows = c(2L, 2L, 3L, 1L, 1L)
+  )
+}
+
+# Sorting by name rather than by symbol keeps the outer keys out of this
+# file's global-variable surface, which the linter reads without a data mask.
+arrange_outer_keys <- function(result) {
+  dplyr::arrange(
+    dplyr::ungroup(result),
+    dplyr::across(dplyr::all_of(c("region", "store")))
+  )
+}
+
+nested_cell_dims <- function(result) {
+  ordered <- arrange_outer_keys(result)
+  list(
+    region = ordered$region,
+    store = ordered$store,
+    rows = vapply(ordered$data, nrow, integer(1)),
+    cols = vapply(ordered$data, ncol, integer(1)),
+    names = lapply(ordered$data, names)
+  )
+}
+
+test_that("nesting keeps source-row cardinality with no payload columns", {
+  input <- keys_only_sales()
+  expected <- keys_only_expected()
+  verbs <- list(
+    nest_with_margins = nest_with_margins,
+    nest_by_with_margins = nest_by_with_margins
+  )
+
+  for (verb_name in names(verbs)) {
+    result <- verbs[[verb_name]](
+      input,
+      .grouping = rollup(region, store),
+      .sort = "last"
+    )
+    actual <- nested_cell_dims(result)
+
+    expect_identical(actual$region, expected$region, info = verb_name)
+    expect_identical(actual$store, expected$store, info = verb_name)
+    # Repeated detail groups, the `East` subtotal, and the grand total each
+    # nest every source row they stand for.
+    expect_identical(actual$rows, expected$rows, info = verb_name)
+    expect_identical(
+      actual$cols,
+      rep(0L, length(expected$rows)),
+      info = verb_name
+    )
+    expect_identical(
+      actual$names,
+      rep(list(character()), length(expected$rows)),
+      info = verb_name
+    )
+
+    # An internal column that survived into a cell would be invisible in the
+    # counts above once it was the thing being counted.
+    printed <- paste(utils::capture.output(print(result)), collapse = "\n")
+    expect_false(grepl("marginplyr", printed, fixed = TRUE), info = verb_name)
+  }
+})
+
+test_that("nesting keeps cardinality under both keep options", {
+  input <- keys_only_sales()
+  expected <- keys_only_expected()
+
+  for (verb in list(nest_with_margins, nest_by_with_margins)) {
+    kept <- verb(
+      input,
+      .grouping = rollup(region, store),
+      .sort = "last",
+      .keep = TRUE
+    )
+    actual <- nested_cell_dims(kept)
+
+    expect_identical(actual$rows, expected$rows)
+    expect_identical(actual$cols, rep(2L, length(expected$rows)))
+    expect_identical(
+      actual$names,
+      rep(list(c("region", "store")), length(expected$rows))
+    )
+    # `.keep = TRUE` nests pre-margin values, so the grand-total cell still
+    # holds the source keys rather than the Margin label.
+    total <- arrange_outer_keys(kept)$data[[3L]]
+    expect_identical(
+      sort(as.character(total$region)),
+      c("East", "East", "West")
+    )
+  }
+})
+
+test_that("dtplyr nesting agrees with the local result and stays lazy", {
+  skip_if_backend_absent("dtplyr")
+  # Both inputs are needed: whether a payload column remains is what selects
+  # the cell expression, and a keys-only input alone would pass however that
+  # choice was made.
+  inputs <- list(
+    keys_only = keys_only_sales(),
+    with_payload = payload_sales()
+  )
+  expected_names <- list(
+    keys_only = list(character(), c("region", "store")),
+    with_payload = list("units", c("region", "store", "units"))
+  )
+
+  for (input_name in names(inputs)) {
+    input <- inputs[[input_name]]
+
+    for (keep in c(FALSE, TRUE)) {
+      query <- nest_with_margins(
+        dtplyr::lazy_dt(input),
+        .grouping = rollup(region, store),
+        .sort = "last",
+        .keep = keep
+      )
+      expect_s3_class(query, "dtplyr_step")
+
+      local_result <- nest_with_margins(
+        input,
+        .grouping = rollup(region, store),
+        .sort = "last",
+        .keep = keep
+      )
+      lazy_result <- dplyr::collect(query)
+
+      # Reading the cell names back separately, because comparing the two
+      # backends only says they agree, not that either kept the payload.
+      expect_identical(
+        nested_cell_dims(lazy_result)$names[[1L]],
+        expected_names[[input_name]][[keep + 1L]]
+      )
+
+      # The element class follows the backend and is not part of the API, so
+      # compare the cells as tibbles; everything else must match exactly.
+      as_cells <- function(result) {
+        ordered <- arrange_outer_keys(result)
+        ordered$data <- lapply(ordered$data, dplyr::as_tibble)
+        dplyr::as_tibble(ordered)
+      }
+      expect_equal(as_cells(lazy_result), as_cells(local_result))
+
+      by_result <- nest_by_with_margins(
+        dtplyr::lazy_dt(input),
+        .grouping = rollup(region, store),
+        .sort = "last",
+        .keep = keep
+      )
+      expect_identical(
+        nested_cell_dims(by_result)$rows,
+        nested_cell_dims(local_result)$rows
+      )
+      expect_identical(
+        nested_cell_dims(by_result)$names[[1L]],
+        expected_names[[input_name]][[keep + 1L]]
+      )
+    }
+  }
+})
+
+test_that("zero-column and empty nesting match an independent construction", {
+  # A frame with rows and no columns at all: every cell is a payload-free
+  # cell, and `dplyr::nest_by()` is the upstream verb that answers it.
+  rows_only <- data.frame(row.names = 1:3)
+  expect_identical(dim(rows_only), c(3L, 0L))
+
+  nested <- nest_with_margins(rows_only, .sort = "last")
+  expect_identical(names(nested), "data")
+  expect_identical(nrow(nested), 1L)
+  expect_identical(dim(nested$data[[1L]]), c(3L, 0L))
+
+  by_nested <- nest_by_with_margins(rows_only, .sort = "last")
+  expect_identical(
+    dim(by_nested$data[[1L]]),
+    dim(dplyr::nest_by(rows_only)$data[[1L]])
+  )
+
+  # An empty input keeps `tidyr::nest()` semantics for one verb and
+  # `dplyr::nest_by()` semantics for the other, with no columns to infer a
+  # size from in either.
+  empty <- data.frame()
+  expect_identical(nrow(nest_with_margins(empty, .sort = "last")), 0L)
+
+  by_empty <- nest_by_with_margins(empty, .sort = "last")
+  expect_identical(nrow(by_empty), 1L)
+  expect_identical(
+    dim(by_empty$data[[1L]]),
+    dim(dplyr::nest_by(empty)$data[[1L]])
+  )
+
+  # A keyed but rowless input nests nothing under either verb.
+  keyed_empty <- data.frame(region = character())
+  expect_identical(
+    nrow(nest_with_margins(keyed_empty, .grouping = rollup(region))),
+    0L
+  )
+  expect_identical(
+    nrow(nest_by_with_margins(keyed_empty, .grouping = rollup(region))),
+    0L
+  )
+})
+
 test_that("nesting rejects unsupported sources with a package condition", {
   remote <- dbplyr::tbl_lazy(
     data.frame(group = c("x", "y"), value = 1:2),

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -278,7 +278,7 @@ payload_sales <- function() {
   cbind(keys_only_sales(), units = c(10L, 20L, 30L))
 }
 
-# Sorted by the outer keys rather than by `.sort`, so the expectation reads the
+# Sorted by the sales keys rather than by `.sort`, so the expectation reads the
 # same for both verbs and both backends whatever Margin order they return.
 keys_only_expected <- function() {
   list(
@@ -288,17 +288,20 @@ keys_only_expected <- function() {
   )
 }
 
-# Sorting by name rather than by symbol keeps the outer keys out of this
-# file's global-variable surface, which the linter reads without a data mask.
-arrange_outer_keys <- function(result) {
+# The three helpers below read the sales fixtures specifically, hence the
+# names: each one knows that `region` and `store` are the keys.
+#
+# Sorting by name rather than by symbol keeps those keys out of this file's
+# global-variable surface, which the linter reads without a data mask.
+arrange_sales_keys <- function(result) {
   dplyr::arrange(
     dplyr::ungroup(result),
     dplyr::across(dplyr::all_of(c("region", "store")))
   )
 }
 
-nested_cell_dims <- function(result) {
-  ordered <- arrange_outer_keys(result)
+sales_cell_shape <- function(result) {
+  ordered <- arrange_sales_keys(result)
   list(
     region = ordered$region,
     store = ordered$store,
@@ -306,6 +309,14 @@ nested_cell_dims <- function(result) {
     cols = vapply(ordered$data, ncol, integer(1)),
     names = lapply(ordered$data, names)
   )
+}
+
+# The element class follows the backend and is not part of the API, so cells
+# are compared as tibbles; everything else must match exactly.
+sales_cells_as_tibble <- function(result) {
+  ordered <- arrange_sales_keys(result)
+  ordered$data <- lapply(ordered$data, dplyr::as_tibble)
+  dplyr::as_tibble(ordered)
 }
 
 test_that("nesting keeps source-row cardinality with no payload columns", {
@@ -322,11 +333,11 @@ test_that("nesting keeps source-row cardinality with no payload columns", {
       .grouping = rollup(region, store),
       .sort = "last"
     )
-    actual <- nested_cell_dims(result)
+    actual <- sales_cell_shape(result)
 
     expect_identical(actual$region, expected$region, info = verb_name)
     expect_identical(actual$store, expected$store, info = verb_name)
-    # Repeated detail groups, the `East` subtotal, and the grand total each
+    # Repeated detail groups, the `East` subtotal, and the Grand total set each
     # nest every source row they stand for.
     expect_identical(actual$rows, expected$rows, info = verb_name)
     expect_identical(
@@ -340,9 +351,18 @@ test_that("nesting keeps source-row cardinality with no payload columns", {
       info = verb_name
     )
 
-    # An internal column that survived into a cell would be invisible in the
-    # counts above once it was the thing being counted.
-    printed <- paste(utils::capture.output(print(result)), collapse = "\n")
+    # The cells are printed as well as the result, because the outer result is
+    # a data frame and `print.data.frame()` renders a list column as `NULL` —
+    # a scan of that alone would see no cell at all.
+    printed <- paste(
+      c(
+        utils::capture.output(print(result)),
+        unlist(lapply(result$data, function(cell) {
+          utils::capture.output(print(cell))
+        }))
+      ),
+      collapse = "\n"
+    )
     expect_false(grepl("marginplyr", printed, fixed = TRUE), info = verb_name)
   }
 })
@@ -358,7 +378,7 @@ test_that("nesting keeps cardinality under both keep options", {
       .sort = "last",
       .keep = TRUE
     )
-    actual <- nested_cell_dims(kept)
+    actual <- sales_cell_shape(kept)
 
     expect_identical(actual$rows, expected$rows)
     expect_identical(actual$cols, rep(2L, length(expected$rows)))
@@ -366,13 +386,41 @@ test_that("nesting keeps cardinality under both keep options", {
       actual$names,
       rep(list(c("region", "store")), length(expected$rows))
     )
-    # `.keep = TRUE` nests pre-margin values, so the grand-total cell still
-    # holds the source keys rather than the Margin label.
-    total <- arrange_outer_keys(kept)$data[[3L]]
+    # `.keep = TRUE` nests pre-margin values, so the Grand total set's cell
+    # still holds the source keys rather than the Margin label.
+    total <- arrange_sales_keys(kept)$data[[3L]]
     expect_identical(
       sort(as.character(total$region)),
       c("East", "East", "West")
     )
+  }
+})
+
+test_that("nesting keeps cardinality when duplicate sets are dropped", {
+  # `.duplicates` is the other option the cardinality has to survive, and a
+  # dropped repeat must leave the surviving set's cells the size they were.
+  input <- keys_only_sales()
+  spec <- grouping_sets(rollup(region, store), grouping_set(region, store))
+  expected <- keys_only_expected()
+
+  for (verb in list(nest_with_margins, nest_by_with_margins)) {
+    expect_error(
+      verb(input, .grouping = spec, .sort = "last"),
+      "Duplicate grouping sets"
+    )
+
+    dropped <- verb(
+      input,
+      .grouping = spec,
+      .duplicates = "drop",
+      .sort = "last"
+    )
+    actual <- sales_cell_shape(dropped)
+
+    expect_identical(actual$region, expected$region)
+    expect_identical(actual$store, expected$store)
+    expect_identical(actual$rows, expected$rows)
+    expect_identical(actual$cols, rep(0L, length(expected$rows)))
   }
 })
 
@@ -381,72 +429,77 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
   # Both inputs are needed: whether a payload column remains is what selects
   # the cell expression, and a keys-only input alone would pass however that
   # choice was made.
-  inputs <- list(
-    keys_only = keys_only_sales(),
-    with_payload = payload_sales()
+  scenarios <- list(
+    list(input = keys_only_sales(), keep = FALSE, names = character()),
+    list(input = keys_only_sales(), keep = TRUE, names = c("region", "store")),
+    list(input = payload_sales(), keep = FALSE, names = "units"),
+    list(
+      input = payload_sales(),
+      keep = TRUE,
+      names = c("region", "store", "units")
+    )
   )
-  expected_names <- list(
-    keys_only = list(character(), c("region", "store")),
-    with_payload = list("units", c("region", "store", "units"))
-  )
 
-  for (input_name in names(inputs)) {
-    input <- inputs[[input_name]]
+  for (scenario in scenarios) {
+    query <- nest_with_margins(
+      dtplyr::lazy_dt(scenario$input),
+      .grouping = rollup(region, store),
+      .sort = "last",
+      .keep = scenario$keep
+    )
+    expect_s3_class(query, "dtplyr_step")
 
-    for (keep in c(FALSE, TRUE)) {
-      query <- nest_with_margins(
-        dtplyr::lazy_dt(input),
-        .grouping = rollup(region, store),
-        .sort = "last",
-        .keep = keep
-      )
-      expect_s3_class(query, "dtplyr_step")
+    local_result <- nest_with_margins(
+      scenario$input,
+      .grouping = rollup(region, store),
+      .sort = "last",
+      .keep = scenario$keep
+    )
+    lazy_result <- dplyr::collect(query)
 
-      local_result <- nest_with_margins(
-        input,
-        .grouping = rollup(region, store),
-        .sort = "last",
-        .keep = keep
-      )
-      lazy_result <- dplyr::collect(query)
+    # Reading the cell names back separately, because comparing the two
+    # backends only says they agree, not that either kept the payload.
+    expect_identical(
+      sales_cell_shape(lazy_result)$names[[1L]],
+      scenario$names
+    )
+    expect_equal(
+      sales_cells_as_tibble(lazy_result),
+      sales_cells_as_tibble(local_result)
+    )
 
-      # Reading the cell names back separately, because comparing the two
-      # backends only says they agree, not that either kept the payload.
-      expect_identical(
-        nested_cell_dims(lazy_result)$names[[1L]],
-        expected_names[[input_name]][[keep + 1L]]
-      )
-
-      # The element class follows the backend and is not part of the API, so
-      # compare the cells as tibbles; everything else must match exactly.
-      as_cells <- function(result) {
-        ordered <- arrange_outer_keys(result)
-        ordered$data <- lapply(ordered$data, dplyr::as_tibble)
-        dplyr::as_tibble(ordered)
-      }
-      expect_equal(as_cells(lazy_result), as_cells(local_result))
-
-      by_result <- nest_by_with_margins(
-        dtplyr::lazy_dt(input),
-        .grouping = rollup(region, store),
-        .sort = "last",
-        .keep = keep
-      )
-      expect_identical(
-        nested_cell_dims(by_result)$rows,
-        nested_cell_dims(local_result)$rows
-      )
-      expect_identical(
-        nested_cell_dims(by_result)$names[[1L]],
-        expected_names[[input_name]][[keep + 1L]]
-      )
-    }
+    # The row-wise verb collects before it groups, so its cells compare
+    # exactly as the other verb's do once the row-wise grouping is dropped.
+    lazy_by <- nest_by_with_margins(
+      dtplyr::lazy_dt(scenario$input),
+      .grouping = rollup(region, store),
+      .sort = "last",
+      .keep = scenario$keep
+    )
+    local_by <- nest_by_with_margins(
+      scenario$input,
+      .grouping = rollup(region, store),
+      .sort = "last",
+      .keep = scenario$keep
+    )
+    expect_identical(sales_cell_shape(lazy_by)$names[[1L]], scenario$names)
+    expect_equal(
+      sales_cells_as_tibble(lazy_by),
+      sales_cells_as_tibble(local_by)
+    )
   }
 })
 
 test_that("zero-column and empty nesting match an independent construction", {
   # A frame with rows and no columns at all: every cell is a payload-free
   # cell, and `dplyr::nest_by()` is the upstream verb that answers it.
+  #
+  # Local only, deliberately. A `dtplyr` input cannot reach this case as
+  # itself: `as.data.table()` cannot carry rows without columns, so
+  # `lazy_dt(rows_only)` is already empty, and a zero-column step then gains a
+  # row of its own when the Grouping set identifier is attached. That is the
+  # union adapter rather than nesting, it predates this behavior, and it is
+  # tracked in #184.
   rows_only <- data.frame(row.names = 1:3)
   expect_identical(dim(rows_only), c(3L, 0L))
 

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -399,16 +399,14 @@ test_that("nesting keeps cardinality under both keep options", {
 test_that("nesting keeps cardinality when duplicate sets are dropped", {
   # `.duplicates` is the other option the cardinality has to survive, and a
   # dropped repeat must leave the surviving set's cells the size they were.
+  # Refusing the repeat is asserted where it belongs, in "nesting drops
+  # duplicate grouping sets" above; this covers only what dropping it does to
+  # a cell with no payload column.
   input <- keys_only_sales()
   spec <- grouping_sets(rollup(region, store), grouping_set(region, store))
   expected <- keys_only_expected()
 
   for (verb in list(nest_with_margins, nest_by_with_margins)) {
-    expect_error(
-      verb(input, .grouping = spec, .sort = "last"),
-      "Duplicate grouping sets"
-    )
-
     dropped <- verb(
       input,
       .grouping = spec,


### PR DESCRIPTION
Closes #175. The zero-column dtplyr corner of two acceptance criteria is
delegated to #184; the record is [on the ticket](https://github.com/sayuks/marginplyr/issues/175#issuecomment-5292916212).

## What this is

A nesting whose payload has no columns still stands for a known number of
source rows. `dplyr::pick(dplyr::everything())` cannot say how many: with an
empty selection it answers a one-row frame locally and an empty `data.table`
under dtplyr. So every cell of a keys-only input reported a cardinality no
source row produced, and the two backends did not report the same wrong number.

For `data.frame(region = c("East", "East", "West"), store = c("A", "A", "B"))`
under `rollup(region, store)`:

| cell | source rows | before (local) | before (dtplyr) | now |
| --- | --- | --- | --- | --- |
| `East` / `A` | 2 | 1 × 0 | 0 × 0 | 2 × 0 |
| `East` / `Total` | 2 | 1 × 0 | 0 × 0 | 2 × 0 |
| `Total` / `Total` | 3 | 1 × 0 | 0 × 0 | 3 × 0 |

`dplyr::nest_by()` answers the same call with `n × 0`, so this is the upstream
behaviour rather than a new rule.

## How

`n()` is that count, and dtplyr translates it to `.N`, so `nest_cell_expr()`
picks one expression that serves both backends:
`dplyr::tibble(.rows = dplyr::n())` where nothing remains to nest, `pick()`
where something does.

The row count is what this package constructs, so it is promised. The cell's
class is described rather than promised, as ADR 0016 requires of every element
class: on both backends it is what `dplyr::tibble()` produced, because a
`data.table` cannot hold rows without columns at all — its `dim()` reads the
row count from the first column.

`.keep = TRUE` needs no count while there is a grouping column, since it nests
those; that branch is unchanged.

`nest_by_with_margins()`'s empty-input fallback reads the same helper. Its
nested frame is the whole input, so a zero-column input nests zero rows rather
than one — again what `dplyr::nest_by()` answers, which the fallback already
claims to follow.

## A defect this branch introduced and removed

Review of the branch caught the first draft asking `colnames(.data)` for the
payload columns. `colnames()` reads `dimnames()` and answers `NULL` for a
`dtplyr_step`, so under dtplyr the empty-payload branch was always taken and
**every payload column was silently dropped from every cell** — a worse defect
than the one being fixed, under the one backend the change set out to make
agree. It now asks `get_col_names()`, the package's portable reader, built on
`dplyr::tbl_vars()`.

The dtplyr test would not have caught it either: its only input was keys-only,
where both branches produce the same answer. It now runs a scenario table over
both inputs and both `.keep` values, and reads the cell names back rather than
only comparing the two backends — two backends agreeing says nothing about
whether either kept the payload. Confirmed red against the `colnames()`
version.

## The zero-column boundary: what moves, and what is documented

Local and dtplyr results agree for every input with at least one column, which
is what the tests compare cell-for-cell. An input with **no columns at all**
sits outside that, for two different reasons that this PR deliberately keeps
apart:

- **A fabricated row — #184.** Adding a column to a zero-column `data.table`
  materialises one, and the union adapter attaches the Grouping set identifier
  with exactly that `mutate()`. It predates this branch and reaches
  `expand_with_margins(.id =)` too, so no workaround for it is in this PR.
- **A row count lost on the way in — documented, not ticketed.**
  `dtplyr::lazy_dt(data.frame(row.names = 1:3))` is already empty before
  marginplyr reads it. Nothing in this package can restore those rows, so
  `nest_with_margins()` now says so and tells a reader whose count matters to
  nest locally.

NEWS states the agreement with that exclusion attached rather than
unconditionally.

## Tests

Five tests in `test-nest-operation.R` cover the ticket's criteria: repeated
detail groups, subtotals and the Grand total set; both verbs under both `.keep`
values and under `.duplicates = "drop"`; local/dtplyr agreement cell-for-cell
for both verbs plus `expect_s3_class(query, "dtplyr_step")` for laziness; and
the zero-column and empty boundaries compared against `dplyr::nest_by()` as the
independent construction. The sentinel scan prints the cells as well as the
result, because `print.data.frame()` renders a list column as `NULL` and a scan
of the result alone would see no cell at all. Refusing a duplicate set stays
asserted once, in the test that already owned it.

Locally: lint clean, `spell_check_package()` clean, `roxygenise()` a no-op
after the committed regeneration, `R CMD check`'s Rd cross-references OK, the
full suite 2774 passing with 0 failures, 0 skips and 0 warnings, and
`verify-suite-coverage.R` confirms all 462 tests still execute in a
single-backend configuration.