### PR TITLE
Resolve contextual helper names by static spelling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,6 +93,22 @@ fixed `.by` group, so a fixed key never contributes to another partition's
 denominator.
 _Avoid_: Percent of total, root share, grand total percentage
 
+**Contextual helper**:
+A spelling whose meaning inside a Margin summary arises only through static
+rewriting, and which is therefore recognized by spelling and never resolved
+from the calling environment. It is recognized when the name matches and the
+namespace is absent or the owning package; any other qualifier is an ordinary
+call. A caller binding of the same name never changes what a Margin verb does
+with it, and the rewritten call names the owning package so that what executes
+is what was analyzed. Every other name in a summary expression follows
+ordinary lexical and data-mask lookup, including `dplyr::n()`. Grouping
+specification constructors are not Contextual helpers: their spelling decides
+only whether a nested argument is evaluated, and the caller's own function
+runs when it is. A diagnostic refusing one tells the caller their spelling is
+*reserved*; that is this same fact addressed to someone who has not read this
+glossary, and not a second term.
+_Avoid_: Contextual function, masked helper, reserved argument
+
 **Package condition**:
 An error marginplyr itself raises, inheriting the `marginplyr_error` base
 class. It reports something the caller can avoid by rewriting the call within

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,21 @@
   overwrite grouping keys, always return ungrouped output, and reject
   branch-local `cur_group*()` helpers in favor of `grouping_bit()` and
   `grouping_id()`.
+* Summary expressions now resolve every contextual helper by spelling.
+  `grouping_bit()`, `grouping_id()`, `share_of_parent()`, `share_of_total()`,
+  `across()`, `if_any()`, `if_all()`, `pick()`, `where()`, and the rejected
+  `cur_group*()` helpers mean what marginplyr rewrites them into, whether they
+  are written bare or qualified with the package that owns them, and a binding
+  of the same name in the calling environment never changes what the verb does
+  with one. A qualifier naming any other package is an ordinary call, and every
+  other name — `dplyr::n()` included — follows ordinary lookup. Three
+  resolutions changed: `across()`, `if_any()`, and `if_all()` previously ran a
+  caller's binding while the rules that reject a selection were checked against
+  dplyr's helper; a shadowed `pick()` ran a caller's binding inside a `~`
+  lambda or a `function` body, which is the one position plain dplyr also lets
+  it; and a `where()` qualified with a package that does not own it is no
+  longer read as a selection predicate inside a contextual share's `across()`.
+  See *Relationship to dplyr summaries* in `?summarize_with_margins`.
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/R/contextual-helpers.R
+++ b/R/contextual-helpers.R
@@ -1,0 +1,275 @@
+# Every spelling a Margin verb recognizes as a Contextual helper or as one of
+# the three families read alongside them, keyed by the family that decides what
+# recognition does. It is the one place those names and the namespaces they may
+# carry are written down, and the one place their namespace test is
+# implemented. Before #172 each reader carried a spelling and a test of its
+# own, two derived from a rules table and the rest written out, and one --
+# `where`, in `contains_selection_predicate()` -- had no namespace test at all,
+# so a spelling could be recognized by the analysis and missed by the rewrite
+# beside it. `investigation/contextual-helper-execution-mechanism.md` counts
+# and tabulates them (#172, ADR 0019).
+#
+# The language-capture primitives are the one set of names read statically and
+# deliberately kept out. `language_capture_formal()` and
+# `captured_call_parts()` (`R/utils.R`) carry `quote`, `substitute`, and
+# `expression` with a `base` namespace test of their own, and that test is not
+# this one: a capture is refused where the head names a binding the analysis
+# can see, so it answers to the calling environment where every family here
+# refuses to. Registering them would put two rules under one reader.
+#
+# A family names its own spellings only where no other table already owns them.
+# `share_kind_rules()` is the authoritative description of a contextual share
+# and `grouping_kind_rules()` of a specification kind, so those two families
+# derive; a third share helper or a sixth constructor appears here without
+# being written down a second time. Read the other way, a family listing names
+# outright is a family whose names exist nowhere else.
+#
+# Each entry is a function rather than a value, so asking about one family
+# builds that family and no other. That is what keeps this module's dependency
+# running the way `design/architecture.md` requires: built eagerly, a
+# `grouping_helper_name()` lookup would evaluate `share_kind_rules()` and make
+# the grouping-context rewrite reach into the contextual-share module for a
+# fact that is not about shares, which is exactly what #179 separated. Nothing
+# but the list of family names is available without naming a family, and
+# `test-contextual-helpers.R` asserts the laziness rather than trusting it.
+#
+# `contextual` is what ADR 0019's criterion decides, and it is not a synonym
+# for "read statically". A Contextual helper's meaning arises only through
+# static rewriting, so no caller binding can change what the verb does with it.
+# The other three families are read statically and are still ordinary names: a
+# Grouping specification constructor's spelling decides only whether a nested
+# argument is evaluated at all -- which is what separates a nested
+# specification from a tidyselect selection -- and a data-frame constructor's
+# spelling is read only to predict the output names of a data-frame-valued
+# summary. Both really run whatever the name is bound to.
+static_spelling_rules <- function() {
+  list(
+    grouping = function() {
+      list(
+        namespaces = "marginplyr",
+        contextual = TRUE,
+        names = c("grouping_bit", "grouping_id")
+      )
+    },
+    share = function() {
+      list(
+        namespaces = "marginplyr",
+        contextual = TRUE,
+        names = vapply(share_kind_rules(), `[[`, character(1), "helper")
+      )
+    },
+    selection = function() {
+      list(
+        namespaces = "dplyr",
+        contextual = TRUE,
+        names = c("across", "if_any", "if_all", "pick")
+      )
+    },
+    # tidyselect exports `where()` and dplyr re-exports it, so both qualifiers
+    # name the same function. Which owners a spelling has is a property of the
+    # spelling, and this is the one place it is recorded. tidyselect leads
+    # because it defines the function, which is the rule the canonical
+    # qualifier below reads.
+    #
+    # Only `qualify_static_spelling()` writes a qualifier back, and only for
+    # the `selection` family; the marginplyr-owned families are rewritten away
+    # entirely and a refused spelling never runs, so three of the five need no
+    # qualifier either. What is peculiar to `where` is what happens in the
+    # positions this family does *not* decide.
+    #
+    # It is read here only to refuse it -- a contextual share's `across()`
+    # selects among preceding summaries by name, and a type predicate has
+    # nothing to test there -- and every other `where()` a caller writes is
+    # left to execute, reaching `tidyselect::eval_select()`, which binds the
+    # name in the selection mask itself. So a caller binding loses to
+    # tidyselect rather than to anything written here, which makes it the one
+    # entry in this table whose promise another package's code keeps.
+    # `test-contextual-helpers.R` asserts it for that reason.
+    predicate = function() {
+      list(
+        namespaces = c("tidyselect", "dplyr"),
+        contextual = TRUE,
+        names = "where"
+      )
+    },
+    refused = function() {
+      list(
+        namespaces = "dplyr",
+        contextual = TRUE,
+        names = c(
+          "cur_group",
+          "cur_group_id",
+          "cur_group_rows",
+          "cur_data",
+          "cur_data_all"
+        )
+      )
+    },
+    grouping_constructor = function() {
+      list(
+        namespaces = "marginplyr",
+        contextual = FALSE,
+        names = grouping_constructor_names()
+      )
+    },
+    tibble_frame = function() {
+      list(
+        namespaces = "tibble",
+        contextual = FALSE,
+        names = c("tibble", "data_frame")
+      )
+    },
+    base_frame = function() {
+      list(
+        namespaces = "base",
+        contextual = FALSE,
+        names = "data.frame"
+      )
+    }
+  )
+}
+
+# The family names, which is everything available without naming one. Reading
+# them costs no domain module, which is the property the laziness above exists
+# to give.
+static_spelling_families <- function() {
+  names(static_spelling_rules())
+}
+
+# An invariant rather than a Package condition (ADR 0015): a family name is
+# written in this package's own source, so an unknown one is a typo in a call
+# no caller can reach and not something a caller can rewrite.
+static_spelling_rule <- function(family) {
+  build <- static_spelling_rules()[[family]]
+  if (is.null(build)) {
+    stop("Unknown static-spelling family: ", family, call. = FALSE)
+  }
+  build()
+}
+
+static_spelling_names <- function(family) {
+  unname(static_spelling_rule(family)$names)
+}
+
+static_spelling_namespaces <- function(family) {
+  static_spelling_rule(family)$namespaces
+}
+
+# The one qualifier a rewrite writes back, where a family has more than one
+# owner. It is the first, and the order is the table's rather than incidental:
+# a family lists the package that defines the function first and its
+# re-exporters after, so `where` is written back as `tidyselect::where` and not
+# as `dplyr::where`. Nothing but `qualify_static_spelling()` needs this --
+# recognition accepts every owner -- and naming it is what stops the choice
+# living as an unexplained `[[1L]]` at the one site that makes it.
+static_spelling_qualifier <- function(family) {
+  static_spelling_namespaces(family)[[1L]]
+}
+
+# The families whose spellings are Contextual helpers. Tests derive from this
+# rather than from the whole table, because the assertion that separates the
+# two is exactly that a caller binding cannot win: for a constructor it can,
+# and asserting otherwise would assert the opposite of ADR 0019.
+contextual_helper_families <- function() {
+  families <- static_spelling_families()
+  contextual <- vapply(
+    families,
+    function(family) static_spelling_rule(family)$contextual,
+    logical(1)
+  )
+  unname(families[contextual])
+}
+
+# The spelling this call is recognized as within one family, or `NULL` where it
+# is not one. Recognition is the name matching and the namespace being absent
+# or an owner of that name; any other qualifier is another package's function
+# and passes through to ordinary evaluation, where R answers it.
+#
+# Asked of any expression, not only of a call: a node that is no call has no
+# name, and no name matches.
+static_spelling_name <- function(expr, family) {
+  name <- static_call_name(expr)
+  if (is.null(name) || !name %in% static_spelling_names(family)) {
+    return(NULL)
+  }
+  namespace <- static_call_ns(expr)
+  owners <- static_spelling_namespaces(family)
+  if (!is.null(namespace) && !namespace %in% owners) {
+    return(NULL)
+  }
+  name
+}
+
+is_static_spelling_call <- function(expr, family, name) {
+  identical(static_spelling_name(expr, family), name)
+}
+
+# Whether a call is recognized in any of several families, for the one reader
+# that treats them alike: a data-frame-valued summary's output names are
+# predicted the same way whether tibble or base owns the constructor.
+is_any_static_spelling_call <- function(expr, families) {
+  any(vapply(
+    families,
+    function(family) !is.null(static_spelling_name(expr, family)),
+    logical(1)
+  ))
+}
+
+# The name a function *reference* is recognized as, for the one position that
+# takes a helper by value rather than by call: an `across()` `.fns` argument
+# written as `share_of_total` or as `marginplyr::share_of_total`. The namespace
+# rule is the same one calls follow, and reading it from the same table is what
+# keeps a reference position from drifting away from the call position.
+static_spelling_reference_name <- function(expr, family) {
+  if (rlang::is_symbol(expr)) {
+    name <- rlang::as_name(expr)
+  } else if (
+    rlang::is_call(expr, "::") &&
+      length(expr) == 3L &&
+      rlang::is_symbol(expr[[2L]]) &&
+      rlang::as_name(expr[[2L]]) %in% static_spelling_namespaces(family) &&
+      rlang::is_symbol(expr[[3L]])
+  ) {
+    name <- rlang::as_name(expr[[3L]])
+  } else {
+    return(NULL)
+  }
+  if (!name %in% static_spelling_names(family)) {
+    return(NULL)
+  }
+  name
+}
+
+# The recognized call written so that nothing but the owning package's function
+# can run it. ADR 0019's rule has a consequence beyond naming: a spelling read
+# statically has to execute as the code that was read, or a rule is checked
+# against an expression that never runs -- which is what a shadowed `across()`
+# did, evaluating the caller's function underneath a grouping-column exclusion
+# check that had already passed on dplyr's (#172).
+#
+# Qualifying the head is what closes it, and it closes every position at once.
+# `dplyr:::summarise_cols()` expands `pick()` syntactically wherever it appears
+# but expands `across()` only in an unnamed top-level dot, so every summary a
+# Margin verb stages -- all of them named -- reached the data mask with its head
+# resolved by ordinary lexical lookup. A qualified head is out of reach of any
+# binding there, and neither static expansion notices the difference: both
+# accept an absent or `dplyr` qualifier, as does dbplyr's `partial_eval()`,
+# which matches these names without examining the qualifier at all.
+#
+# The rebuild goes through `rebuild_static_call()` rather than through
+# `expr[[1L]] <-` for the reason that function's own comment gives: the two
+# spellings a walk reaches for are the ones rlang soft-deprecated on a quosure.
+# No quosure reaches here -- `static_call_name()` answers a `~` call as no name,
+# so recognition never fires on one -- but routing every rebuild through one
+# function is what makes that rule checkable rather than remembered.
+qualify_static_spelling <- function(expr, family, name) {
+  rebuild_static_call(
+    expr,
+    static_call_args(expr),
+    head = rlang::call2(
+      "::",
+      rlang::sym(static_spelling_qualifier(family)),
+      rlang::sym(name)
+    )
+  )
+}

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -185,18 +185,13 @@ rewrite_grouping_expr <- function(expr,
   )
 }
 
+# Which grouping-context helper this call spells, or `NULL` for anything else.
+# It names the family this module rewrites, so the rewrite above asks a question
+# in its own vocabulary rather than quoting a registry key, and the one place
+# that key is written down is here. `test-static-expression-analysis.R` asserts
+# it by name, as one of the analyses that must read a formula as a `~` call.
 grouping_helper_name <- function(expr) {
-  name <- static_call_name(expr)
-  namespace <- static_call_ns(expr)
-  if (
-    !is.null(name) &&
-      name %in% c("grouping_bit", "grouping_id") &&
-      (is.null(namespace) || identical(namespace, "marginplyr"))
-  ) {
-    return(name)
-  }
-
-  NULL
+  static_spelling_name(expr, "grouping")
 }
 
 grouping_helper_vars <- function(args, helper, plan) {

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -711,13 +711,14 @@ grouping_arg_spec <- function(arg, data_vars) {
     return(NULL)
   }
 
-  constructors <- grouping_constructor_names()
-  call_name <- static_call_name(expr)
-  call_ns <- static_call_ns(expr)
+  # The spelling gates evaluation and nothing else: a nested argument is
+  # ambiguous between a tidyselect selection and a nested specification, and
+  # evaluating every nested call would run `starts_with("re")` outside a
+  # selection context. What runs once the gate opens is whatever the name is
+  # bound to, so a constructor is not a Contextual helper even though it is
+  # read statically (ADR 0019).
   is_constructor_call <-
-    !is.null(call_name) &&
-    call_name %in% constructors &&
-    (is.null(call_ns) || identical(call_ns, "marginplyr"))
+    !is.null(static_spelling_name(expr, "grouping_constructor"))
 
   should_evaluate <-
     is_constructor_call ||

--- a/R/share.R
+++ b/R/share.R
@@ -2545,34 +2545,15 @@ share_named_kind <- function(name) {
   kind
 }
 
+# A node that is no call, and a name no share helper carries, both answer
+# `NULL` from the shared reader, which is the answer a guard would have
+# returned.
 share_helper_call_kind <- function(expr) {
-  # A node that is no call answers `NULL` here, which the next line already
-  # turns into the answer a guard would have returned.
-  name <- static_call_name(expr)
-  if (is.null(name)) {
-    return(NULL)
-  }
-  namespace <- static_call_ns(expr)
-  if (!is.null(namespace) && !identical(namespace, "marginplyr")) {
-    return(NULL)
-  }
-  share_named_kind(name)
+  share_named_kind(static_spelling_name(expr, "share"))
 }
 
 share_helper_function_kind <- function(expr) {
-  name <- if (rlang::is_symbol(expr)) {
-    rlang::as_name(expr)
-  } else if (
-    rlang::is_call(expr, "::") &&
-      length(expr) == 3L &&
-      rlang::is_symbol(expr[[2L]], "marginplyr") &&
-      rlang::is_symbol(expr[[3L]])
-  ) {
-    rlang::as_name(expr[[3L]])
-  } else {
-    return(NULL)
-  }
-  share_named_kind(name)
+  share_named_kind(static_spelling_reference_name(expr, "share"))
 }
 
 is_share_helper_call <- function(expr) {
@@ -2645,9 +2626,7 @@ share_request_kinds <- function(requests) {
 is_across_call <- function(expr) {
   # Asked of any expression, not only of a call: a node that is no call has no
   # name, and no name matches.
-  identical(static_call_name(expr), "across") &&
-    (is.null(static_call_ns(expr)) ||
-       identical(static_call_ns(expr), "dplyr"))
+  is_static_spelling_call(expr, "selection", "across")
 }
 
 # `error_call` is the caller's own `across()` call rather than this frame,
@@ -2786,7 +2765,7 @@ contains_selection_predicate <- function(expr) {
   if (!rlang::is_call(expr)) {
     return(FALSE)
   }
-  if (identical(static_call_name(expr), "where")) {
+  if (is_static_spelling_call(expr, "predicate", "where")) {
     return(TRUE)
   }
   any(vapply(

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -228,6 +228,24 @@
 #'
 #' @section Relationship to dplyr summaries:
 #' The `...` expressions use [dplyr::summarize()] data-masking semantics.
+#'
+#' A few spellings mean something only because marginplyr rewrites them before
+#' anything runs. Those are recognized by spelling and are never looked up in
+#' the environment the call was written in, so binding a function of your own
+#' to one of their names does not change what this verb does with it. They are
+#' [grouping_bit()] and [grouping_id()]; [share_of_parent()] and
+#' [share_of_total()]; [dplyr::across()], [dplyr::if_any()],
+#' [dplyr::if_all()], and [dplyr::pick()]; [tidyselect::where()]; and the
+#' branch-local helpers rejected below. A spelling is recognized when the name
+#' matches and it is written bare or qualified with the package that owns it,
+#' so `dplyr::across()` is the same request as `across()` while
+#' `mypkg::across()` is an ordinary call to another package's function.
+#'
+#' Every other name follows ordinary lookup, [dplyr::n()] included, and so do
+#' the Grouping specification constructors: a nested `rollup(region)` is
+#' evaluated because of how it is spelled, but what runs is whatever `rollup`
+#' is bound to where you wrote it.
+#'
 #' [dplyr::across()] and [dplyr::pick()] cannot select any column named in the
 #' complete grouping plan. This extends dplyr's grouping-column rule across
 #' every branch: a dimension remains excluded even in a grouping set from
@@ -245,7 +263,11 @@
 #' rejected. They describe one branch-local grouping or data mask, whereas a
 #' margin result combines several grouping sets and their identifiers, row
 #' positions, or columns would not have one global meaning. Use
-#' [grouping_bit()] and [grouping_id()] to identify margin levels.
+#' [grouping_bit()] and [grouping_id()] to identify margin levels. They are
+#' rejected by spelling like the rest, which is stricter than
+#' [dplyr::summarize()]: a caller who has bound `cur_group_id` to a function
+#' of their own still gets the refusal, because reading that binding would
+#' mean resolving a call head against the calling environment.
 #'
 #' Every rule above reads the expression the data mask evaluates. An expression
 #' captured as language data — the argument of a plainly written

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -126,12 +126,24 @@ check_summary_context_helpers <- function(dots) {
     return(invisible(NULL))
   }
 
+  # `does not support` opens the message deliberately. Six assertions match
+  # that phrase by regular expression rather than by condition class, and it is
+  # still what the message says; the sentence after it is the part #172 added,
+  # because a caller who had bound one of these names themselves was told only
+  # that the verb refused the helper and had no way to learn that their own
+  # function was never going to run (ADR 0019).
   abort_marginplyr(
     paste0(
       "`summarize_with_margins()` does not support ",
       paste0("`", unsupported, "()`", collapse = ", "),
-      ". These helpers describe one branch-local dplyr grouping or data mask, ",
-      "but a margin result combines multiple grouping sets. Use ",
+      if (length(unsupported) == 1L) {
+        ". This spelling is reserved inside a Margin summary and is not "
+      } else {
+        ". These spellings are reserved inside a Margin summary and are not "
+      },
+      "resolved from the calling environment. These helpers describe one ",
+      "branch-local dplyr grouping or data mask, but a margin result ",
+      "combines multiple grouping sets. Use ",
       "`grouping_bit()` or ",
       "`grouping_id()` when identifying margin levels."
     )
@@ -251,23 +263,8 @@ find_summary_context_helpers <- function(expr) {
   }
 
   call_name <- static_call_name(expr)
-  call_ns <- static_call_ns(expr)
-  unsupported <- c(
-    "cur_group",
-    "cur_group_id",
-    "cur_group_rows",
-    "cur_data",
-    "cur_data_all"
-  )
-  found <- if (
-    !is.null(call_name) &&
-      call_name %in% unsupported &&
-      (is.null(call_ns) || identical(call_ns, "dplyr"))
-  ) {
-    call_name
-  } else {
-    character()
-  }
+  refused <- static_spelling_name(expr, "refused")
+  found <- if (is.null(refused)) character() else refused
 
   # The arguments the mask evaluates, and the language the call evaluates. A
   # helper name the caller quoted describes no grouping this call has to
@@ -354,14 +351,21 @@ rewrite_summary_selections <- function(expr,
     }
   )
 
-  call_name <- static_call_name(expr)
-  call_ns <- static_call_ns(expr)
-  is_dplyr_call <- is.null(call_ns) || identical(call_ns, "dplyr")
-  if (!is_dplyr_call) {
+  call_name <- static_spelling_name(expr, "selection")
+  if (is.null(call_name)) {
     return(expr)
   }
 
-  if (!is.null(call_name) && call_name %in% c("across", "if_any", "if_all")) {
+  # The head is qualified before either branch reads the call, so every rebuild
+  # below inherits it through `rebuild_static_call()` and no branch has to
+  # remember. This is what makes the call that executes the call this function
+  # analyzed: an unqualified head reaches the data mask resolved by ordinary
+  # lexical lookup, and a caller's own `across` then ran underneath a
+  # grouping-column exclusion check that had already passed on dplyr's
+  # (#172, ADR 0019).
+  expr <- qualify_static_spelling(expr, "selection", call_name)
+
+  if (call_name %in% c("across", "if_any", "if_all")) {
     return(rewrite_across_selection(
       expr,
       env,
@@ -374,7 +378,17 @@ rewrite_summary_selections <- function(expr,
     return(rewrite_pick_selection(expr, env, data_proxy))
   }
 
-  expr
+  # An invariant, not a Package condition (ADR 0015): the branches above answer
+  # every name the `selection` family holds, so reaching this means a spelling
+  # was registered without a rewrite. Falling through to one of them instead
+  # would rewrite the new spelling as whichever helper happened to be last,
+  # which is a silently wrong selection rather than a missing one.
+  stop(
+    "No rewrite is registered for the selection helper `",
+    call_name,
+    "()`.",
+    call. = FALSE
+  )
 }
 
 # `call_name` is the caller's answer rather than one asked again here. Asking
@@ -514,16 +528,13 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     return(character())
   }
 
-  call_name <- static_call_name(expr)
-  call_ns <- static_call_ns(expr)
-  is_tibble_constructor <-
-    !is.null(call_name) &&
-    call_name %in% c("tibble", "data_frame") &&
-    (is.null(call_ns) || identical(call_ns, "tibble"))
-  is_data_frame_constructor <-
-    identical(call_name, "data.frame") &&
-    (is.null(call_ns) || identical(call_ns, "base"))
-  if (is_tibble_constructor || is_data_frame_constructor) {
+  # Two families rather than one, because the owner differs and the owner is
+  # what recognition tests: tibble owns `tibble()` and `data_frame()`, base
+  # owns `data.frame()`. Neither is a Contextual helper -- nothing rewrites
+  # them, and a caller who binds `tibble` gets their own function -- so what is
+  # read here is only which output names the summary is going to produce
+  # (ADR 0019).
+  if (is_any_static_spelling_call(expr, c("tibble_frame", "base_frame"))) {
     call_args <- static_call_args(expr)
     arg_names <- names(call_args)
     if (is.null(arg_names)) {
@@ -540,10 +551,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     ))
   }
 
-  if (
-    identical(call_name, "pick") &&
-      (is.null(call_ns) || identical(call_ns, "dplyr"))
-  ) {
+  if (is_static_spelling_call(expr, "selection", "pick")) {
     call_args <- static_call_args(expr)
     selection <- if (length(call_args) == 0L) {
       rlang::expr(dplyr::everything())
@@ -553,10 +561,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     return(names(resolve_summary_selection(selection, env, data_proxy)))
   }
 
-  if (
-    identical(call_name, "across") &&
-      (is.null(call_ns) || identical(call_ns, "dplyr"))
-  ) {
+  if (is_static_spelling_call(expr, "selection", "across")) {
     return(known_across_output_names(expr, env, data_proxy))
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -241,7 +241,13 @@ is_name_part <- function(part) {
   !rlang::is_missing(part) && rlang::is_symbol(part)
 }
 
-rebuild_static_call <- function(expr, args) {
+# `head` defaults to the head the node already has, which is what every walk
+# wants: a rewrite of a call's arguments is not a rewrite of what it calls.
+# Passing one is how a recognized spelling is written back qualified
+# (`qualify_static_spelling()`), and it goes through this rather than through
+# `expr[[1L]] <-` so that the quosure and formula attributes are carried across
+# by the one function that knows to carry them.
+rebuild_static_call <- function(expr, args, head = static_call_head(expr)) {
   # An invariant, not a Package condition (ADR-0015): a quosure carries exactly
   # one expression, so rebuilding one around any other number of arguments
   # would attach its class to a `~` call that is not a quosure at all -- an
@@ -250,7 +256,7 @@ rebuild_static_call <- function(expr, args) {
   # arguments `static_call_args()` gave them one to one, and the ones that
   # change an argument count are named `across()` and `pick()` calls.
   stopifnot(!rlang::is_quosure(expr) || length(args) == 1L)
-  rebuilt <- rlang::call2(static_call_head(expr), !!!args)
+  rebuilt <- rlang::call2(head, !!!args)
   # Argument names live in the call's own pairlist tags rather than in an
   # attribute, so this replaces nothing `call2()` just set.
   attributes(rebuilt) <- attributes(expr)

--- a/design/adr/0007-capture-user-expressions-at-public-verbs.md
+++ b/design/adr/0007-capture-user-expressions-at-public-verbs.md
@@ -11,3 +11,8 @@ expose lifecycle helper calls. `nest_with_margins()` and
 `nest_by_with_margins()` capture independently at their public boundaries and
 pass those quosures to one private nest pipeline; neither public verb
 re-injects expressions through the other.
+
+This decision fixes where an expression is captured and whose environment it
+keeps. Which names *inside* a captured expression are resolved from that
+environment, and which are recognized by spelling and rewritten before
+anything runs, is ADR 0019.

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -137,3 +137,11 @@ independent module; they are the grammar used exclusively by Grouping plan
 compilation. Making the Grouping plan opaque at the same time was also
 deferred so rule consolidation is not mixed with changes to executor,
 adapter, and test access to plan fields.
+
+## Related decisions
+
+The constructor names this registry derives are also the spellings that gate
+evaluation of a nested specification argument. ADR 0019 registers every
+statically recognized spelling in one place and derives the constructor family
+from this table rather than restating it, and records why a constructor is not
+a Contextual helper even though its spelling is read before anything runs.

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -1,0 +1,322 @@
+# Resolve Contextual helper names by static spelling
+
+A Margin verb reads some of the names in a caller's expression before anything
+runs, and rewrites what it finds. Which names those are, and whether a caller
+who binds one of them in their own environment changes what the verb does, was
+never written down. Issue #172 recorded the question as a spec conflict: the
+package behaved three different ways across the families of names it reads, and
+two of those disagreed with `dplyr::summarise()` in opposite directions.
+
+This decision states the rule, records the mechanism behind the disagreement,
+and fixes the one family whose execution did not match the analysis already
+running against it.
+
+Evidence: `investigation/contextual-helper-name-resolution.md` for what the
+package and dplyr were measured to do, and
+`investigation/contextual-helper-execution-mechanism.md` for which of dplyr's
+two expansion paths each spelling takes, which is what the fix below rests on.
+
+## Decision
+
+### The rule
+
+> A spelling whose meaning inside a Margin summary arises **only through static
+> rewriting** is a **Contextual helper**: it is recognized by spelling and is
+> never resolved from the calling environment. Every other name follows
+> ordinary lexical and data-mask lookup.
+
+It is stated as a criterion rather than as a list of families so that a name
+added later inherits it without a second rule to keep in step. `CONTEXT.md`
+carries the term.
+
+The criterion is what a name *is*, not what marginplyr happens to look at. A
+spelling marginplyr merely reads is not covered by it: `tibble()`,
+`data.frame()`, and `tibble::data_frame()` are examined by
+`known_summary_output_names()` so that a data-frame-valued summary's output
+names are known before the query is built, but they are ordinary functions that
+really run, and a caller who binds `tibble` gets their own function. Nothing
+about their meaning arises from rewriting, so they are not Contextual helpers
+and this decision does not reserve them.
+
+### Namespace forms
+
+A spelling is recognized when the name matches **and** the namespace is either
+absent or the owning package. Any other qualifier passes through to ordinary
+evaluation, where R answers it. `marginplyr::grouping_id()` and
+`dplyr::cur_group_id()` are recognized; `stats::grouping_id()` and
+`stats::pick()` are not, and fail with R's own "not an exported object" error.
+
+`where()` has two owners, because tidyselect exports it and dplyr re-exports
+it, so both qualifiers are accepted. That is a property of the name and is
+recorded with the name.
+
+### What the criterion decides
+
+| spelling | resolution |
+| --- | --- |
+| `grouping_id`, `grouping_bit` | Contextual helper |
+| `share_of_parent`, `share_of_total` | Contextual helper |
+| `cur_group`, `cur_group_id`, `cur_group_rows`, `cur_data`, `cur_data_all` | Contextual helper — refused |
+| `across`, `if_any`, `if_all`, `pick` | Contextual helper |
+| `where` | Contextual helper |
+| `grouping_set`, `grouping_sets`, `rollup`, `cube`, `grouping_spec` | ordinary lookup; the spelling gates *evaluation only*, in a nested specification position |
+| `n`, and every other name | ordinary lookup |
+
+`n()` is the case that shows the criterion is doing work rather than describing
+a habit. dplyr's `n()` has real semantics that marginplyr does not rewrite, so
+a caller who binds `n` gets their own function, exactly as under
+`dplyr::summarise()`.
+
+The constructor row is the one entry that is not a Contextual helper and is
+still read statically. Its five spellings are the `constructor` fields of
+`grouping_kind_rules()` and are written out here only for the reader; the
+registry derives them, so a sixth kind adds a sixth spelling without this row
+being edited — and `product` is the kind key of `grouping_spec()` rather than a
+spelling of its own. A nested argument of a Grouping specification is
+ambiguous between a tidyselect selection and a nested specification, so
+`grouping_arg_spec()` evaluates a nested call only when its head names a known
+constructor; evaluating every nested call would run `starts_with("re")` outside
+a selection context. The gate therefore decides *whether the argument is
+evaluated at all*, and the caller's own function runs when it is. That is
+ordinary lookup with a static admission test in front of it, not a Contextual
+helper.
+
+### The recognized spellings live in one registry
+
+`static_spelling_rules()` is the single table naming every recognized
+spelling, its owning namespaces, and the family that decides what recognition
+does. Every site that reads one of these spellings derives from it, and their
+namespace test is implemented once inside it rather than repeated at each site.
+Before this decision every reader carried a spelling and a test of its own, and
+one of them — `where`, in `contains_selection_predicate()` — had no namespace
+test at all;
+`investigation/contextual-helper-execution-mechanism.md` tabulates them.
+
+The language-capture primitives are read statically too and stay out of the
+registry, for the reason `design/architecture.md` records: their `base`
+namespace test answers to the calling environment, since a capture is refused
+where the head names a binding the analysis can see, and every family here
+refuses to read the calling environment at all. Putting them under one reader
+would put two rules under it.
+
+The table records per family whether its spellings are Contextual helpers, and
+`contextual_helper_families()` is that subset. The distinction is load-bearing
+rather than descriptive: what a Contextual helper promises is that a caller
+binding cannot win, and asserting that of a constructor would assert the
+opposite of the entry above. Three families are not Contextual helpers: the
+Grouping specification constructors, and the data-frame constructors
+`tibble()`, `tibble::data_frame()`, and `data.frame()`, whose spellings are
+read only to predict a data-frame-valued summary's output names and which run
+whatever the caller has bound.
+
+Every entry in the table is a function, so asking about one family builds that
+family alone. That is not an optimization: the share family derives from
+`share_kind_rules()`, so an eagerly built table would make a
+`grouping_helper_name()` lookup evaluate the contextual-share module for a fact
+that is not about shares — the reach `design/architecture.md` separates on
+#179's authority, arriving one module further out. `test-contextual-helpers.R`
+asserts the laziness rather than trusting it.
+
+The table does not restate what another table already owns. The share family is
+derived from `share_kind_rules()` and the constructor family from
+`grouping_kind_rules()`, both of which existed and were already the
+authoritative description of their helpers; a third helper added to either
+appears in this registry without being written down again. ADR 0008 made the
+grouping kind rules authoritative for the specification grammar, and this
+decision extends that registry's reach to name recognition rather than starting
+a competing list.
+
+### Refusing a shadowed `cur_group_id()` is deliberate
+
+dplyr resolves `cur_group_id()` by ordinary lookup, so refusing one that a
+caller has shadowed is stricter than dplyr. It stays refused. Honouring the
+shadow would mean resolving a call head against the calling environment, which
+is the reflective lookup #130 deliberately declined to perform, and which the
+rule above forbids by construction.
+
+What changes is the diagnostic, which said only that the verb "does not
+support" the helper and left a caller who had bound the name themselves with no
+way to tell why their own function did not run. It now says that the spelling is
+reserved and is not resolved from the calling environment.
+
+The message keeps `does not support` as its opening phrase. Six assertions
+match that phrase by regular expression rather than by condition class, and the
+phrase is still true; nothing is gained by making them all say something else.
+
+### Analysis and execution must agree
+
+The criterion has a consequence that is stronger than a naming rule: if a
+spelling is recognized statically, the code that runs has to be the code the
+analysis read. Otherwise a rule is checked against an expression that does not
+execute, which is what #172 found.
+
+**`across()`, `if_any()`, and `if_all()` did not satisfy this.**
+`find_summary_context_helpers()` and `rewrite_summary_selections()` recognized
+the spelling and checked the grouping-column exclusion rule against it, and a
+caller binding of the same name then ran instead:
+
+```r
+across <- function(...) "CALLER"
+summarize_with_margins(d, k = across(units, sum), .grouping = rollup(region))
+#>   region      k
+#> 1      E CALLER
+```
+
+**The mechanism is in dplyr, and it is not head qualification.**
+`dplyr:::summarise_cols()` processes each dot as `expand_pick()` and then
+`expand_across()`, and the two have different reach:
+
+- `expand_pick_call()` matches `pick` syntactically and descends through every
+  argument of the expression, so a `pick()` anywhere in a dot is expanded
+  before evaluation and no binding can capture it. It stops at `~` and
+  `function`, which is the one position where plain dplyr does let a caller's
+  `pick` run.
+- `expand_across()` returns the quosure untouched unless the dot's **top-level**
+  expression is a call to `across` **and** the dot is unnamed. A named dot
+  (`k = across(...)`), a nested `across()` (`ncol(across(...))`), and every
+  `if_any()`/`if_all()` in a summary are left to be evaluated in the data mask,
+  where the head resolves by ordinary lexical lookup from the quosure
+  environment.
+
+Every summary marginplyr stages is a named dot, so it always took the second
+path. The asymmetry with `pick()` was never about the call head — both rewrites
+end in `rebuild_static_call()`, which preserves it — but about which of dplyr's
+two paths the dot reached. Measured against dplyr 1.2.1 and recorded in
+`investigation/contextual-helper-execution-mechanism.md`.
+
+**The fix is to qualify the recognized head.** A recognized `across`, `if_any`,
+`if_all`, or `pick` is rebuilt as `dplyr::across` and so on, so the call that
+executes names the function the analysis read. Qualification is chosen because
+it is the smallest change that closes every position at once: it settles the
+runtime lookup in the data mask, and it does not disturb dplyr's own static
+expansion, which accepts an absent or `dplyr` qualifier alike. dbplyr's
+`partial_eval()` matches these four names without examining the qualifier, so
+lazy backends are unaffected by the change.
+
+Marginplyr's own walk descends into a `function` or `~` written as an
+*argument*, where dplyr's expansion does not, so qualification also makes those
+positions agree — a place where marginplyr previously analysed a helper that
+plain dplyr would have let a binding capture.
+
+It does not descend into a function literal used as a *call head*:
+`(function() cur_group_id())()` has no readable name, so the walk reads it as a
+call to nothing and never visits the body. That blind spot is uniform — the
+analysis and the execution agree, because neither sees it — so it is not the
+disagreement this decision fixes, and it is not introduced by it. It is the
+same conservative reading of a computed head that "Boundary for callable
+identity" above records, and it belongs to #178's question rather than this
+one.
+
+The marginplyr-owned helpers need nothing here. `grouping_id()`,
+`grouping_bit()`, `share_of_parent()`, and `share_of_total()` are error stubs
+whose bodies raise; inside a Margin verb they are rewritten away and the
+function object is never called, so there is no execution for an analysis to
+disagree with.
+
+### Boundary for callable identity
+
+Identity here is **syntactic**, never environmental. `(grouping_id)(region)` is
+the same spelling through transparent parentheses, and treating it as such is a
+change to what counts as the same written call. `get("grouping_id")(region)`
+and a caller binding both require reading the environment, and stay outside the
+rule under the conservative #130 policy.
+
+#178 asks for the parenthesized form to be recognized. This decision fixes its
+reading in advance so that it is a change to spelling normalization and not a
+first step toward environmental resolution. Parenthesis transparency is not
+implemented here.
+
+### Recorded behaviour changes
+
+Three, all of them a name resolving differently. `DESCRIPTION`'s
+`Config/marginplyr/cran-status` reads `unpublished`, so no released version
+carried any of the old behaviour.
+
+**A shadowed `across`, `if_any`, or `if_all` now runs dplyr's helper.** This is
+the change the decision is for, and the one the acceptance criteria name.
+
+**A shadowed `pick` now runs dplyr's `pick()` in a `~` lambda or a `function`
+body.** dplyr's `expand_pick_call()` returns early on both, so a caller's
+binding used to run there while marginplyr's own walk — which descends into
+both — had already analysed the call. It is the same disagreement as the first
+change, in the one position where plain dplyr has it too, and qualification
+closes it in the same motion.
+
+**A `where()` qualified with a package that does not own it is no longer read
+as a selection predicate.** `contains_selection_predicate()` matched the name
+with no namespace test at all, so `mypkg::where(...)` inside a contextual
+share's `across()` tripped a refusal written for tidyselect's. Bringing it
+under the namespace rule is what makes the rule uniform; the cost is that such
+a call now reaches ordinary evaluation, which is what the rule says it should
+have done all along.
+
+## Test strategy
+
+The regression tests derive their cases from `static_spelling_rules()` rather
+than enumerating spellings, so a spelling added to the registry is covered
+without editing the tests. Each registered spelling is exercised unqualified,
+namespace-qualified, under a foreign qualifier, and against every other
+family; each Contextual helper is additionally exercised with a caller binding
+of the same name in scope, on a local input and on a lazy one.
+
+A behaviour case needs a call to write, which no rule can derive, so the probe
+that supplies one per helper is asserted to cover exactly the registered
+Contextual helpers. That assertion is what keeps the derivation honest: a
+spelling registered with no probe fails there rather than being silently
+uncovered, which is the failure a hand-maintained list produces.
+
+An enumeration of demonstrated spellings was rejected for the reason
+`verify-site.R` derives its page list: a list that is maintained by hand
+records what someone remembered to add, and the failure it has to catch is a
+spelling nobody remembered.
+
+## Considered options
+
+**Resolving a Contextual helper from the calling environment, matching dplyr's
+treatment of `cur_group_id()`.** Rejected. It is the reflective lookup #130
+declined, it cannot be done at all for the four marginplyr helpers, whose
+function objects only raise, and it would make the analysis a Margin verb runs
+before execution depend on bindings that analysis cannot see.
+
+**Leaving `across()` as it was and removing the static rules checked against
+it.** Rejected: the grouping-column exclusion rule is the rule
+`summarize_with_margins()` exists to extend across grouping sets, and it has to
+be checked before a query is built (ADR 0005).
+
+**Rewriting the head to a call to the function object rather than to a
+qualified name.** Rejected: a call whose head is a function value is not
+readable by dbplyr's `partial_eval()` or by dplyr's own expansion, both of
+which match a name, so it would trade a caller-binding problem for a backend
+problem.
+
+**Refusing a summary that shadows a Contextual helper.** Rejected: the shadow is
+often incidental — a caller with their own `pick` used elsewhere in a script —
+and refusing the call teaches nothing the Contextual helper rule does not
+already say.
+
+**Registering the data-frame constructors (`tibble()`, `data.frame()`)
+alongside the helpers**, since they too are read statically. Rejected above:
+they really run, so reserving them would change behaviour rather than describe
+it.
+
+## Related decisions
+
+- ADR 0007 fixes where a caller's expressions are captured. This decision
+  covers how names inside those captured expressions are resolved.
+- ADR 0008 makes the grouping kind rules authoritative for the specification
+  grammar; the constructor spellings this decision reads are derived from that
+  registry.
+- ADR 0005 requires locally decidable errors before a backend read, which is
+  why the recognized spellings are read statically at all.
+- ADR 0015 separates Package conditions from internal invariants; the refusal
+  diagnostic reworded here is a Package condition.
+- `design/architecture.md` gains the registry as a module and records why it
+  builds one family at a time.
+- #190 is split out of #172 and is not decided here. Nested specification
+  positions refuse a genuine `margin_grouping_spec` returned by a caller's own
+  function, with a diagnostic saying the object is the wrong kind for a
+  position where it is exactly the right kind. It sits one layer below this
+  rule — the gate above decides whether the argument is evaluated, and #190 is
+  about what happens to the value once it is.
+- #178 is the parenthesized spelling, bounded by "Boundary for callable
+  identity" above.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -136,6 +136,44 @@ dependency runs one way: a reader that lived in `R/share.R` would make the
 grouping-context rewrite reach into the contextual-share module for a fact
 that is not about shares (#179).
 
+### Recognized spellings (`R/contextual-helpers.R`)
+
+Owns which names a Margin verb recognizes before anything runs, and decides
+nothing about what recognition then does. One table keyed by family carries
+each family's spellings, the namespaces a recognized call may be qualified
+with, and whether its spellings are Contextual helpers; every site that reads
+one of those spellings derives from it, and their namespace test exists only
+here (ADR 0019).
+
+The language-capture primitives are read statically too and are deliberately
+not among them. `language_capture_formal()` and `captured_call_parts()` above
+carry `quote`, `substitute`, and `expression` with a `base` namespace test of
+their own, and it is a different test: a capture is refused where the head
+names a binding the analysis can see, so it answers to the calling environment
+where every family in the registry refuses to.
+
+Two families derive their spellings from the module that owns them —
+contextual shares from `share_kind_rules()`, Grouping specification
+constructors from `grouping_kind_rules()` — so a helper added to either is
+recognized without being written down twice. This module therefore reads two
+deep modules as well as `R/utils.R`, and both of those two read it back;
+stated baldly that is a cycle, and what keeps it from being one in practice is
+that every entry in the table is a function, so a family lookup evaluates that
+family's owner and no other. `R/utils.R` is not part of it: the dependency on
+it runs one way, as it does from everything else.
+
+That is the property worth checking rather than the layering, because the
+layering alone would not say which module reaches which. Under it, the only
+module that evaluates `share_kind_rules()` through this table is `R/share.R`
+itself, asking about the spellings it owns — a module reading its own table
+through a shared reader, which is what the section above describes rather than
+what it forbids. What it forbids is the grouping-context rewrite reaching into
+the contextual-share module for a fact that is not about shares, and a
+`grouping_helper_name()` lookup evaluates the grouping family alone. Built
+eagerly it would evaluate every family the table holds, which is that reach
+arriving one module further out; `test-contextual-helpers.R` asserts it does
+not.
+
 ### Contextual shares (`R/share.R`)
 
 One deep private module owns every contextual-share responsibility: request

--- a/investigation/contextual-helper-execution-mechanism.md
+++ b/investigation/contextual-helper-execution-mechanism.md
@@ -1,0 +1,131 @@
+# Which dplyr path a contextual helper spelling takes
+
+Investigated: 2026-08-15
+
+`investigation/contextual-helper-name-resolution.md` established that a
+shadowed `across()` inside a Margin summary ran the caller's function while a
+shadowed `pick()` reached dplyr's semantics, and recorded that the mechanism
+behind that asymmetry "was **not** established", ruling out head qualification
+because both rewrites end in `rebuild_static_call()`, which preserves the call
+head. It asked that an implementation establish the mechanism rather than
+assume it. This note is that work.
+
+Measured against dplyr **1.2.1** and dbplyr **2.6.0**, on R 4.6.1,
+aarch64-apple-darwin23. The predecessor note's findings were taken on dplyr
+1.1.4, so one of its rows is revisited below. Every result was produced by
+running the call or by reading the installed source, not by inference.
+
+## The mechanism is in dplyr, and it is not head qualification
+
+The predecessor's reasoning about `rebuild_static_call()` was right, and the
+cause is that marginplyr does not distinguish the two paths at all — dplyr
+does. `dplyr:::summarise_cols()` processes each dot as `expand_pick(dot, mask)`
+and then `expand_across(dot)`, and the two have different reach:
+
+- `dplyr:::expand_pick_call()` matches
+  `is_call(expr, name = "pick", ns = c("", "dplyr"))` and descends through every
+  argument, so a `pick()` anywhere in a dot is expanded before evaluation and no
+  binding can capture it. It returns early on
+  `is_call(expr, name = c("~", "function"))`.
+- `dplyr:::expand_across()` returns the quosure unchanged unless the dot's
+  top-level expression is a call to `across` **and**
+  `attr(quo, "dplyr:::data")$is_named` is `FALSE`. Nothing in it looks at
+  `if_any` or `if_all`; `dplyr:::expand_if_across()` is reached from
+  `filter_expand()` and not from a summary.
+
+Every summary a Margin verb stages is a named dot, so `across()` always took
+the second path and reached the data mask with its head resolved by ordinary
+lexical lookup.
+
+Four runs pin the boundary, all under `across <- function(...) "CALLER"` and
+`pick <- function(...) "CALLER"` with plain `dplyr::summarise()`:
+
+| call | result |
+| --- | --- |
+| `summarise(g, across(c(units, qty), sum))` — unnamed | package won |
+| `summarise(g, k = across(units, sum))` — named | caller binding won |
+| `summarise(g, k = ncol(pick(units)))` | package won |
+| `summarise(g, k = (function() pick(units))())` | caller binding won |
+
+The last row is the `function` early return, and it is the one position where
+plain dplyr lets a caller's `pick` run.
+
+## One predecessor row is revisited
+
+The predecessor's table reports that plain dplyr under a shadow let the caller
+binding win for `pick()`. At 1.2.1 that holds only inside a `~` or a
+`function`; a `pick()` anywhere else is expanded syntactically and the package
+wins, as the third row above shows. The form the predecessor measured is not
+recorded there, so what changed — the dplyr version, or the shape of the probe
+— was not determined. Whether 1.1.4 behaved differently was not tested, and no
+1.1.4 library was available to test it against.
+
+Nothing else in the predecessor's tables was contradicted.
+
+## marginplyr's walk reaches further than dplyr's expansion
+
+`captured_call_parts()` excludes only plainly written `quote()`-family
+captures, so marginplyr's own walk descends into a `function` or a `~` written
+as an argument. It therefore analysed helpers in a position where dplyr's
+expansion does not reach, which is a second place the analysis and the
+execution disagreed, and one the predecessor did not look at.
+
+The reach stops short of a function literal used as a *call head*. Measured:
+`summarize_with_margins(d, k = (function(z) dplyr::cur_group_id())(1),
+.grouping = rollup(region))` returned values rather than the refusal, because
+`static_call_name()` answers a call whose head is itself a call as no name and
+the walk maps over arguments alone, so the body is never visited. Nothing
+inside such a literal is analysed or rewritten, which makes the blind spot
+uniform rather than a disagreement.
+
+## Head qualification was measured to close every position
+
+Under the same shadows, `dplyr::across`, `dplyr::if_any`, `dplyr::if_all`, and
+`dplyr::pick` each ran dplyr's function in the named, nested, and lambda
+positions, and the unnamed top-level `dplyr::across()` was still expanded
+statically — both dplyr entry points accept `ns = c("", "dplyr")`.
+
+`dbplyr:::partial_eval()` matches all four names with `is_call(call, "across")`
+and no `ns` argument, and `rlang::is_call()` documents that a `NULL` namespace
+does not participate in the match; `is_call(quote(dplyr::across(x)), "across")`
+was confirmed `TRUE`. Runs on local, dtplyr, and DuckDB inputs then agreed
+value for value between the shadowed and unshadowed calls for `across()`,
+`if_any()`, `if_all()`, and `pick()`.
+
+## Nine functions read a spelling, not four
+
+The predecessor lists four, and adds `grouping_arg_spec()` in passing as a
+fifth. Counted at `7f73d5e` by grepping `R/` for each recognized spelling as a
+string literal and following every match to the function containing it, then
+reading each of those for how it tested the namespace. Starting from the
+namespace test instead would have missed the one function that has none, which
+is the row the count exists to surface. Nine functions across four files read a
+spelling:
+
+| function | file | spellings | namespace test |
+| --- | --- | --- | --- |
+| `grouping_helper_name()` | `R/grouping-context.R` | `grouping_bit`, `grouping_id` | `marginplyr` |
+| `find_summary_context_helpers()` | `R/summary-selections.R` | the five `cur_*` | `dplyr` |
+| `rewrite_summary_selections()` | `R/summary-selections.R` | `across`, `if_any`, `if_all`, `pick` | `dplyr` |
+| `known_data_frame_output_names()` | `R/summary-selections.R` | `tibble`, `data_frame`, `data.frame`, `pick`, `across` | four separate tests |
+| `share_helper_call_kind()` | `R/share.R` | derived from `share_kind_rules()` | `marginplyr` |
+| `share_helper_function_kind()` | `R/share.R` | the same, in reference position | `marginplyr`, written as `is_symbol(expr[[2L]], "marginplyr")` |
+| `is_across_call()` | `R/share.R` | `across` | `dplyr` |
+| `contains_selection_predicate()` | `R/share.R` | `where` | **none** |
+| `grouping_arg_spec()` | `R/grouping-plan.R` | derived from `grouping_kind_rules()` | `marginplyr` |
+
+Eleven namespace tests among them, four of those inside
+`known_data_frame_output_names()` alone, and one function with none. Two
+derived their spellings from a rules table; the rest wrote them out.
+
+The `tibble()` and `data.frame()` rows are read statically for their output
+names and are never rewritten, which is why they are the one group here whose
+recognition changes nothing about what runs.
+
+## Reproduction
+
+The probe scripts are not committed. Each was a `pkgload::load_all(".")` or a
+bare `library(dplyr)` followed by `tryCatch()` around the calls in the tables
+above, printing the result or the condition's message. The source readings were
+`print(dplyr:::summarise_cols)`, `print(dplyr:::expand_across)`,
+`print(dplyr:::expand_pick_call)`, and `print(dbplyr:::partial_eval)`.

--- a/investigation/contextual-helper-name-resolution.md
+++ b/investigation/contextual-helper-name-resolution.md
@@ -1,6 +1,7 @@
 # Contextual helper name resolution
 
 Investigated: 2026-08-15
+Revised: 2026-08-15 — investigation/contextual-helper-execution-mechanism.md
 
 Evidence gathered for #172, which asks whether an unqualified contextual
 helper spelling inside a Margin summary is reserved syntax or an ordinary
@@ -63,6 +64,21 @@ dplyr's semantics while the shadowed `across()` did not. Whatever the cause, it
 was not read out of the source during this investigation, and an implementation
 should establish it rather than assume the two paths differ only in the branch
 they take at `:364` and `:373`.
+
+## Revisions (2026-08-15)
+
+`investigation/contextual-helper-execution-mechanism.md` establishes the
+mechanism the section above records as "**not** established", and revisits one
+row of the plain-dplyr table.
+
+The asymmetry is decided inside dplyr, not by anything marginplyr writes: a
+`pick()` spelling is expanded syntactically wherever it appears except under a
+`~` or a `function`, while an `across()` spelling is expanded only in an
+unnamed top-level dot — and every summary a Margin verb stages is a named dot.
+The successor note also finds that this note's plain-dplyr `pick()` row holds
+at dplyr 1.2.1 only inside a `~` or a `function`, and that nine functions read
+a spelling rather than the four listed below, carrying eleven namespace tests
+between them.
 
 ## Nested constructor positions refuse a genuine specification
 

--- a/investigation/contextual-helper-name-resolution.md
+++ b/investigation/contextual-helper-name-resolution.md
@@ -1,0 +1,157 @@
+# Contextual helper name resolution
+
+Investigated: 2026-08-15
+
+Evidence gathered for #172, which asks whether an unqualified contextual
+helper spelling inside a Margin summary is reserved syntax or an ordinary
+lexical lookup. The ticket records the question as a SPEC CONFLICT and does not
+answer it. This note records what the package and dplyr were measured to do, so
+that the decision — which belongs in an ADR, not here — rests on behaviour
+rather than on the historical safety rationale the ticket says is insufficient.
+
+Measured against `7f73d5e` with `pkgload::load_all(".")`, dplyr 1.1.4,
+tidyselect 1.2.1, R 4.6.1, aarch64-apple-darwin23. Every row below was produced
+by running the call, not by reading the source.
+
+## What was measured
+
+Each spelling was called three ways inside `summarize_with_margins()`: bare,
+namespace-qualified, and with a caller binding of the same name in scope
+(`f <- function(...) "CALLER"`). The same three were run against plain
+`dplyr::summarise()` for comparison.
+
+| spelling | plain dplyr under a shadow | marginplyr under a shadow |
+| --- | --- | --- |
+| `n()` | caller binding won | caller binding won |
+| `where()` | package won | package won |
+| `cur_group_id()` | **caller binding won** | **package won** — refused |
+| `cur_group()`, `cur_group_rows()`, `cur_data()`, `cur_data_all()` | not measured individually | refused, same message |
+| `pick()` | **caller binding won** | **package won** — dplyr semantics, argument rewritten |
+| `across()` | **package won** | **caller binding won** — `"CALLER"` returned |
+| `grouping_id()`, `grouping_bit()` | n/a | package won |
+| `share_of_parent()`, `share_of_total()` | n/a | package won |
+| `rollup()`, `cube()`, and the other constructors | n/a | caller binding was evaluated; refused on the returned object's class |
+
+Two of these rows disagree with dplyr, and they disagree in opposite
+directions: marginplyr refused a shadowed `cur_group_id()` and a shadowed
+`pick()` that dplyr honoured, and honoured a shadowed `across()` that dplyr
+refused.
+
+## The `across()` row is an analysis/execution disagreement
+
+`find_summary_context_helpers()` and the `across` branch of
+`rewrite_summary_selection()` (`R/summary-selections.R:249`, `:364`) recognize
+the spelling statically and check the grouping-column exclusion rule against
+it. The measured result showed the check running and the caller's function
+executing anyway:
+
+```r
+across <- function(...) "CALLER"
+summarize_with_margins(d, k = across(units, sum), .grouping = rollup(region))
+#>   region      k
+#> 1      E CALLER
+```
+
+So the grouping-column exclusion rule was evaluated against an expression that
+did not run, and a caller binding was sufficient to reach execution without it.
+
+The mechanism behind the asymmetry with `pick()` was **not** established.
+`rewrite_pick_selection()` (`R/summary-selections.R:461`) ends in
+`rebuild_static_call()`, which preserves the original call head, so head
+qualification does not on its own explain why the shadowed `pick()` reached
+dplyr's semantics while the shadowed `across()` did not. Whatever the cause, it
+was not read out of the source during this investigation, and an implementation
+should establish it rather than assume the two paths differ only in the branch
+they take at `:364` and `:373`.
+
+## Nested constructor positions refuse a genuine specification
+
+A caller function that returns a real `margin_grouping_spec` was accepted at
+the top level of `.grouping` and refused when nested:
+
+```r
+my_spec <- function(...) rollup(...)
+
+summarize_with_margins(d, t = sum(units), .grouping = my_spec(region))
+#> works
+
+summarize_with_margins(d, t = sum(units),
+                       .grouping = grouping_sets(my_spec(region), grade))
+#> Error: Can't select columns with `my_spec(region)`.
+#> x `my_spec(region)` must be numeric or character, not a <margin_grouping_spec> object.
+```
+
+`grouping_arg_spec()` (`R/grouping-plan.R:701-735`) evaluates a nested argument
+only when its call head is a known constructor spelling, when it is a symbol,
+or when it is not language. Anything else falls through to tidyselect, which
+then reports the specification as the wrong kind of object for a position where
+a specification is exactly what belongs.
+
+The name gate is load-bearing rather than incidental: a nested argument is
+ambiguous between a tidyselect selection and a nested specification, and
+evaluating every nested call would run selections such as `starts_with("re")`
+outside a selection context. A pre-built specification passed by symbol was
+measured to work, which is the workaround the diagnostic does not mention.
+
+## The marginplyr helpers have no runtime semantics to fall back to
+
+`grouping_id()`, `grouping_bit()` (`R/grouping-context.R:100`, `:108`),
+`share_of_parent()` and `share_of_total()` (`R/share.R:561`, `:573`) are error
+stubs whose bodies are a single `abort_marginplyr()` call. Outside a Margin
+verb they raise; inside one they are recognized statically and rewritten, and
+the function object is never called. A caller binding of one of these names was
+therefore the only way to obtain a callable of that name, and it was measured
+to be ignored.
+
+## Where the recognized spellings were written down
+
+Four sites carried a list of names, each with its own namespace test, and no
+site derived from another:
+
+- `grouping_helper_name()` — `R/grouping-context.R:188`; `grouping_bit`,
+  `grouping_id`; namespace `NULL` or `marginplyr`.
+- `find_summary_context_helpers()` — `R/summary-selections.R:249`; the five
+  refused `cur_*` spellings; namespace `NULL` or `dplyr`.
+- `rewrite_summary_selection()` — `R/summary-selections.R:357-377`; `across`,
+  `if_any`, `if_all`, `pick`; namespace `NULL` or `dplyr`.
+- `share_helper_call_kind()` — `R/share.R:2548`; derived from
+  `share_kind_rules()` through `share_named_kind()`; namespace `NULL` or
+  `marginplyr`.
+
+`grouping_constructor_names()` (`R/grouping-plan.R:683`) derives from
+`grouping_kind_rules()`, and `share_named_kind()` from `share_kind_rules()`, so
+the derived-table pattern the repository prefers already existed in two of the
+five places a spelling was read.
+
+The namespace test was uniform across all four sites and was measured to hold:
+`marginplyr::grouping_id()` and `dplyr::cur_group_id()` were recognized, while
+`stats::grouping_id()`, `stats::pick()`, `stats::share_of_total()` and
+`stats::where()` all fell through to ordinary evaluation and failed with R's
+own "not an exported object" error.
+
+## What was searched for and not found
+
+- **No snapshot asserts the refusal message.** `grep` over
+  `tests/testthat/_snaps/` for `cur_group` and for `does not support` matched
+  nothing, so changing that message breaks no snapshot.
+- **Six assertions anchor on the phrase `does not support`**, by regular
+  expression rather than by condition class:
+  `test-grouping-interface.R:957`, `:965`, `:973`, `:981`,
+  `test-static-expression-analysis.R:484`, `:3317`, and
+  `test-summarize-operation.R:286`. A rewording that drops that phrase changes
+  those assertions; one that keeps it as the opening does not.
+- **A data column named `grouping_id` was not affected.** It is a symbol rather
+  than a call, and summing it worked, so the reserved spellings were measured
+  to reserve the call position only.
+- **A computed head was refused, and so was a redundantly parenthesized one.**
+  `get("grouping_id")(region)` and `(grouping_id)(region)` both reached the
+  stub's error. The first is the conservative #130 policy behaving as designed;
+  the second is #178.
+
+## Reproduction
+
+The four probe scripts this note was written from are not committed. Each was a
+short `pkgload::load_all(".")` followed by `tryCatch()` around the calls in the
+tables above, printing the result or the condition's class and message. Every
+result quoted here can be reproduced by running any single call from this note
+in a session with the working tree loaded.

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -279,6 +279,24 @@ package.
 \section{Relationship to dplyr summaries}{
 
 The \code{...} expressions use \code{\link[dplyr:summarize]{dplyr::summarize()}} data-masking semantics.
+
+A few spellings mean something only because marginplyr rewrites them before
+anything runs. Those are recognized by spelling and are never looked up in
+the environment the call was written in, so binding a function of your own
+to one of their names does not change what this verb does with it. They are
+\code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}}; \code{\link[=share_of_parent]{share_of_parent()}} and
+\code{\link[=share_of_total]{share_of_total()}}; \code{\link[dplyr:across]{dplyr::across()}}, \code{\link[dplyr:if_any]{dplyr::if_any()}},
+\code{\link[dplyr:if_all]{dplyr::if_all()}}, and \code{\link[dplyr:pick]{dplyr::pick()}}; \code{\link[tidyselect:where]{tidyselect::where()}}; and the
+branch-local helpers rejected below. A spelling is recognized when the name
+matches and it is written bare or qualified with the package that owns it,
+so \code{dplyr::across()} is the same request as \code{across()} while
+\code{mypkg::across()} is an ordinary call to another package's function.
+
+Every other name follows ordinary lookup, \code{\link[dplyr:n]{dplyr::n()}} included, and so do
+the Grouping specification constructors: a nested \code{rollup(region)} is
+evaluated because of how it is spelled, but what runs is whatever \code{rollup}
+is bound to where you wrote it.
+
 \code{\link[dplyr:across]{dplyr::across()}} and \code{\link[dplyr:pick]{dplyr::pick()}} cannot select any column named in the
 complete grouping plan. This extends dplyr's grouping-column rule across
 every branch: a dimension remains excluded even in a grouping set from
@@ -296,7 +314,11 @@ Use a new summary name, or rename the grouping column before this call.
 rejected. They describe one branch-local grouping or data mask, whereas a
 margin result combines several grouping sets and their identifiers, row
 positions, or columns would not have one global meaning. Use
-\code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}} to identify margin levels.
+\code{\link[=grouping_bit]{grouping_bit()}} and \code{\link[=grouping_id]{grouping_id()}} to identify margin levels. They are
+rejected by spelling like the rest, which is stricter than
+\code{\link[dplyr:summarize]{dplyr::summarize()}}: a caller who has bound \code{cur_group_id} to a function
+of their own still gets the refusal, because reading that binding would
+mean resolving a call head against the calling environment.
 
 Every rule above reads the expression the data mask evaluates. An expression
 captured as language data — the argument of a plainly written

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -1,0 +1,487 @@
+# The regression suite for ADR 0019. Every case below is derived from
+# `static_spelling_rules()` rather than written out, because the failure this
+# has to catch is a spelling nobody remembered: an enumeration records what
+# someone thought to add, and a registry entry with no coverage is exactly the
+# entry that reintroduces #172.
+#
+# Two layers, because they fail differently. The reader assertions run over
+# every registered spelling and every namespace form and need no data, so they
+# hold for a spelling whose end-to-end shape nobody has written yet. The
+# behaviour assertions need a call to write, which no rule can derive; the
+# probe table below supplies one per Contextual helper and is checked against
+# the registry, so a spelling added without a probe fails here rather than
+# going uncovered.
+
+# A data frame every probe reads. Two numeric columns so that a selection can
+# select more than one, and two dimensions so that a rollup and a cube of them
+# differ -- which is what the constructor case below needs to tell a caller's
+# own function from the package's.
+contextual_probe_data <- function() {
+  data.frame(
+    region = c("E", "E", "W", "W"),
+    grade = c("a", "b", "a", "b"),
+    units = c(1, 2, 3, 4),
+    qty = c(4, 5, 6, 7),
+    stringsAsFactors = FALSE
+  )
+}
+
+# One call per Contextual helper, as an expression rather than as a closure.
+# It has to be an expression because the shadow the assertions install is a
+# binding in the environment the summary is *written* in: a probe that closed
+# over its own environment would capture its quosures there and never see the
+# binding, which is the shape a first draft of this file had and which passes
+# whatever the package does.
+#
+# `head` is how the three writings differ -- a bare symbol, a qualified call,
+# or a foreign qualifier -- and `.probe_data` is the symbol the input is bound
+# to in the evaluation environment.
+#
+# Every name below sits inside a defused expression, so `codetools` reads the
+# input symbol and the grouping columns as undefined globals.
+# nolint start: object_usage_linter.
+contextual_probes <- function() {
+  summary_probe <- function(build) {
+    function(head) {
+      rlang::expr(summarize_with_margins(
+        .probe_data,
+        k = !!build(head),
+        .grouping = rollup(region),
+        .sort = "last"
+      ))
+    }
+  }
+  share_probe <- function(head) {
+    rlang::expr(summarize_with_margins(
+      .probe_data,
+      t = sum(units),
+      k = !!rlang::call2(head, quote(t)),
+      .grouping = rollup(region),
+      .sort = "last"
+    ))
+  }
+  arguments <- function(...) {
+    args <- rlang::exprs(...)
+    function(head) rlang::call2(head, !!!args)
+  }
+
+  list(
+    # A per-branch constant, so the value itself is what a caller binding would
+    # have replaced.
+    grouping_bit = summary_probe(arguments(region)),
+    grouping_id = summary_probe(arguments(region)),
+    share_of_parent = share_probe,
+    share_of_total = share_probe,
+    # Wrapped so that the selection helper's own result reaches the summary as
+    # a scalar. A caller binding answering a string is then a different value
+    # or an error rather than a differently shaped result, which is what makes
+    # the two outcomes comparable.
+    across = summary_probe(function(head) {
+      rlang::expr(ncol(!!rlang::call2(head, quote(c(units, qty)), quote(sum))))
+    }),
+    pick = summary_probe(function(head) {
+      rlang::expr(ncol(!!rlang::call2(head, quote(units))))
+    }),
+    if_any = summary_probe(function(head) {
+      rlang::expr(sum(!!rlang::call2(head, quote(units), quote(~ .x > 1))))
+    }),
+    if_all = summary_probe(function(head) {
+      rlang::expr(sum(!!rlang::call2(head, quote(units), quote(~ .x > 1))))
+    }),
+    # A selection predicate in a contextual share's `across()` selection, which
+    # is the one position the `predicate` family decides. It has to be the full
+    # share `across()` grammar -- an explicit `.names`, the helper as `.fns` --
+    # because a shorter spelling is refused by the source-shape rule before
+    # `contains_selection_predicate()` is ever reached, and a probe rejected
+    # upstream of the code under test asserts nothing about it.
+    #
+    # The share is refused here, so this probe compares diagnostics rather than
+    # values, which is the other half of what a Contextual helper promises.
+    where = function(head) {
+      rlang::expr(summarize_with_margins(
+        .probe_data,
+        t = sum(units),
+        u = sum(qty),
+        dplyr::across(
+          !!rlang::call2(head, quote(is.numeric)),
+          share_of_total,
+          .names = "{.col}_share"
+        ),
+        .grouping = rollup(region),
+        .sort = "last"
+      ))
+    },
+    cur_group = summary_probe(arguments()),
+    cur_group_id = summary_probe(arguments()),
+    cur_group_rows = summary_probe(arguments()),
+    cur_data = summary_probe(arguments()),
+    cur_data_all = summary_probe(arguments())
+  )
+}
+# nolint end
+
+# Every spelling the registry holds, in one flat table of family and name, so
+# that a loop over it covers a family added later without being told about it.
+contextual_registry_table <- function(families = static_spelling_families()) {
+  rows <- lapply(
+    families,
+    function(family) {
+      lapply(
+        static_spelling_names(family),
+        function(name) list(family = family, name = name)
+      )
+    }
+  )
+  unlist(rows, recursive = FALSE)
+}
+
+# The environment a probe is evaluated in: the package namespace, plus the
+# input, plus optionally a binding of the spelling under test. The namespace is
+# the parent rather than this file's environment so that the binding really is
+# the only difference between the two calls each assertion makes -- a test-local
+# name reachable from one and not the other would be a second difference
+# nothing declared. Everything a probe names resolves through it: the verb and
+# `rollup()` are exported, and `sum()` and `ncol()` reach base along the
+# namespace's own parents.
+contextual_probe_env <- function(data, shadow = NULL) {
+  env <- rlang::new_environment(parent = rlang::ns_env("marginplyr"))
+  rlang::env_bind(env, .probe_data = data)
+  if (!is.null(shadow)) {
+    rlang::env_bind(env, !!shadow := function(...) "CALLER")
+  }
+  env
+}
+
+# What a probe did, in a form two writings can be compared by. An error is
+# reported as its message rather than propagated, because a family that refuses
+# its spelling has to refuse all three writings identically, which is an
+# agreement between messages and not the absence of one.
+contextual_probe_outcome <- function(expr, data, shadow = NULL) {
+  env <- contextual_probe_env(data, shadow = shadow)
+  tryCatch(
+    list(value = as.data.frame(collect_probe_result(
+      rlang::eval_bare(expr, env)
+    ))),
+    error = function(cnd) list(error = conditionMessage(cnd))
+  )
+}
+
+collect_probe_result <- function(result) {
+  if (is.data.frame(result)) {
+    return(result)
+  }
+  dplyr::collect(result)
+}
+
+test_that("the probe table covers exactly the Contextual helper spellings", {
+  # The assertion that makes every loop below derived rather than enumerated:
+  # a spelling added to `static_spelling_rules()` with no probe fails here, and
+  # a probe naming no registered spelling fails here too, so neither side can
+  # drift ahead of the other.
+  registered <- vapply(
+    contextual_registry_table(contextual_helper_families()),
+    `[[`,
+    character(1),
+    "name"
+  )
+  expect_setequal(names(contextual_probes()), registered)
+  # Every loop iterates over this set, so a set that arrived empty is a set
+  # that passes.
+  expect_gt(length(registered), 0L)
+  # And the registry holds more than the helpers, which is what the constructor
+  # case below exists for.
+  expect_gt(length(contextual_registry_table()), length(registered))
+})
+
+test_that("a registered spelling is recognized bare and under every owner", {
+  for (entry in contextual_registry_table()) {
+    expect_identical(
+      static_spelling_name(rlang::call2(entry$name), entry$family),
+      entry$name,
+      info = paste(entry$family, entry$name)
+    )
+    for (namespace in static_spelling_namespaces(entry$family)) {
+      qualified <- rlang::call2(rlang::call2(
+        "::",
+        rlang::sym(namespace),
+        rlang::sym(entry$name)
+      ))
+      expect_identical(
+        static_spelling_name(qualified, entry$family),
+        entry$name,
+        info = paste(entry$family, namespace, entry$name)
+      )
+    }
+  }
+})
+
+test_that("a foreign namespace passes a registered spelling through", {
+  # `stats` owns none of these names, so every one of them qualified with it is
+  # an ordinary call this package must not claim. Recognizing one would send a
+  # caller's `stats::pick()` down a rewrite written for dplyr's.
+  for (entry in contextual_registry_table()) {
+    foreign <- rlang::call2(rlang::call2(
+      "::",
+      quote(stats),
+      rlang::sym(entry$name)
+    ))
+    expect_null(
+      static_spelling_name(foreign, entry$family),
+      info = paste(entry$family, entry$name)
+    )
+  }
+})
+
+test_that("no registered spelling is recognized by another family", {
+  # Each site asks about one family, so a spelling answered by two would be
+  # rewritten twice, or refused in a position that accepts it.
+  for (entry in contextual_registry_table()) {
+    others <- setdiff(static_spelling_families(), entry$family)
+    for (family in others) {
+      expect_null(
+        static_spelling_name(rlang::call2(entry$name), family),
+        info = paste(entry$name, "must not be", family)
+      )
+    }
+  }
+})
+
+test_that("a Contextual helper resolves the same bare and qualified", {
+  data <- contextual_probe_data()
+  probes <- contextual_probes()
+  for (entry in contextual_registry_table(contextual_helper_families())) {
+    probe <- probes[[entry$name]]
+    bare <- contextual_probe_outcome(probe(rlang::sym(entry$name)), data)
+    for (namespace in static_spelling_namespaces(entry$family)) {
+      head <- rlang::call2("::", rlang::sym(namespace), rlang::sym(entry$name))
+      expect_identical(
+        contextual_probe_outcome(probe(head), data),
+        bare,
+        info = paste(namespace, entry$name)
+      )
+    }
+  }
+})
+
+test_that("a foreign qualifier is not the same request", {
+  # What stops every probe above from being vacuous. Each of those asserts that
+  # two writings agree, which a spelling the registry has stopped recognizing
+  # satisfies just as well -- both writings would then change together and the
+  # comparison would still hold. This one asserts a difference: `stats` owns
+  # none of these names, so a `stats::`-qualified probe must not reach the
+  # rewrite the bare one reaches, and it fails the moment recognition stops.
+  #
+  # It is the assertion that gives `where` its only end-to-end coverage. A
+  # caller binding cannot change a spelling that is refused statically -- the
+  # function is never called on either arm -- so the shadow assertion below can
+  # only ever confirm that the refusal is stable, never that it happens.
+  data <- contextual_probe_data()
+  probes <- contextual_probes()
+  for (entry in contextual_registry_table(contextual_helper_families())) {
+    probe <- probes[[entry$name]]
+    foreign <- rlang::call2("::", quote(stats), rlang::sym(entry$name))
+    expect_false(
+      identical(
+        contextual_probe_outcome(probe(foreign), data),
+        contextual_probe_outcome(probe(rlang::sym(entry$name)), data)
+      ),
+      info = paste(entry$family, entry$name)
+    )
+  }
+})
+
+test_that("asking about one family builds no other", {
+  # `static_spelling_rules()` derives the share family from `share_kind_rules()`
+  # and the constructor family from `grouping_kind_rules()`. Built eagerly that
+  # would make a grouping-family lookup evaluate the contextual-share module for
+  # a fact that is not about shares, which is the reach `design/architecture.md`
+  # separates on #179's authority. The table holds one builder per family so
+  # that it does not, and this is what says so rather than the comment.
+  local_mocked_bindings(
+    share_kind_rules = function() stop("the share family was built"),
+    grouping_kind_rules = function() stop("the constructor family was built")
+  )
+  expect_identical(
+    static_spelling_name(quote(grouping_id(region)), "grouping"),
+    "grouping_id"
+  )
+  expect_identical(
+    static_spelling_name(quote(across(a, sum)), "selection"),
+    "across"
+  )
+  expect_identical(
+    static_spelling_name(quote(cur_group_id()), "refused"),
+    "cur_group_id"
+  )
+  # And the mocks really would have fired, so the three above are not passing
+  # because the bindings were never reachable.
+  expect_error(static_spelling_names("share"), "the share family was built")
+  expect_error(
+    static_spelling_names("grouping_constructor"),
+    "the constructor family was built"
+  )
+})
+
+test_that("an unregistered selection helper is refused rather than rewritten", {
+  # The `selection` family's rewrite dispatches by name, and every name it holds
+  # has a branch. A spelling registered without one used to fall through to
+  # `pick()`'s rewrite, which is a silently wrong selection rather than a
+  # missing one; ADR 0015 makes that an invariant.
+  local_mocked_bindings(
+    static_spelling_name = function(expr, family) {
+      if (identical(family, "selection")) "slice_head" else NULL
+    }
+  )
+  expect_error(
+    rewrite_summary_selections(
+      quote(slice_head(units)),
+      env = rlang::current_env(),
+      data_proxy = data.frame(units = double()),
+      normalize_across_names = FALSE
+    ),
+    "No rewrite is registered for the selection helper"
+  )
+})
+
+test_that("a caller binding never changes a Contextual helper", {
+  # The regression #172 recorded. Each spelling is bound, in the environment
+  # the summary is written in, to a function answering something no probe could
+  # produce, and the outcome must be the outcome of the unshadowed call.
+  #
+  # Both halves of ADR 0019 are asserted at once: a spelling that runs must run
+  # the owning package's function, and a spelling that is refused must stay
+  # refused with the same message.
+  data <- contextual_probe_data()
+  probes <- contextual_probes()
+  for (entry in contextual_registry_table(contextual_helper_families())) {
+    expr <- probes[[entry$name]](rlang::sym(entry$name))
+    expect_identical(
+      contextual_probe_outcome(expr, data, shadow = entry$name),
+      contextual_probe_outcome(expr, data),
+      info = paste(entry$family, entry$name)
+    )
+  }
+})
+
+test_that("a caller binding never changes a helper on a lazy input", {
+  # dtplyr rather than a database, because several probes wrap their result in
+  # `ncol()`, which SQL cannot translate. What the lazy half proves is that the
+  # rewrite survives a backend that re-reads the expression: dtplyr and dbplyr
+  # both re-analyze the call, and dbplyr's `partial_eval()` matches these names
+  # without examining the qualifier at all, so a qualified head reaches the
+  # translation an unqualified one did.
+  skip_if_backend_absent("dtplyr")
+  data <- contextual_probe_data()
+  probes <- contextual_probes()
+  for (entry in contextual_registry_table(contextual_helper_families())) {
+    expr <- probes[[entry$name]](rlang::sym(entry$name))
+    expect_identical(
+      contextual_probe_outcome(
+        expr,
+        dtplyr::lazy_dt(data),
+        shadow = entry$name
+      ),
+      contextual_probe_outcome(expr, dtplyr::lazy_dt(data)),
+      info = paste(entry$family, entry$name)
+    )
+  }
+})
+
+test_that("a shadowed `where()` still selects by predicate", {
+  # The half of `where`'s contract that the registry does not keep. It is
+  # recognized only to be refused inside a contextual share's `across()`, so
+  # every probe above compares two diagnostics; a `where()` in an ordinary
+  # selection reaches `tidyselect::eval_select()` instead, which binds the name
+  # in the selection mask itself.
+  #
+  # This is asserted here because the Rd, the vignette, and NEWS all say a
+  # binding of `where` never wins, and nothing else in this change would notice
+  # tidyselect stopping. The promise is this package's; the code keeping it is
+  # another package's, which is exactly the kind of claim that needs a test
+  # rather than a comment.
+  data <- contextual_probe_data()
+  select_numeric <- rlang::expr(summarize_with_margins(
+    .probe_data,
+    dplyr::across(where(is.numeric), sum),
+    .grouping = rollup(region),
+    .sort = "last"
+  ))
+  expect_identical(
+    contextual_probe_outcome(select_numeric, data, shadow = "where"),
+    contextual_probe_outcome(select_numeric, data)
+  )
+  # And the selection really was made by the predicate, so the agreement above
+  # is not two calls that both selected nothing.
+  expect_named(
+    contextual_probe_outcome(select_numeric, data)$value,
+    c("region", "units", "qty")
+  )
+})
+
+test_that("a Grouping specification constructor is an ordinary name", {
+  # The other direction of ADR 0019, and the reason the constructor family
+  # carries `contextual = FALSE`. Its spelling decides only whether a nested
+  # argument is evaluated; what runs once the gate opens is whatever the name
+  # is bound to, so a caller's own function reaches the nested position and its
+  # result is what the verb compiles.
+  data <- contextual_probe_data()
+  summarize <- function(spec) {
+    summarize_with_margins(
+      data,
+      k = sum(units),
+      .grouping = !!spec,
+      .sort = "last"
+    )
+  }
+  rollup <- function(...) marginplyr::cube(...)
+  shadowed <- summarize_with_margins(
+    data,
+    k = sum(units),
+    .grouping = grouping_sets(rollup(region, grade)),
+    .sort = "last"
+  )
+  expect_identical(
+    shadowed,
+    summarize(rlang::expr(grouping_sets(marginplyr::cube(region, grade))))
+  )
+  # And the caller's function really won: a cube of two dimensions holds a set
+  # the rollup this spelling names does not.
+  expect_false(identical(
+    shadowed,
+    summarize(rlang::expr(grouping_sets(marginplyr::rollup(region, grade))))
+  ))
+})
+
+test_that("the refusal names the helper and keeps its opening", {
+  data <- contextual_probe_data()
+  # The opening phrase six other assertions match by regular expression. It is
+  # asserted here as well so that a rewording is caught where the wording is
+  # decided rather than only where it is relied on.
+  expect_error(
+    summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region),
+    "^`summarize_with_margins\\(\\)` does not support `cur_group_id\\(\\)`\\."
+  )
+  expect_error(
+    summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region),
+    "reserved inside a Margin summary and is not resolved from the calling"
+  )
+  # A caller who bound the name themselves is the reader that sentence was
+  # added for, so it has to survive the shadow that motivates it.
+  expect_error(
+    local({
+      cur_group_id <- function() 1L
+      summarize_with_margins(data, k = cur_group_id(), .by = region)
+    }),
+    "is not resolved from the calling environment"
+  )
+  # More than one refused spelling in one call reads as a list.
+  expect_error(
+    summarize_with_margins(
+      data,
+      k = dplyr::cur_group_id(),
+      j = list(dplyr::cur_group()),
+      .by = region
+    ),
+    "These spellings are reserved"
+  )
+})

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -645,6 +645,18 @@ retail_sales |>
   )
 ```
 
+That refusal is by spelling, as every recognized name here is. A few names mean
+what marginplyr rewrites them into rather than what they are bound to:
+`grouping_bit()`, `grouping_id()`, `share_of_parent()`, `share_of_total()`,
+`across()`, `if_any()`, `if_all()`, `pick()`, `where()`, and the
+`cur_group*()` family are recognized bare or qualified with the package that
+owns them, and a binding of the same name in your own environment never
+changes what a Margin verb does with one. For `cur_group_id()` that is
+stricter than `dplyr::summarize()`, which resolves it by ordinary lookup;
+here it stays refused, because reading the binding would mean resolving a call
+head against the calling environment. Every other name, `n()` included,
+follows ordinary lookup.
+
 Two familiar conveniences also behave differently. Row order is unspecified
 for local and lazy results alike unless `.sort` asks for a Margin order, which
 puts each margin row with the rows it summarizes; call `arrange()` for any


### PR DESCRIPTION
Closes #172.

## The rule

ADR 0019 states the one rule the ticket asks for, as a criterion rather than a
list of families so that a name added later inherits it:

> A spelling whose meaning inside a Margin summary arises **only through static
> rewriting** is a **Contextual helper**: it is recognized by spelling and is
> never resolved from the calling environment. Every other name follows
> ordinary lexical and data-mask lookup.

A spelling is recognized when the name matches *and* the namespace is absent or
an owner of that name, so `dplyr::across()` is the same request as `across()`
while `mypkg::across()` is an ordinary call. `n()` is the case that shows the
criterion is doing work rather than describing a habit: dplyr's `n()` has real
semantics that marginplyr does not rewrite, so a caller who binds `n` gets
their own function, exactly as under `dplyr::summarise()`.

## The defect

The criterion has a consequence beyond naming. If a spelling is read
statically, the code that runs has to be the code the analysis read — otherwise
a rule is checked against an expression that never executes. `across()`,
`if_any()`, and `if_all()` failed that:

``` r
across <- function(...) "CALLER"
summarize_with_margins(d, k = across(units, sum), .grouping = rollup(region))
#>   region      k
#> 1      E CALLER
```

The grouping-column exclusion rule ran against dplyr's helper; the caller's
function executed.

## The mechanism

The investigation note left this open, ruling out head qualification because
`rewrite_pick_selection()` and `rewrite_across_selection()` both end in
`rebuild_static_call()`, which preserves the head. That was right, and the
cause is that marginplyr does not distinguish the two paths — dplyr does.
`dplyr:::summarise_cols()` processes each dot as `expand_pick()` then
`expand_across()`, and the two have different reach:

- `expand_pick_call()` matches `pick` syntactically and descends through every
  argument, so no binding can capture it. It returns early on `~` and
  `function`, the one position plain dplyr does let a caller's `pick` run.
- `expand_across()` returns the quosure untouched unless the dot's **top-level**
  expression is a call to `across` **and** the dot is **unnamed**. Nothing in it
  looks at `if_any` or `if_all` at all.

Every summary a Margin verb stages is a named dot, so it always took the second
path and reached the data mask with its head resolved by ordinary lexical
lookup. Measured against dplyr 1.2.1, with plain `dplyr::summarise()`:

| call | result |
|---|---|
| `summarise(g, across(c(units, qty), sum))` — unnamed | package won |
| `summarise(g, k = across(units, sum))` — named | caller binding won |
| `summarise(g, k = ncol(pick(units)))` | package won |
| `summarise(g, k = (function() pick(units))())` | caller binding won |

`investigation/contextual-helper-execution-mechanism.md` records this, and
revisits one row of the predecessor note it supersedes in part.

## The fix

Qualify the recognized head. It is the smallest change that closes every
position at once: it settles the runtime lookup in the data mask, and it does
not disturb dplyr's own static expansion, which accepts an absent or `dplyr`
qualifier alike. dbplyr's `partial_eval()` matches these four names without
examining the qualifier, so lazy backends are unaffected — verified value for
value on local, dtplyr, and DuckDB.

## One registry

Nine functions across four files read a spelling before this, carrying eleven
namespace tests between them — and `where`, in `contains_selection_predicate()`,
carried none. All of them now derive from `static_spelling_rules()`, which is
also where the namespace test is implemented.

Two families derive in turn from the tables that own them, `share_kind_rules()`
and `grouping_kind_rules()`, so the registry holds **one builder per family**.
That is not an optimization: built eagerly, a `grouping_helper_name()` lookup
would evaluate the contextual-share module for a fact that is not about shares
— the reach `design/architecture.md` separates on #179's authority, arriving one
module further out. A test asserts the laziness rather than the comment
claiming it.

The language-capture primitives stay out deliberately. Their `base` namespace
test answers to the calling environment (a capture is refused where the head
names a binding the analysis can see), and every family here refuses to read
the calling environment at all.

## The diagnostic

`does not support` stays as the opening phrase — six assertions match it by
regular expression rather than by condition class, and it is still true. What
it gains is the sentence a caller who had bound the name themselves needed:

> `summarize_with_margins()` does not support `cur_group_id()`. This spelling is
> reserved inside a Margin summary and is not resolved from the calling
> environment. …

Refusing a shadowed `cur_group_id()` is stricter than dplyr and stays that way:
honouring the shadow means resolving a call head against the calling
environment, which #130 declined and this rule forbids by construction.

## Tests

Derived from the registry rather than enumerated, and the probe table is
asserted **against** it, so a spelling registered without coverage fails here
rather than going uncovered. Each registered spelling is exercised unqualified,
namespace-qualified, foreign-qualified, and against every other family; each
Contextual helper additionally with a caller binding in scope, local and lazy.

What keeps them from being vacuous is an assertion of *difference*: a `stats::`
qualified probe must not reach the rewrite the bare one reaches. Verified by
breaking things deliberately — removing the fix fails six cases, removing
`where` recognition fails the difference assertion, and making the registry
eager fails the laziness assertion.

## Behaviour changes

Three, all recorded in `NEWS.md` and the ADR. `Config/marginplyr/cran-status`
reads `unpublished`, so no released version carried the old behaviour.

| shadowed spelling | before | after |
|---|---|---|
| `across`, `if_any`, `if_all` | caller's binding ran | dplyr's helper runs |
| `pick` inside a `~` lambda or `function` body | caller's binding ran | dplyr's `pick()` runs |
| `where` qualified with a foreign package, in a share `across()` | read as a selection predicate | ordinary evaluation |

## Out of scope

#190 (nested specification positions refusing a genuine `margin_grouping_spec`)
is split out and referenced from the ADR. #178 is bounded rather than
implemented: the ADR fixes `callable identity` as **syntactic**, never
environmental, so `(grouping_id)(region)` is in its scope and `get("grouping_id")(region)`
and a caller binding are not. Parenthesis transparency is not implemented here.

## Checks

`devtools::test()` 3219 passes, 0 failures, 0 skips · `lintr::lint_package()`
0 lints · `spelling::spell_check_package()` clean · `roxygenise()` idempotent ·
`verify-suite-coverage.R` all 502 tests execute in a single-backend
configuration. `README.md` is unchanged and was not regenerated: its chunk
output is byte-identical to what is committed, and local pandoc is 3.10.1
against `document.yaml`'s pinned 3.8.3.
