### PR TITLE
Respect non-evaluation boundaries in static summary analysis

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -166,15 +166,23 @@ rewrite_grouping_expr <- function(expr,
     return(as.integer(sum(bits * weights)))
   }
 
-  call_args <- lapply(
-    static_call_args(expr),
-    rewrite_grouping_expr,
-    plan = plan,
-    grouping_set = grouping_set,
-    sql = sql,
-    con = con
+  # A helper the caller quoted is language data rather than a request to
+  # compile, so the rewrite descends past it: `deparse1(quote(
+  # grouping_bit(region)))` answered `"0L"` in one branch and `"1L"` in
+  # another, which is the branch-local constant this helper exists to produce
+  # and not the object the caller wrote (#179).
+  rewrite_evaluated_call_parts(
+    expr,
+    function(part) {
+      rewrite_grouping_expr(
+        part,
+        plan = plan,
+        grouping_set = grouping_set,
+        sql = sql,
+        con = con
+      )
+    }
   )
-  rebuild_static_call(expr, call_args)
 }
 
 grouping_helper_name <- function(expr) {

--- a/R/share.R
+++ b/R/share.R
@@ -2612,7 +2612,7 @@ share_expression_kind <- function(expr) {
   # helper the call does use: `eval(quote(share_of_total(total)))` reaches the
   # helper itself, which answers for a position it cannot see and names a
   # Grouping plan the caller already has.
-  arguments <- c(evaluated_call_args(expr), searched_language_parts(expr))
+  arguments <- searched_call_parts(expr)
   for (index in seq_along(arguments)) {
     kind <- share_expression_kind(arguments[[index]])
     if (!is.null(kind)) {
@@ -2790,7 +2790,7 @@ contains_selection_predicate <- function(expr) {
     return(TRUE)
   }
   any(vapply(
-    c(evaluated_call_args(expr), searched_language_parts(expr)),
+    searched_call_parts(expr),
     contains_selection_predicate,
     logical(1)
   ))
@@ -2919,10 +2919,7 @@ expression_data_symbols <- function(expr, bound = character()) {
   # own. `(get)` is the redundant-parenthesis shape #130 recorded, and a head
   # built by `match.fun()` or `getFunction()` names the same primitive through
   # one whose whole purpose is to name a function.
-  callee_name <- call_name
-  if (is.null(callee_name)) {
-    callee_name <- static_callee_name(static_call_head(expr))
-  }
+  callee_name <- resolved_callee_name(expr, call_name)
   if (is_reflective_lookup(callee_name)) {
     return(unique(c(
       call_part_symbols(expr, bound),
@@ -3032,20 +3029,10 @@ expression_data_symbols <- function(expr, bound = character()) {
 # rather than testing for a capture of its own (#179).
 call_part_symbols <- function(expr, bound) {
   call_head <- static_call_head(expr)
-  # A name the expression has bound may be the function this call reaches, so
-  # the capture is not claimed for it: a block that binds `quote` to a function
-  # of its own and then calls it evaluates the argument. R's function lookup
-  # skips a non-function binding, so the name may still reach `base::quote()`
-  # and the parts be data after all -- undecidable here, and answered in the
-  # direction that reports the read rather than the one that hides it. A
-  # qualified head is out of reach of any binding and keeps its capture.
-  shadowed <- rlang::is_symbol(call_head) &&
-    rlang::as_name(call_head) %in% bound
-  parts <- if (shadowed) {
-    static_call_args(expr)
-  } else {
-    evaluated_call_args(expr)
-  }
+  # The bound set travels into the capture reading, which is where a name this
+  # expression has bound to a function of its own stops being read as the
+  # primitive it spells. This walk is the only caller that has one to pass.
+  parts <- evaluated_call_args(expr, bound = bound)
   if (!rlang::is_symbol(call_head)) {
     parts <- c(list(call_head), parts)
   }
@@ -3249,104 +3236,6 @@ lookup_has_external_env <- function(expr) {
   )
 }
 
-# The function an expression statically names, however it spells it: a symbol,
-# a namespace qualifier, redundant parentheses, or a call to a primitive whose
-# purpose is to name a function. `get("get")("share")`,
-# `match.fun("get")("share")` and `getFunction("get")("share")` all invoke the
-# same primitive as `get("share")`, and a branch matching on the call's own
-# name sees none of them, because a call whose head is a call has no name.
-#
-# What none of those spellings change is that the head is a read: `(f)`,
-# `match.fun("f")` and the rest are evaluated in the mask as values rather than
-# through R's function lookup. `call_part_symbols()` reports that read, and
-# every caller of this unions the two answers.
-#
-# A literal string is here for `do.call()`, which takes its function that way.
-static_callee_name <- function(callee) {
-  if (rlang::is_symbol(callee)) {
-    return(rlang::as_name(callee))
-  }
-  if (!rlang::is_call(callee)) {
-    named <- static_character_value(callee)
-    if (is.null(named) || length(named) != 1L) {
-      return(NULL)
-    }
-    return(named)
-  }
-  if (rlang::is_call(callee, "(") && length(callee) >= 2L) {
-    return(static_callee_name(callee[[2L]]))
-  }
-  if (rlang::is_call(callee, c("::", ":::")) && length(callee) >= 3L) {
-    return(static_callee_name(callee[[3L]]))
-  }
-  call_name <- static_call_name(callee)
-  if (is.null(call_name)) {
-    return(NULL)
-  }
-  formal <- function_naming_formal(call_name)
-  if (is.null(formal)) {
-    return(NULL)
-  }
-  static_callee_name_from(callee, formal)
-}
-
-# The name a function-naming primitive was given, where that name is statically
-# knowable. One that is not leaves the head unnamed, which is the answer for
-# any other computed head: the walk reports the head's own reads and treats the
-# call as the ordinary call it cannot recognize.
-static_callee_name_from <- function(callee, formal) {
-  argument <- call_formal_argument(callee, formal)
-  if (length(argument) == 0L) {
-    return(NULL)
-  }
-  named <- static_character_value(argument[[1L]])
-  if (is.null(named) || length(named) != 1L) {
-    return(NULL)
-  }
-  named
-}
-
-# The formal each function-naming primitive takes its name in, and `NULL` for a
-# call that names no function. `mget()` and `exists()` are absent because
-# neither can answer a function to call: one answers a list and the other a
-# flag.
-function_naming_formal <- function(call_name) {
-  switch(call_name,
-    match.fun = "FUN",
-    getFunction = "name",
-    get = ,
-    get0 = "x",
-    NULL
-  )
-}
-
-# The primitives that resolve a name given as a string. Each searches ordinary
-# lexical scope from an environment that, under a data mask, is the mask, so a
-# name one of them is handed is a mask read exactly as the symbol is.
-#
-# `dynGet()` is deliberately absent: it searches the calling frames rather than
-# the lexical scope, so it does not reach the mask -- measured, not assumed.
-#
-# One of these reached as a *value* rather than as a callee is out of reach of
-# any static walk, and is safe for the same measured reason: in
-# `sapply(c("share"), get)` the environment `get()` searches from is the frame
-# that called it, inside `sapply()`, so the call raises rather than reading a
-# column. Which function a value holds is undecidable in general -- `f <- get`
-# is the smallest case -- so a walk answering it would have to over-report
-# every call it cannot name, and that is nearly all of them.
-is_reflective_lookup <- function(callee_name) {
-  !is.null(callee_name) &&
-    callee_name %in% c("get", "get0", "mget", "exists")
-}
-
-# The primitives that evaluate a language object. `evalq()` is absent because
-# it quotes its first argument, so the general walk already reports the symbols
-# under it -- adding it here would answer the same thing twice.
-is_reflective_evaluation <- function(callee_name) {
-  !is.null(callee_name) &&
-    callee_name %in% c("eval", "eval_tidy", "eval_bare")
-}
-
 # The names a reflective lookup resolves in the mask.
 #
 # An environment argument terminates the search: all four primitives require an
@@ -3419,185 +3308,6 @@ evaluated_language_symbols <- function(expr, bound) {
     lapply(values, expression_data_symbols, bound = bound),
     use.names = FALSE
   ))
-}
-
-# Where in a call's arguments the language it evaluates sits, and `0L` for a
-# call that evaluates none. The searches and the rewrites open the argument the
-# dependency walk reads, so the three read its position once -- through
-# `static_callee_name()`, since a head that names the primitive without being a
-# symbol names it here as it does there.
-evaluated_language_index <- function(expr, call_name = static_call_name(expr)) {
-  callee_name <- call_name
-  if (is.null(callee_name)) {
-    callee_name <- static_callee_name(static_call_head(expr))
-  }
-  if (!is_reflective_evaluation(callee_name)) {
-    return(0L)
-  }
-  call_formal_index(static_call_args(expr), "expr")
-}
-
-# The language a call is statically known to evaluate: `list()` for a call that
-# evaluates none, and `NULL` where what it evaluates is not knowable. The two
-# empty answers are the ones `static_language_values()` separates, kept apart
-# because the walk turns one of them into the marker.
-evaluated_language_parts <- function(expr, call_name = static_call_name(expr)) {
-  index <- evaluated_language_index(expr, call_name = call_name)
-  if (index == 0L) {
-    return(list())
-  }
-  static_language_values(static_call_args(expr)[[index]])
-}
-
-# The same language as parts a search analyzes beside a call's own arguments.
-# `eval()` runs what it is handed in the data mask, so a helper written under a
-# capture there is one this call really does use, and the boundary #179 draws
-# must not hide it: without this, `eval(quote(cur_group_id()))` ran and
-# answered a branch-local identifier, which is the value that guard exists to
-# refuse (#179).
-#
-# What is not knowable contributes nothing rather than a marker. The dependency
-# walk has an alias set to compare an over-report against and turns an
-# unreadable one into a read of every alias; a search has nothing to compare,
-# so refusing on one would reject `eval(built)` wherever it appears, which is
-# legal code and always was.
-searched_language_parts <- function(expr, call_name = static_call_name(expr)) {
-  values <- evaluated_language_parts(expr, call_name = call_name)
-  if (is.null(values)) {
-    return(list())
-  }
-  values
-}
-
-# The language objects an expression is statically known to hand `eval()`, and
-# `NULL` where it is not knowable. An empty list is the third answer and is not
-# the same as `NULL`: a constant evaluates to itself and looks nothing up.
-#
-# The constructors that hide a name from the walk need a case, and so do the
-# two that capture one. A name written as a string was never reported by the
-# walk of the call's parts, and a name written under `quote()` or
-# `substitute()` no longer is, since the mask evaluates neither (#179) -- so
-# this is the only thing standing between `eval(quote(share))` and the silence
-# that #173 removed.
-#
-# A capture evaluated in place, as `evalq()` evaluates its argument, needs no
-# case of its own: the walk of the call's parts reports the symbol under it as
-# it always did.
-#
-# `bquote()` is not among them because `.()` substitutes an expression this
-# walk cannot see, which leaves it with the answer it gives any other
-# unrecognized shape.
-static_language_values <- function(expr) {
-  if (rlang::is_symbol(expr)) {
-    # The symbol names a value, and which language object that value holds is
-    # not visible here.
-    return(NULL)
-  }
-  if (!rlang::is_call(expr)) {
-    return(list())
-  }
-  call_name <- static_call_name(expr)
-  if (is.null(call_name)) {
-    return(NULL)
-  }
-  if (identical(call_name, "quote")) {
-    return(call_formal_argument(expr, "expr"))
-  }
-  if (identical(call_name, "substitute")) {
-    # What `substitute()` answers is its captured argument with names replaced
-    # from `env`. A call supplying one is a substitution this walk cannot read,
-    # so the language reaching `eval()` is unknown; a call supplying none
-    # substitutes from the mask, which leaves a column and an earlier summary
-    # alias alone -- measured under dplyr -- so the expression arrives as
-    # written.
-    if (call_supplies_other_argument(expr, "expr", "env")) {
-      return(NULL)
-    }
-    return(call_formal_argument(expr, "expr"))
-  }
-  if (identical(call_name, "expression")) {
-    return(static_call_args(expr))
-  }
-  if (call_name %in% c("as.name", "as.symbol")) {
-    return(recovered_name_values(call_formal_argument(expr, "x")))
-  }
-  if (identical(call_name, "str2lang")) {
-    return(parsed_language_values(call_formal_argument(expr, "s")))
-  }
-  if (identical(call_name, "str2expression")) {
-    return(parsed_language_values(call_formal_argument(expr, "text")))
-  }
-  if (identical(call_name, "parse")) {
-    # Matched by name alone: `parse()`'s first positional argument is a
-    # connection, and what a connection holds is not knowable here.
-    return(parsed_language_values(
-      call_formal_argument(expr, "text", positional = FALSE)
-    ))
-  }
-  NULL
-}
-
-# The symbols a statically known string names. An empty string is dropped
-# rather than turned into a symbol, because `as.name("")` is an error in R and
-# the walk must raise none of its own.
-recovered_name_values <- function(argument) {
-  if (length(argument) == 0L) {
-    return(NULL)
-  }
-  text <- static_character_value(argument[[1L]])
-  if (is.null(text)) {
-    return(NULL)
-  }
-  lapply(text[nzchar(text)], as.name)
-}
-
-# The language a statically known string parses to. Parsing is not evaluation:
-# nothing the caller wrote runs here, which is what lets the recovery happen
-# during planning at all. Text that does not parse is reported as unknown
-# rather than raised, since the call itself raises R's own condition when it
-# runs.
-parsed_language_values <- function(argument) {
-  if (length(argument) == 0L) {
-    return(NULL)
-  }
-  text <- static_character_value(argument[[1L]])
-  if (is.null(text)) {
-    return(NULL)
-  }
-  parsed <- tryCatch(
-    str2expression(paste(text, collapse = "\n")),
-    error = function(cnd) NULL
-  )
-  if (is.null(parsed)) {
-    return(NULL)
-  }
-  as.list(parsed)
-}
-
-# The character vector an expression is statically known to be, and `NULL`
-# where it is not. A literal is one, and so is a `c()` of literals, which is
-# how a caller writes the vector `mget()` takes; anything else names a value
-# this walk cannot see without running it.
-static_character_value <- function(expr) {
-  if (is.character(expr)) {
-    if (anyNA(expr)) {
-      return(NULL)
-    }
-    return(expr)
-  }
-  if (!rlang::is_call(expr, "c")) {
-    return(NULL)
-  }
-  values <- lapply(rlang::call_args(expr), static_character_value)
-  if (any(vapply(values, is.null, logical(1)))) {
-    return(NULL)
-  }
-  recovered <- unlist(values, use.names = FALSE)
-  if (is.null(recovered)) {
-    # `c()` of nothing, which names nothing.
-    return(character())
-  }
-  recovered
 }
 
 # The name the walk reports for a read it could not resolve.

--- a/R/share.R
+++ b/R/share.R
@@ -2607,7 +2607,12 @@ share_expression_kind <- function(expr) {
   # share_of_total(units))` is a language object the caller is carrying, and
   # naming it a Total share written in the wrong position refused a call that
   # asks for no share at all (#179).
-  arguments <- evaluated_call_args(expr)
+  #
+  # The language the call evaluates is searched beside them, because that is a
+  # helper the call does use: `eval(quote(share_of_total(total)))` reaches the
+  # helper itself, which answers for a position it cannot see and names a
+  # Grouping plan the caller already has.
+  arguments <- c(evaluated_call_args(expr), searched_language_parts(expr))
   for (index in seq_along(arguments)) {
     kind <- share_expression_kind(arguments[[index]])
     if (!is.null(kind)) {
@@ -2785,7 +2790,7 @@ contains_selection_predicate <- function(expr) {
     return(TRUE)
   }
   any(vapply(
-    evaluated_call_args(expr),
+    c(evaluated_call_args(expr), searched_language_parts(expr)),
     contains_selection_predicate,
     logical(1)
   ))
@@ -3406,11 +3411,7 @@ deferred_call_symbols <- function(expr) {
 # list(a = 1))` reads the share. Which of the two an argument evaluates to is
 # not decidable here, so the node resolves toward over-reporting.
 evaluated_language_symbols <- function(expr, bound) {
-  argument <- call_formal_argument(expr, "expr")
-  if (length(argument) == 0L) {
-    return(character())
-  }
-  values <- static_language_values(argument[[1L]])
+  values <- evaluated_language_parts(expr)
   if (is.null(values)) {
     return(unresolved_lookup_name())
   }
@@ -3418,6 +3419,54 @@ evaluated_language_symbols <- function(expr, bound) {
     lapply(values, expression_data_symbols, bound = bound),
     use.names = FALSE
   ))
+}
+
+# Where in a call's arguments the language it evaluates sits, and `0L` for a
+# call that evaluates none. The searches and the rewrites open the argument the
+# dependency walk reads, so the three read its position once -- through
+# `static_callee_name()`, since a head that names the primitive without being a
+# symbol names it here as it does there.
+evaluated_language_index <- function(expr, call_name = static_call_name(expr)) {
+  callee_name <- call_name
+  if (is.null(callee_name)) {
+    callee_name <- static_callee_name(static_call_head(expr))
+  }
+  if (!is_reflective_evaluation(callee_name)) {
+    return(0L)
+  }
+  call_formal_index(static_call_args(expr), "expr")
+}
+
+# The language a call is statically known to evaluate: `list()` for a call that
+# evaluates none, and `NULL` where what it evaluates is not knowable. The two
+# empty answers are the ones `static_language_values()` separates, kept apart
+# because the walk turns one of them into the marker.
+evaluated_language_parts <- function(expr, call_name = static_call_name(expr)) {
+  index <- evaluated_language_index(expr, call_name = call_name)
+  if (index == 0L) {
+    return(list())
+  }
+  static_language_values(static_call_args(expr)[[index]])
+}
+
+# The same language as parts a search analyzes beside a call's own arguments.
+# `eval()` runs what it is handed in the data mask, so a helper written under a
+# capture there is one this call really does use, and the boundary #179 draws
+# must not hide it: without this, `eval(quote(cur_group_id()))` ran and
+# answered a branch-local identifier, which is the value that guard exists to
+# refuse (#179).
+#
+# What is not knowable contributes nothing rather than a marker. The dependency
+# walk has an alias set to compare an over-report against and turns an
+# unreadable one into a read of every alias; a search has nothing to compare,
+# so refusing on one would reject `eval(built)` wherever it appears, which is
+# legal code and always was.
+searched_language_parts <- function(expr, call_name = static_call_name(expr)) {
+  values <- evaluated_language_parts(expr, call_name = call_name)
+  if (is.null(values)) {
+    return(list())
+  }
+  values
 }
 
 # The language objects an expression is statically known to hand `eval()`, and

--- a/R/share.R
+++ b/R/share.R
@@ -2602,8 +2602,12 @@ share_expression_kind <- function(expr) {
   }
   # By subscript for the reason `static_call_args()` gives. An empty argument
   # holds no share helper, so it answers `NULL` like any other unrecognized
-  # shape and the walk carries on to the arguments after it.
-  arguments <- static_call_args(expr)
+  # shape and the walk carries on to the arguments after it. A captured one
+  # holds no request either, however it is spelled inside: `quote(
+  # share_of_total(units))` is a language object the caller is carrying, and
+  # naming it a Total share written in the wrong position refused a call that
+  # asks for no share at all (#179).
+  arguments <- evaluated_call_args(expr)
   for (index in seq_along(arguments)) {
     kind <- share_expression_kind(arguments[[index]])
     if (!is.null(kind)) {
@@ -2781,7 +2785,7 @@ contains_selection_predicate <- function(expr) {
     return(TRUE)
   }
   any(vapply(
-    static_call_args(expr),
+    evaluated_call_args(expr),
     contains_selection_predicate,
     logical(1)
   ))
@@ -3011,20 +3015,49 @@ expression_data_symbols <- function(expr, bound = character()) {
   call_part_symbols(expr, bound)
 }
 
-# The reads of a call's own parts: its arguments, and its head when the head is
-# not a bare symbol. This is the general walk above, reached by name so that
-# the reflective branches can add their resolved names to it instead of
+# The reads of a call's own parts: its evaluated arguments, and its head when
+# the head is not a bare symbol. This is the general walk above, reached by name
+# so that the reflective branches can add their resolved names to it instead of
 # answering in its place.
+#
+# An argument a call captures as language is not one of those parts, and this
+# is where `quote(share)` stops being read as the column `share`: the boundary
+# is drawn once here, so every branch above that ends at the parts -- the
+# pronoun, the binding constructs, the reflective primitives -- inherits it
+# rather than testing for a capture of its own (#179).
 call_part_symbols <- function(expr, bound) {
   call_head <- static_call_head(expr)
-  parts <- static_call_args(expr)
+  # A name the expression has bound may be the function this call reaches, so
+  # the capture is not claimed for it: a block that binds `quote` to a function
+  # of its own and then calls it evaluates the argument. R's function lookup
+  # skips a non-function binding, so the name may still reach `base::quote()`
+  # and the parts be data after all -- undecidable here, and answered in the
+  # direction that reports the read rather than the one that hides it. A
+  # qualified head is out of reach of any binding and keeps its capture.
+  shadowed <- rlang::is_symbol(call_head) &&
+    rlang::as_name(call_head) %in% bound
+  parts <- if (shadowed) {
+    static_call_args(expr)
+  } else {
+    evaluated_call_args(expr)
+  }
   if (!rlang::is_symbol(call_head)) {
     parts <- c(list(call_head), parts)
   }
-  unique(unlist(
+  reads <- unlist(
     lapply(parts, expression_data_symbols, bound = bound),
     use.names = FALSE
-  ))
+  )
+  # `unlist()` answers `NULL` for a walk that reached no part at all, and every
+  # member of this family answers a character vector: `intersect()` and `%in%`
+  # read the two alike, but `expect_identical()` does not, and a caller storing
+  # the answer would find one branch of the walk typeless. A call whose parts
+  # are all captured is the shape that made it reachable for a name-carrying
+  # call rather than only for `f()` (#179).
+  if (is.null(reads)) {
+    return(character())
+  }
+  unique(reads)
 }
 
 # A function definition binds its formals, so its body reads the mask only
@@ -3204,15 +3237,11 @@ removal_retained_bound <- function(expr, bound) {
 }
 
 lookup_has_external_env <- function(expr) {
-  args <- rlang::call_args(expr)
-  arg_names <- argument_names(args)
-  if (any(arg_names %in% c("pos", "envir", "where", "frame"))) {
-    return(TRUE)
-  }
-
-  unnamed_count <- sum(arg_names == "")
-  x_is_named <- "x" %in% arg_names
-  unnamed_count > as.integer(!x_is_named)
+  call_supplies_other_argument(
+    expr,
+    "x",
+    c("pos", "envir", "where", "frame")
+  )
 }
 
 # The function an expression statically names, however it spells it: a symbol,
@@ -3395,12 +3424,20 @@ evaluated_language_symbols <- function(expr, bound) {
 # `NULL` where it is not knowable. An empty list is the third answer and is not
 # the same as `NULL`: a constant evaluates to itself and looks nothing up.
 #
-# Only the constructors that hide a name from the walk need a case. A name
-# written as a symbol -- `eval(quote(share))`, `evalq(share)` -- is already
-# reported by the walk of the call's parts; a name written as a string is not,
-# and that is the whole of what this recovers. `bquote()` is not among them
-# because `.()` substitutes an expression this walk cannot see, which leaves it
-# with the answer it gives any other unrecognized shape.
+# The constructors that hide a name from the walk need a case, and so do the
+# two that capture one. A name written as a string was never reported by the
+# walk of the call's parts, and a name written under `quote()` or
+# `substitute()` no longer is, since the mask evaluates neither (#179) -- so
+# this is the only thing standing between `eval(quote(share))` and the silence
+# that #173 removed.
+#
+# A capture evaluated in place, as `evalq()` evaluates its argument, needs no
+# case of its own: the walk of the call's parts reports the symbol under it as
+# it always did.
+#
+# `bquote()` is not among them because `.()` substitutes an expression this
+# walk cannot see, which leaves it with the answer it gives any other
+# unrecognized shape.
 static_language_values <- function(expr) {
   if (rlang::is_symbol(expr)) {
     # The symbol names a value, and which language object that value holds is
@@ -3415,6 +3452,18 @@ static_language_values <- function(expr) {
     return(NULL)
   }
   if (identical(call_name, "quote")) {
+    return(call_formal_argument(expr, "expr"))
+  }
+  if (identical(call_name, "substitute")) {
+    # What `substitute()` answers is its captured argument with names replaced
+    # from `env`. A call supplying one is a substitution this walk cannot read,
+    # so the language reaching `eval()` is unknown; a call supplying none
+    # substitutes from the mask, which leaves a column and an earlier summary
+    # alias alone -- measured under dplyr -- so the expression arrives as
+    # written.
+    if (call_supplies_other_argument(expr, "expr", "env")) {
+      return(NULL)
+    }
     return(call_formal_argument(expr, "expr"))
   }
   if (identical(call_name, "expression")) {
@@ -3500,31 +3549,6 @@ static_character_value <- function(expr) {
     return(character())
   }
   recovered
-}
-
-# The name each of a call's arguments was given, empty where it was passed
-# positionally. An unnamed call carries no names at all rather than empty ones,
-# which is the case every site reading both name and position has to fill in.
-argument_names <- function(args) {
-  arg_names <- names(args)
-  if (is.null(arg_names)) {
-    return(rep("", length(args)))
-  }
-  arg_names
-}
-
-# The argument a call gives one formal, matched by name and then by position,
-# which is how R matches the primitives above. Returned as a list of length one
-# or an empty list, so that an argument written as `NULL` is not read as an
-# absent one.
-call_formal_argument <- function(expr, formal, positional = TRUE) {
-  args <- rlang::call_args(expr)
-  arg_names <- argument_names(args)
-  index <- match(formal, arg_names, nomatch = 0L)
-  if (index == 0L && positional) {
-    index <- match("", arg_names, nomatch = 0L)
-  }
-  args[index]
 }
 
 # The name the walk reports for a read it could not resolve.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -247,6 +247,14 @@
 #' positions, or columns would not have one global meaning. Use
 #' [grouping_bit()] and [grouping_id()] to identify margin levels.
 #'
+#' Every rule above reads the expression the data mask evaluates. An expression
+#' captured as language data — the argument of [base::quote()] or of
+#' [base::substitute()] — is a value the summary carries, so marginplyr neither
+#' analyzes nor rewrites what is inside it: a quoted helper name requests
+#' nothing, creates no dependency on an earlier summary, and reaches the
+#' backend as written. Evaluating one, as [base::eval()] does, performs the
+#' reads it holds and is analyzed accordingly.
+#'
 #' @section Contextual shares:
 #' [share_of_parent()] and [share_of_total()] calculate a preceding named
 #' numeric scalar summary's ratio to the same summary on another row of the

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -248,14 +248,23 @@
 #' [grouping_bit()] and [grouping_id()] to identify margin levels.
 #'
 #' Every rule above reads the expression the data mask evaluates. An expression
-#' captured as language data — the argument of [base::quote()], of
-#' [base::substitute()], or of [base::expression()] — is a value the summary
-#' carries, so marginplyr neither analyzes nor rewrites what is inside it: a
-#' captured helper name requests nothing, creates no dependency on an earlier
-#' summary, and reaches the backend as written. Evaluating one with
-#' [base::eval()] runs it in the data mask, so what it holds is analyzed as
-#' the code it becomes and every rule above applies to it, wherever the
-#' language it evaluates can be read without running the call.
+#' captured as language data — the argument of a plainly written
+#' [base::quote()], [base::substitute()], or [base::expression()] — is a value
+#' the summary carries, so marginplyr neither analyzes nor rewrites what is
+#' inside it: a captured helper name requests nothing, creates no dependency on
+#' an earlier summary, and reaches the backend as written. Evaluating one with
+#' [base::eval()], [rlang::eval_tidy()], or [rlang::eval_bare()] runs it in the
+#' data mask, so what it holds is analyzed as the code it becomes and every
+#' rule above applies to it.
+#'
+#' Both halves are read statically, so both stop where a static reading does.
+#' A capture is one where the call names the primitive plainly, qualified with
+#' `base::` or not; any other spelling — another namespace, or a head computed
+#' at run time — is analyzed as ordinary code, which can refuse a call that
+#' only carries language. An evaluation is followed wherever the language it
+#' runs can be read without running the call, which covers a capture written
+#' out and text parsed from a literal, but not language a summary builds while
+#' it runs.
 #'
 #' @section Contextual shares:
 #' [share_of_parent()] and [share_of_total()] calculate a preceding named

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -248,12 +248,14 @@
 #' [grouping_bit()] and [grouping_id()] to identify margin levels.
 #'
 #' Every rule above reads the expression the data mask evaluates. An expression
-#' captured as language data — the argument of [base::quote()] or of
-#' [base::substitute()] — is a value the summary carries, so marginplyr neither
-#' analyzes nor rewrites what is inside it: a quoted helper name requests
-#' nothing, creates no dependency on an earlier summary, and reaches the
-#' backend as written. Evaluating one, as [base::eval()] does, performs the
-#' reads it holds and is analyzed accordingly.
+#' captured as language data — the argument of [base::quote()], of
+#' [base::substitute()], or of [base::expression()] — is a value the summary
+#' carries, so marginplyr neither analyzes nor rewrites what is inside it: a
+#' captured helper name requests nothing, creates no dependency on an earlier
+#' summary, and reaches the backend as written. Evaluating one with
+#' [base::eval()] runs it in the data mask, so what it holds is analyzed as
+#' the code it becomes and every rule above applies to it, wherever the
+#' language it evaluates can be read without running the call.
 #'
 #' @section Contextual shares:
 #' [share_of_parent()] and [share_of_total()] calculate a preceding named

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -269,14 +269,20 @@ find_summary_context_helpers <- function(expr) {
     character()
   }
 
-  # The arguments the mask evaluates. A helper name the caller quoted describes
-  # no grouping this call has to combine -- nothing calls it -- and refusing
-  # the call over one refused a summary that only names the helper (#179).
+  # The arguments the mask evaluates, and the language the call evaluates. A
+  # helper name the caller quoted describes no grouping this call has to
+  # combine -- nothing calls it -- and refusing the call over one refused a
+  # summary that only names the helper. Handing one to `eval()` is the opposite
+  # case and needs the opposite answer: the helper runs, and it answers the
+  # branch-local identifier this guard exists to refuse (#179).
   c(
     found,
     unlist(
       lapply(
-        evaluated_call_args(expr, call_name = call_name),
+        c(
+          evaluated_call_args(expr, call_name = call_name),
+          searched_language_parts(expr, call_name = call_name)
+        ),
         find_summary_context_helpers
       ),
       use.names = FALSE

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -279,10 +279,7 @@ find_summary_context_helpers <- function(expr) {
     found,
     unlist(
       lapply(
-        c(
-          evaluated_call_args(expr, call_name = call_name),
-          searched_language_parts(expr, call_name = call_name)
-        ),
+        searched_call_parts(expr, call_name = call_name),
         find_summary_context_helpers
       ),
       use.names = FALSE

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -269,10 +269,16 @@ find_summary_context_helpers <- function(expr) {
     character()
   }
 
+  # The arguments the mask evaluates. A helper name the caller quoted describes
+  # no grouping this call has to combine -- nothing calls it -- and refusing
+  # the call over one refused a summary that only names the helper (#179).
   c(
     found,
     unlist(
-      lapply(static_call_args(expr), find_summary_context_helpers),
+      lapply(
+        evaluated_call_args(expr, call_name = call_name),
+        find_summary_context_helpers
+      ),
       use.names = FALSE
     )
   )
@@ -328,14 +334,22 @@ rewrite_summary_selections <- function(expr,
     env <- rlang::quo_get_env(expr)
   }
 
-  call_args <- lapply(
-    static_call_args(expr),
-    rewrite_summary_selections,
-    env = env,
-    data_proxy = data_proxy,
-    normalize_across_names = normalize_across_names
+  # A selection the caller quoted is language data, so the walk descends past
+  # it and gives the object back as it was written. Resolving it turned
+  # `quote(dplyr::across(value, mean))` into
+  # `quote(dplyr::across(dplyr::all_of("value"), mean))`, which is a different
+  # expression to whatever the caller meant to carry (#179).
+  expr <- rewrite_evaluated_call_parts(
+    expr,
+    function(part) {
+      rewrite_summary_selections(
+        part,
+        env = env,
+        data_proxy = data_proxy,
+        normalize_across_names = normalize_across_names
+      )
+    }
   )
-  expr <- rebuild_static_call(expr, call_args)
 
   call_name <- static_call_name(expr)
   call_ns <- static_call_ns(expr)

--- a/R/utils.R
+++ b/R/utils.R
@@ -304,20 +304,33 @@ call_supplies_other_argument <- function(expr, formal, other_names) {
   sum(arg_names == "") > as.integer(!(formal %in% arg_names))
 }
 
-# The formal a language-capturing primitive takes its captured argument in, and
-# `NULL` for a call that captures nothing. R evaluates that argument nowhere:
-# `quote()` answers it unchanged, and `substitute()` answers it with names
-# replaced from an environment. Until something evaluates what either returns,
-# the expression under it is data the caller is carrying rather than code the
-# data mask runs, so no analysis here may read a helper, a selection, or a
-# column reference out of it, and no rewrite may replace what is inside it
-# (#179).
+# The formal a language-capturing primitive takes its captured argument in,
+# `NA_character_` where it captures every argument it is given, and `NULL` for
+# a call that captures nothing. R evaluates a captured argument nowhere:
+# `quote()` answers it unchanged, `substitute()` answers it with names replaced
+# from an environment, and `expression()` collects however many it is given.
+# Until something evaluates what one of them returns, the expression under it
+# is data the caller is carrying rather than code the data mask runs, so no
+# analysis here may read a helper, a selection, or a column reference out of
+# it, and no rewrite may replace what is inside it (#179).
+#
+# `expression()` is here because `static_language_values()` already recovers
+# it: the two halves of one boundary would otherwise disagree about the same
+# call, reading it as a language object where `eval()` runs it and as ordinary
+# code everywhere else.
 #
 # `evalq()` and `bquote()` are deliberately absent. `evalq()` captures its
 # first argument and then evaluates it, so the symbols under it are read;
 # `bquote()` evaluates whatever `.()` wraps in the enclosing frame, which under
 # a data mask is the mask, so `bquote(f(.(share)))` reads the share. Both stay
 # analyzed, which over-reports the parts of them that really are data.
+#
+# rlang's `expr()` and `quo()` are absent for a different reason, and it is the
+# asymmetry below rather than a claim about what they do. Recognizing a name
+# here is a decision to stop reporting what sits under it, and `expr` is a name
+# callers bind -- this package binds it in nearly every function -- so a bare
+# call to one is not evidence of rlang's. Reading them as ordinary code keeps
+# the pre-#179 answer, which is a false refusal at worst.
 language_capture_formal <- function(call_name) {
   if (is.null(call_name)) {
     return(NULL)
@@ -325,6 +338,7 @@ language_capture_formal <- function(call_name) {
   switch(call_name,
     quote = ,
     substitute = "expr",
+    expression = NA_character_,
     NULL
   )
 }
@@ -365,6 +379,9 @@ captured_call_parts <- function(expr, call_name = static_call_name(expr)) {
   if (!is.null(namespace) && !identical(namespace, "base")) {
     return(captured)
   }
+  if (is.na(formal)) {
+    return(rep(TRUE, length(args)))
+  }
   index <- call_formal_index(args, formal)
   if (index == 0L) {
     return(captured)
@@ -394,14 +411,42 @@ evaluated_call_args <- function(expr, call_name = static_call_name(expr)) {
 rewrite_evaluated_call_parts <- function(expr, rewrite) {
   parts <- static_call_args(expr)
   captured <- captured_call_parts(expr)
+  language_index <- evaluated_language_index(expr)
   rewritten <- lapply(
     seq_along(parts),
     function(index) {
       if (captured[[index]]) {
         return(parts[[index]])
       }
+      if (index == language_index) {
+        return(rewrite_evaluated_language(parts[[index]], rewrite))
+      }
       rewrite(parts[[index]])
     }
+  )
+  rebuild_static_call(expr, stats::setNames(rewritten, names(parts)))
+}
+
+# The argument an `eval()` runs, rewritten as the code it becomes. A capture
+# written there is opened, because the mask evaluates what it holds after all:
+# `eval(quote(grouping_bit(region)))` compiled to its branch constant before
+# the boundary was drawn, and leaving the capture closed sent the helper itself
+# to the caller, which reports that it can only be used inside the verb they
+# are already inside (#179).
+#
+# Only a capture written out can be opened. Language built at run time --
+# `eval(str2lang("grouping_bit(region)"))` -- has nothing in the source to
+# rewrite, and it reached the helper before this ticket exactly as it does
+# after: what a search can recover by parsing, a rewrite cannot put back.
+rewrite_evaluated_language <- function(expr, rewrite) {
+  captured <- captured_call_parts(expr)
+  if (!any(captured)) {
+    return(rewrite(expr))
+  }
+  parts <- static_call_args(expr)
+  rewritten <- lapply(
+    seq_along(parts),
+    function(index) rewrite(parts[[index]])
   )
   rebuild_static_call(expr, stats::setNames(rewritten, names(parts)))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -368,11 +368,33 @@ language_capture_formal <- function(call_name) {
 # recognizes either. R refuses `quote(a, b)` when it runs, so the argument
 # beyond the captured one is reported rather than protected, which is the same
 # direction the length tests in `expression_data_symbols()` resolve toward.
-captured_call_parts <- function(expr, call_name = static_call_name(expr)) {
+#
+# `bound` is what the caller knows about the names in scope where this call
+# sits, and a bare head naming one of them is not claimed as a capture: a block
+# that binds `quote` to a function of its own and then calls it evaluates the
+# argument. R's function lookup skips a non-function binding, so the name may
+# still reach `base::quote()` and the parts be data after all -- undecidable
+# here, and answered in the direction that analyses rather than the one that
+# hides. A qualified head is out of reach of any binding and keeps its capture.
+#
+# Only the share dependency walk passes a set, because it is the only analysis
+# that tracks bindings and the only one whose wrong answer is silence about a
+# wrong number (#130, #162). The searches and the rewrites pass none, and that
+# is the reading they already give every name they match: a locally bound
+# `across` is resolved as a selection today, and a locally bound `cur_group` is
+# refused as the branch-local helper. Their wrong answer is a diagnostic or an
+# uncompiled helper, both of which the caller sees.
+captured_call_parts <- function(expr,
+                                call_name = static_call_name(expr),
+                                bound = character()) {
   args <- static_call_args(expr)
   captured <- rep(FALSE, length(args))
   formal <- language_capture_formal(call_name)
   if (is.null(formal)) {
+    return(captured)
+  }
+  call_head <- static_call_head(expr)
+  if (rlang::is_symbol(call_head) && rlang::as_name(call_head) %in% bound) {
     return(captured)
   }
   namespace <- static_call_ns(expr)
@@ -394,8 +416,10 @@ captured_call_parts <- function(expr, call_name = static_call_name(expr)) {
 # nothing it captures. Every search that descends into a call reaches its parts
 # through this rather than through `static_call_args()` directly, which is what
 # keeps one reading of the boundary from being four.
-evaluated_call_args <- function(expr, call_name = static_call_name(expr)) {
-  static_call_args(expr)[!captured_call_parts(expr, call_name)]
+evaluated_call_args <- function(expr,
+                                call_name = static_call_name(expr),
+                                bound = character()) {
+  static_call_args(expr)[!captured_call_parts(expr, call_name, bound = bound)]
 }
 
 # The call a rewrite gives back once it has descended into the same parts:
@@ -409,22 +433,49 @@ evaluated_call_args <- function(expr, call_name = static_call_name(expr)) {
 # dropped them would turn `across(value, .names = "{.col}")` into a call whose
 # template is a positional argument.
 rewrite_evaluated_call_parts <- function(expr, rewrite) {
-  parts <- static_call_args(expr)
   captured <- captured_call_parts(expr)
-  language_index <- evaluated_language_index(expr)
-  rewritten <- lapply(
-    seq_along(parts),
-    function(index) {
+  language_index <- readable_language_index(expr)
+  map_call_parts(
+    expr,
+    function(part, index) {
       if (captured[[index]]) {
-        return(parts[[index]])
+        return(part)
       }
       if (index == language_index) {
-        return(rewrite_evaluated_language(parts[[index]], rewrite))
+        return(rewrite_evaluated_language(part, rewrite))
       }
-      rewrite(parts[[index]])
+      rewrite(part)
     }
   )
-  rebuild_static_call(expr, stats::setNames(rewritten, names(parts)))
+}
+
+# The call rebuilt around parts a walk mapped one to one. The arguments are
+# read by index rather than mapped over, because a rewrite has to put its
+# replacements back in the positions they came from, and the names have to be
+# carried across with them: they live in the call's pairlist tags, which
+# `rebuild_static_call()` takes from this list, so an index map that dropped
+# them would turn `across(value, .names = "{.col}")` into a call whose template
+# is a positional argument.
+map_call_parts <- function(expr, map) {
+  parts <- static_call_args(expr)
+  mapped <- lapply(
+    seq_along(parts),
+    function(index) map(parts[[index]], index)
+  )
+  rebuild_static_call(expr, stats::setNames(mapped, names(parts)))
+}
+
+# Where a rewrite may open a capture: the argument an `eval()` runs, and only
+# where what it runs is statically readable. `eval(substitute(x, env))`
+# substitutes from an environment this analysis cannot read, so what reaches
+# the mask is unknown -- and a rewrite that opened it anyway would compile a
+# helper the searches beside it contribute nothing about, which is the same
+# index read three ways instead of one.
+readable_language_index <- function(expr, call_name = static_call_name(expr)) {
+  if (is.null(evaluated_language_parts(expr, call_name = call_name))) {
+    return(0L)
+  }
+  evaluated_language_index(expr, call_name = call_name)
 }
 
 # The argument an `eval()` runs, rewritten as the code it becomes. A capture
@@ -439,16 +490,320 @@ rewrite_evaluated_call_parts <- function(expr, rewrite) {
 # rewrite, and it reached the helper before this ticket exactly as it does
 # after: what a search can recover by parsing, a rewrite cannot put back.
 rewrite_evaluated_language <- function(expr, rewrite) {
-  captured <- captured_call_parts(expr)
-  if (!any(captured)) {
+  if (!any(captured_call_parts(expr))) {
     return(rewrite(expr))
   }
-  parts <- static_call_args(expr)
-  rewritten <- lapply(
-    seq_along(parts),
-    function(index) rewrite(parts[[index]])
+  map_call_parts(expr, function(part, index) rewrite(part))
+}
+
+# The readers below say what a call names and what language it holds. They
+# answer questions about an expression and decide nothing about it: which
+# function a head names however it is spelled, which primitives resolve a name
+# or evaluate language, and which language object a call is statically known to
+# build. Every walk in the package reads through them -- the share dependency
+# walk in `R/share.R`, the two rewrites, and the three searches -- and each
+# decides for itself what to do with the answer.
+#
+# They live here rather than beside the walk that first needed them, in #173
+# and then #179, so that the dependency runs one way. `R/share.R` owns every
+# contextual share decision, as design/architecture.md records, and a shared
+# reader that lived there would be a deep module the grouping-context rewrite
+# and the summary-selection searches had to reach into for a fact that is not
+# about shares at all.
+#
+# The function an expression statically names, however it spells it: a symbol,
+# a namespace qualifier, redundant parentheses, or a call to a primitive whose
+# purpose is to name a function. `get("get")("share")`,
+# `match.fun("get")("share")` and `getFunction("get")("share")` all invoke the
+# same primitive as `get("share")`, and a branch matching on the call's own
+# name sees none of them, because a call whose head is a call has no name.
+#
+# What none of those spellings change is that the head is a read: `(f)`,
+# `match.fun("f")` and the rest are evaluated in the mask as values rather than
+# through R's function lookup. `call_part_symbols()` reports that read, and
+# every caller of this unions the two answers.
+#
+# A literal string is here for `do.call()`, which takes its function that way.
+static_callee_name <- function(callee) {
+  if (rlang::is_symbol(callee)) {
+    return(rlang::as_name(callee))
+  }
+  if (!rlang::is_call(callee)) {
+    named <- static_character_value(callee)
+    if (is.null(named) || length(named) != 1L) {
+      return(NULL)
+    }
+    return(named)
+  }
+  if (rlang::is_call(callee, "(") && length(callee) >= 2L) {
+    return(static_callee_name(callee[[2L]]))
+  }
+  if (rlang::is_call(callee, c("::", ":::")) && length(callee) >= 3L) {
+    return(static_callee_name(callee[[3L]]))
+  }
+  call_name <- static_call_name(callee)
+  if (is.null(call_name)) {
+    return(NULL)
+  }
+  formal <- function_naming_formal(call_name)
+  if (is.null(formal)) {
+    return(NULL)
+  }
+  static_callee_name_from(callee, formal)
+}
+
+# The name a function-naming primitive was given, where that name is statically
+# knowable. One that is not leaves the head unnamed, which is the answer for
+# any other computed head: the walk reports the head's own reads and treats the
+# call as the ordinary call it cannot recognize.
+static_callee_name_from <- function(callee, formal) {
+  argument <- call_formal_argument(callee, formal)
+  if (length(argument) == 0L) {
+    return(NULL)
+  }
+  named <- static_character_value(argument[[1L]])
+  if (is.null(named) || length(named) != 1L) {
+    return(NULL)
+  }
+  named
+}
+
+# The formal each function-naming primitive takes its name in, and `NULL` for a
+# call that names no function. `mget()` and `exists()` are absent because
+# neither can answer a function to call: one answers a list and the other a
+# flag.
+function_naming_formal <- function(call_name) {
+  switch(call_name,
+    match.fun = "FUN",
+    getFunction = "name",
+    get = ,
+    get0 = "x",
+    NULL
   )
-  rebuild_static_call(expr, stats::setNames(rewritten, names(parts)))
+}
+
+# The primitives that resolve a name given as a string. Each searches ordinary
+# lexical scope from an environment that, under a data mask, is the mask, so a
+# name one of them is handed is a mask read exactly as the symbol is.
+#
+# `dynGet()` is deliberately absent: it searches the calling frames rather than
+# the lexical scope, so it does not reach the mask -- measured, not assumed.
+#
+# One of these reached as a *value* rather than as a callee is out of reach of
+# any static walk, and is safe for the same measured reason: in
+# `sapply(c("share"), get)` the environment `get()` searches from is the frame
+# that called it, inside `sapply()`, so the call raises rather than reading a
+# column. Which function a value holds is undecidable in general -- `f <- get`
+# is the smallest case -- so a walk answering it would have to over-report
+# every call it cannot name, and that is nearly all of them.
+is_reflective_lookup <- function(callee_name) {
+  !is.null(callee_name) &&
+    callee_name %in% c("get", "get0", "mget", "exists")
+}
+
+# The primitives that evaluate a language object. `evalq()` is absent because
+# it quotes its first argument, so the general walk already reports the symbols
+# under it -- adding it here would answer the same thing twice.
+is_reflective_evaluation <- function(callee_name) {
+  !is.null(callee_name) &&
+    callee_name %in% c("eval", "eval_tidy", "eval_bare")
+}
+
+# The function a call reaches, read from its own name where it has one and from
+# its head where it does not. `(get)("share")` and `match.fun("get")("share")`
+# name the primitive through a head that is a call, so a site matching on the
+# call's name alone sees neither (#130, #173).
+#
+# `call_name` is taken rather than read again because every caller has read it
+# already, and reading a node's name once is what the analysis sites here were
+# folded down to (#163). That is also why the readers below thread it: one
+# search hands its own read all the way through.
+resolved_callee_name <- function(expr, call_name = static_call_name(expr)) {
+  if (!is.null(call_name)) {
+    return(call_name)
+  }
+  static_callee_name(static_call_head(expr))
+}
+
+# Where in a call's arguments the language it evaluates sits, and `0L` for a
+# call that evaluates none. The searches, the rewrites, and the dependency walk
+# open the same argument, so its position is read once here.
+evaluated_language_index <- function(expr, call_name = static_call_name(expr)) {
+  if (!is_reflective_evaluation(resolved_callee_name(expr, call_name))) {
+    return(0L)
+  }
+  call_formal_index(static_call_args(expr), "expr")
+}
+
+# The language a call is statically known to evaluate: `list()` for a call that
+# evaluates none, and `NULL` where what it evaluates is not knowable. The two
+# empty answers are the ones `static_language_values()` separates, kept apart
+# because each reader resolves them differently -- the walk turns `NULL` into
+# the marker, a search into nothing, and a rewrite into a capture it may not
+# open.
+#
+# An `envir` argument is not an exemption, here or at the walk that used to ask
+# this question alone. `eval()`'s `enclos` defaults to `parent.frame()`, which
+# under a data mask is the mask, so a supplied `envir` that is a list or a data
+# frame leaves the mask on the lookup path -- `eval(as.name("share"),
+# list(a = 1))` reads the share, measured rather than assumed. Which of the two
+# an argument evaluates to is not decidable here.
+evaluated_language_parts <- function(expr, call_name = static_call_name(expr)) {
+  index <- evaluated_language_index(expr, call_name = call_name)
+  if (index == 0L) {
+    return(list())
+  }
+  static_language_values(static_call_args(expr)[[index]])
+}
+
+# Everything a search descends into: the arguments the mask evaluates, and the
+# language the call hands `eval()`. Both halves are the boundary #179 draws,
+# read in one place because a search that took only the first half would let
+# `eval(quote(cur_group_id()))` run and answer a branch-local identifier, which
+# is the value that guard exists to refuse.
+#
+# Language that is not statically readable contributes nothing rather than a
+# marker. The dependency walk has an alias set to compare an over-report
+# against and turns an unreadable one into a read of every alias; a search has
+# nothing to compare, so refusing on one would reject `eval(built)` wherever it
+# appears, which is legal code and always was.
+searched_call_parts <- function(expr, call_name = static_call_name(expr)) {
+  language <- evaluated_language_parts(expr, call_name = call_name)
+  if (is.null(language)) {
+    language <- list()
+  }
+  c(evaluated_call_args(expr, call_name = call_name), language)
+}
+
+# The language objects an expression is statically known to hand `eval()`, and
+# `NULL` where it is not knowable. An empty list is the third answer and is not
+# the same as `NULL`: a constant evaluates to itself and looks nothing up.
+#
+# The constructors that hide a name from the walk need a case, and so do the
+# two that capture one. A name written as a string was never reported by the
+# walk of the call's parts, and a name written under `quote()` or
+# `substitute()` no longer is, since the mask evaluates neither (#179) -- so
+# this is the only thing standing between `eval(quote(share))` and the silence
+# that #173 removed.
+#
+# A capture evaluated in place, as `evalq()` evaluates its argument, needs no
+# case of its own: the walk of the call's parts reports the symbol under it as
+# it always did.
+#
+# `bquote()` is not among them because `.()` substitutes an expression this
+# walk cannot see, which leaves it with the answer it gives any other
+# unrecognized shape.
+static_language_values <- function(expr) {
+  if (rlang::is_symbol(expr)) {
+    # The symbol names a value, and which language object that value holds is
+    # not visible here.
+    return(NULL)
+  }
+  if (!rlang::is_call(expr)) {
+    return(list())
+  }
+  call_name <- static_call_name(expr)
+  if (is.null(call_name)) {
+    return(NULL)
+  }
+  if (identical(call_name, "quote")) {
+    return(call_formal_argument(expr, "expr"))
+  }
+  if (identical(call_name, "substitute")) {
+    # What `substitute()` answers is its captured argument with names replaced
+    # from `env`. A call supplying one is a substitution this walk cannot read,
+    # so the language reaching `eval()` is unknown; a call supplying none
+    # substitutes from the mask, which leaves a column and an earlier summary
+    # alias alone -- measured under dplyr -- so the expression arrives as
+    # written.
+    if (call_supplies_other_argument(expr, "expr", "env")) {
+      return(NULL)
+    }
+    return(call_formal_argument(expr, "expr"))
+  }
+  if (identical(call_name, "expression")) {
+    return(static_call_args(expr))
+  }
+  if (call_name %in% c("as.name", "as.symbol")) {
+    return(recovered_name_values(call_formal_argument(expr, "x")))
+  }
+  if (identical(call_name, "str2lang")) {
+    return(parsed_language_values(call_formal_argument(expr, "s")))
+  }
+  if (identical(call_name, "str2expression")) {
+    return(parsed_language_values(call_formal_argument(expr, "text")))
+  }
+  if (identical(call_name, "parse")) {
+    # Matched by name alone: `parse()`'s first positional argument is a
+    # connection, and what a connection holds is not knowable here.
+    return(parsed_language_values(
+      call_formal_argument(expr, "text", positional = FALSE)
+    ))
+  }
+  NULL
+}
+
+# The symbols a statically known string names. An empty string is dropped
+# rather than turned into a symbol, because `as.name("")` is an error in R and
+# the walk must raise none of its own.
+recovered_name_values <- function(argument) {
+  if (length(argument) == 0L) {
+    return(NULL)
+  }
+  text <- static_character_value(argument[[1L]])
+  if (is.null(text)) {
+    return(NULL)
+  }
+  lapply(text[nzchar(text)], as.name)
+}
+
+# The language a statically known string parses to. Parsing is not evaluation:
+# nothing the caller wrote runs here, which is what lets the recovery happen
+# during planning at all. Text that does not parse is reported as unknown
+# rather than raised, since the call itself raises R's own condition when it
+# runs.
+parsed_language_values <- function(argument) {
+  if (length(argument) == 0L) {
+    return(NULL)
+  }
+  text <- static_character_value(argument[[1L]])
+  if (is.null(text)) {
+    return(NULL)
+  }
+  parsed <- tryCatch(
+    str2expression(paste(text, collapse = "\n")),
+    error = function(cnd) NULL
+  )
+  if (is.null(parsed)) {
+    return(NULL)
+  }
+  as.list(parsed)
+}
+
+# The character vector an expression is statically known to be, and `NULL`
+# where it is not. A literal is one, and so is a `c()` of literals, which is
+# how a caller writes the vector `mget()` takes; anything else names a value
+# this walk cannot see without running it.
+static_character_value <- function(expr) {
+  if (is.character(expr)) {
+    if (anyNA(expr)) {
+      return(NULL)
+    }
+    return(expr)
+  }
+  if (!rlang::is_call(expr, "c")) {
+    return(NULL)
+  }
+  values <- lapply(rlang::call_args(expr), static_character_value)
+  if (any(vapply(values, is.null, logical(1)))) {
+    return(NULL)
+  }
+  recovered <- unlist(values, use.names = FALSE)
+  if (is.null(recovered)) {
+    # `c()` of nothing, which names nothing.
+    return(character())
+  }
+  recovered
 }
 
 # Required because dtplyr is an optional Suggest rather than an Import: it

--- a/R/utils.R
+++ b/R/utils.R
@@ -257,6 +257,155 @@ rebuild_static_call <- function(expr, args) {
   rebuilt
 }
 
+# The name each of a call's arguments was given, empty where it was passed
+# positionally. An unnamed call carries no names at all rather than empty ones,
+# which is the case every site reading both name and position has to fill in.
+argument_names <- function(args) {
+  arg_names <- names(args)
+  if (is.null(arg_names)) {
+    return(rep("", length(args)))
+  }
+  arg_names
+}
+
+# The argument a call gives one formal, matched by name and then by position,
+# which is how R matches the primitives the analyses here read. Returned as a
+# list of length one or an empty list, so that an argument written as `NULL` is
+# not read as an absent one.
+call_formal_argument <- function(expr, formal, positional = TRUE) {
+  args <- rlang::call_args(expr)
+  args[call_formal_index(args, formal, positional = positional)]
+}
+
+# Where that argument sits, and `0L` when the call supplies none. The two
+# answers are one matching rule read two ways: a site reading the argument
+# takes the value, and one that has to put something back where the caller
+# wrote it takes the position.
+call_formal_index <- function(args, formal, positional = TRUE) {
+  arg_names <- argument_names(args)
+  index <- match(formal, arg_names, nomatch = 0L)
+  if (index == 0L && positional) {
+    index <- match("", arg_names, nomatch = 0L)
+  }
+  index
+}
+
+# Whether a call supplies an argument beyond the one it takes in `formal`,
+# either by naming one of `other_names` or by leaving one more argument unnamed
+# than `formal` accounts for. Both primitives that ask this ask it about an
+# environment: `get()` and its siblings search the one they are given instead of
+# the mask, and `substitute()` substitutes from it.
+call_supplies_other_argument <- function(expr, formal, other_names) {
+  args <- rlang::call_args(expr)
+  arg_names <- argument_names(args)
+  if (any(arg_names %in% other_names)) {
+    return(TRUE)
+  }
+  sum(arg_names == "") > as.integer(!(formal %in% arg_names))
+}
+
+# The formal a language-capturing primitive takes its captured argument in, and
+# `NULL` for a call that captures nothing. R evaluates that argument nowhere:
+# `quote()` answers it unchanged, and `substitute()` answers it with names
+# replaced from an environment. Until something evaluates what either returns,
+# the expression under it is data the caller is carrying rather than code the
+# data mask runs, so no analysis here may read a helper, a selection, or a
+# column reference out of it, and no rewrite may replace what is inside it
+# (#179).
+#
+# `evalq()` and `bquote()` are deliberately absent. `evalq()` captures its
+# first argument and then evaluates it, so the symbols under it are read;
+# `bquote()` evaluates whatever `.()` wraps in the enclosing frame, which under
+# a data mask is the mask, so `bquote(f(.(share)))` reads the share. Both stay
+# analyzed, which over-reports the parts of them that really are data.
+language_capture_formal <- function(call_name) {
+  if (is.null(call_name)) {
+    return(NULL)
+  }
+  switch(call_name,
+    quote = ,
+    substitute = "expr",
+    NULL
+  )
+}
+
+# Which of a call's arguments are captured that way, as a logical vector over
+# `static_call_args()`. Everything else the call holds is evaluated:
+# `substitute()`'s `env` is an ordinary operand, and so is every argument of a
+# call that captures nothing.
+#
+# A capture is recognized only where it is written plainly -- `quote()`, or
+# `base::quote()`. A qualifier naming another namespace is another package's
+# function, and a computed head names nothing this can read, so both fall
+# through to the walk that reports the symbols under them. That asymmetry is
+# the point: reading a capture where there is none costs a diagnostic about a
+# column the caller did write, while missing one is the silent miss #130 fixed
+# this walk to prevent, and no static reading tells `pkg::quote()` from
+# `base::quote()` except the qualifier itself.
+#
+# What the name alone cannot rule out is a caller who binds a function of their
+# own to it. A binding this analysis can see is answered where the bound names
+# are known, in `call_part_symbols()`; one made outside the expression --
+# `quote <- function(e) e` in the calling environment -- is the undecidable
+# case `is_reflective_lookup()` records for `f <- get`, and it resolves the
+# same way, by reading what the name says.
+#
+# A call carrying more arguments than the primitive takes is not the shape this
+# recognizes either. R refuses `quote(a, b)` when it runs, so the argument
+# beyond the captured one is reported rather than protected, which is the same
+# direction the length tests in `expression_data_symbols()` resolve toward.
+captured_call_parts <- function(expr, call_name = static_call_name(expr)) {
+  args <- static_call_args(expr)
+  captured <- rep(FALSE, length(args))
+  formal <- language_capture_formal(call_name)
+  if (is.null(formal)) {
+    return(captured)
+  }
+  namespace <- static_call_ns(expr)
+  if (!is.null(namespace) && !identical(namespace, "base")) {
+    return(captured)
+  }
+  index <- call_formal_index(args, formal)
+  if (index == 0L) {
+    return(captured)
+  }
+  captured[[index]] <- TRUE
+  captured
+}
+
+# The arguments of a call a walk analyzes: everything the mask evaluates, and
+# nothing it captures. Every search that descends into a call reaches its parts
+# through this rather than through `static_call_args()` directly, which is what
+# keeps one reading of the boundary from being four.
+evaluated_call_args <- function(expr, call_name = static_call_name(expr)) {
+  static_call_args(expr)[!captured_call_parts(expr, call_name)]
+}
+
+# The call a rewrite gives back once it has descended into the same parts:
+# each evaluated argument replaced by what `rewrite` makes of it, each captured
+# argument left as the caller wrote it.
+#
+# The arguments are read by index rather than mapped over, because a rewrite
+# has to put its replacements back in the positions they came from, and the
+# names have to be carried across with them: they live in the call's pairlist
+# tags, which `rebuild_static_call()` takes from this list, so an index map that
+# dropped them would turn `across(value, .names = "{.col}")` into a call whose
+# template is a positional argument.
+rewrite_evaluated_call_parts <- function(expr, rewrite) {
+  parts <- static_call_args(expr)
+  captured <- captured_call_parts(expr)
+  rewritten <- lapply(
+    seq_along(parts),
+    function(index) {
+      if (captured[[index]]) {
+        return(parts[[index]])
+      }
+      rewrite(parts[[index]])
+    }
+  )
+  rebuild_static_call(expr, stats::setNames(rewritten, names(parts)))
+}
+
 # Required because dtplyr is an optional Suggest rather than an Import: it
 # brings data.table, which reads this flag from the calling namespace.
 # data.table fixes the spelling of this name, so it cannot follow the package's

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -121,6 +121,21 @@ names, and preventing summary outputs from overwriting grouping columns. These
 checks occur before semantic label validation, including any opt-in lazy
 collision query.
 
+### Static expression reading (`R/utils.R`)
+
+Owns what a summary expression *says*, and decides nothing about it: the name
+and namespace a call carries, the head and arguments a walk descends into and
+the node rebuilt around them, which arguments a call captures as language
+rather than evaluating, which primitives resolve a name or evaluate language,
+and which language object a call is statically known to build.
+
+Four analyses read through it and each decides for itself — the share
+dependency walk, the two rewrites, and the three searches — so the module is
+shallow by design where the ones below it are deep. It is also why the
+dependency runs one way: a reader that lived in `R/share.R` would make the
+grouping-context rewrite reach into the contextual-share module for a fact
+that is not about shares (#179).
+
 ### Contextual shares (`R/share.R`)
 
 One deep private module owns every contextual-share responsibility: request

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -299,14 +299,23 @@ positions, or columns would not have one global meaning. Use
 \code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}} to identify margin levels.
 
 Every rule above reads the expression the data mask evaluates. An expression
-captured as language data — the argument of \code{\link[base:quote]{base::quote()}}, of
-\code{\link[base:substitute]{base::substitute()}}, or of \code{\link[base:expression]{base::expression()}} — is a value the summary
-carries, so marginplyr neither analyzes nor rewrites what is inside it: a
-captured helper name requests nothing, creates no dependency on an earlier
-summary, and reaches the backend as written. Evaluating one with
-\code{\link[base:eval]{base::eval()}} runs it in the data mask, so what it holds is analyzed as
-the code it becomes and every rule above applies to it, wherever the
-language it evaluates can be read without running the call.
+captured as language data — the argument of a plainly written
+\code{\link[base:quote]{base::quote()}}, \code{\link[base:substitute]{base::substitute()}}, or \code{\link[base:expression]{base::expression()}} — is a value
+the summary carries, so marginplyr neither analyzes nor rewrites what is
+inside it: a captured helper name requests nothing, creates no dependency on
+an earlier summary, and reaches the backend as written. Evaluating one with
+\code{\link[base:eval]{base::eval()}}, \code{\link[rlang:eval_tidy]{rlang::eval_tidy()}}, or \code{\link[rlang:eval_bare]{rlang::eval_bare()}} runs it in the
+data mask, so what it holds is analyzed as the code it becomes and every
+rule above applies to it.
+
+Both halves are read statically, so both stop where a static reading does.
+A capture is one where the call names the primitive plainly, qualified with
+\verb{base::} or not; any other spelling — another namespace, or a head computed
+at run time — is analyzed as ordinary code, which can refuse a call that
+only carries language. An evaluation is followed wherever the language it
+runs can be read without running the call, which covers a capture written
+out and text parsed from a literal, but not language a summary builds while
+it runs.
 }
 
 \section{Contextual shares}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -299,12 +299,14 @@ positions, or columns would not have one global meaning. Use
 \code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}} to identify margin levels.
 
 Every rule above reads the expression the data mask evaluates. An expression
-captured as language data — the argument of \code{\link[base:quote]{base::quote()}} or of
-\code{\link[base:substitute]{base::substitute()}} — is a value the summary carries, so marginplyr neither
-analyzes nor rewrites what is inside it: a quoted helper name requests
-nothing, creates no dependency on an earlier summary, and reaches the
-backend as written. Evaluating one, as \code{\link[base:eval]{base::eval()}} does, performs the
-reads it holds and is analyzed accordingly.
+captured as language data — the argument of \code{\link[base:quote]{base::quote()}}, of
+\code{\link[base:substitute]{base::substitute()}}, or of \code{\link[base:expression]{base::expression()}} — is a value the summary
+carries, so marginplyr neither analyzes nor rewrites what is inside it: a
+captured helper name requests nothing, creates no dependency on an earlier
+summary, and reaches the backend as written. Evaluating one with
+\code{\link[base:eval]{base::eval()}} runs it in the data mask, so what it holds is analyzed as
+the code it becomes and every rule above applies to it, wherever the
+language it evaluates can be read without running the call.
 }
 
 \section{Contextual shares}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -297,6 +297,14 @@ rejected. They describe one branch-local grouping or data mask, whereas a
 margin result combines several grouping sets and their identifiers, row
 positions, or columns would not have one global meaning. Use
 \code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}} to identify margin levels.
+
+Every rule above reads the expression the data mask evaluates. An expression
+captured as language data — the argument of \code{\link[base:quote]{base::quote()}} or of
+\code{\link[base:substitute]{base::substitute()}} — is a value the summary carries, so marginplyr neither
+analyzes nor rewrites what is inside it: a quoted helper name requests
+nothing, creates no dependency on an earlier summary, and reaches the
+backend as written. Evaluating one, as \code{\link[base:eval]{base::eval()}} does, performs the
+reads it holds and is analyzed accordingly.
 }
 
 \section{Contextual shares}{

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2717,3 +2717,383 @@ test_that("an unnamed argument list still answers one name per argument", {
   expect_identical(argument_names(list(1, 2)), c("", ""))
   expect_identical(argument_names(list(a = 1, 2)), c("a", ""))
 })
+
+# The tests below cover the boundary R draws between an expression the data
+# mask evaluates and one a call captures as language data (#179). Every
+# analysis here walked into `quote()` as if its argument were code: the
+# dependency walk reported a quoted name as a read of that column, the share,
+# selection, and context-helper searches found helpers no caller had asked
+# for, and the two rewrites replaced the quoted object with what the helper
+# compiles to -- so `deparse1(quote(grouping_bit(region)))` answered `"0L"`
+# and a summary holding `quote(share_of_total(units))` was refused as a share
+# helper written in the wrong position.
+#
+# The rule the analyses follow is R's own. A captured argument is data until
+# something evaluates it; an operand the capturing call does evaluate --
+# `substitute()`'s `env` -- is code like any other; and a captured expression
+# handed to `eval()` is the read it performs, which is what keeps #173's
+# dependency rule from being escaped by spelling a share `eval(quote(share))`.
+#
+# Only a capture written plainly is recognized, `quote()` or `base::quote()`.
+# Every other spelling falls through to the walk, which reports the symbols
+# under it. That direction is deliberate: reading a capture where there is
+# none costs a diagnostic, while missing one is the silent miss #130 fixed the
+# walk to prevent, and no static reading of `pkg::quote()` or of a computed
+# head can tell which of the two it is.
+
+test_that("a quoted expression is data at every analysis that walks one", {
+  proxy <- data.frame(value = double(), other = double())
+  env <- rlang::current_env()
+
+  # The dependency walk. A quoted name is not a read of the column, and the
+  # arguments beside the quoted one are still walked.
+  expect_identical(expression_data_symbols(quote(quote(share))), character())
+  expect_identical(
+    expression_data_symbols(quote(deparse1(quote(share * units)))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(list(quote(share), value))),
+    "value"
+  )
+  # A quoted name reaches no branch of the walk that resolves one, either: the
+  # pronoun, the reflective primitives, and the binding constructs are all
+  # code the mask never runs here.
+  expect_identical(
+    expression_data_symbols(quote(quote(.data$share))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(quote(get("share")))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(quote({
+      tmp <- share
+      tmp
+    }))),
+    character()
+  )
+
+  # The share search, which decides both whether a summary requests a share
+  # and whether it is refused for writing a helper in a position that is not
+  # the complete right-hand side.
+  expect_null(share_expression_kind(quote(deparse1(quote(share_of_total(x))))))
+  expect_false(contains_share_helper(quote(quote(share_of_parent(x)))))
+
+  # The context-helper search, whose finding is a refusal of the whole call.
+  expect_identical(
+    find_summary_context_helpers(quote(deparse1(quote(dplyr::cur_group())))),
+    character()
+  )
+  # The predicate search, which refuses a share `across()` naming `where()`.
+  expect_false(contains_selection_predicate(quote(quote(where(is.numeric)))))
+
+  # The selection rewrite gives back the quoted object the caller wrote, down
+  # to the argument names inside it: the walk descends past a capture into the
+  # parts beside it, so the rebuilt call must carry the tags of the ones it
+  # did not rewrite.
+  quoted_selection <- quote(paste(
+    deparse1(quote(dplyr::across(value, mean, .names = "{.col}"))),
+    collapse = ""
+  ))
+  expect_identical(
+    rewrite_summary_selections(
+      quoted_selection,
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quoted_selection
+  )
+  # A node the caller injected keeps its class and its environment across the
+  # rebuild, as #165 requires of every walk -- and here without the walk ever
+  # reading it, since a captured part is given back as the object it is.
+  injected <- rlang::quo(dplyr::across(value, mean))
+  captured <- rlang::call2("quote", injected)
+  expect_identical(
+    rewrite_summary_selections(
+      captured,
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    captured
+  )
+
+  # The selection beside the quoted one is still resolved.
+  expect_identical(
+    rewrite_summary_selections(
+      quote(list(
+        quote(dplyr::across(value, mean)),
+        dplyr::across(value, mean)
+      )),
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quote(list(
+      quote(dplyr::across(value, mean)),
+      dplyr::across(dplyr::all_of("value"), mean)
+    ))
+  )
+})
+
+test_that("`substitute()` protects what it captures and reads what it runs", {
+  # `substitute()` captures its first argument and evaluates its second, so
+  # the two halves of one call get opposite answers. Under a data mask the
+  # capture reads nothing: dplyr binds a column and an earlier summary alike
+  # so that `substitute(share)` answers the symbol rather than the value --
+  # measured, not assumed, which is why the bare form is protected at all.
+  expect_identical(
+    expression_data_symbols(quote(substitute(share))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(substitute(expr = share))),
+    character()
+  )
+  # The `env` argument is evaluated in the mask like any other operand.
+  expect_identical(
+    expression_data_symbols(quote(substitute(share, list(x = other)))),
+    "other"
+  )
+  expect_identical(
+    expression_data_symbols(quote(substitute(share, env = mask))),
+    "mask"
+  )
+})
+
+test_that("a capture the walk cannot name plainly is analyzed, not assumed", {
+  # A namespace qualifier naming base is the same primitive; one naming
+  # anything else is a function this walk knows nothing about, and a computed
+  # head is the shape it cannot name at all. Both fall through and report the
+  # symbols under them, which over-reports rather than protecting an
+  # expression that may well be evaluated.
+  expect_identical(
+    expression_data_symbols(quote(base::quote(share))),
+    character()
+  )
+  expect_identical(expression_data_symbols(quote(pkg::quote(share))), "share")
+  # A parenthesized head is evaluated in the mask like any other operand, so
+  # the name of the primitive is itself a read there -- the answer the walk has
+  # given every head that is not a bare symbol since #130.
+  expect_identical(
+    expression_data_symbols(quote((quote)(share))),
+    c("quote", "share")
+  )
+  # A call carrying more arguments than the primitive takes is not the shape
+  # this recognizes either: R refuses `quote(a, b)` when it runs, and the walk
+  # reports the argument beyond the captured one rather than claiming it is
+  # data.
+  expect_identical(expression_data_symbols(quote(quote(share, units))), "units")
+
+  # A name the expression itself binds may be the function the call reaches,
+  # and a binding is the one shadowing this walk can see. R's function lookup
+  # would skip a non-function binding and find `base::quote()` anyway, which
+  # makes the shape undecidable, so it is answered in the direction that
+  # reports the read: a summary that binds `quote` and then calls it is walked
+  # as the call to its own function it may well be.
+  expect_identical(
+    expression_data_symbols(quote({
+      quote <- function(e) e
+      quote(share)
+    })),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote(quote(share)), bound = "quote"),
+    "share"
+  )
+  # A qualified head is out of reach of any binding, so it keeps its capture.
+  expect_identical(
+    expression_data_symbols(quote({
+      quote <- function(e) e
+      base::quote(share)
+    })),
+    character()
+  )
+
+  # `evalq()` captures its first argument and then evaluates it, so it is no
+  # boundary: the walk reports the symbols under it, as it always has.
+  expect_identical(expression_data_symbols(quote(evalq(share))), "share")
+  # `bquote()` captures too, but `.()` substitutes an expression evaluated in
+  # the enclosing frame -- the mask -- so `bquote(f(.(share)))` really does
+  # read the share. The whole call stays analyzed rather than being read for
+  # the parts of it that are data.
+  expect_identical(expression_data_symbols(quote(bquote(share))), "share")
+  expect_identical(
+    expression_data_symbols(quote(bquote(f(.(share))))),
+    "share"
+  )
+})
+
+test_that("evaluating a captured expression is the read it performs", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  # What the capture branch stops reporting, the evaluation branch recovers:
+  # `eval()` runs the language it is handed in the mask, so the names under a
+  # recovered `quote()` are read exactly as a written symbol is.
+  expect_identical(expression_data_symbols(quote(eval(quote(share)))), "share")
+  expect_identical(
+    expression_data_symbols(quote(eval(substitute(share)))),
+    "share"
+  )
+  # A bound name shadows the recovered read as it shadows a symbol.
+  expect_identical(
+    expression_data_symbols(quote(eval(quote(share))), bound = "share"),
+    character()
+  )
+  # A `substitute()` given an environment replaces names from it, which this
+  # walk cannot read, so the language handed to `eval()` is unknown and the
+  # marker says so -- beside the read of the environment argument itself.
+  expect_identical(
+    expression_data_symbols(quote(eval(substitute(share, mask)))),
+    c("mask", unresolved_lookup_name())
+  )
+
+  expect_share_dependency_error(data, quote(eval(quote(share)) * 100))
+  expect_share_dependency_error(data, quote(eval(substitute(share)) * 100))
+})
+
+test_that("a quoted helper reaches the summary as the language it is", {
+  # End to end, on the local planning path. Each of these was analyzed as a
+  # request the caller never made: the grouping helper compiled to its
+  # branch-local constant, the context helper refused the call, the selection
+  # was resolved to `all_of()`, and the share helper was refused for its
+  # position (#179).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    total = sum(value),
+    grouping = deparse1(quote(grouping_bit(region))),
+    context = deparse1(quote(dplyr::cur_group())),
+    selection = deparse1(quote(dplyr::across(value, mean))),
+    helper = deparse1(quote(share_of_total(total))),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expect_identical(
+    names(result),
+    c("region", "total", "grouping", "context", "selection", "helper")
+  )
+  expect_identical(unique(result$grouping), "grouping_bit(region)")
+  expect_identical(unique(result$context), "dplyr::cur_group()")
+  expect_identical(unique(result$selection), "dplyr::across(value, mean)")
+  expect_identical(unique(result$helper), "share_of_total(total)")
+
+  # A language object the caller keeps is the same object on the way out,
+  # rather than one carrying whatever the analysis rewrote inside it.
+  kept <- summarize_with_margins(
+    data,
+    total = sum(value),
+    call = list(quote(share_of_total(total))),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(kept$call[[1L]], quote(share_of_total(total)))
+})
+
+test_that("a quoted alias of an earlier share is not a dependency on it", {
+  # The guard #130 wrote and #173 extended reports a read of an earlier share,
+  # and a quoted name is not one. Refusing this call named a share the summary
+  # never reads and left the caller no rewrite that keeps the quoted object.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(value),
+    share = share_of_total(units),
+    label = deparse1(quote(share)),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expect_identical(names(result), c("region", "units", "share", "label"))
+  expect_identical(unique(result$label), "share")
+})
+
+test_that("a share source quoting an earlier alias is still self-contained", {
+  # The other direction of the same rule, which #173 asserts for the reads a
+  # source really makes: a source summary must depend on nothing written
+  # earlier, and quoting an earlier name is not a dependency on it. Refusing
+  # this named the source as depending on a summary it never reads.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  result <- summarize_with_margins(
+    data,
+    alias = sum(value),
+    units = length(quote(alias)) * sum(value),
+    share = share_of_total(units),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expect_identical(names(result), c("region", "alias", "units", "share"))
+  expect_identical(result$units, result$alias)
+  expect_identical(result$share, result$units / sum(data$value))
+})
+
+test_that("a lazy plan reads a quoted expression as data too", {
+  # The same planning decisions on the lazy path, which makes them before any
+  # SQL is rendered. The quoted grouping helper was compiled to the branch
+  # constant of whichever grouping set was being staged -- the rendered query
+  # said `deparse1(quote(GROUPING("region")))` -- while the quoted context and
+  # share helpers were refused outright, so neither call reached a dialect at
+  # all.
+  #
+  # What the dialect then does with a `quote()` call is the dialect's own
+  # translation and not this package's: dbplyr has no capture rule, so it
+  # builds SQL out of whatever the call holds. The helper names surviving into
+  # the query are what says the analysis left the expression alone.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+
+  query <- summarize_with_margins(
+    postgres,
+    total = sum(value),
+    grouping = deparse1(quote(grouping_bit(region))),
+    context = deparse1(quote(cur_group())),
+    helper = deparse1(quote(share_of_total(value))),
+    .grouping = rollup(region)
+  )
+  sql <- as.character(dbplyr::sql_render(query))
+  expect_match(sql, "quote(grouping_bit(", fixed = TRUE)
+  expect_match(sql, "quote(cur_group())", fixed = TRUE)
+  expect_match(sql, "quote(share_of_total(", fixed = TRUE)
+
+  # A quoted alias of an earlier share is no longer refused here either. It
+  # does not execute: dbplyr's own rule about a name created in the same
+  # `summarise()` reads the quoted symbol as a use of it and says so, in its
+  # own class. That is the External condition ADR-0015 keeps intact, and the
+  # assertion is written so that it holds whichever way dbplyr answers -- what
+  # this ticket changed is that the refusal is not marginplyr's.
+  planned <- tryCatch(
+    summarize_with_margins(
+      postgres,
+      units = sum(value),
+      share = share_of_total(units),
+      label = deparse1(quote(share)),
+      .grouping = rollup(region)
+    ),
+    error = function(cnd) cnd
+  )
+  expect_false(inherits(planned, "marginplyr_error"))
+})

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -3079,6 +3079,27 @@ test_that("a lazy plan reads a quoted expression as data too", {
   expect_match(sql, "quote(cur_group())", fixed = TRUE)
   expect_match(sql, "quote(share_of_total(", fixed = TRUE)
 
+  # A share beside a quoted expression plans and renders, which is the
+  # positive half: the planner stages both, and the query carries the
+  # expression the caller wrote. The quoted name has to be a column here,
+  # which is the same fact as the paragraph above -- dbplyr resolves what a
+  # `quote()` holds rather than carrying it, so a name no column has fails at
+  # build time. Round-tripping language is a local guarantee; what holds on
+  # every backend is that this package's analysis leaves the expression alone.
+  shared <- summarize_with_margins(
+    postgres,
+    units = sum(value),
+    share = share_of_total(units),
+    label = deparse1(quote(value)),
+    .grouping = rollup(region)
+  )
+  expect_s3_class(shared, "tbl_lazy")
+  expect_match(
+    as.character(dbplyr::sql_render(shared)),
+    "quote(\"value\")",
+    fixed = TRUE
+  )
+
   # A quoted alias of an earlier share is no longer refused here either. It
   # does not execute: dbplyr's own rule about a name created in the same
   # `summarise()` reads the quoted symbol as a use of it and says so, in its
@@ -3249,4 +3270,125 @@ test_that("`expression()` is one capture on both sides of the boundary", {
     .margin_label = NULL
   )
   expect_identical(unique(carried$e), "expression(share_of_total(total))")
+})
+
+test_that("only the walk that tracks bindings reads a shadowed capture", {
+  # One reading of the capture, told what each caller knows.
+  # `captured_call_parts()` is where a bound name stops being read as the
+  # primitive it spells, and the share dependency walk is the only analysis
+  # with a bound set to hand it -- the only one that tracks bindings at all,
+  # and the only one whose wrong answer is silence about a wrong number.
+  proxy <- data.frame(value = double())
+  env <- rlang::current_env()
+
+  expect_identical(
+    captured_call_parts(quote(quote(share)), bound = "quote"),
+    FALSE
+  )
+  expect_identical(captured_call_parts(quote(quote(share))), TRUE)
+
+  # The searches and the rewrites pass no bound set, which is the reading they
+  # already give every name they match: a locally bound `across` is resolved
+  # as a selection, and a locally bound `cur_group` is refused as the
+  # branch-local helper. A shadowed capture is read the same scope-blind way,
+  # so the answer is a diagnostic or an uncompiled helper rather than a silent
+  # value.
+  expect_identical(
+    rewrite_summary_selections(
+      quote({
+        across <- function(...) 1
+        dplyr::across(value, mean)
+      }),
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quote({
+      across <- function(...) 1
+      dplyr::across(dplyr::all_of("value"), mean)
+    })
+  )
+  expect_identical(
+    find_summary_context_helpers(quote({
+      cur_group <- function() 1
+      cur_group()
+    })),
+    "cur_group"
+  )
+  expect_identical(
+    find_summary_context_helpers(quote({
+      quote <- function(e) e
+      quote(cur_group())
+    })),
+    character()
+  )
+})
+
+test_that("a rewrite opens only the language a search can read", {
+  # The rewrite and the searches read one index. `substitute()` given an
+  # environment substitutes from it, which this analysis cannot read, so what
+  # reaches the mask is unknown: the searches contribute nothing about it and
+  # the rewrite leaves it alone rather than compiling a helper nothing else
+  # can see. Without the environment the language is the expression as
+  # written, and both halves read it.
+  proxy <- data.frame(value = double())
+  env <- rlang::current_env()
+
+  unreadable <- quote(eval(substitute(dplyr::across(value, mean), env)))
+  expect_identical(
+    rewrite_summary_selections(
+      unreadable,
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    unreadable
+  )
+  expect_identical(
+    find_summary_context_helpers(
+      quote(eval(substitute(dplyr::cur_group(), env)))
+    ),
+    character()
+  )
+
+  expect_identical(
+    rewrite_summary_selections(
+      quote(eval(substitute(dplyr::across(value, mean)))),
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quote(eval(substitute(dplyr::across(dplyr::all_of("value"), mean))))
+  )
+  expect_identical(
+    find_summary_context_helpers(quote(eval(substitute(dplyr::cur_group())))),
+    "cur_group"
+  )
+})
+
+test_that("a formula a capture carries keeps its class and environment", {
+  # #165's rule reaches the captured part too, and by a stronger route: the
+  # rewrite gives back the object rather than rebuilding it, so a formula the
+  # caller injected inside a `quote()` keeps the `.Environment` a lambda
+  # resolves against. Asserted end to end, because a flattened one still
+  # answers `TRUE` to `rlang::is_formula()` and shows only where the class is
+  # used.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  written_in <- rlang::env(offset = 100)
+  lambda <- rlang::new_formula(NULL, quote(.x + offset), env = written_in)
+
+  result <- summarize_with_margins(
+    data,
+    units = sum(value),
+    kept = identical(attr(quote(!!lambda), ".Environment"), !!written_in),
+    applied = rlang::as_function(quote(!!lambda))(units),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+
+  expect_true(all(result$kept))
+  expect_identical(result$applied, result$units + 100)
 })

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -3097,3 +3097,156 @@ test_that("a lazy plan reads a quoted expression as data too", {
   )
   expect_false(inherits(planned, "marginplyr_error"))
 })
+
+# The boundary has two sides, and the first pass drew only one of them. A
+# capture stopped being analyzed everywhere, including where an `eval()`
+# evaluates it, so `eval(quote(cur_group_id()))` ran and answered a
+# branch-local identifier -- the value that guard exists to refuse, now
+# returned silently -- while `eval(quote(share_of_total(total)))` reached the
+# helper itself, which reports a Grouping plan the caller already has, and
+# `eval(quote(grouping_bit(region)))` stopped compiling to its branch constant
+# and reported that it works only inside the verb it was inside.
+#
+# The dependency walk never had that hole: #173 built `static_language_values()`
+# to recover the language `eval()` runs. The searches and the rewrites read the
+# same recovery now, so what a capture withholds from the analysis, evaluating
+# it gives back.
+
+test_that("a capture an `eval()` runs is analyzed as the code it becomes", {
+  proxy <- data.frame(value = double(), other = double())
+  env <- rlang::current_env()
+
+  # The three searches, over the language the call evaluates.
+  expect_identical(
+    find_summary_context_helpers(quote(eval(quote(dplyr::cur_group_id())))),
+    "cur_group_id"
+  )
+  expect_identical(
+    share_expression_kind(quote(eval(quote(share_of_total(total))))),
+    "total"
+  )
+  expect_true(contains_selection_predicate(quote(eval(quote(where(
+    is.numeric
+  ))))))
+
+  # Whatever the recovery can read reaches them, not only a capture: a name
+  # parsed from a string is language this call evaluates too, and a head that
+  # names `eval()` without being a symbol names it here as it does in the
+  # dependency walk.
+  expect_identical(
+    find_summary_context_helpers(quote(eval(str2lang("cur_group()")))),
+    "cur_group"
+  )
+  expect_identical(
+    find_summary_context_helpers(quote(eval(expression(cur_group())))),
+    "cur_group"
+  )
+  expect_identical(
+    find_summary_context_helpers(quote((eval)(quote(cur_group())))),
+    "cur_group"
+  )
+
+  # The rewrite reaches inside the capture the `eval()` runs, and only there:
+  # the selection is resolved as it would be without the `quote()`.
+  expect_identical(
+    rewrite_summary_selections(
+      quote(eval(quote(dplyr::across(value, mean)))),
+      env = env,
+      data_proxy = proxy,
+      normalize_across_names = FALSE
+    ),
+    quote(eval(quote(dplyr::across(dplyr::all_of("value"), mean))))
+  )
+})
+
+test_that("evaluating a captured helper reaches the rule it always did", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  context <- expect_error(
+    summarize_with_margins(
+      data,
+      gid = eval(quote(dplyr::cur_group_id())),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    ),
+    "does not support `cur_group_id()`",
+    fixed = TRUE
+  )
+  expect_s3_class(context, "marginplyr_error")
+
+  position <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      s = eval(quote(share_of_total(total))),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    ),
+    "must be the complete right-hand side of a named summary",
+    fixed = TRUE
+  )
+  expect_s3_class(position, "marginplyr_error")
+
+  # The grouping helpers are the case that must keep working rather than keep
+  # failing: the rewrite compiles the helper inside the capture, so the
+  # summary answers the branch constant it answered before this boundary
+  # existed.
+  compiled <- summarize_with_margins(
+    data,
+    bit = eval(quote(grouping_bit(region))),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(compiled$bit, c(0L, 0L, 1L))
+
+  # And on the lazy path the dialect gets its own `GROUPING()` rather than a
+  # call to a helper no backend can run.
+  postgres <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+  query <- summarize_with_margins(
+    postgres,
+    total = sum(value),
+    bit = eval(quote(grouping_bit(region))),
+    .grouping = rollup(region)
+  )
+  sql <- as.character(dbplyr::sql_render(query))
+  expect_match(sql, "eval(quote(GROUPING(", fixed = TRUE)
+})
+
+test_that("`expression()` is one capture on both sides of the boundary", {
+  # `static_language_values()` has recovered `expression()` for `eval()` since
+  # #173, so reading it as ordinary code everywhere else made the two halves
+  # of one boundary disagree about the same call: it was language where an
+  # `eval()` ran it and a share helper written in the wrong position where
+  # nothing did.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+
+  expect_identical(
+    expression_data_symbols(quote(expression(share))),
+    character()
+  )
+  expect_identical(
+    expression_data_symbols(quote(expression(share, units))),
+    character()
+  )
+  expect_null(share_expression_kind(quote(expression(share_of_total(x)))))
+  # The recovery is unchanged, and is now the only thing that reports it.
+  expect_identical(
+    expression_data_symbols(quote(eval(expression(share)))),
+    "share"
+  )
+
+  carried <- summarize_with_margins(
+    data,
+    total = sum(value),
+    e = deparse1(expression(share_of_total(total))),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(unique(carried$e), "expression(share_of_total(total))")
+})


### PR DESCRIPTION
Closes #179.

## The defect

Every analysis that reads a summary expression walked into `quote()` as if its
argument were code the data mask runs. A caller carrying language in a summary
therefore got the analysis applied to their data:

``` r
summarize_with_margins(
  data,
  total = sum(value),
  label = deparse1(quote(grouping_bit(region))),
  .grouping = rollup(region)
)
#> label is "0L" in one grouping set and "1L" in another
```

The grouping rewrite compiled the quoted helper to the branch-local constant it
exists to produce; `quote(dplyr::across(value, mean))` came back as
`quote(dplyr::across(dplyr::all_of("value"), mean))`; `quote(cur_group())`
refused the whole call; `quote(share_of_total(units))` was refused for writing a
helper outside a complete right-hand side; and a quoted name matching an earlier
share was reported as a dependency on it, with a diagnostic naming a summary the
expression never reads.

## The rule

R's own. A captured argument is data until something evaluates it. The boundary
is read in one place — `captured_call_parts()` answers which of a call's
arguments are captured, `evaluated_call_args()` and `searched_call_parts()` are
what the searches descend into, and `rewrite_evaluated_call_parts()` is what the
two rewrites rebuild through, so a captured argument comes back as the object the
caller wrote, argument names and injected quosures included.

`quote()`, `substitute()`, and `expression()` are the primitives it names.
`substitute()` gets both halves of its contract: the captured expression is data,
while `env` is an ordinary operand evaluated in the mask. Under dplyr the bare
form reads nothing there — a column and an earlier summary alias both come back
as symbols, measured rather than assumed — which is what makes protecting it
safe. `evalq()` and `bquote()` are deliberately not boundaries: the first
evaluates what it captured, and the second evaluates whatever `.()` wraps in the
enclosing frame, which under a data mask is the mask.

## Evaluating a capture is not an escape hatch

The boundary has two sides, and drawing only the first one opens what #173
closed. `eval(quote(dplyr::cur_group_id()))` ran and answered a branch-local
identifier per grouping set — the value that guard exists to refuse, returned
silently — while `eval(quote(grouping_bit(region)))` stopped compiling and
reported that the helper works only inside the verb the caller was already
inside.

`static_language_values()`, which #173 built to read the language an `eval()`
runs, is now read by the searches and the rewrites as well as by the dependency
walk. `evaluated_language_index()` is the one reading of where that argument
sits, and `readable_language_index()` is where a rewrite may open a capture:
`eval(substitute(x, env))` substitutes from an environment nothing here can
read, so it is left as written rather than compiled into something the searches
beside it contribute nothing about.

## Where the reading stops

Both halves are static, so both stop where a static reading does, and the
asymmetry is deliberate: reading a capture where there is none costs a
diagnostic about a column the caller did write, while missing one is the silent
miss #130 fixed this walk to prevent. A capture is recognized where the call
names the primitive plainly — `quote()`, or `base::quote()`. Another namespace,
a computed head, and an argument beyond the one the primitive takes all fall
through to the walk.

Shadowing is one rule, held in `captured_call_parts()` with the bound set as an
argument. The share dependency walk passes one, because it is the only analysis
that tracks bindings and the only one whose wrong answer is silence about a
wrong number. The searches and the rewrites pass none, which is the reading they
already give every name they match: a locally bound `across` is resolved as a
selection today, and a locally bound `cur_group` is refused as the branch-local
helper.

## Where the readers live

`R/share.R` owns every contextual-share decision, as `design/architecture.md`
records, and a shared reader living there made the grouping-context rewrite
reach into the deep share module for a fact that is not about shares. What a
call names and what language it holds now sits in `R/utils.R`, so the dependency
runs one way; `design/architecture.md` gains the module entry that says so.
Nothing about a share moved.

## Coverage

At the walk and through the public verb, on the local and lazy planning paths:
quoted language round-trips as a list column, `substitute()`'s two halves get
opposite answers, quoted share, grouping, selection, and context-helper
spellings create no dependency and no hidden column, and evaluating any of them
reaches the rule it always did. A formula a capture carries keeps its class and
its `.Environment`.

One limit is asserted rather than papered over: round-tripping language is a
local guarantee. dbplyr has no capture rule and resolves what a `quote()` holds
into SQL, so what holds on every backend is that this package's analysis leaves
the expression alone — which is what the lazy assertions check.
