### PR TITLE
Make installation instructions follow CRAN publication state

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -78,5 +78,15 @@ jobs:
       - name: Check man/ and NAMESPACE are up to date
         run: git diff --exit-code man/ NAMESPACE
 
+      # The diff is shown, and then what it might mean: a byte comparison of
+      # rendered markdown reds for two different reasons, and the second one
+      # sends a reader looking for an edit nobody made. Whoever committed this
+      # `README.md` may have rendered it against a different pandoc from the
+      # one pinned above.
       - name: Check README.md is up to date
-        run: git diff --exit-code README.md
+        run: |
+          if git diff --exit-code README.md; then
+            exit 0
+          fi
+          echo '::error::README.md is not what README.Rmd renders. Regenerate it with rmarkdown::render("README.Rmd") and commit the result. If the only differences are code-fence info strings or rewrapped prose, the pandoc you rendered with differs from the version this workflow pins.'
+          exit 1

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -23,16 +23,48 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # README.md is knitted through rmarkdown's `github_document` format,
+      # which is pandoc; nothing else in this job needs it.
+      #
+      # The version is pinned because pandoc's markdown writer is not stable
+      # across versions and the check below is a byte comparison: 3.8.3 writes
+      # the `text` info string on the fence at `README.Rmd`'s reporting-levels
+      # block, and 3.10.1 omits it. So an unpinned action reds this job on a
+      # README that is perfectly up to date, and reds it again on whatever
+      # r-lib moves its default to next. The pin names the renderer the
+      # committed `README.md` came from; moving it means regenerating that
+      # file in the same commit.
+      - uses: r-lib/actions/setup-pandoc@v2
+        with:
+          pandoc-version: '3.10.1'
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::roxygen2, local::.
+          extra-packages: any::roxygen2, any::rmarkdown, local::.
 
       - name: Regenerate documentation
         run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      # README.md is generated from README.Rmd the same way, and it is read
+      # further than any other generated file here: GitHub shows it, and the
+      # website's home page includes it. `.Rbuildignore` keeps the source out
+      # of the tarball, so nothing a check run can reach says what the
+      # generated file was supposed to contain, and an installation
+      # instruction edited into one half alone is invisible until a reader
+      # follows it.
+      #
+      # Both regenerations run before either check, because this one writes
+      # into `man/` as well: `README.Rmd` sets `fig.path` to
+      # `man/figures/README-`, so a figure chunk added later produces a file
+      # the check below does not look at and the `man/` check would already
+      # have passed.
+      - name: Regenerate README.md
+        run: rmarkdown::render("README.Rmd", quiet = TRUE)
         shell: Rscript {0}
 
       # The committed help pages and NAMESPACE must be what the roxygen
@@ -45,3 +77,6 @@ jobs:
       # and `R CMD check` only rejects exports of objects that do not exist.
       - name: Check man/ and NAMESPACE are up to date
         run: git diff --exit-code man/ NAMESPACE
+
+      - name: Check README.md is up to date
+        run: git diff --exit-code README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,19 +364,21 @@ using the guard must source it and vice versa. The Rd half reads `man/` when it
 is present and `tools::Rd_db("marginplyr")` otherwise, so it holds under
 `R CMD check` too; the vignette half is repository-only, because `R CMD check`
 unpacks the tarball beside the `.Rcheck` directory rather than inside it; the
-README is reachable either way, since `.Rbuildignore` keeps `README.Rmd` out of
-the tarball while R installs `README.md` at the package root, and
-`metadata_path()` takes whichever is there. The README is in the set because it
-is installation documentation, which is where a version-blind test is likeliest
-to be written in the first place — the same reason `verify-site.R` forbids
-`installed.packages` anywhere on the rendered site. Prose that needs to name a
-version-blind call has to spell it some other way — the scan is deliberately
-blunt.
+README is read from the repository where there is one, and otherwise from the
+installed `README.md`, which exists only from R 4.6.0 — "Package `README.md`
+files are now installed and featured in HTML help" — while `DESCRIPTION`
+supports 4.1.0, so an oldrel job checking a tarball reaches neither half. The
+README is in the set because it is installation documentation, which is where a
+version-blind test is likeliest to be written in the first place — the same
+reason `verify-site.R` forbids `installed.packages` anywhere on the rendered
+site. Prose that needs to name a version-blind call has to spell it some other
+way — the scan is deliberately blunt.
 
-Those two sources also make the set non-empty in every run, which is why
-neither scan carries a skip: a skip naming no withheld backend is what
-`verify-backend.R` fails a job over, and one that could never fire is a line
-claiming a condition the code no longer has.
+A source is added where it is reachable rather than skipped for where it is
+not, since a skip naming no withheld backend is what `verify-backend.R` fails a
+job over. Reaching nothing at all is the other case, and
+`documentation_sources()` stops on it: every scan iterates over that set, so a
+set that arrived empty is a set that passes.
 
 ### Release matrix
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,15 +73,25 @@ reads `unpublished` no page may name the CRAN installation call, the cranlogs
 badge, or this package's CRAN page — the badge included because it renders
 `CRAN downloads 0/month` for a package CRAN has never seen, which is a claim
 of availability and not a report of zero interest. Once the field reads
-`published`, `README.md` has to carry the CRAN instruction. Both directions
-are load-bearing: the first is what stops the documentation getting ahead of
-CRAN, and the second is what stops a release flipping the field while the
-README still sends readers to GitHub alone.
+`published`, `README.md` has to carry both halves of what publication gives a
+reader: the instruction to run, and the badge or link saying where it goes.
+Both directions are load-bearing: the first is what stops the documentation
+getting ahead of CRAN, and the second is what stops a release flipping the
+field while the README still sends readers to GitHub alone.
+
+The rule is written as a function of the state and the pages rather than as a
+branch on the field, so the fixtures beside it execute the `published`
+direction today. A branch first evaluated on the day of the release is a
+branch nothing has ever run, which is the objection *Chunks that must fail*
+makes to an assertion that cannot fail.
 
 The scan is deliberately blunt, as the version-blind guard scan above is:
 prose that needs to name the CRAN installation call has to spell it some other
 way. Its markers all name marginplyr, because the README's comparison table
-links to another package's CRAN page and that is not a claim about this one.
+links to another package's CRAN page and that is not a claim about this one,
+and they match case-insensitively, because `cran.r-project.org` and
+`CRAN.R-project.org` are one host and a claim is not less of one for being
+typed the second way.
 
 The milestone is publication, not submission. The field flips on the day
 `https://cran.r-project.org/package=marginplyr` resolves — not when the
@@ -98,6 +108,15 @@ took. On that day:
    which stays true in both states and is why nothing asserts them — but the
    distinction between the released and the development version becomes worth
    drawing again, and it is deliberately not drawn now.
+
+Steps 1 to 3 hold each other up rather than relying on this list being
+followed: 1 without 2 fails the suite, 2 without 1 fails it too, and 3 is what
+`document.yaml` checks, so a `README.md` regenerated from a `README.Rmd` that
+step 2 never touched fails at step 2's assertion instead. Step 4 is the one a
+release can genuinely skip, which is why it is last and why it changes prose
+that is true either way. No other file needs editing: the field is the release
+process's copy of this fact, and it sits in `DESCRIPTION` beside the `Version`
+a release is already bumping.
 
 ### Chunks that must fail
 
@@ -339,14 +358,25 @@ installation alone while reading as protection.
 
 Two scans in `test-documentation.R` are what keep this from decaying, and they
 scan rather than list, for the reason every other gate here derives rather than
-lists. Each runs over the Rd topics and over the vignette sources: no page may
-name a version-blind guard, and a page using the guard must source it and vice
-versa. The Rd half reads `man/` when it is present and
-`tools::Rd_db("marginplyr")` otherwise, so it holds under `R CMD check` too;
-the vignette half is repository-only, because `R CMD check` unpacks the tarball
-beside the `.Rcheck` directory rather than inside it. Prose that needs to name
-a version-blind call has to spell it some other way — the scan is deliberately
+lists. Each runs over three sources — the Rd topics, the vignette sources, and
+both halves of the README: no page may name a version-blind guard, and a page
+using the guard must source it and vice versa. The Rd half reads `man/` when it
+is present and `tools::Rd_db("marginplyr")` otherwise, so it holds under
+`R CMD check` too; the vignette half is repository-only, because `R CMD check`
+unpacks the tarball beside the `.Rcheck` directory rather than inside it; the
+README is reachable either way, since `.Rbuildignore` keeps `README.Rmd` out of
+the tarball while R installs `README.md` at the package root, and
+`metadata_path()` takes whichever is there. The README is in the set because it
+is installation documentation, which is where a version-blind test is likeliest
+to be written in the first place — the same reason `verify-site.R` forbids
+`installed.packages` anywhere on the rendered site. Prose that needs to name a
+version-blind call has to spell it some other way — the scan is deliberately
 blunt.
+
+Those two sources also make the set non-empty in every run, which is why
+neither scan carries a skip: a skip naming no withheld backend is what
+`verify-backend.R` fails a job over, and one that could never fire is a line
+claiming a condition the code no longer has.
 
 ### Release matrix
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,70 @@ honest: any leak into `man/` fails CI.
 
 ### Documentation
 
-`man/` and `NAMESPACE` are generated. After changing roxygen comments run
-`roxygen2::roxygenise()` and commit the result;
-`.github/workflows/document.yaml` regenerates both and fails when either
-differs from what the roxygen comments produce.
+`man/`, `NAMESPACE`, and `README.md` are generated. After changing roxygen
+comments run `roxygen2::roxygenise()`; after changing `README.Rmd` run
+`rmarkdown::render("README.Rmd")`. Commit what either produces;
+`.github/workflows/document.yaml` regenerates all three and fails when any
+differs from what its source produces.
+
+The README is the generated file with the widest reach — GitHub shows it and
+the website's home page includes it — and the only one whose source
+`.Rbuildignore` keeps out of the tarball, so nothing a check run reaches
+records what it should have contained. Rendering it executes its chunks
+against the *installed* marginplyr, as the site build does, so install the
+working tree first or the regenerated file shows an older package's output.
+
+Its renderer is pinned, unlike roxygen2's, because pandoc's markdown writer
+is not stable across versions while the check is a byte comparison: pandoc
+3.8.3 — what `setup-pandoc@v2` installs by default — writes a `text` info
+string on the fence holding the reporting-levels block, and 3.10.1 omits it,
+so an unpinned job reds on a README nobody touched. `document.yaml` names the
+version the committed file came from; regenerating locally against a
+different pandoc produces a diff that is a pandoc difference and not a stale
+file. Moving the pin means regenerating `README.md` in the same commit.
+
+### Installation instructions
+
+An installation instruction is a claim about the outside world, and no file
+here can be read to check it: a README saying `install.packages()` finds
+marginplyr reads exactly the same whether CRAN has published the package or
+not. `DESCRIPTION`'s `Config/marginplyr/cran-status` field is where that fact
+is recorded — `unpublished` or `published`, no other value — and it is the
+only place it is written down. While it reads `unpublished`, the route the
+documentation gives is the one an external user can actually run today,
+`pak::pkg_install("sayuks/marginplyr")`.
+
+`test-documentation.R` asserts both directions against the field, over the Rd
+topics, the vignette sources, and both halves of the README. While the field
+reads `unpublished` no page may name the CRAN installation call, the cranlogs
+badge, or this package's CRAN page — the badge included because it renders
+`CRAN downloads 0/month` for a package CRAN has never seen, which is a claim
+of availability and not a report of zero interest. Once the field reads
+`published`, `README.md` has to carry the CRAN instruction. Both directions
+are load-bearing: the first is what stops the documentation getting ahead of
+CRAN, and the second is what stops a release flipping the field while the
+README still sends readers to GitHub alone.
+
+The scan is deliberately blunt, as the version-blind guard scan above is:
+prose that needs to name the CRAN installation call has to spell it some other
+way. Its markers all name marginplyr, because the README's comparison table
+links to another package's CRAN page and that is not a claim about this one.
+
+The milestone is publication, not submission. The field flips on the day
+`https://cran.r-project.org/package=marginplyr` resolves — not when the
+tarball is uploaded, not when `cran-comments.md` is written, and not when a
+release ticket is closed. A submission can be rejected or archived, and an
+instruction made true by uploading one would be false for however long that
+took. On that day:
+
+1. set the field to `published`;
+2. restore the CRAN paragraph to `README.Rmd`'s installation section, above
+   the GitHub route, and a CRAN badge to its badge block;
+3. regenerate `README.md`; and
+4. revisit the vignette installation blocks. They name the GitHub route only,
+   which stays true in both states and is why nothing asserts them — but the
+   distinction between the released and the development version becomes worth
+   drawing again, and it is deliberately not drawn now.
 
 ### Chunks that must fail
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Suggests:
     testthat (>= 3.0.0),
     tibble,
     tidyr
+Config/marginplyr/cran-status: unpublished
 Config/testthat/edition: 3
 VignetteBuilder:
     quarto

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,6 @@ table.
 [![altdoc](https://github.com/sayuks/marginplyr/actions/workflows/altdoc.yaml/badge.svg)](https://github.com/sayuks/marginplyr/actions/workflows/altdoc.yaml)
 [![Codecov test coverage](https://codecov.io/gh/sayuks/marginplyr/graph/badge.svg)](https://app.codecov.io/gh/sayuks/marginplyr)
 [![lint.yaml](https://github.com/sayuks/marginplyr/actions/workflows/lint.yaml/badge.svg)](https://github.com/sayuks/marginplyr/actions/workflows/lint.yaml)
-<a href = "https://sayuks.github.io/marginplyr/" target = "_blank"><img src="https://cranlogs.r-pkg.org/badges/marginplyr"></a>
 <!-- badges: end -->
 
 ```{r}
@@ -83,13 +82,7 @@ backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html).
 
 ## Installation
 
-You can install `marginplyr` from CRAN:
-
-``` r
-install.packages("marginplyr")
-```
-
-You can install the development version from
+`marginplyr` is not on CRAN yet. Install it from
 [GitHub](https://github.com/sayuks/marginplyr) with:
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ a lazy database table.
 [![Codecov test
 coverage](https://codecov.io/gh/sayuks/marginplyr/graph/badge.svg)](https://app.codecov.io/gh/sayuks/marginplyr)
 [![lint.yaml](https://github.com/sayuks/marginplyr/actions/workflows/lint.yaml/badge.svg)](https://github.com/sayuks/marginplyr/actions/workflows/lint.yaml)
-<a href = "https://sayuks.github.io/marginplyr/" target = "_blank"><img src="https://cranlogs.r-pkg.org/badges/marginplyr"></a>
 <!-- badges: end -->
 
 ``` r
@@ -81,13 +80,7 @@ backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html).
 
 ## Installation
 
-You can install `marginplyr` from CRAN:
-
-``` r
-install.packages("marginplyr")
-```
-
-You can install the development version from
+`marginplyr` is not on CRAN yet. Install it from
 [GitHub](https://github.com/sayuks/marginplyr) with:
 
 ``` r

--- a/tests/testthat/helper-package-metadata.R
+++ b/tests/testthat/helper-package-metadata.R
@@ -1,0 +1,36 @@
+# Reading a file the package ships alongside its code. Both callers --
+# `test-package-metadata.R` on the license files and `test-documentation.R` on
+# DESCRIPTION and the generated README -- need the same two answers, so they are
+# given once here rather than once per test file.
+
+# Prefer the repository copy, because `system.file()` reads whichever marginplyr
+# happens to be installed. `R CMD check` runs the tests from a directory holding
+# no repository copy, and there the installed package is the only one -- which
+# reaches these files because R installs them: `LICENSE` because the `License`
+# field names it, `README.md` because R installs it at the package root.
+metadata_path <- function(file) {
+  source_copy <- test_path("..", "..", file)
+  if (file.exists(source_copy)) {
+    return(source_copy)
+  }
+  installed <- system.file(file, package = "marginplyr")
+  if (!nzchar(installed)) {
+    stop(sprintf("No copy of %s is available to read.", file), call. = FALSE)
+  }
+  installed
+}
+
+# A field this cannot find is a failure rather than a pass, since a file that
+# states no value is exactly the drift being guarded against.
+dcf_field <- function(path, field) {
+  # `read.dcf()` names the value after the field, which would otherwise turn a
+  # mismatch into a report about names.
+  value <- unname(read.dcf(path, fields = field)[1L, 1L])
+  if (is.na(value)) {
+    stop(
+      sprintf("%s states no %s field.", basename(path), field),
+      call. = FALSE
+    )
+  }
+  value
+}

--- a/tests/testthat/helper-package-metadata.R
+++ b/tests/testthat/helper-package-metadata.R
@@ -1,13 +1,15 @@
 # Reading a file the package ships alongside its code. Both callers --
 # `test-package-metadata.R` on the license files and `test-documentation.R` on
-# DESCRIPTION and the generated README -- need the same two answers, so they are
-# given once here rather than once per test file.
+# DESCRIPTION -- need the same two answers, so they are given once here rather
+# than once per test file.
 
 # Prefer the repository copy, because `system.file()` reads whichever marginplyr
 # happens to be installed. `R CMD check` runs the tests from a directory holding
 # no repository copy, and there the installed package is the only one -- which
-# reaches these files because R installs them: `LICENSE` because the `License`
-# field names it, `README.md` because R installs it at the package root.
+# reaches these files because R installs them, `LICENSE` because the `License`
+# field names it. A file whose installation depends on the R version, as
+# `README.md`'s does, cannot use this: absence there is a fact about the
+# checking machine and not the drift being guarded against.
 metadata_path <- function(file) {
   source_copy <- test_path("..", "..", file)
   if (file.exists(source_copy)) {

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -143,28 +143,42 @@ version_blind_guards <- c("requireNamespace", "is_installed")
 # Both halves of the README are pages: `README.Rmd` is where a claim is
 # written, and `README.md` is what a reader on GitHub is shown and what the
 # website's home page includes.
+#
+# A repository run reads both. A check run reads whichever half R installed,
+# and that is a question about the R running the check, not about this package:
+# `.Rbuildignore` keeps `README.Rmd` out of the tarball, and "Package README.md
+# files are now installed and featured in HTML help" is an R 4.6.0 change, while
+# `DESCRIPTION` supports 4.1.0. So an older R checking a tarball reaches
+# neither, which is a page the scans do not see rather than a failure -- the
+# residency the vignette sources already have.
 readme_sources <- function() {
-  source <- testthat::test_path("..", "..", "README.Rmd")
-  read_pages(c(source[file.exists(source)], metadata_path("README.md")))
+  repository <- c(
+    testthat::test_path("..", "..", "README.Rmd"),
+    testthat::test_path("..", "..", "README.md")
+  )
+  paths <- repository[file.exists(repository)]
+  if (length(paths) == 0L) {
+    installed <- system.file("README.md", package = "marginplyr")
+    paths <- installed[nzchar(installed)]
+  }
+  read_pages(paths)
 }
 
 # Every shipped page the scans below hold to their rules, whatever it is
 # written in. The three sources reach a run from different places, and each
 # takes the strongest route open to it:
 #
-# - Rd topics: `man/` in a repository, `tools::Rd_db()` otherwise, so they are
-#   there either way.
-# - Vignette sources: repository-only. `.Rbuildignore` keeps none of them out
-#   of the tarball, but `R CMD check` unpacks it beside the `.Rcheck`
-#   directory rather than inside it.
-# - The README: `metadata_path()`, so the repository copy when there is one and
-#   the copy `R CMD INSTALL` leaves at the installed package root otherwise --
-#   which is also why it stops rather than returning nothing.
+# - Rd topics: `man/` in a repository, `tools::Rd_db()` otherwise.
+# - Vignette sources: repository-only, because `R CMD check` unpacks the
+#   tarball beside the `.Rcheck` directory rather than inside it.
+# - The README: repository copies, else the installed `README.md` where the R
+#   running the check is new enough to have installed one.
 #
-# The vignettes are added conditionally rather than skipped for, because a skip
-# naming no withheld backend is what `verify-backend.R` fails a job over. No
-# scan below needs a skip of its own either: the Rd topics and the README are
-# both always there, so this set is never empty.
+# Each is added when it is reachable rather than skipped for when it is not,
+# because a skip naming no withheld backend is what `verify-backend.R` fails a
+# job over. Reaching nothing at all is a different thing and stops: every scan
+# below iterates over this set, so a set that arrived empty is a set that
+# passes.
 documentation_sources <- function() {
   pages <- rd_topics()
   vignettes <- testthat::test_path("..", "..", "vignettes")
@@ -172,7 +186,11 @@ documentation_sources <- function() {
     sources <- list.files(vignettes, pattern = "[.]qmd$", full.names = TRUE)
     pages <- c(pages, read_pages(sources))
   }
-  c(pages, readme_sources())
+  pages <- c(pages, readme_sources())
+  if (length(pages) == 0L) {
+    stop("No documentation source is reachable to scan.", call. = FALSE)
+  }
+  pages
 }
 
 test_that("no shipped page guards on installation alone", {
@@ -285,19 +303,30 @@ cran_state_disagreements <- function(status, pages) {
   }
 
   readme <- pages[["README.md"]]
+  if (is.null(readme)) {
+    # No copy of the generated README was reachable, which is the older-R
+    # tarball case `readme_sources()` describes. There is nothing to judge
+    # here, and the repository run that produced the tarball judged it.
+    return(character())
+  }
+
   complete <- holds_any(readme, cran_install_call) &&
     holds_any(readme, setdiff(cran_claims, cran_install_call))
   if (complete) character() else "README.md"
 }
 
 test_that("installation instructions follow the recorded CRAN state", {
-  # The generated README is the page both directions are about, and
-  # `readme_sources()` stops rather than leaving it out, so neither direction
-  # can pass by having nothing to check.
-  disagreeing <- cran_state_disagreements(
-    cran_status(),
-    documentation_sources()
-  )
+  pages <- documentation_sources()
+
+  # The generated README is the page the `published` direction is about, and a
+  # repository run always has both halves on disk. Asserting that they reached
+  # the page set is what stops a broken derivation from reading as a state
+  # nothing disagrees with -- which is the one way this gate could go quiet.
+  if (file.exists(testthat::test_path("..", "..", "README.md"))) {
+    expect_true(all(c("README.Rmd", "README.md") %in% names(pages)))
+  }
+
+  disagreeing <- cran_state_disagreements(cran_status(), pages)
 
   # Named rather than counted, so the failure says which page is out of step
   # with the state, and where the rule it broke is written down.
@@ -342,6 +371,15 @@ test_that("the CRAN-state rule reads both states", {
     cran_state_disagreements("published", instruction_only),
     "README.md"
   )
+
+  # An older R checking a tarball, where neither half of the README is
+  # readable. The Rd topics are still held to `unpublished`.
+  no_readme <- list("summarize_with_margins.Rd" = cran_install_call)
+  expect_equal(
+    cran_state_disagreements("unpublished", no_readme),
+    "summarize_with_margins.Rd"
+  )
+  expect_equal(cran_state_disagreements("published", no_readme), character())
 })
 
 test_that("an unreadable CRAN state stops rather than choosing a direction", {

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -6,6 +6,12 @@ read_documentation <- function(path) {
   paste(readLines(path, warn = FALSE), collapse = "\n")
 }
 
+# Pages keyed by the file name a failure has to name, which is the only handle
+# a reader has on a page read out of two directories and an installed library.
+read_pages <- function(paths) {
+  stats::setNames(lapply(paths, read_documentation), basename(paths))
+}
+
 rd_topics <- function() {
   # Prefer the source `man/` directory, because `tools::Rd_db()` reads whatever
   # marginplyr version happens to be installed and would silently test stale
@@ -13,8 +19,7 @@ rd_topics <- function() {
   man <- testthat::test_path("..", "..", "man")
   if (dir.exists(man)) {
     files <- list.files(man, pattern = "[.]Rd$", full.names = TRUE)
-    topics <- lapply(files, read_documentation)
-    return(stats::setNames(topics, basename(files)))
+    return(read_pages(files))
   }
 
   db <- tryCatch(tools::Rd_db("marginplyr"), error = function(cnd) NULL)
@@ -137,39 +142,41 @@ version_blind_guards <- c("requireNamespace", "is_installed")
 
 # Both halves of the README are pages: `README.Rmd` is where a claim is
 # written, and `README.md` is what a reader on GitHub is shown and what the
-# website's home page includes. `.Rbuildignore` keeps the source out of the
-# tarball, so a check run reaches the generated half alone -- but it does reach
-# it, and `metadata_path()` is what finds it there, so a run that could reach
-# neither copy stops rather than returning a page set with no README in it.
+# website's home page includes.
 readme_sources <- function() {
   source <- testthat::test_path("..", "..", "README.Rmd")
-  paths <- c(source[file.exists(source)], metadata_path("README.md"))
-  stats::setNames(lapply(paths, read_documentation), basename(paths))
+  read_pages(c(source[file.exists(source)], metadata_path("README.md")))
 }
 
-# Every shipped page whose guards this holds to, whatever it is written in.
+# Every shipped page the scans below hold to their rules, whatever it is
+# written in. The three sources reach a run from different places, and each
+# takes the strongest route open to it:
 #
-# `.Rbuildignore` keeps no vignette out of the tarball, but `R CMD check`
-# unpacks it beside the `.Rcheck` directory rather than inside it, so a vignette
-# source is reachable from a repository run only. The Rd topics are reachable
-# either way -- from `man/` in a repository, from `tools::Rd_db()` otherwise --
-# so a run that finds no vignette still asserts these rules over the examples,
-# and adding the pages conditionally rather than skipping keeps
-# `verify-backend.R`'s rule that every skip names a backend its job withheld.
+# - Rd topics: `man/` in a repository, `tools::Rd_db()` otherwise, so they are
+#   there either way.
+# - Vignette sources: repository-only. `.Rbuildignore` keeps none of them out
+#   of the tarball, but `R CMD check` unpacks it beside the `.Rcheck`
+#   directory rather than inside it.
+# - The README: `metadata_path()`, so the repository copy when there is one and
+#   the copy `R CMD INSTALL` leaves at the installed package root otherwise --
+#   which is also why it stops rather than returning nothing.
+#
+# The vignettes are added conditionally rather than skipped for, because a skip
+# naming no withheld backend is what `verify-backend.R` fails a job over. No
+# scan below needs a skip of its own either: the Rd topics and the README are
+# both always there, so this set is never empty.
 documentation_sources <- function() {
   pages <- rd_topics()
   vignettes <- testthat::test_path("..", "..", "vignettes")
   if (dir.exists(vignettes)) {
     sources <- list.files(vignettes, pattern = "[.]qmd$", full.names = TRUE)
-    text <- lapply(sources, read_documentation)
-    pages <- c(pages, stats::setNames(text, basename(sources)))
+    pages <- c(pages, read_pages(sources))
   }
   c(pages, readme_sources())
 }
 
 test_that("no shipped page guards on installation alone", {
   pages <- documentation_sources()
-  skip_if(length(pages) == 0L, "No documentation sources available")
 
   blind <- vapply(
     pages,
@@ -201,19 +208,20 @@ test_that("no shipped page guards on installation alone", {
 # page can be read to find it out: a README claiming CRAN availability reads
 # exactly the same whether CRAN has published the package or not. DESCRIPTION's
 # `Config/marginplyr/cran-status` field is where that fact is recorded, once,
-# and it is what the two directions below are asserted against.
-#
-# Only `unpublished` and `published` can be read. Any other value stops the
-# test rather than being treated as either, for the reason a malformed
-# `must_error` header halts a render: a field this cannot read is a field whose
-# assertions silently stopped happening.
-cran_status <- function() {
-  field <- "Config/marginplyr/cran-status"
-  status <- dcf_field(metadata_path("DESCRIPTION"), field)
+# and it is what the directions below are asserted against. It sits beside
+# `Version`, which is the line a release edits anyway.
+cran_status_field <- "Config/marginplyr/cran-status"
+
+# Only `unpublished` and `published` can be read. Any other value stops rather
+# than being treated as either, for the reason a malformed `must_error` header
+# halts a render: a field this cannot read is a field whose assertions silently
+# stopped happening. Reading and checking are separate so that the refusal is
+# executed by a test today, rather than first attempted on release day.
+checked_cran_status <- function(status) {
   if (!isTRUE(status %in% c("unpublished", "published"))) {
     stop(
       "DESCRIPTION's `",
-      field,
+      cran_status_field,
       "` must read `unpublished` or `published`, not `",
       status,
       "`.",
@@ -223,9 +231,13 @@ cran_status <- function() {
   status
 }
 
-# The instruction itself, which is what a reader installs from. The other two
-# forms below claim availability without giving the reader anything to run, so
-# only this one can stand for the published direction.
+cran_status <- function() {
+  description <- metadata_path("DESCRIPTION")
+  checked_cran_status(dcf_field(description, cran_status_field))
+}
+
+# The instruction itself, which is the only one of the three forms below that
+# gives a reader something to run.
 cran_install_call <- "install.packages(\"marginplyr\")"
 
 # The concrete forms in which a page tells a reader that CRAN has this package.
@@ -239,45 +251,109 @@ cran_claims <- c(
   "cran.r-project.org/package=marginplyr"
 )
 
-test_that("installation instructions follow the recorded CRAN state", {
-  # The generated README is the page both directions below are about, and
-  # `readme_sources()` stops rather than leaving it out, so neither direction
-  # can pass by having nothing to check.
-  pages <- documentation_sources()
-
-  claiming <- names(pages)[vapply(
-    pages,
-    function(text) {
-      any(vapply(cran_claims, grepl, logical(1), x = text, fixed = TRUE))
+# Matched case-insensitively, because the CRAN host is written
+# `cran.r-project.org` and `CRAN.R-project.org` about equally often and the
+# same claim in the second spelling is still the claim. `\Q...\E` quotes the
+# marker so that a call's own parentheses and quotes stay text rather than
+# becoming a pattern, as `verify-site.R` quotes a home directory.
+holds_any <- function(text, markers) {
+  any(vapply(
+    markers,
+    function(marker) {
+      grepl(paste0("\\Q", marker, "\\E"), text, perl = TRUE, ignore.case = TRUE)
     },
     logical(1)
-  )]
+  ))
+}
 
-  if (identical(cran_status(), "unpublished")) {
-    # Named rather than counted, so the failure says which page is telling
-    # readers to install from a repository that does not have the package.
-    expect_equal(
-      claiming,
-      character(),
-      info = paste(
-        "Set `Config/marginplyr/cran-status` to `published` only once CRAN",
-        "has published the package; until then no page may claim it."
-      )
-    )
-  } else {
-    # The other direction, so flipping the field is what activates the CRAN
-    # instruction rather than something a release can forget to write. It asks
-    # for the instruction and not merely a claim, because the release also
-    # restores a CRAN badge to the same file: a check any claim satisfied
-    # would pass a README carrying the badge and still sending every reader to
-    # GitHub for the install itself.
-    expect_true(grepl(cran_install_call, pages[["README.md"]], fixed = TRUE))
+# The pages that disagree with the recorded state, which is what both
+# directions reduce to. Taking the state as an argument is what lets the
+# fixtures below execute the direction the field does not currently select: a
+# `published` branch first evaluated on release day is a branch nothing has
+# ever run.
+#
+# A page disagrees with `unpublished` by claiming CRAN has the package. The
+# README disagrees with `published` by dropping either half of what publication
+# gives a reader -- the instruction to run, and the badge or link that says
+# where it goes. Requiring both is what holds the release to its own steps,
+# since a check either half satisfied would pass a README that carries the
+# badge and still sends every reader to GitHub to install.
+cran_state_disagreements <- function(status, pages) {
+  claiming <- names(pages)[vapply(pages, holds_any, logical(1), cran_claims)]
+  if (identical(status, "unpublished")) {
+    return(claiming)
   }
+
+  readme <- pages[["README.md"]]
+  complete <- holds_any(readme, cran_install_call) &&
+    holds_any(readme, setdiff(cran_claims, cran_install_call))
+  if (complete) character() else "README.md"
+}
+
+test_that("installation instructions follow the recorded CRAN state", {
+  # The generated README is the page both directions are about, and
+  # `readme_sources()` stops rather than leaving it out, so neither direction
+  # can pass by having nothing to check.
+  disagreeing <- cran_state_disagreements(
+    cran_status(),
+    documentation_sources()
+  )
+
+  # Named rather than counted, so the failure says which page is out of step
+  # with the state, and where the rule it broke is written down.
+  expect_equal(
+    disagreeing,
+    character(),
+    info = paste(
+      "See *Installation instructions* in `AGENTS.md`:",
+      "`Config/marginplyr/cran-status` becomes `published` on the day CRAN",
+      "publishes the package, and the README changes with it."
+    )
+  )
+})
+
+test_that("the CRAN-state rule reads both states", {
+  github_route <- list("README.md" = "pak::pkg_install(\"sayuks/marginplyr\")")
+  # The uppercase spelling of the host, which is the same claim.
+  badge <- "https://CRAN.R-project.org/package=marginplyr"
+  badge_only <- list("README.md" = badge)
+  instruction_only <- list("README.md" = cran_install_call)
+  published_readme <- list("README.md" = paste(badge, cran_install_call))
+
+  expect_equal(
+    cran_state_disagreements("unpublished", github_route),
+    character()
+  )
+  expect_equal(cran_state_disagreements("unpublished", badge_only), "README.md")
+  expect_equal(
+    cran_state_disagreements("unpublished", instruction_only),
+    "README.md"
+  )
+
+  expect_equal(
+    cran_state_disagreements("published", published_readme),
+    character()
+  )
+  expect_equal(cran_state_disagreements("published", github_route), "README.md")
+  # Half a release is a failure in both halves: a badge is not an instruction,
+  # and an instruction is not the link the badge block is supposed to regain.
+  expect_equal(cran_state_disagreements("published", badge_only), "README.md")
+  expect_equal(
+    cran_state_disagreements("published", instruction_only),
+    "README.md"
+  )
+})
+
+test_that("an unreadable CRAN state stops rather than choosing a direction", {
+  expect_equal(checked_cran_status("unpublished"), "unpublished")
+  expect_equal(checked_cran_status("published"), "published")
+  expect_error(checked_cran_status("soon"), "must read")
+  # What `read.dcf()` returns for a field DESCRIPTION does not state.
+  expect_error(checked_cran_status(NA_character_), "must read")
 })
 
 test_that("every shipped page using the guard also sources it", {
   pages <- documentation_sources()
-  skip_if(length(pages) == 0L, "No documentation sources available")
 
   # An example is evaluated with marginplyr attached but nothing sourced, and a
   # vignette chunk is knitted the same way, so a guard call without the

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -318,13 +318,20 @@ cran_state_disagreements <- function(status, pages) {
 test_that("installation instructions follow the recorded CRAN state", {
   pages <- documentation_sources()
 
-  # The generated README is the page the `published` direction is about, and a
-  # repository run always has both halves on disk. Asserting that they reached
-  # the page set is what stops a broken derivation from reading as a state
-  # nothing disagrees with -- which is the one way this gate could go quiet.
-  if (file.exists(testthat::test_path("..", "..", "README.md"))) {
-    expect_true(all(c("README.Rmd", "README.md") %in% names(pages)))
-  }
+  # Every half that is on disk has to have reached the page set, which is what
+  # stops a broken derivation from reading as a state nothing disagrees with --
+  # the one way this gate could go quiet. Asserted over what is there rather
+  # than over a fixed pair, because which halves are there varies and none of
+  # the variation is this package's doing: covr runs from a copy built without
+  # the `.Rbuildignore`d `README.Rmd`, and an R older than 4.6.0 checking a
+  # tarball has neither half.
+  on_disk <- c("README.Rmd", "README.md")
+  on_disk <- on_disk[vapply(
+    on_disk,
+    function(file) file.exists(testthat::test_path("..", "..", file)),
+    logical(1)
+  )]
+  expect_true(all(on_disk %in% names(pages)))
 
   disagreeing <- cran_state_disagreements(cran_status(), pages)
 

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -2,6 +2,10 @@
 # rules they state must be reachable from every topic that points at them.
 # These tests read the Rd sources rather than any private roxygen structure.
 
+read_documentation <- function(path) {
+  paste(readLines(path, warn = FALSE), collapse = "\n")
+}
+
 rd_topics <- function() {
   # Prefer the source `man/` directory, because `tools::Rd_db()` reads whatever
   # marginplyr version happens to be installed and would silently test stale
@@ -9,9 +13,7 @@ rd_topics <- function() {
   man <- testthat::test_path("..", "..", "man")
   if (dir.exists(man)) {
     files <- list.files(man, pattern = "[.]Rd$", full.names = TRUE)
-    topics <- lapply(files, function(file) {
-      paste(readLines(file, warn = FALSE), collapse = "\n")
-    })
+    topics <- lapply(files, read_documentation)
     return(stats::setNames(topics, basename(files)))
   }
 
@@ -133,6 +135,18 @@ test_that("the Grouping-identity comparison has exactly one canonical home", {
 # which makes it the likelier of the two to arrive looking correct.
 version_blind_guards <- c("requireNamespace", "is_installed")
 
+# Both halves of the README are pages: `README.Rmd` is where a claim is
+# written, and `README.md` is what a reader on GitHub is shown and what the
+# website's home page includes. `.Rbuildignore` keeps the source out of the
+# tarball, so a check run reaches the generated half alone -- but it does reach
+# it, and `metadata_path()` is what finds it there, so a run that could reach
+# neither copy stops rather than returning a page set with no README in it.
+readme_sources <- function() {
+  source <- testthat::test_path("..", "..", "README.Rmd")
+  paths <- c(source[file.exists(source)], metadata_path("README.md"))
+  stats::setNames(lapply(paths, read_documentation), basename(paths))
+}
+
 # Every shipped page whose guards this holds to, whatever it is written in.
 #
 # `.Rbuildignore` keeps no vignette out of the tarball, but `R CMD check`
@@ -147,12 +161,10 @@ documentation_sources <- function() {
   vignettes <- testthat::test_path("..", "..", "vignettes")
   if (dir.exists(vignettes)) {
     sources <- list.files(vignettes, pattern = "[.]qmd$", full.names = TRUE)
-    text <- lapply(sources, function(path) {
-      paste(readLines(path, warn = FALSE), collapse = "\n")
-    })
+    text <- lapply(sources, read_documentation)
     pages <- c(pages, stats::setNames(text, basename(sources)))
   }
-  pages
+  c(pages, readme_sources())
 }
 
 test_that("no shipped page guards on installation alone", {
@@ -183,6 +195,84 @@ test_that("no shipped page guards on installation alone", {
       "`inst/suggests/guard.R` instead."
     )
   )
+})
+
+# Where a reader can get the package is a fact about the outside world, and no
+# page can be read to find it out: a README claiming CRAN availability reads
+# exactly the same whether CRAN has published the package or not. DESCRIPTION's
+# `Config/marginplyr/cran-status` field is where that fact is recorded, once,
+# and it is what the two directions below are asserted against.
+#
+# Only `unpublished` and `published` can be read. Any other value stops the
+# test rather than being treated as either, for the reason a malformed
+# `must_error` header halts a render: a field this cannot read is a field whose
+# assertions silently stopped happening.
+cran_status <- function() {
+  field <- "Config/marginplyr/cran-status"
+  status <- dcf_field(metadata_path("DESCRIPTION"), field)
+  if (!isTRUE(status %in% c("unpublished", "published"))) {
+    stop(
+      "DESCRIPTION's `",
+      field,
+      "` must read `unpublished` or `published`, not `",
+      status,
+      "`.",
+      call. = FALSE
+    )
+  }
+  status
+}
+
+# The instruction itself, which is what a reader installs from. The other two
+# forms below claim availability without giving the reader anything to run, so
+# only this one can stand for the published direction.
+cran_install_call <- "install.packages(\"marginplyr\")"
+
+# The concrete forms in which a page tells a reader that CRAN has this package.
+# Each one names marginplyr, because the README's comparison table links to
+# another package's CRAN page and that is not a claim about this one. Prose
+# needing to mention the CRAN call has to spell it some other way, as the
+# version-blind guard scan above already requires of prose naming those calls.
+cran_claims <- c(
+  cran_install_call,
+  "cranlogs.r-pkg.org/badges/marginplyr",
+  "cran.r-project.org/package=marginplyr"
+)
+
+test_that("installation instructions follow the recorded CRAN state", {
+  # The generated README is the page both directions below are about, and
+  # `readme_sources()` stops rather than leaving it out, so neither direction
+  # can pass by having nothing to check.
+  pages <- documentation_sources()
+
+  claiming <- names(pages)[vapply(
+    pages,
+    function(text) {
+      any(vapply(cran_claims, grepl, logical(1), x = text, fixed = TRUE))
+    },
+    logical(1)
+  )]
+
+  if (identical(cran_status(), "unpublished")) {
+    # Named rather than counted, so the failure says which page is telling
+    # readers to install from a repository that does not have the package.
+    expect_equal(
+      claiming,
+      character(),
+      info = paste(
+        "Set `Config/marginplyr/cran-status` to `published` only once CRAN",
+        "has published the package; until then no page may claim it."
+      )
+    )
+  } else {
+    # The other direction, so flipping the field is what activates the CRAN
+    # instruction rather than something a release can forget to write. It asks
+    # for the instruction and not merely a claim, because the release also
+    # restores a CRAN badge to the same file: a check any claim satisfied
+    # would pass a README carrying the badge and still sending every reader to
+    # GitHub for the install itself.
+    expect_true(grepl(cran_install_call, pages[["README.md"]], fixed = TRUE))
+  }
 })
 
 test_that("every shipped page using the guard also sources it", {

--- a/tests/testthat/test-package-metadata.R
+++ b/tests/testthat/test-package-metadata.R
@@ -7,36 +7,9 @@
 # of restating it, so the holder is recorded in one place and the license files
 # are checked against that record.
 
-# Prefer the repository copy, because `system.file()` reads whichever marginplyr
-# happens to be installed. `R CMD check` runs the tests from a directory holding
-# neither copy, and there the installed package is the only one -- `LICENSE` is
-# installed beside `DESCRIPTION` because the `License` field names it.
-metadata_path <- function(file) {
-  source_copy <- test_path("..", "..", file)
-  if (file.exists(source_copy)) {
-    return(source_copy)
-  }
-  installed <- system.file(file, package = "marginplyr")
-  if (!nzchar(installed)) {
-    stop(sprintf("No copy of %s is available to read.", file), call. = FALSE)
-  }
-  installed
-}
-
-# A field this cannot find is a failure rather than a pass, since a file that
-# states no holder is exactly the drift being guarded against.
-dcf_field <- function(path, field) {
-  # `read.dcf()` names the value after the field, which would otherwise turn a
-  # holder mismatch into a report about names.
-  value <- unname(read.dcf(path, fields = field)[1L, 1L])
-  if (is.na(value)) {
-    stop(
-      sprintf("%s states no %s field.", basename(path), field),
-      call. = FALSE
-    )
-  }
-  value
-}
+# `metadata_path()` and `dcf_field()` come from `helper-package-metadata.R`,
+# because `test-documentation.R` asks the same two questions of DESCRIPTION and
+# the generated README.
 
 # `format()` renders a `person` the way a license notice names someone, so the
 # expectation comes from the metadata rather than from a second copy of the

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -23,7 +23,7 @@ first. This guide focuses on query shape, execution, and backend support.
 
 ## Installation
 
-Install the development version of marginplyr from GitHub:
+Install marginplyr from GitHub:
 
 ```{r}
 #| eval: false

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -24,7 +24,7 @@ guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html).
 
 ## Installation
 
-Install the development version from GitHub:
+Install marginplyr from GitHub:
 
 ```{r}
 #| eval: false

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -26,7 +26,7 @@ guide that explains why its answer works.
 
 ## Installation
 
-Install the development version of marginplyr from GitHub:
+Install marginplyr from GitHub:
 
 ```{r}
 #| eval: false


### PR DESCRIPTION
Closes #177.

## The defect

The README's first instruction was one no reader could follow:

``` r
install.packages("marginplyr")
```

marginplyr has never been published on CRAN — `cran.r-project.org/package=marginplyr`
returns 404 today — so the authoritative installation route was the one that
could not work, on the page GitHub shows and the website's home page includes.
The cranlogs badge made the same claim more quietly, rendering
`CRAN downloads 0/month` for a package CRAN has never seen.

## Why prose alone cannot fix it

A README claiming CRAN availability reads exactly the same whether CRAN has
published the package or not, so no file in the repository could be read to
tell the true version from the false one. Rewriting the paragraph fixes today
and leaves the same defect available tomorrow, in the other direction: a
release that publishes and forgets to restore the instruction.

`DESCRIPTION`'s `Config/marginplyr/cran-status` records that fact once —
`unpublished` or `published`, nothing else — beside the `Version` a release is
already bumping. `test-documentation.R` asserts both directions against it over
the Rd topics, the vignette sources, and both halves of the README:

- while it reads `unpublished`, no page may name the CRAN installation call,
  the cranlogs badge, or this package's CRAN page;
- once it reads `published`, `README.md` must carry both halves of what
  publication gives a reader — the instruction to run, and the badge or link
  saying where it goes.

So the field cannot be flipped without rewriting the README, and the README
cannot get ahead of the field. The rule is a function of the state and the
pages rather than a branch on the field, with fixtures running both directions
today: a `published` branch first evaluated on release day is a branch nothing
has ever executed. Markers match case-insensitively, because
`CRAN.R-project.org` is the same claim spelled the way a case-sensitive scan
could not see.

## The generated README had no gate at all

`README.md` is generated from `README.Rmd`, and nothing regenerated it —
`.Rbuildignore` keeps the source out of the tarball, so no check run can reach
what the shipped file was supposed to contain. `document.yaml` now renders it
and diffs it, before the `man/` check because `README.Rmd`'s `fig.path` writes
into `man/figures` too.

Its pandoc is pinned, unlike roxygen2. pandoc's markdown writer is not stable
across versions — 3.8.3, which `setup-pandoc@v2` installs by default, writes a
`text` info string on the fence 3.10.1 leaves bare — and the check is a byte
comparison, so an unpinned job would red on a README nobody touched. Verified
by rendering under both versions. The step says so when it fails, since that
red and a stale file look identical.

## The milestone

`AGENTS.md` gains an *Installation instructions* section naming it: the field
flips the day `cran.r-project.org/package=marginplyr` resolves — not when the
tarball is uploaded, not when `cran-comments.md` is written. A submission can
be rejected or archived, and an instruction made true by uploading one would be
false for however long that took. Steps 1 to 3 of the release hold each other
up rather than relying on the list being followed; step 4 (vignette wording) is
the one a release can genuinely skip, which is why it changes only prose true
in both states.

## Also

- The vignettes said "the development version", which implies a released one
  exists. They say "marginplyr" until there is.
- `metadata_path()` and `dcf_field()` move to `helper-package-metadata.R`: the
  CRAN state is the second question asked of a file the package ships beside
  its code.
- Both version-blind guard scans now cover the README too — installation
  documentation is where a version-blind test is likeliest to be written, which
  is why `verify-site.R` already forbids `installed.packages` site-wide. The
  README is always reachable, so those scans' `skip_if()` calls could no longer
  fire and are gone.

## Verification

- Mutation-tested in both states: a CRAN claim under `unpublished` fails naming
  the page; `published` without the instruction fails; `published` with only a
  badge fails; an unreadable field value stops.
- `R CMD check` on a built tarball: `Status: OK`, 2804 passing, **0 skips** —
  which is also what confirms the removed skips were dead and that
  `metadata_path()`'s installed-copy fallback resolves where no repository copy
  exists.
- `--as-cran`: only the expected new-submission NOTE; the `Config/` field draws
  none.
- lintr, `spelling::spell_check_package()`, and a byte-identical `README.md`
  regeneration.