### PR TITLE
Select typed metadata safely for admitted data-frame subclasses

### DIFF
--- a/.github/scripts/verify-library-isolation.R
+++ b/.github/scripts/verify-library-isolation.R
@@ -1,7 +1,7 @@
 # Confirms that a job got the library it declared, before it checks anything.
 #
 # Which optional backends a job installs is the whole signal of `depends-only`,
-# `tarball`, and the four `backend` jobs, and the dependency cache is what
+# `tarball`, and the `backend` jobs, and the dependency cache is what
 # nearly took it away: `setup-r-dependencies@v2` falls back to a `restore-keys`
 # prefix, so jobs sharing a `cache-version` share a library (#64). The
 # `cache-version` scheme that separates them is recorded in

--- a/.github/scripts/verify-suite-coverage.R
+++ b/.github/scripts/verify-suite-coverage.R
@@ -25,7 +25,7 @@
 # cannot pass by being self-consistently wrong the way two backends agreeing
 # with each other can.
 #
-# The measurement is a simulation rather than an aggregate over the four jobs'
+# The measurement is a simulation rather than an aggregate over those jobs'
 # artifacts, for one reason: an agent can run this before pushing. A guard is
 # the only thing that decides whether a test skips, and the hook drives the
 # guards, so simulating absence answers the same structural question the real

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -117,13 +117,13 @@ jobs:
   # Every test executes in some single-backend configuration. Proving it needs
   # the whole suite run once per backend with the others withheld, which the
   # `backend` jobs cannot answer between them: each reports its own green, and
-  # a test that skipped in all four leaves four greens behind.
+  # a test that skipped in every one of them leaves a green behind for each.
   #
-  # So this simulates the four configurations in one job, through
+  # So this simulates every configuration in one job, through
   # `MARGINPLYR_HIDE_SUGGESTS`. Simulated rather than aggregated from the real
   # jobs' artifacts for one reason: an agent can run it before pushing. A guard
   # is the only thing that decides whether a test skips and the hook drives the
-  # guards, so the structural answer is the same one four jobs would give; what
+  # guards, so the structural answer is the one those jobs would give; what
   # a simulation cannot answer -- whether a backend works when the others are
   # genuinely gone -- is what those jobs remain for.
   #

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -30,10 +30,12 @@
 # into a false green. See `tests/testthat/helper-optional-backends.R`.
 #
 # Which contracts those jobs prove is settled by construction rather than by a
-# list (#93). Every `backend` job installs one optional backend and withholds
-# the rest, so between them they execute every test that requires at most one
-# backend; a test requiring two is executed by none of them and skips in all of
-# them, unnoticed. Three layers close that, and no one of them is enough:
+# list (#93). Every `backend` job installs one optional backend -- plus the
+# companions its entry declares, which may themselves be tracked backends when
+# one drags another in -- and withholds everything else, so between them they
+# execute every test that requires at most one backend; a test requiring two is
+# executed by none of them and skips in all of them, unnoticed. Three layers
+# close that, and no one of them is enough:
 #
 #   Structure    `structure`, against the working tree. Every test executes in
 #                some single-backend configuration and asserts something there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,9 +320,13 @@ structural rather than a list of test names (#93). One policy carries it:
 > No test may require more than one member of `optional_backends()`.
 
 While that holds, the `backend` jobs cover the whole suite by construction —
-each installs one backend and withholds the rest, so between them they execute
-every test that requires at most one. A test requiring two is executed by none
-of them and skips in all of them. Splitting such a test is the fix, and the
+each installs one backend, plus whatever companions its entry declares, and
+withholds everything else, so between them they execute every test that
+requires at most one. A test requiring two is executed by none of them and
+skips in all of them — including in a job that happens to hold both, because
+`verify-suite-coverage.R` hides all but one whatever a job installs, which is
+why the guarantee does not rest on a job's package count. Splitting such a test
+is the fix, and the
 idiom that makes it free is in `test-margin-order.R`: compare each backend
 against the **local** result, which needs no optional backend, so a backend
 cannot pass by being self-consistently wrong the way two agreeing backends can.
@@ -375,7 +379,12 @@ loudly:
    and gets no job, so nothing asserts it — which is the DBI case above, and
    the reason that value exists. `companions` names what the generated job
    installs alongside the backend, which is how `DBI` reaches the driver jobs
-   without a job of its own.
+   without a job of its own. It is also how a backend declares what its own
+   dependencies drag in, and there the companion is a tracked entry rather
+   than an untracked one: dtplyr declares `Imports: data.table`, so its job
+   installs data.table whichever way the entry is written, and leaving it
+   undeclared makes `verify-library-isolation.R` fail the job for a leak that
+   is really the requested backend's own closure.
 2. the `skip_if_backend_absent()` or `backend_available()` call in the tests.
    Doing only this errors immediately: those helpers refuse a package
    `optional_suggests()` does not name, since nothing would execute it and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     utils
 Suggests:
     arrow (>= 13.0.0),
+    data.table,
     DBI,
     dtplyr (>= 1.3.2),
     duckdb (>= 1.5.5),

--- a/NEWS.md
+++ b/NEWS.md
@@ -83,3 +83,10 @@
   `data.table` cannot represent one. The class of such a cell is described
   rather than promised, as every nested element class is: on both backends it
   is what `dplyr::tibble()` produced.
+* A `data.frame` subclass whose `[` is not column selection — a raw
+  `data.table` is the case — now reaches every Margin verb that accepts local
+  data frames. Factor levels and the prototypes behind an absent Margin label
+  are read one column at a time, so a subclass that reads a character index as
+  a join key no longer fails before any grouping happens, and the input is not
+  modified by reference. The result's class still follows the dplyr verb the
+  Margin verb ends in, and is not promised to be the input's.

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -15,6 +15,39 @@ grouping_selection_proxy <- function(.data,
   .data
 }
 
+# The selection proxy's columns, as a plain named list.
+#
+# `[` is not read here, and a data frame subclass is the reason. The public API
+# admits any object dplyr can group (#77), so the proxy for a local backend is
+# the caller's own object, and a subclass is free to give `[` other semantics:
+# `data.table`'s reads a character index as a join key and errors rather than
+# selecting columns. `[[` is the operator such a subclass keeps as column
+# extraction, and reading one name at a time is also what keeps this from
+# constructing an object of the subclass at all -- the list below is what the
+# metadata is read from, so no subclass behaviour reaches the rest of this file.
+#
+# Every name is known to be a column by the time this runs, having been resolved
+# against the same data by tidyselect, so a `NULL` from `[[` reports a defect
+# rather than anything a caller can rewrite their way out of -- either a proxy
+# that does not answer for its own columns, or a subclass whose `[[` is not
+# column extraction. It is still worth stopping on, and stopping bare: silence
+# here would report the dimension as an absent prototype and label its margin
+# rows `NA` instead.
+proxy_columns <- function(data_proxy, dimensions) {
+  columns <- lapply(dimensions, function(col) data_proxy[[col]])
+  names(columns) <- dimensions
+  absent <- dimensions[vapply(columns, is.null, logical(1))]
+  if (length(absent) > 0L) {
+    stop(
+      "The selection proxy has no column ",
+      paste0("`", absent, "`", collapse = ", "),
+      ".",
+      call. = FALSE
+    )
+  }
+  columns
+}
+
 margin_column_info <- function(data_proxy,
                                dimensions,
                                backend) {
@@ -26,7 +59,7 @@ margin_column_info <- function(data_proxy,
     return(list(factors = list(), prototypes = list()))
   }
 
-  schema <- data_proxy[dimensions]
+  schema <- proxy_columns(data_proxy, dimensions)
 
   prototypes <- lapply(schema, function(x) x[NA_integer_])
   factors <- if (backend$can_restore_factors) {

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -21,10 +21,16 @@ grouping_selection_proxy <- function(.data,
 # admits any object dplyr can group (#77), so the proxy for a local backend is
 # the caller's own object, and a subclass is free to give `[` other semantics:
 # `data.table`'s reads a character index as a join key and errors rather than
-# selecting columns. `[[` is the operator such a subclass keeps as column
-# extraction, and reading one name at a time is also what keeps this from
+# selecting columns. Reading one name at a time is also what keeps this from
 # constructing an object of the subclass at all -- the list below is what the
 # metadata is read from, so no subclass behaviour reaches the rest of this file.
+#
+# `[[` is not merely the other base operator. It is the read dplyr itself
+# performs on any data frame it accepts -- `dplyr:::pull.data.frame()` is
+# `.data[[var]]` -- so routing this through `dplyr::pull()` would reach the same
+# operator with a tidyselect resolution on top, and a subclass that redefined it
+# would already be failing inside dplyr. #77 admits exactly what dplyr can
+# group, so depending on the read dplyr depends on adds no assumption.
 #
 # Every name is known to be a column by the time this runs, having been resolved
 # against the same data by tidyselect, so a `NULL` from `[[` reports a defect
@@ -34,12 +40,15 @@ grouping_selection_proxy <- function(.data,
 # here would report the dimension as an absent prototype and label its margin
 # rows `NA` instead.
 proxy_columns <- function(data_proxy, dimensions) {
-  columns <- lapply(dimensions, function(col) data_proxy[[col]])
-  names(columns) <- dimensions
+  columns <- stats::setNames(
+    lapply(dimensions, function(col) data_proxy[[col]]),
+    dimensions
+  )
   absent <- dimensions[vapply(columns, is.null, logical(1))]
   if (length(absent) > 0L) {
     stop(
-      "The selection proxy has no column ",
+      "The selection proxy has no column",
+      if (length(absent) == 1L) " " else "s ",
       paste0("`", absent, "`", collapse = ", "),
       ".",
       call. = FALSE

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -32,6 +32,16 @@ grouping_selection_proxy <- function(.data,
 # would already be failing inside dplyr. #77 admits exactly what dplyr can
 # group, so depending on the read dplyr depends on adds no assumption.
 #
+# That is a boundary rather than a guarantee, and it is worth naming because the
+# failure on the wrong side of it is silent. A subclass whose `[[` returned a
+# wrong value rather than `NULL` would have that value read as the column's
+# levels and prototype, so the Margin label would be added to the wrong factor
+# and no diagnostic would say so -- the check below catches only the absent
+# case. No detection is available that dplyr does not already need: a column
+# read is a column read, and a class breaking it is producing wrong answers in
+# the pipeline that grouped it long before reaching here. No such class is
+# known, and marginplyr is not the layer that would find one.
+#
 # Every name is known to be a column by the time this runs, having been resolved
 # against the same data by tidyselect, so a `NULL` from `[[` reports a defect
 # rather than anything a caller can rewrite their way out of -- either a proxy

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -160,9 +160,10 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # second entry to stretch the word "backend" -- `DBI` was the first -- since
 # what the table actually holds is every optional Suggest a guard may name, and
 # what a `backend` job proves for this one is an input class rather than a
-# translation target. The name is left alone deliberately: it is spelled into
-# four CI scripts, the workflow, and every guard, and renaming it would be a
-# larger change than any entry it holds.
+# translation target. The name is left alone deliberately and the choice is
+# #185's to make: it is spelled into four CI scripts, the workflow, and every
+# guard, so renaming it is a larger change than any entry it holds, and nothing
+# reads the table wrongly today.
 optional_backend_spec <- function() {
   list(
     arrow = list(asserted = TRUE, companions = character()),

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -148,11 +148,21 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # `companions` names the packages a job proving this backend must install
 # alongside it. They are not the backend, so they are not what the job promises
 # to execute -- but a driver package without DBI installs and then does nothing.
+# It is also how a job declares what its backend drags in: dtplyr declares
+# `Imports: data.table`, so a job installing dtplyr installs data.table whether
+# it asked for it or not, and `verify-library-isolation.R` would read that as a
+# leak from a shared cache. Naming it here is the job saying it expected it.
+#
+# `data.table` is an entry of its own as well, because it is not only dtplyr's
+# dependency here: raw `data.table` input reaches the local backend as an
+# ordinary data frame subclass (#176), and it is genuinely absent under
+# `_R_CHECK_DEPENDS_ONLY_=true`, which is what `asserted` claims.
 optional_backend_spec <- function() {
   list(
     arrow = list(asserted = TRUE, companions = character()),
     duckdb = list(asserted = TRUE, companions = "DBI"),
-    dtplyr = list(asserted = TRUE, companions = character()),
+    dtplyr = list(asserted = TRUE, companions = "data.table"),
+    data.table = list(asserted = TRUE, companions = character()),
     RSQLite = list(asserted = TRUE, companions = "DBI"),
     DBI = list(asserted = FALSE, companions = character())
   )

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -156,7 +156,13 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # `data.table` is an entry of its own as well, because it is not only dtplyr's
 # dependency here: raw `data.table` input reaches the local backend as an
 # ordinary data frame subclass (#176), and it is genuinely absent under
-# `_R_CHECK_DEPENDS_ONLY_=true`, which is what `asserted` claims.
+# `_R_CHECK_DEPENDS_ONLY_=true`, which is what `asserted` claims. It is the
+# second entry to stretch the word "backend" -- `DBI` was the first -- since
+# what the table actually holds is every optional Suggest a guard may name, and
+# what a `backend` job proves for this one is an input class rather than a
+# translation target. The name is left alone deliberately: it is spelled into
+# four CI scripts, the workflow, and every guard, and renaming it would be a
+# larger change than any entry it holds.
 optional_backend_spec <- function() {
   list(
     arrow = list(asserted = TRUE, companions = character()),

--- a/tests/testthat/test-data-frame-subclass.R
+++ b/tests/testthat/test-data-frame-subclass.R
@@ -1,0 +1,216 @@
+# A data frame subclass is admitted input, and `[` is what made one fail.
+#
+# The public verbs accept any object dplyr can group (#77), which includes every
+# `data.frame` subclass. A subclass is free to give `[` semantics of its own,
+# and `data.table`'s reads a character index as a join key rather than as a
+# column selection. Typed metadata -- the factor levels
+# `restore_margin_factors()` rebuilds from, and the prototypes an absent Margin
+# label falls back to -- was read with `data_proxy[dimensions]`, so a raw
+# `data.table` failed before any grouping happened, with data.table's join
+# diagnostic and nothing naming the input class as the reason (#176).
+#
+# Every assertion below compares a raw `data.table` against the same data as a
+# base `data.frame`, because the claim is agreement rather than any particular
+# result: a literal would go on passing if both paths broke the same way. What
+# these deliberately do not assert is the result's own class. ADR 0016 leaves
+# that to the dplyr verb each Margin verb ends in, and pinning it for a subclass
+# would convert a described behavior into a promise.
+#
+# `data.table` is guarded like any other optional Suggest, so these skip where
+# it is absent and the generated `data.table` job in `release-matrix.yaml` is
+# what executes them. dtplyr is not the guard even though it brings data.table:
+# guarding on a package other than the one used is the mistake `AGENTS.md`
+# names, and the two are separate entries in `optional_backend_spec()`.
+
+subclass_data <- function() {
+  data.frame(
+    region = c("East", "East", "West", "West"),
+    size = factor(
+      c("small", "large", NA, "small"),
+      levels = c("small", "large")
+    ),
+    units = c(1, 2, 4, 8)
+  )
+}
+
+# Values only, both sides flattened to a base data frame first.
+# `as.data.frame()` removes the one difference ADR 0016 refuses to promise
+# either way, and it removes nothing else: column classes, factor levels, and
+# row order all survive it, which is the whole of what these tests are about.
+expect_margin_agrees <- function(subclass_result, data_frame_result) {
+  expect_equal(
+    as.data.frame(subclass_result),
+    as.data.frame(data_frame_result)
+  )
+}
+
+test_that("summarize_with_margins() accepts a raw data.table", {
+  skip_if_backend_absent("data.table")
+  data <- subclass_data()
+
+  expect_margin_agrees(
+    summarize_with_margins(
+      data.table::as.data.table(data),
+      total = sum(units),
+      share = share_of_total(total),
+      .grouping = rollup(region, size),
+      .sort = "last"
+    ),
+    summarize_with_margins(
+      data,
+      total = sum(units),
+      share = share_of_total(total),
+      .grouping = rollup(region, size),
+      .sort = "last"
+    )
+  )
+})
+
+test_that("expand_with_margins() accepts a raw data.table", {
+  skip_if_backend_absent("data.table")
+  data <- subclass_data()
+
+  expect_margin_agrees(
+    expand_with_margins(
+      data.table::as.data.table(data),
+      .grouping = cube(region, size),
+      .id = "set"
+    ),
+    expand_with_margins(data, .grouping = cube(region, size), .id = "set")
+  )
+})
+
+test_that("the nesting verbs accept a raw data.table", {
+  skip_if_backend_absent("data.table")
+  data <- subclass_data()
+
+  expect_margin_agrees(
+    nest_with_margins(
+      data.table::as.data.table(data),
+      .grouping = rollup(region, size)
+    ),
+    nest_with_margins(data, .grouping = rollup(region, size))
+  )
+  expect_margin_agrees(
+    nest_by_with_margins(
+      data.table::as.data.table(data),
+      .grouping = rollup(region, size)
+    ),
+    nest_by_with_margins(data, .grouping = rollup(region, size))
+  )
+})
+
+test_that("inspect_grouping() accepts a raw data.table", {
+  skip_if_backend_absent("data.table")
+  data <- subclass_data()
+
+  expect_identical(
+    inspect_grouping(
+      data.table::as.data.table(data),
+      .grouping = cube(region, size),
+      .format = "list"
+    ),
+    inspect_grouping(data, .grouping = cube(region, size), .format = "list")
+  )
+})
+
+test_that("a factor dimension of a raw data.table keeps its typed metadata", {
+  skip_if_backend_absent("data.table")
+  # The narrower half of the agreement above, stated on its own because it is
+  # the metadata the old `[` was reading: a Margin label arrives as a synthetic
+  # level rather than coercing the column to character, and the missing value
+  # stays missing rather than becoming one.
+  result <- summarize_with_margins(
+    data.table::as.data.table(subclass_data()),
+    total = sum(units),
+    .grouping = rollup(size),
+    .margin_label_position = "first"
+  )
+
+  expect_s3_class(result$size, "factor")
+  expect_identical(levels(result$size), c("Total", "small", "large"))
+  expect_true(anyNA(result$size))
+})
+
+test_that("a Margin-label collision is found in a raw data.table", {
+  skip_if_backend_absent("data.table")
+  # The collision check reads the same columns, so a subclass that reached the
+  # verbs without it would accept a label already present and silently merge
+  # two meanings into one row.
+  data <- data.frame(region = c("East", "Total"), units = c(1, 2))
+
+  expect_error(
+    summarize_with_margins(
+      data.table::as.data.table(data),
+      total = sum(units),
+      .grouping = rollup(region)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(units),
+      .grouping = rollup(region)
+    ),
+    class = "marginplyr_error"
+  )
+})
+
+test_that("a raw data.table is not modified by reference", {
+  skip_if_backend_absent("data.table")
+  # A data.table can be changed in place, so "the input still works afterwards"
+  # is not the same claim as "the input is unchanged". Compared against an
+  # independent copy taken before the call, which catches a column rewritten in
+  # place, a key added, and a class or attribute set on the object itself.
+  data <- data.table::as.data.table(subclass_data())
+  before <- data.table::copy(data)
+
+  summarize_with_margins(
+    data,
+    total = sum(units),
+    .grouping = cube(region, size)
+  )
+  expand_with_margins(data, .grouping = rollup(region, size))
+  nest_with_margins(data, .grouping = rollup(region))
+
+  expect_identical(data, before)
+})
+
+test_that("an ordinary data frame reads the same typed metadata", {
+  # The other half of the regression. `proxy_columns()` replaced a `[` whose
+  # behavior on a base `data.frame` was correct, so the subclass tests above
+  # cannot tell a working replacement from one that returns the wrong columns
+  # in the right shape.
+  data <- subclass_data()
+  info <- margin_column_info(
+    data,
+    dimensions = c("size", "region"),
+    backend = grouping_backend(data)
+  )
+
+  expect_identical(names(info$prototypes), c("size", "region"))
+  expect_identical(info$prototypes$region, NA_character_)
+  expect_identical(
+    info$prototypes$size,
+    factor(NA_character_, levels = c("small", "large"))
+  )
+  expect_identical(
+    vapply(info$factors, function(x) x$col, character(1)),
+    "size"
+  )
+  expect_identical(info$factors[[1]]$levels, c("small", "large"))
+})
+
+test_that("a proxy that cannot answer for a column is an internal invariant", {
+  # Every dimension is resolved against the same data by tidyselect before this
+  # runs, so a `NULL` here reports a defect -- a subclass whose `[[` is not
+  # column extraction -- and no rewrite of the call avoids it. Bare per ADR
+  # 0015, which is what keeps it distinguishable from the validation errors the
+  # verbs raise on input a caller can fix.
+  data <- data.frame(region = "East", units = 1)
+
+  condition <- expect_error(proxy_columns(data, c("region", "absent")))
+  expect_false(inherits(condition, "marginplyr_error"))
+  expect_match(conditionMessage(condition), "`absent`")
+})

--- a/tests/testthat/test-data-frame-subclass.R
+++ b/tests/testthat/test-data-frame-subclass.R
@@ -16,6 +16,12 @@
 # that to the dplyr verb each Margin verb ends in, and pinning it for a subclass
 # would convert a described behavior into a promise.
 #
+# `summarise_with_margins()` is deliberately not swept alongside the verbs
+# below. "British and American summary spellings are synonyms" in
+# `test-grouping-interface.R` asserts it is the same object with the same
+# formals, so a copy here would restate that test rather than add a subclass it
+# does not already cover.
+#
 # `data.table` is guarded like any other optional Suggest, so these skip where
 # it is absent and the generated `data.table` job in `release-matrix.yaml` is
 # what executes them. dtplyr is not the guard even though it brings data.table:
@@ -33,75 +39,73 @@ subclass_data <- function() {
   )
 }
 
-# Values only, both sides flattened to a base data frame first.
-# `as.data.frame()` removes the one difference ADR 0016 refuses to promise
-# either way, and it removes nothing else: column classes, factor levels, and
-# row order all survive it, which is the whole of what these tests are about.
-expect_margin_agrees <- function(subclass_result, data_frame_result) {
+# Runs one Margin call twice -- over the raw `data.table` and over the same data
+# as a base `data.frame` -- and compares the results. The call is written once
+# and the input is the parameter, so the two sides cannot drift into comparing
+# different computations; it is `expect_margin_order_agrees()`'s shape in
+# `test-margin-order.R`, and so is the `all_of()` spelling of the dimensions,
+# because `codetools` cannot follow an NSE pronoun through the closure that a
+# `test_that()` block does not create.
+#
+# Both sides are flattened to a base data frame first. `as.data.frame()` removes
+# the one difference ADR 0016 refuses to promise either way, and it removes
+# nothing else: column classes, factor levels, and row order all survive it,
+# which is the whole of what these tests are about.
+expect_margin_agrees <- function(margin_call) {
+  data <- subclass_data()
   expect_equal(
-    as.data.frame(subclass_result),
-    as.data.frame(data_frame_result)
+    as.data.frame(margin_call(data.table::as.data.table(data))),
+    as.data.frame(margin_call(data))
   )
 }
 
 test_that("summarize_with_margins() accepts a raw data.table", {
   skip_if_backend_absent("data.table")
-  data <- subclass_data()
 
-  expect_margin_agrees(
+  expect_margin_agrees(function(input) {
     summarize_with_margins(
-      data.table::as.data.table(data),
+      input,
       total = sum(units),
       share = share_of_total(total),
-      .grouping = rollup(region, size),
-      .sort = "last"
-    ),
-    summarize_with_margins(
-      data,
-      total = sum(units),
-      share = share_of_total(total),
-      .grouping = rollup(region, size),
+      .grouping = rollup(dplyr::all_of(c("region", "size"))),
       .sort = "last"
     )
-  )
+  })
 })
 
 test_that("expand_with_margins() accepts a raw data.table", {
   skip_if_backend_absent("data.table")
-  data <- subclass_data()
 
-  expect_margin_agrees(
+  expect_margin_agrees(function(input) {
     expand_with_margins(
-      data.table::as.data.table(data),
-      .grouping = cube(region, size),
+      input,
+      .grouping = cube(dplyr::all_of(c("region", "size"))),
       .id = "set"
-    ),
-    expand_with_margins(data, .grouping = cube(region, size), .id = "set")
-  )
+    )
+  })
 })
 
 test_that("the nesting verbs accept a raw data.table", {
   skip_if_backend_absent("data.table")
-  data <- subclass_data()
 
-  expect_margin_agrees(
+  expect_margin_agrees(function(input) {
     nest_with_margins(
-      data.table::as.data.table(data),
-      .grouping = rollup(region, size)
-    ),
-    nest_with_margins(data, .grouping = rollup(region, size))
-  )
-  expect_margin_agrees(
+      input,
+      .grouping = rollup(dplyr::all_of(c("region", "size")))
+    )
+  })
+  expect_margin_agrees(function(input) {
     nest_by_with_margins(
-      data.table::as.data.table(data),
-      .grouping = rollup(region, size)
-    ),
-    nest_by_with_margins(data, .grouping = rollup(region, size))
-  )
+      input,
+      .grouping = rollup(dplyr::all_of(c("region", "size")))
+    )
+  })
 })
 
 test_that("inspect_grouping() accepts a raw data.table", {
   skip_if_backend_absent("data.table")
+  # Not through `expect_margin_agrees()`: this returns no data frame, and the
+  # plan it reports is one object to compare rather than two to flatten.
   data <- subclass_data()
 
   expect_identical(

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -251,7 +251,11 @@ test_that("a backend job installs its backend and its companions", {
   # would install, run nothing, and report green.
   expect_identical(backend_job_packages("duckdb"), c("duckdb", "DBI"))
   expect_identical(backend_job_packages("RSQLite"), c("RSQLite", "DBI"))
-  expect_identical(backend_job_packages("dtplyr"), "dtplyr")
+  # dtplyr declares `Imports: data.table`, so the job installs it regardless;
+  # naming it is what keeps `verify-library-isolation.R` from reading a
+  # dependency of the requested backend as a cache leak.
+  expect_identical(backend_job_packages("dtplyr"), c("dtplyr", "data.table"))
+  expect_identical(backend_job_packages("data.table"), "data.table")
   expect_error(backend_job_packages(absent_package), "optional_backend_spec")
 })
 


### PR DESCRIPTION
Closes #176.

## The defect

The public verbs accept any object dplyr can group (#77), which includes every
`data.frame` subclass — but typed metadata was read with
`data_proxy[dimensions]`. `[` is the operator a subclass is most likely to
redefine: `data.table`'s reads a character index as a join key, so a raw
`data.table` failed in `margin_column_info()` before any grouping happened.

```r
dt <- data.table::data.table(g = c("a", "a", "b"), v = 1:3)
summarize_with_margins(dt, s = sum(v), .grouping = rollup(g))
#> Error in `[.data.table`(data_proxy, dimensions):
#>   When i is a data.table (or character vector), the columns to join by must
#>   be specified using the 'on=' argument ...
```

Nothing in that diagnostic names the input class as the reason.

## The fix

`proxy_columns()` reads one dimension at a time with `[[` and hands the rest of
the file a plain named list, so no object of the subclass is constructed at all
and the collision check and factor restoration downstream see only base
vectors. `[[` is not merely the other base operator: `dplyr:::pull.data.frame()`
is `.data[[var]]`, so a subclass redefining it would already be failing inside
dplyr — which #77's admission policy rests on.

A dimension that is not a column there is a bare `stop()` rather than a Package
condition. Every name arrives resolved against the same data by tidyselect, so
a `NULL` reports a defect no rewrite of the call avoids, which is ADR 0015's
split.

The collision check needed no change — `check_margin_label_collision()` already
went through `dplyr::select()`/`summarize()` — and the new tests pin it.

## Registration

`data.table` joins Suggests and `optional_backend_spec()` (`asserted = TRUE`,
generating its own `backend` job), and is declared as **dtplyr's companion**,
because dtplyr declares `Imports: data.table`: without that,
`verify-library-isolation.R` reads the dtplyr job's own dependency closure as a
cache leak. Dependency closures were computed per job to confirm no other job
sees data.table.

That made three prose sites false — a `backend` job no longer installs exactly
one optional backend — so `AGENTS.md` and `release-matrix.yaml` now say "plus
the companions its entry declares", and `AGENTS.md` states what the count never
carried: `verify-suite-coverage.R` hides all but one whatever a job installs,
so a test requiring two is still executed nowhere and the guarantee does not
rest on a job's package count.

## Tests

`tests/testthat/test-data-frame-subclass.R`. Each verb call is written once
with the input as the parameter and run over both the raw `data.table` and the
base `data.frame`, so the two sides cannot be edited apart into comparing
different computations. No result class is asserted: ADR 0016 leaves that to
the dplyr verb each Margin verb ends in. The ordinary-data-frame half is
asserted on `margin_column_info()` directly, since a replacement returning the
wrong columns in the right shape would pass every subclass test.

All six data.table tests were confirmed red before the fix.

## Verification

| gate | result |
| --- | --- |
| full suite | green |
| `lintr::lint_package()` | no lints |
| `roxygen2::roxygenise()` | no diff |
| `R CMD check` (tarball) | Status: OK |
| `verify-suite-coverage.R` | 471 tests over 5 configurations, none uncovered |
| skip wording with data.table hidden | `{data.table} is not installed` |

## Deliberately not done

- **Renaming the optional-backend table.** `data.table` is the second entry
  that is not a backend. Split out as #185 rather than done here: renaming
  reaches four CI scripts, the workflow, and every guard, and nothing reads the
  table wrongly today.
- **Guarding a subclass whose `[[` is not column extraction.** Documented as a
  boundary in `proxy_columns()`, including the fact that the failure there is
  silent. There is nothing to detect it with that dplyr does not already need.
- **`summarise_with_margins()` is not swept alongside the other verbs** —
  "British and American summary spellings are synonyms" already asserts it is
  the same object with the same formals.