### PR TITLE
Refuse an empty argument as the non-column it is

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -200,6 +200,29 @@ grouping_helper_name <- function(expr) {
 }
 
 grouping_helper_vars <- function(args, helper, plan) {
+  # Each argument is read as a value rather than bound to a name, for the reason
+  # `static_call_args()` gives: one of them may be R's empty argument, which is
+  # a symbol whose name is `""`. `is.symbol()` therefore read one as a bare
+  # column and `as.character()` wrote `""` into `vars`, so the caller was told
+  # about a column nobody wrote -- `grouping_id(region, )` named `` `` `` as
+  # missing from the plan, and `grouping_id(, )` named it a duplicate, because
+  # both empty arguments read as the same name (#181). `is_name_part()` is the
+  # actually being asked: a symbol, and not the empty argument.
+  not_a_column_message <- sprintf(
+    "`%s()` only accepts bare grouping columns.", helper
+  )
+
+  # The empty argument is refused ahead of the arity checks so that the answer
+  # does not depend on which check runs first. `grouping_bit(, )` is two
+  # arguments to the parser, so arity is what catches it today, and a message
+  # counting columns describes neither of the two things the caller wrote.
+  # Nothing else moves: a non-column that is not empty -- `grouping_bit(1, 2)`
+  # -- still reaches the arity diagnostic first, which is the one a caller
+  # passing two of anything needs.
+  if (any(vapply(args, rlang::is_missing, logical(1)))) {
+    abort_marginplyr(not_a_column_message)
+  }
+
   if (identical(helper, "grouping_bit") && length(args) != 1L) {
     abort_marginplyr(
       "`grouping_bit()` requires exactly one column."
@@ -211,11 +234,14 @@ grouping_helper_vars <- function(args, helper, plan) {
     )
   }
 
-  is_symbol <- vapply(args, is.symbol, logical(1))
-  if (!all(is_symbol)) {
-    abort_marginplyr(
-      sprintf("`%s()` only accepts bare grouping columns.", helper)
-    )
+  # The compound question, asked here even though the check above has already
+  # answered half of it: this is the test protecting `as.character()` below, and
+  # what it must be true of is the whole of what a column is. Narrowing it to
+  # `is.symbol()` on the grounds that nothing empty survives the pre-check would
+  # make the reordering above load-bearing for correctness rather than for which
+  # diagnostic a caller reads.
+  if (!all(vapply(args, is_name_part, logical(1)))) {
+    abort_marginplyr(not_a_column_message)
   }
 
   vars <- vapply(args, as.character, character(1))

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -207,7 +207,7 @@ grouping_helper_vars <- function(args, helper, plan) {
   # about a column nobody wrote -- `grouping_id(region, )` named `` `` `` as
   # missing from the plan, and `grouping_id(, )` named it a duplicate, because
   # both empty arguments read as the same name (#181). `is_name_part()` is the
-  # actually being asked: a symbol, and not the empty argument.
+  # question actually being asked: a symbol, and not the empty argument.
   not_a_column_message <- sprintf(
     "`%s()` only accepts bare grouping columns.", helper
   )

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2189,6 +2189,26 @@ test_that("a grouping helper reads an empty argument as a non-column", {
     error
   }
 
+  # The answer this has to reach, asserted first because it is the baseline and
+  # not a message of its own: what the same function already gives a non-column
+  # argument. Nothing asserted it before, which is how the empty argument came
+  # to be read as a column at all -- the branch that refuses a literal is one
+  # the suite never executed.
+  literal_id <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_id(1),
+      .grouping = rollup(region, store)
+    )
+  ))
+  literal_bit <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_bit("region"),
+      .grouping = rollup(region, store)
+    )
+  ))
+
   trailing <- refuse(expect_error(
     summarize_with_margins(
       data,
@@ -2230,6 +2250,16 @@ test_that("a grouping helper reads an empty argument as a non-column", {
       .grouping = rollup(region, store)
     )
   ))
+
+  # Each empty spelling reaches its own helper's baseline exactly, which is the
+  # whole of what was asked for: not a new diagnostic, but the one a caller
+  # writing anything else that is not a column already gets.
+  for (error in list(trailing, leading, both)) {
+    expect_identical(conditionMessage(error), conditionMessage(literal_id))
+  }
+  for (error in list(bit, bit_trailing)) {
+    expect_identical(conditionMessage(error), conditionMessage(literal_bit))
+  }
 
   # The column vector is what these diagnostics are built from, so a message
   # naming the empty name is the direct witness that an empty argument reached

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2162,6 +2162,97 @@ test_that("`parse_across_arguments()` answers an empty argument as omitted", {
   expect_identical(supplied$unpack, FALSE)
 })
 
+test_that("a grouping helper reads an empty argument as a non-column", {
+  # The third place an empty argument reaches, found by the same audit and
+  # reached by neither path above: a `grouping_id()` or `grouping_bit()` call is
+  # read by `grouping_helper_vars()` rather than by the `across()` rebuild #174
+  # fixed. That read tested each argument with `is.symbol()`, which the empty
+  # argument passes because it is a symbol whose name is `""`, so
+  # `as.character()` wrote that name into the column vector. A trailing empty
+  # argument was then refused for a column missing from the plan, and two empty
+  # arguments for a duplicate that exists only because both read as the same
+  # name. Both conditions were already Package conditions -- what the
+  # caller could not act on is a diagnostic naming a column they never wrote
+  # (#181).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    store = c("a", "b", "c"),
+    value = c(1, 3, 6)
+  )
+  refuse <- function(error) {
+    expect_s3_class(error, "marginplyr_error")
+    expect_match(
+      conditionMessage(error),
+      "only accepts bare grouping columns",
+      fixed = TRUE
+    )
+    error
+  }
+
+  trailing <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_id(region, ),
+      .grouping = rollup(region, store)
+    )
+  ))
+  leading <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_id(, region),
+      .grouping = rollup(region, store)
+    )
+  ))
+  both <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_id(, ),
+      .grouping = rollup(region, store)
+    )
+  ))
+  # `grouping_bit()` is two arguments to the parser here, so its arity check is
+  # what caught this call before -- an answer that depended on which check ran
+  # first, and one describing a column count rather than either of the two
+  # things the caller wrote.
+  bit <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_bit(, ),
+      .grouping = rollup(region, store)
+    )
+  ))
+  # Its one-argument form was refused for the same wrong reason, and reaches
+  # the same answer now that the empty argument is read before the count is.
+  bit_trailing <- refuse(expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_bit(region, ),
+      .grouping = rollup(region, store)
+    )
+  ))
+
+  # The column vector is what these diagnostics are built from, so a message
+  # naming the empty name is the direct witness that an empty argument reached
+  # it.
+  for (error in list(trailing, leading, both, bit, bit_trailing)) {
+    expect_no_match(conditionMessage(error), "``", fixed = TRUE)
+  }
+
+  # Only the empty argument moves ahead of the arity checks. A non-column that
+  # is not empty is still counted first, which is what a caller passing two of
+  # anything to `grouping_bit()` needs told.
+  arity <- expect_error(
+    summarize_with_margins(
+      data,
+      b = grouping_bit(1, 2),
+      .grouping = rollup(region, store)
+    ),
+    "requires exactly one column",
+    fixed = TRUE
+  )
+  expect_s3_class(arity, "marginplyr_error")
+})
+
 test_that("no analysed shape reaches the caller as an untyped condition", {
   # The classes below are what each site raised before #100, and before #168 in
   # `missingArgError`'s case. Asserting their absence together keeps a future


### PR DESCRIPTION
Closes #181.

## The defect

R's empty argument is a symbol whose name is `""`, so it passed the bare
`is.symbol()` test that decided whether a `grouping_id()` or `grouping_bit()`
argument was a bare column, and `as.character()` put `""` into the column
vector. Every diagnostic in `grouping_helper_vars()` is built from that vector,
so the caller was told about a column they never wrote:

``` r
d <- data.frame(
  region = c("East", "East", "West"),
  store = c("a", "b", "c"),
  value = c(1, 3, 6)
)

summarize_with_margins(d, b = grouping_id(region, ), .grouping = rollup(region, store))
#> Error: Column `` is not part of `.by` or `.grouping`.

summarize_with_margins(d, b = grouping_id(, ), .grouping = rollup(region, store))
#> Error: `grouping_id()` does not accept duplicate columns.
```

Both are already `marginplyr_error`, so this is not #168's untyped
`missingArgError` — the caller gets a Package condition. What they do not get is
one they can act on. Nothing in either message names the empty argument, and the
second describes a duplicate that exists only because both empty arguments read
as the same name.

This is not #174 and not a regression from it: the `across()` planning path that
ticket covers never reaches `grouping_helper_vars()`.

## The rule

The one the same function already gives a non-column. An empty argument is not a
bare grouping column, so `grouping_id(1)`'s message is the one it should reach —
ahead of the membership test and the duplicate test both.

`is_name_part()` is the question the site is asking — a symbol, and not the
empty argument — and it replaces `is.symbol()`. It exists as of #174 for exactly
this, and the arguments are read as values rather than bound to a name, which is
the rule `static_call_args()` records.

## Where it sits in the order

The empty argument is refused ahead of the arity checks, so the answer does not
depend on which check runs first. `grouping_bit(, )` is two arguments to the
parser, so arity is what caught it before, and a message counting columns
describes neither of the two things the caller wrote. That moves
`grouping_bit(region, )` off the arity diagnostic it reached by accident and
onto the same one — the one change here the ticket did not list, and the one
its second acceptance criterion cannot be met without.

Nothing else moves. A non-column that is not empty still meets the count first:

| call | before | after |
|---|---|---|
| `grouping_id(region, )` / `(, region)` | membership | `only accepts bare grouping columns` |
| `grouping_id(, )` | duplicate | `only accepts bare grouping columns` |
| `grouping_bit(, )` / `(region, )` | arity | `only accepts bare grouping columns` |
| `grouping_bit(1, 2)`, `grouping_bit()`, `grouping_id()` | arity | unchanged |
| `grouping_id(1)`, duplicates, unknown columns, valid calls | — | unchanged |

The later `is_name_part()` call still asks the compound question even though the
pre-check has answered half of it. That test is what protects `as.character()`,
and what it must hold of is the whole of what a column is; narrowing it to
`is.symbol()` would make the reordering load-bearing for correctness rather than
for which diagnostic a caller reads.

## Coverage

Beside the empty-argument family in `test-static-expression-analysis.R`, which
is where the two earlier readings of this shape are asserted. Both helpers, in
every empty spelling, by condition class as well as by message; the arity
diagnostic that deliberately did not move, asserted so a later reorder cannot
take it silently; and, directly, that no message names the empty name — the
column vector is what every diagnostic here is built from, so that is the
witness that no empty argument reached it.

No generated file changes, and no NEWS entry: `0.1.0` is still the unreleased
initial submission, so no diagnostic corrected here was ever shipped, which is
what #168 and #174 did for the same shape.