### PR TITLE
Treat redundant parentheses as transparent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,9 +98,12 @@ A spelling whose meaning inside a Margin summary arises only through static
 rewriting, and which is therefore recognized by spelling and never resolved
 from the calling environment. It is recognized when the name matches and the
 namespace is absent or the owning package; any other qualifier is an ordinary
-call. A caller binding of the same name never changes what a Margin verb does
-with it, and the rewritten call names the owning package so that what executes
-is what was analyzed. Every other name in a summary expression follows
+call. Redundant parentheses are transparent to that reading, around the name
+or around the whole call, because `(` is the identity function; a head that
+must be evaluated to know what it calls is not recognized at all. A caller
+binding of the same name never changes what a Margin verb does with it, and
+the rewritten call names the owning package so that what executes is what was
+analyzed. Every other name in a summary expression follows
 ordinary lexical and data-mask lookup, including `dplyr::n()`. Grouping
 specification constructors are not Contextual helpers: their spelling decides
 only whether a nested argument is evaluated, and the caller's own function

--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,12 @@
   lambda or a `function` body, which is the one position plain dplyr also lets
   it; and a `where()` qualified with a package that does not own it is no
   longer read as a selection predicate inside a contextual share's `across()`.
+  Redundant parentheses are transparent to all of this, around the name or
+  around the whole call, so `(pick)(units)` and `(pick(units))` are the same
+  request as `pick(units)`; a nested `(rollup(region))` is the specification it
+  is, and `(share_of_total(units))` is a Total share. A head that has to be
+  evaluated to know what it calls — `get("pick")(units)` — is an ordinary call
+  as it was.
   See *Relationship to dplyr summaries* in `?summarize_with_margins`.
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.

--- a/R/contextual-helpers.R
+++ b/R/contextual-helpers.R
@@ -220,7 +220,23 @@ is_any_static_spelling_call <- function(expr, families) {
 # written as `share_of_total` or as `marginplyr::share_of_total`. The namespace
 # rule is the same one calls follow, and reading it from the same table is what
 # keeps a reference position from drifting away from the call position.
+#
+# Redundant parentheses are read through here for the same reason they are read
+# through in a call head: `(share_of_total)` is the value `share_of_total` is,
+# so refusing it while accepting the call spelling would leave one position out
+# of the rule the rest of the registry follows (#178).
+#
+# By recursion rather than by rebinding `expr`, which is an argument the caller
+# may have left empty -- an `across()` written `across(units, )` reaches here
+# with R's missing marker, and assigning that to a local raises
+# `missingArgError` on the next read of it (#174).
 static_spelling_reference_name <- function(expr, family) {
+  if (is_redundant_parens(expr)) {
+    return(static_spelling_reference_name(
+      unparenthesized_value(expr),
+      family
+    ))
+  }
   if (rlang::is_symbol(expr)) {
     name <- rlang::as_name(expr)
   } else if (

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -294,7 +294,7 @@ is_name_only_expr <- function(expr, env, data_vars) {
     return(FALSE)
   }
 
-  args <- rlang::call_args(expr)
+  args <- static_call_args(expr)
   all(vapply(
     args,
     is_name_only_expr,

--- a/R/share.R
+++ b/R/share.R
@@ -1448,7 +1448,7 @@ validate_share_direct_syntax <- function(expr, output_name) {
       )
     )
   }
-  args <- rlang::call_args(expr)
+  args <- static_call_args(expr)
   if (length(args) != 1L || !rlang::is_symbol(args[[1L]])) {
     abort_marginplyr(
       paste0(
@@ -2838,6 +2838,18 @@ expression_data_symbols <- function(expr, bound = character()) {
   if (!rlang::is_call(expr)) {
     return(character())
   }
+  # Redundant parentheses come off before any branch below reads the node. This
+  # walk reads shapes as well as names -- `length(expr)`, `expr[[2L]]`, the
+  # formals of a definition -- and the shared name read sees through a pair of
+  # them, so a `(f(x))` reaching a branch unwrapped would be named `f` and
+  # subscripted as the wrapper. Restarting once here keeps the two readings one
+  # reading for every branch at once (#178).
+  #
+  # It restarts rather than filters, so `(share)` re-enters at the top and is
+  # reported by the symbol branch above exactly as a bare `share` is.
+  if (is_parenthesized(expr)) {
+    return(expression_data_symbols(unparenthesized_value(expr), bound))
+  }
   # A call whose head is itself a call -- `fns$total(x)`, an inline lambda --
   # has no name, so `call_name()` returns `NULL`. Every comparison below is
   # written to be NULL-safe, since such a call is simply not the shape this
@@ -3113,16 +3125,20 @@ block_reads_and_bound <- function(expr, bound) {
 # One statement's reads together with the bound set the statement after it
 # sees. A node that binds nothing returns the set it was given.
 statement_reads_and_bound <- function(expr, bound) {
-  call_name <- static_call_name(expr)
   # A nested block and a redundant parenthesis are transparent here for the
   # reason the enclosing block is: neither opens a scope, and both always run,
   # so `{ { tmp <- share }; tmp }` and `{ (tmp <- share); tmp }` bind `tmp` for
   # what follows exactly as the unwrapped statement does.
+  #
+  # The parenthesis comes off through the shared reading rather than through a
+  # branch of its own, so that the name read below and the operands the branches
+  # read beside it are read from one node (#178).
+  if (is_parenthesized(expr)) {
+    return(statement_reads_and_bound(unparenthesized_value(expr), bound))
+  }
+  call_name <- static_call_name(expr)
   if (identical(call_name, "{")) {
     return(block_reads_and_bound(expr, bound))
-  }
-  if (identical(call_name, "(") && length(expr) >= 2L) {
-    return(statement_reads_and_bound(expr[[2L]], bound))
   }
   # `rm()` and its alias `remove()` are the only statements that take a name
   # out of scope again, and losing one from the set is the direction this walk
@@ -3182,7 +3198,7 @@ statement_reads_and_bound <- function(expr, bound) {
 # side, while ignoring them would hide a read of a column that came back into
 # view (#162).
 removal_retained_bound <- function(expr, bound) {
-  args <- rlang::call_args(expr)
+  args <- static_call_args(expr)
   arg_names <- argument_names(args)
   removed <- character()
   for (i in seq_along(args)) {

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -241,6 +241,11 @@
 #' so `dplyr::across()` is the same request as `across()` while
 #' `mypkg::across()` is an ordinary call to another package's function.
 #'
+#' Redundant parentheses change nothing, because `(` is the identity function:
+#' `(pick)(units)` and `(pick(units))` are the same request as `pick(units)`. A
+#' head that has to be evaluated to know what it calls is not a spelling at all,
+#' so `get("pick")(units)` is an ordinary call.
+#'
 #' Every other name follows ordinary lookup, [dplyr::n()] included, and so do
 #' the Grouping specification constructors: a nested `rollup(region)` is
 #' evaluated because of how it is spelled, but what runs is whatever `rollup`

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -728,7 +728,12 @@ name_unnamed_by_position <- function(arg_names, prefix) {
 # it -- `for (part in parts)` as in #168, or `part <- parts[[index]]` as here --
 # raises base R's untyped `missingArgError` on the first read of that name.
 parse_across_arguments <- function(expr) {
-  call_args <- rlang::call_args(expr)
+  # Through the shared reader, so that the arguments parsed here are the
+  # arguments of the call recognized as `across()`. Both readings see through a
+  # redundant pair of parentheses, and a parse that did not would read
+  # `(across(v, sum))` as one argument -- the `across()` call itself -- and hand
+  # it to `eval_select()` as a selection (#178).
+  call_args <- static_call_args(expr)
   arg_names <- names(call_args)
   if (is.null(arg_names)) {
     arg_names <- rep("", length(call_args))

--- a/R/utils.R
+++ b/R/utils.R
@@ -142,17 +142,19 @@ assert_lazy_table <- function(x) {
 # that expression as a part and analyses it there, where the operands are its
 # own.
 static_call_name <- function(expr) {
-  if (!is_nameable_call(expr)) {
+  named <- nameable_call(expr)
+  if (is.null(named)) {
     return(NULL)
   }
-  rlang::call_name(expr)
+  rlang::call_name(named)
 }
 
 static_call_ns <- function(expr) {
-  if (!is_nameable_call(expr)) {
+  named <- nameable_call(expr)
+  if (is.null(named)) {
     return(NULL)
   }
-  rlang::call_ns(expr)
+  rlang::call_ns(named)
 }
 
 # Whether `rlang::call_name()` and `rlang::call_ns()` may be asked about this
@@ -164,10 +166,130 @@ is_nameable_call <- function(expr) {
   rlang::is_call(expr) && !rlang::is_call(expr, "~")
 }
 
+# The node those two read a name from: this call with its redundant parentheses
+# removed, and `NULL` where there is no name to read. Where the parentheses were
+# around the head, the node is rebuilt without them, because that is the only
+# way to ask rlang about a head it would otherwise refuse to read -- and the
+# rebuilt node is used for naming alone, never handed back to a rewrite, so the
+# head a walk puts back is still the head the caller wrote.
+#
+# The shape test comes before anything is bound to a local, which is the rule
+# `static_call_args()` states, applied to the two readers every walk asks first.
+# `expr` here is a call part like any other, so it can be R's empty argument,
+# and `rlang::is_call()` answers that as the `FALSE` it always did while
+# `expr <- ...` would bind the missing marker and raise `missingArgError` on the
+# next read of it (#168, #174).
+nameable_call <- function(expr) {
+  if (!is_nameable_call(expr)) {
+    return(NULL)
+  }
+  unwrapped <- unparenthesized_call(expr)
+  head <- static_call_head(unwrapped)
+  spelled <- unparenthesized_name(head)
+  if (identical(spelled, head)) {
+    return(unwrapped)
+  }
+  rebuild_static_call(unwrapped, static_call_args(unwrapped), head = spelled)
+}
+
+# `(` is the identity function, so a redundant pair of parentheses changes
+# nothing about what a call calls or what it is given: `(grouping_id)(region)`,
+# `(grouping_id(region))`, and `grouping_id(region)` are one call written three
+# ways. The three readers below see through them, which is what gives every
+# analysis in the package the same answer for the three at once, rather than
+# each family recognizing whichever spellings someone thought to enumerate
+# (#178, ADR 0019).
+#
+# Identity here stays syntactic. `(get("grouping_id"))(region)` strips to a
+# call rather than to a name, so the head is unresolved and stays that way,
+# which is the conservative #130 policy these three are written not to weaken.
+#
+# Everything a pair of parentheses wraps, however many pairs deep. This is the
+# reading for a position holding a value -- a `.fns` argument, a name given to
+# `get()` -- where `(x)` is the value of `x` and nothing else.
+#
+# It stops at R's empty argument rather than unwrapping to it, so that nothing
+# below can bind the missing marker to a local: the first read of such a local
+# raises base R's untyped `missingArgError`, naming this frame's variable rather
+# than anything the caller wrote (#168, #174). A constructed `(` call holding
+# one wraps no value to read, which is the answer stopping gives.
+unparenthesized_value <- function(expr) {
+  while (is_redundant_parens(expr) && !rlang::is_missing(expr[[2L]])) {
+    expr <- expr[[2L]]
+  }
+  expr
+}
+
+# The name a head or a function reference spells. A head is unwrapped only down
+# to a name, because that is the only thing a head can be unwrapped to without
+# changing what R does with it: `("sum")(1)` is not a call to `sum` but the
+# error R raises for applying a non-function, and `(function(x) x)(1)` names
+# nothing either way. Both keep the answer they have always had.
+#
+# The early return is the other half of the missing-marker rule above. This is
+# asked of an argument a caller may have left empty -- an `across()` `.fns` is
+# one -- and an argument that is not a pair of parentheses is given straight
+# back rather than reaching the local below.
+unparenthesized_name <- function(expr) {
+  if (!is_redundant_parens(expr)) {
+    return(expr)
+  }
+  spelled <- unparenthesized_value(expr)
+  if (is_name_part(spelled) || rlang::is_call(spelled, c("::", ":::"))) {
+    return(spelled)
+  }
+  expr
+}
+
+# The call a node is, through parentheses wrapped around the whole of it. A
+# pair wrapping anything but a call is kept: `(share)` wraps a bare symbol, and
+# that symbol is a genuine data-mask read which the walks report by descending
+# into the `(` call as they descend into any other, so unwrapping it would hand
+# a walk a symbol where it has just tested for a call.
+#
+# `is_nameable_call()` rather than `rlang::is_call()` is what keeps an injected
+# quosure or formula wrapped. Both are calls to `~` carrying an environment and
+# a class, and a node reached through this is the node `rebuild_static_call()`
+# rebuilds around -- from the outer `(` call's attributes, which are none. That
+# is the identity loss #165 removed, arriving one pair of parentheses later.
+unparenthesized_call <- function(expr) {
+  if (!is_redundant_parens(expr)) {
+    return(expr)
+  }
+  spelled <- unparenthesized_value(expr)
+  if (is_nameable_call(spelled)) {
+    return(spelled)
+  }
+  expr
+}
+
+# A pair of parentheses R evaluates as itself: the call `(` really is, holding
+# the one argument the parser gives it. A constructed call to `(` holding any
+# other number is not a pair a reader may drop.
+is_redundant_parens <- function(expr) {
+  rlang::is_call(expr, "(") && length(expr) == 2L
+}
+
+# Whether unwrapping answers a different node, which is what a reader that
+# restarts on what the parentheses wrap has to know before it restarts. Asked
+# here rather than compared at each site so that the three walks that restart
+# share one test, and so that none of them binds the answer to a local: a call
+# part may be R's empty argument, and `unparenthesized_value()` stops at one
+# rather than answering it.
+is_parenthesized <- function(expr) {
+  !identical(unparenthesized_value(expr), expr)
+}
+
 # The head and the arguments of a call a walk descends into, and the node
 # rebuilt around rewritten arguments. `static_call_name()` above answers what a
 # walk asks of a node it does not descend into; these three are what it asks of
 # one it does.
+#
+# All three read through the parentheses the name read reads through, so a node
+# has one name and one set of operands rather than a name taken from
+# `(f(x))`'s content and operands taken from its wrapper. That split is the
+# defect the quosure paragraph below describes, and it is the same defect
+# whichever node the two readings disagree about.
 #
 # All three exist for the same node the name read exists for. A quosure is a
 # call to `~`, so a walk descends into it, and the spellings a walk reaches for
@@ -204,7 +326,7 @@ static_call_head <- function(expr) {
   if (rlang::is_quosure(expr)) {
     return(quote(`~`))
   }
-  expr[[1L]]
+  unparenthesized_call(expr)[[1L]]
 }
 
 # An element of what this returns can be R's empty argument, so a caller reads
@@ -227,7 +349,7 @@ static_call_args <- function(expr) {
   if (rlang::is_quosure(expr)) {
     return(list(rlang::quo_get_expr(expr)))
   }
-  as.list(expr)[-1L]
+  as.list(unparenthesized_call(expr))[-1L]
 }
 
 # Whether a call part names something: a symbol, and not the empty argument.
@@ -278,8 +400,13 @@ argument_names <- function(args) {
 # which is how R matches the primitives the analyses here read. Returned as a
 # list of length one or an empty list, so that an argument written as `NULL` is
 # not read as an absent one.
+#
+# Through the shared reader rather than `rlang::call_args()`, because every
+# caller asks this of a call it has just named: reading the arguments any other
+# way is what splits a name taken from `(quote(x))`'s content off the operands
+# of its wrapper.
 call_formal_argument <- function(expr, formal, positional = TRUE) {
-  args <- rlang::call_args(expr)
+  args <- static_call_args(expr)
   args[call_formal_index(args, formal, positional = positional)]
 }
 
@@ -302,7 +429,7 @@ call_formal_index <- function(args, formal, positional = TRUE) {
 # environment: `get()` and its siblings search the one they are given instead of
 # the mask, and `substitute()` substitutes from it.
 call_supplies_other_argument <- function(expr, formal, other_names) {
-  args <- rlang::call_args(expr)
+  args <- static_call_args(expr)
   arg_names <- argument_names(args)
   if (any(arg_names %in% other_names)) {
     return(TRUE)
@@ -383,6 +510,17 @@ language_capture_formal <- function(call_name) {
 # here, and answered in the direction that analyses rather than the one that
 # hides. A qualified head is out of reach of any binding and keeps its capture.
 #
+# A head written inside parentheses is refused a capture outright, whatever
+# `bound` holds, and it is the one place a parenthesized head is not read as the
+# name it spells. `(quote)(x)` evaluates its head as a value, so R's function
+# lookup never runs and *any* binding wins -- a column, a preceding summary, or
+# a caller's own function, none of which this can see. Claiming the capture
+# would stop reporting `x`, which is the silent miss #130 fixed this walk to
+# prevent, so the undecidable head resolves toward analysing as every other one
+# does. This is the asymmetry `R/contextual-helpers.R` records: a capture
+# answers to the environment, and a Contextual helper never does, which is why
+# recognizing one through the same parentheses is right there and wrong here.
+#
 # Only the share dependency walk passes a set, because it is the only analysis
 # that tracks bindings and the only one whose wrong answer is silence about a
 # wrong number (#130, #162). The searches and the rewrites pass none, and that
@@ -400,6 +538,9 @@ captured_call_parts <- function(expr,
     return(captured)
   }
   call_head <- static_call_head(expr)
+  if (is_redundant_parens(call_head)) {
+    return(captured)
+  }
   if (rlang::is_symbol(call_head) && rlang::as_name(call_head) %in% bound) {
     return(captured)
   }
@@ -531,7 +672,12 @@ rewrite_evaluated_language <- function(expr, rewrite) {
 #
 # A literal string is here for `do.call()`, which takes its function that way.
 static_callee_name <- function(callee) {
-  if (rlang::is_symbol(callee)) {
+  # `is_name_part()` rather than `rlang::is_symbol()`, for the reason that
+  # function gives: the empty argument is a symbol whose name is `""`, so a
+  # bare symbol test answers a callee named `""`, which nothing the caller
+  # wrote can be (#174). It answers no name instead, which is what an
+  # unreadable head already answers.
+  if (is_name_part(callee)) {
     return(rlang::as_name(callee))
   }
   if (!rlang::is_call(callee)) {
@@ -541,8 +687,13 @@ static_callee_name <- function(callee) {
     }
     return(named)
   }
-  if (rlang::is_call(callee, "(") && length(callee) >= 2L) {
-    return(static_callee_name(callee[[2L]]))
+  # Through the shared reading of a redundant pair rather than a test of its
+  # own. This branch is where #130 first recorded the shape, and it predates
+  # #178; leaving it written out kept two rules for one pair of parentheses,
+  # which disagreed about a `(` call built by hand with two arguments -- a node
+  # this dropped and every other reader kept.
+  if (is_parenthesized(callee)) {
+    return(static_callee_name(unparenthesized_value(callee)))
   }
   if (rlang::is_call(callee, c("::", ":::")) && length(callee) >= 3L) {
     return(static_callee_name(callee[[3L]]))
@@ -791,6 +942,13 @@ parsed_language_values <- function(argument) {
 # how a caller writes the vector `mget()` takes; anything else names a value
 # this walk cannot see without running it.
 static_character_value <- function(expr) {
+  # A literal is a value, so the parentheses a caller may have written around
+  # one are read through as they are everywhere else: `get(("share"))` names
+  # what `get("share")` names. Read by recursion rather than by rebinding
+  # `expr`, which is an argument a `c()` above may have left empty (#174).
+  if (is_redundant_parens(expr)) {
+    return(static_character_value(unparenthesized_value(expr)))
+  }
   if (is.character(expr)) {
     if (anyNA(expr)) {
       return(NULL)
@@ -800,7 +958,7 @@ static_character_value <- function(expr) {
   if (!rlang::is_call(expr, "c")) {
     return(NULL)
   }
-  values <- lapply(rlang::call_args(expr), static_character_value)
+  values <- lapply(static_call_args(expr), static_character_value)
   if (any(vapply(values, is.null, logical(1)))) {
     return(NULL)
   }

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -224,7 +224,7 @@ rule under the conservative #130 policy.
 #178 asks for the parenthesized form to be recognized. This decision fixes its
 reading in advance so that it is a change to spelling normalization and not a
 first step toward environmental resolution. Parenthesis transparency is not
-implemented here.
+implemented here; the amendment at the end of this file is where it is.
 
 ### Recorded behaviour changes
 
@@ -319,4 +319,91 @@ it.
   rule — the gate above decides whether the argument is evaluated, and #190 is
   about what happens to the value once it is.
 - #178 is the parenthesized spelling, bounded by "Boundary for callable
-  identity" above.
+  identity" above and implemented in the amendment below.
+
+## Amendment: redundant parentheses are read through, in one place
+
+"Boundary for callable identity" above fixed the reading and left the
+transparency unimplemented. #178 implements it. Nothing the decision states
+changes: identity is still syntactic, a caller binding still cannot win, and a
+head that must be evaluated to know what it calls is still unresolved.
+
+**Both positions a caller can write a pair in.** `(grouping_id)(region)` is the
+pair around the head, which the decision above names. `(grouping_id(region))`
+is the pair around the whole call, which it does not, and the two are one
+question: `(` is the identity function, so all three writings of that call
+evaluate identically and R's own parser records the difference in the tree
+rather than in what runs. Both are read through, however many pairs deep.
+
+**One place, not one place per family.** The reading lives in the shared
+readers of `R/utils.R` — the name, the namespace, the head, and the arguments —
+so every analysis that reads an expression inherits it: the registry's four
+recognition sites, the constructor gate, the data-frame output-name
+prediction, the share dependency walk, and the two rewrites. That is what the
+ticket asks for over a fix at the sites that had been demonstrated, and it is
+the same argument the registry itself rests on. Name and operands are read
+through the same unwrapping, so no node is named as its content and
+subscripted as its wrapper — the split the quosure reading in that file already
+warns about, reached by a different route.
+
+`static_callee_name()` is brought under it rather than left beside it. That
+reader carried a pair-of-parentheses rule of its own from #130, written with a
+different arity test, so a `(` call built by hand with two arguments was a
+droppable pair to one reader and a call to `(` to every other. One rule now
+answers both.
+
+**Where the head unwrapping stops.** Only down to a name. `("sum")(1)` is not a
+call to `sum` — R raises "attempt to apply non-function" for it, while a bare
+`"sum"(1)` is parsed as the symbol — and `(function(x) x)(1)` names nothing
+either way. Unwrapping to either would make this package recognize, and
+rewrite, a call R refuses or cannot name.
+
+**The one place the two rules pull apart.** A capture is refused where the head
+names a binding the analysis can see, which is the one static reading here that
+answers to the calling environment. A parenthesized head is evaluated as a
+*value*, so R's function lookup never runs and any binding wins outright:
+`(quote)(share)` therefore claims no capture at all and the walk reports the
+read it would otherwise hide, while `(pick)(units)` is dplyr's `pick()`
+whatever the caller has bound. Reading the same pair of parentheses as a
+spelling in one place and as an unresolvable head in the other is the
+asymmetry the registry's exclusion of the capture primitives already records.
+
+**Every writing this makes recognized was previously an error**, so no result
+changes into a different result: a helper stub reporting it can only be used
+inside the verb, `object 'pick' not found` from the data mask, a tidyselect
+refusal of a specification object, or a share refused for not being the
+complete right-hand side. `DESCRIPTION`'s `Config/marginplyr/cran-status` reads
+`unpublished`.
+
+Two consequences reach expressions this does *not* make recognized, and both
+are recorded rather than avoided.
+
+*A caller's redundant parentheses do not survive into the rewritten
+expression.* The rewrites rebuild every call they descend into, and they
+rebuild it from the node the readers unwrapped, so a summary written
+`sum((a + b))` is staged as `sum(a + b)` and a diagnostic dplyr raises about
+that argument echoes it without the pair. What is evaluated is unchanged —
+the pair is redundant in the tree, not only on the page — and this is the
+normalization the decision above already performs far more visibly, since
+`across(v, mean)` reaches the same diagnostics as
+`dplyr::across(dplyr::all_of("v"), mean)`. Preserving the pair would mean
+rebuilding a node in a spelling the analysis had just been written not to
+distinguish.
+
+*A name written as a parenthesized literal is now resolved rather than
+over-reported.* `get(("share"))` reads the share it names; before, the string
+was unreadable through the pair, and the share dependency walk answered an
+unresolvable lookup by reporting a read of every alias in scope. Both refuse a
+summary that reads an earlier share, so the change is which summaries are
+refused *besides* that one, in the direction of the read the caller actually
+wrote.
+
+**Test strategy.** The writings are derived, as the spellings are. Each
+registered spelling is exercised bare and under every owner, and each of those
+with a pair around the head, two pairs around the head, and a pair around the
+whole call — locally and on a lazy input, with and without a caller binding of
+the same name. Two pairs are what says the reading is not one pair deep. The
+foreign-qualifier writings are asserted to *differ*, which is what stops the
+agreement being two calls that both fail the same way, and the unresolvable
+heads are asserted unrecognized so that the boundary is a case rather than a
+sentence.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -129,6 +129,23 @@ the node rebuilt around them, which arguments a call captures as language
 rather than evaluating, which primitives resolve a name or evaluate language,
 and which language object a call is statically known to build.
 
+It also owns the one reading of a redundant pair of parentheses. `(` is the
+identity function, so `(f)(x)`, `(f(x))`, and `f(x)` are one call written three
+ways, and the readers here answer the three alike — which is what gives every
+analysis above that property at once instead of each family recognizing
+whichever forms someone wrote out (#178, ADR 0019). Name and operands are read
+through the same unwrapping, so a node cannot be named as its content and
+subscripted as its wrapper.
+
+The unwrapping is syntactic and stops there: it reads a name that is written,
+never one that would have to be looked up. So `(get("f"))(x)`, `(function(x)
+x)(1)`, and `("f")(1)` carry no name for a spelling to be recognized by, under
+the conservative #130 policy. What this module does with an unnamed head is a
+separate question it answers separately — `static_callee_name()` resolves
+`get("f")` and its siblings to the primitive they name, because the share
+dependency walk has to over-report a lookup it cannot see through rather than
+recognize a helper by it.
+
 Four analyses read through it and each decides for itself — the share
 dependency walk, the two rewrites, and the three searches — so the module is
 shallow by design where the ones below it are deep. It is also why the
@@ -151,6 +168,12 @@ carry `quote`, `substitute`, and `expression` with a `base` namespace test of
 their own, and it is a different test: a capture is refused where the head
 names a binding the analysis can see, so it answers to the calling environment
 where every family in the registry refuses to.
+
+That difference is what makes the parenthesis reading above split at one point.
+A parenthesized head is a recognized spelling here and is *not* a capture there:
+`(quote)(share)` evaluates its head as a value, so any binding wins and the walk
+reports the read it would otherwise hide, while `(pick)(units)` is dplyr's
+`pick()` however the caller has bound the name.
 
 Two families derive their spellings from the module that owns them —
 contextual shares from `share_kind_rules()`, Grouping specification

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -292,6 +292,11 @@ matches and it is written bare or qualified with the package that owns it,
 so \code{dplyr::across()} is the same request as \code{across()} while
 \code{mypkg::across()} is an ordinary call to another package's function.
 
+Redundant parentheses change nothing, because \code{(} is the identity function:
+\code{(pick)(units)} and \code{(pick(units))} are the same request as \code{pick(units)}. A
+head that has to be evaluated to know what it calls is not a spelling at all,
+so \code{get("pick")(units)} is an ordinary call.
+
 Every other name follows ordinary lookup, \code{\link[dplyr:n]{dplyr::n()}} included, and so do
 the Grouping specification constructors: a nested \code{rollup(region)} is
 evaluated because of how it is spelled, but what runs is whatever \code{rollup}

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -1,16 +1,23 @@
-# The regression suite for ADR 0019. Every case below is derived from
+# The regression suite for ADR 0019 and #178. Every case below is derived from
 # `static_spelling_rules()` rather than written out, because the failure this
 # has to catch is a spelling nobody remembered: an enumeration records what
 # someone thought to add, and a registry entry with no coverage is exactly the
 # entry that reintroduces #172.
 #
+# The writings each spelling is exercised in are derived too, from the rule
+# rather than from the registry: a name is written bare or under each owner the
+# family declares, and each of those through the redundant parentheses #178
+# makes transparent. An enumeration of demonstrated spellings is what that
+# ticket found in the code, where four families recognized whichever forms
+# someone had written out, so an enumeration of them here would assert the
+# defect rather than its absence.
+#
 # Two layers, because they fail differently. The reader assertions run over
-# every registered spelling and every namespace form and need no data, so they
-# hold for a spelling whose end-to-end shape nobody has written yet. The
-# behaviour assertions need a call to write, which no rule can derive; the
-# probe table below supplies one per Contextual helper and is checked against
-# the registry, so a spelling added without a probe fails here rather than
-# going uncovered.
+# every registered spelling and every writing and need no data, so they hold
+# for a spelling whose end-to-end shape nobody has written yet. The behaviour
+# assertions need a call to write, which no rule can derive; the probe table
+# below supplies one per Contextual helper and is checked against the registry,
+# so a spelling added without a probe fails here rather than going uncovered.
 
 # A data frame every probe reads. Two numeric columns so that a selection can
 # select more than one, and two dimensions so that a rollup and a cube of them
@@ -33,36 +40,41 @@ contextual_probe_data <- function() {
 # binding, which is the shape a first draft of this file had and which passes
 # whatever the package does.
 #
-# `head` is how the three writings differ -- a bare symbol, a qualified call,
-# or a foreign qualifier -- and `.probe_data` is the symbol the input is bound
-# to in the evaluation environment.
+# `spell` is how the writings differ. A probe writes its helper's arguments
+# once and hands them to the writing, which decides how the name in front of
+# them is spelled -- bare, qualified, foreign, or wrapped in parentheses. A
+# probe that built the call itself would fix one writing per probe, which is
+# the enumeration this file exists not to be.
+#
+# `.probe_data` is the symbol the input is bound to in the evaluation
+# environment.
 #
 # Every name below sits inside a defused expression, so `codetools` reads the
 # input symbol and the grouping columns as undefined globals.
 # nolint start: object_usage_linter.
 contextual_probes <- function() {
   summary_probe <- function(build) {
-    function(head) {
+    function(spell) {
       rlang::expr(summarize_with_margins(
         .probe_data,
-        k = !!build(head),
+        k = !!build(spell),
         .grouping = rollup(region),
         .sort = "last"
       ))
     }
   }
-  share_probe <- function(head) {
+  share_probe <- function(spell) {
     rlang::expr(summarize_with_margins(
       .probe_data,
       t = sum(units),
-      k = !!rlang::call2(head, quote(t)),
+      k = !!spell(list(quote(t))),
       .grouping = rollup(region),
       .sort = "last"
     ))
   }
   arguments <- function(...) {
     args <- rlang::exprs(...)
-    function(head) rlang::call2(head, !!!args)
+    function(spell) spell(args)
   }
 
   list(
@@ -76,17 +88,17 @@ contextual_probes <- function() {
     # a scalar. A caller binding answering a string is then a different value
     # or an error rather than a differently shaped result, which is what makes
     # the two outcomes comparable.
-    across = summary_probe(function(head) {
-      rlang::expr(ncol(!!rlang::call2(head, quote(c(units, qty)), quote(sum))))
+    across = summary_probe(function(spell) {
+      rlang::expr(ncol(!!spell(list(quote(c(units, qty)), quote(sum)))))
     }),
-    pick = summary_probe(function(head) {
-      rlang::expr(ncol(!!rlang::call2(head, quote(units))))
+    pick = summary_probe(function(spell) {
+      rlang::expr(ncol(!!spell(list(quote(units)))))
     }),
-    if_any = summary_probe(function(head) {
-      rlang::expr(sum(!!rlang::call2(head, quote(units), quote(~ .x > 1))))
+    if_any = summary_probe(function(spell) {
+      rlang::expr(sum(!!spell(list(quote(units), quote(~ .x > 1)))))
     }),
-    if_all = summary_probe(function(head) {
-      rlang::expr(sum(!!rlang::call2(head, quote(units), quote(~ .x > 1))))
+    if_all = summary_probe(function(spell) {
+      rlang::expr(sum(!!spell(list(quote(units), quote(~ .x > 1)))))
     }),
     # A selection predicate in a contextual share's `across()` selection, which
     # is the one position the `predicate` family decides. It has to be the full
@@ -97,13 +109,13 @@ contextual_probes <- function() {
     #
     # The share is refused here, so this probe compares diagnostics rather than
     # values, which is the other half of what a Contextual helper promises.
-    where = function(head) {
+    where = function(spell) {
       rlang::expr(summarize_with_margins(
         .probe_data,
         t = sum(units),
         u = sum(qty),
         dplyr::across(
-          !!rlang::call2(head, quote(is.numeric)),
+          !!spell(list(quote(is.numeric))),
           share_of_total,
           .names = "{.col}_share"
         ),
@@ -119,6 +131,66 @@ contextual_probes <- function() {
   )
 }
 # nolint end
+
+# One writing of a spelling: a function from a call's arguments to the call,
+# labelled by what it produces so that a failure says which writing failed
+# rather than which loop index did. `wrap` is the parenthesis around the whole
+# call, as distinct from the one around its head; both are pairs R evaluates as
+# the identity function, and #178 is the ticket that made the two agree with the
+# call written without either.
+contextual_writing <- function(head, wrap = FALSE) {
+  spell <- function(args) {
+    call <- rlang::call2(head, !!!args)
+    if (wrap) {
+      return(rlang::call2("(", call))
+    }
+    call
+  }
+  list(label = rlang::as_label(spell(list(quote(...)))), spell = spell)
+}
+
+# Every writing of the head spellings it is given. Derived from the parenthesis
+# rule rather than listed: bare, one pair around the head, two pairs around it,
+# and one pair around the whole call. Two pairs are what says the reading is not
+# one pair deep, which a single-step unwrapping would pass while `((pick))(x)`
+# still went unrecognized.
+contextual_writings <- function(spellings) {
+  unlist(
+    lapply(
+      spellings,
+      function(spelling) {
+        parenthesized <- rlang::call2("(", spelling)
+        list(
+          contextual_writing(spelling),
+          contextual_writing(parenthesized),
+          contextual_writing(rlang::call2("(", parenthesized)),
+          contextual_writing(spelling, wrap = TRUE)
+        )
+      }
+    ),
+    recursive = FALSE
+  )
+}
+
+# The head spellings a family owns: the bare name, and the name under each
+# namespace the registry records as an owner of it.
+contextual_owned_spellings <- function(family, name) {
+  c(
+    list(rlang::sym(name)),
+    lapply(
+      static_spelling_namespaces(family),
+      function(namespace) {
+        rlang::call2("::", rlang::sym(namespace), rlang::sym(name))
+      }
+    )
+  )
+}
+
+# `stats` owns none of these names, so every writing of one qualified with it is
+# an ordinary call this package must not claim.
+contextual_foreign_spellings <- function(name) {
+  list(rlang::call2("::", quote(stats), rlang::sym(name)))
+}
 
 # Every spelling the registry holds, in one flat table of family and name, so
 # that a loop over it covers a family added later without being told about it.
@@ -153,16 +225,24 @@ contextual_probe_env <- function(data, shadow = NULL) {
 }
 
 # What a probe did, in a form two writings can be compared by. An error is
-# reported as its message rather than propagated, because a family that refuses
-# its spelling has to refuse all three writings identically, which is an
-# agreement between messages and not the absence of one.
+# reported rather than propagated, because a family that refuses its spelling
+# has to refuse every writing identically, which is an agreement between
+# refusals and not the absence of one.
+#
+# Its class is reported beside its message, so the agreement covers the typed
+# behaviour and not only the wording. That is what the writings need most: a
+# spelling recognition misses is not usually silent but reaches the data mask
+# and fails there, and `object 'pick' not found` is an untyped condition of the
+# class ADR 0015 separates from this package's own.
 contextual_probe_outcome <- function(expr, data, shadow = NULL) {
   env <- contextual_probe_env(data, shadow = shadow)
   tryCatch(
     list(value = as.data.frame(collect_probe_result(
       rlang::eval_bare(expr, env)
     ))),
-    error = function(cnd) list(error = conditionMessage(cnd))
+    error = function(cnd) {
+      list(error = conditionMessage(cnd), class = class(cnd))
+    }
   )
 }
 
@@ -193,23 +273,18 @@ test_that("the probe table covers exactly the Contextual helper spellings", {
   expect_gt(length(contextual_registry_table()), length(registered))
 })
 
-test_that("a registered spelling is recognized bare and under every owner", {
+test_that("a registered spelling is recognized however it is written", {
+  # Bare, under every owner, and through every arrangement of the parentheses
+  # R evaluates as the identity function. Each site reads the name through one
+  # shared reader, so a writing missed here is a writing missed by the
+  # recognition, the rewrite, and the refusal alike.
   for (entry in contextual_registry_table()) {
-    expect_identical(
-      static_spelling_name(rlang::call2(entry$name), entry$family),
-      entry$name,
-      info = paste(entry$family, entry$name)
-    )
-    for (namespace in static_spelling_namespaces(entry$family)) {
-      qualified <- rlang::call2(rlang::call2(
-        "::",
-        rlang::sym(namespace),
-        rlang::sym(entry$name)
-      ))
+    spellings <- contextual_owned_spellings(entry$family, entry$name)
+    for (writing in contextual_writings(spellings)) {
       expect_identical(
-        static_spelling_name(qualified, entry$family),
+        static_spelling_name(writing$spell(list()), entry$family),
         entry$name,
-        info = paste(entry$family, namespace, entry$name)
+        info = paste(entry$family, writing$label)
       )
     }
   }
@@ -218,15 +293,83 @@ test_that("a registered spelling is recognized bare and under every owner", {
 test_that("a foreign namespace passes a registered spelling through", {
   # `stats` owns none of these names, so every one of them qualified with it is
   # an ordinary call this package must not claim. Recognizing one would send a
-  # caller's `stats::pick()` down a rewrite written for dplyr's.
+  # caller's `stats::pick()` down a rewrite written for dplyr's. Parentheses
+  # change nothing about that: they are transparent to which name is written,
+  # not to whose it is.
   for (entry in contextual_registry_table()) {
-    foreign <- rlang::call2(rlang::call2(
-      "::",
-      quote(stats),
-      rlang::sym(entry$name)
-    ))
+    foreign <- contextual_writings(contextual_foreign_spellings(entry$name))
+    for (writing in foreign) {
+      expect_null(
+        static_spelling_name(writing$spell(list()), entry$family),
+        info = paste(entry$family, writing$label)
+      )
+    }
+  }
+})
+
+test_that("a head this cannot resolve statically is no spelling at all", {
+  # The boundary ADR 0019 draws for #178, asserted at the reader. Identity is
+  # syntactic: a pair of parentheses is read through because the name is still
+  # written inside it, while a head that has to be *evaluated* to know what it
+  # calls stays unresolved under the conservative #130 policy -- whether the
+  # evaluation is a lookup, a string R would refuse to apply, or a literal
+  # function.
+  for (entry in contextual_registry_table()) {
+    computed <- rlang::call2("get", entry$name)
+    # The string is written inside the parentheses rather than in front of them
+    # because R's parser reads a bare `"pick"(units)` as the symbol `pick` and
+    # calls it, while `("pick")(units)` keeps the string and raises "attempt to
+    # apply non-function". Recognizing the second would make this package accept
+    # a call R refuses.
+    unresolved <- list(
+      rlang::call2(computed),
+      rlang::call2(rlang::call2("(", computed)),
+      rlang::call2(rlang::call2("(", entry$name)),
+      rlang::call2(quote(function() NULL))
+    )
+    for (call in unresolved) {
+      expect_null(
+        static_spelling_name(call, entry$family),
+        info = paste(entry$family, rlang::as_label(call))
+      )
+    }
+  }
+})
+
+test_that("a helper reference is read through parentheses too", {
+  # The `.fns` position takes a helper by value rather than by call, and `(f)`
+  # is the value `f` is. It reads the same registry through the same namespace
+  # rule, so leaving it out would put one position back on a spelling of its
+  # own -- which is what #172 found at four sites and #178 finds at this one.
+  for (entry in contextual_registry_table()) {
+    references <- c(
+      contextual_owned_spellings(entry$family, entry$name),
+      lapply(
+        contextual_owned_spellings(entry$family, entry$name),
+        function(spelling) rlang::call2("(", rlang::call2("(", spelling))
+      )
+    )
+    for (reference in references) {
+      expect_identical(
+        static_spelling_reference_name(reference, entry$family),
+        entry$name,
+        info = paste(entry$family, rlang::as_label(reference))
+      )
+    }
+    for (foreign in contextual_foreign_spellings(entry$name)) {
+      expect_null(
+        static_spelling_reference_name(
+          rlang::call2("(", foreign),
+          entry$family
+        ),
+        info = paste(entry$family, entry$name)
+      )
+    }
     expect_null(
-      static_spelling_name(foreign, entry$family),
+      static_spelling_reference_name(
+        rlang::call2("(", rlang::call2("get", entry$name)),
+        entry$family
+      ),
       info = paste(entry$family, entry$name)
     )
   }
@@ -246,18 +389,25 @@ test_that("no registered spelling is recognized by another family", {
   }
 })
 
-test_that("a Contextual helper resolves the same bare and qualified", {
+test_that("a Contextual helper resolves the same however it is written", {
+  # What the reader assertions above say about one function, said about the
+  # verb: two writings R evaluates identically must produce identical results,
+  # or identical diagnostics for a spelling that is refused. Parentheses are in
+  # this loop rather than in one of their own because they are the same
+  # question the namespace forms are -- which written call this is -- and #178
+  # is the ticket that found them answered differently.
   data <- contextual_probe_data()
   probes <- contextual_probes()
   for (entry in contextual_registry_table(contextual_helper_families())) {
     probe <- probes[[entry$name]]
-    bare <- contextual_probe_outcome(probe(rlang::sym(entry$name)), data)
-    for (namespace in static_spelling_namespaces(entry$family)) {
-      head <- rlang::call2("::", rlang::sym(namespace), rlang::sym(entry$name))
+    plain <- contextual_writing(rlang::sym(entry$name))
+    bare <- contextual_probe_outcome(probe(plain$spell), data)
+    spellings <- contextual_owned_spellings(entry$family, entry$name)
+    for (writing in contextual_writings(spellings)) {
       expect_identical(
-        contextual_probe_outcome(probe(head), data),
+        contextual_probe_outcome(probe(writing$spell), data),
         bare,
-        info = paste(namespace, entry$name)
+        info = paste(entry$family, writing$label)
       )
     }
   }
@@ -279,14 +429,15 @@ test_that("a foreign qualifier is not the same request", {
   probes <- contextual_probes()
   for (entry in contextual_registry_table(contextual_helper_families())) {
     probe <- probes[[entry$name]]
-    foreign <- rlang::call2("::", quote(stats), rlang::sym(entry$name))
-    expect_false(
-      identical(
-        contextual_probe_outcome(probe(foreign), data),
-        contextual_probe_outcome(probe(rlang::sym(entry$name)), data)
-      ),
-      info = paste(entry$family, entry$name)
-    )
+    plain <- contextual_writing(rlang::sym(entry$name))
+    bare <- contextual_probe_outcome(probe(plain$spell), data)
+    foreign <- contextual_writings(contextual_foreign_spellings(entry$name))
+    for (writing in foreign) {
+      expect_false(
+        identical(contextual_probe_outcome(probe(writing$spell), data), bare),
+        info = paste(entry$family, writing$label)
+      )
+    }
   }
 })
 
@@ -351,15 +502,24 @@ test_that("a caller binding never changes a Contextual helper", {
   # Both halves of ADR 0019 are asserted at once: a spelling that runs must run
   # the owning package's function, and a spelling that is refused must stay
   # refused with the same message.
+  #
+  # Every writing is shadowed, not only the bare one. A parenthesized head is
+  # the writing where a binding is hardest to lose to: R evaluates `(pick)` as
+  # a value, so ordinary lookup would find the caller's function without even
+  # the function-lookup rule that skips a non-function binding (#178).
   data <- contextual_probe_data()
   probes <- contextual_probes()
   for (entry in contextual_registry_table(contextual_helper_families())) {
-    expr <- probes[[entry$name]](rlang::sym(entry$name))
-    expect_identical(
-      contextual_probe_outcome(expr, data, shadow = entry$name),
-      contextual_probe_outcome(expr, data),
-      info = paste(entry$family, entry$name)
-    )
+    probe <- probes[[entry$name]]
+    spellings <- contextual_owned_spellings(entry$family, entry$name)
+    for (writing in contextual_writings(spellings)) {
+      expr <- probe(writing$spell)
+      expect_identical(
+        contextual_probe_outcome(expr, data, shadow = entry$name),
+        contextual_probe_outcome(expr, data),
+        info = paste(entry$family, writing$label)
+      )
+    }
   }
 })
 
@@ -374,16 +534,27 @@ test_that("a caller binding never changes a helper on a lazy input", {
   data <- contextual_probe_data()
   probes <- contextual_probes()
   for (entry in contextual_registry_table(contextual_helper_families())) {
-    expr <- probes[[entry$name]](rlang::sym(entry$name))
-    expect_identical(
-      contextual_probe_outcome(
-        expr,
-        dtplyr::lazy_dt(data),
-        shadow = entry$name
-      ),
-      contextual_probe_outcome(expr, dtplyr::lazy_dt(data)),
-      info = paste(entry$family, entry$name)
-    )
+    probe <- probes[[entry$name]]
+    spellings <- contextual_owned_spellings(entry$family, entry$name)
+    for (writing in contextual_writings(spellings)) {
+      expr <- probe(writing$spell)
+      expect_identical(
+        contextual_probe_outcome(
+          expr,
+          dtplyr::lazy_dt(data),
+          shadow = entry$name
+        ),
+        contextual_probe_outcome(expr, dtplyr::lazy_dt(data)),
+        info = paste(entry$family, writing$label)
+      )
+      # And the lazy plan is the plan the local input produced, so a writing
+      # the rewrite reached locally has reached the backend's re-analysis too.
+      expect_identical(
+        contextual_probe_outcome(expr, dtplyr::lazy_dt(data)),
+        contextual_probe_outcome(expr, data),
+        info = paste("lazy", entry$family, writing$label)
+      )
+    }
   }
 })
 
@@ -452,6 +623,52 @@ test_that("a Grouping specification constructor is an ordinary name", {
   ))
 })
 
+test_that("a nested constructor is gated however it is written", {
+  # The constructor family is not a Contextual helper, so the probe loops above
+  # leave it out -- and it still reads its spelling statically, which is what
+  # puts it under the parenthesis rule (#178). What its gate decides is whether
+  # a nested argument is evaluated at all, so a writing the gate misses is not
+  # refused but *selected*: the specification reaches tidyselect as a column
+  # selection and the caller is told their `rollup()` is not a column.
+  data <- contextual_probe_data()
+  probe <- function(spell) {
+    rlang::expr(summarize_with_margins(
+      .probe_data,
+      k = sum(units),
+      .grouping = grouping_sets(
+        !!spell(list(quote(region), quote(grade)))
+      ),
+      .sort = "last"
+    ))
+  }
+  entries <- contextual_registry_table("grouping_constructor")
+  # Every loop iterates over this set, so a set that arrived empty is a set
+  # that passes.
+  expect_gt(length(entries), 0L)
+  for (entry in entries) {
+    plain <- contextual_writing(rlang::sym(entry$name))
+    bare <- contextual_probe_outcome(probe(plain$spell), data)
+    spellings <- contextual_owned_spellings(entry$family, entry$name)
+    for (writing in contextual_writings(spellings)) {
+      expect_identical(
+        contextual_probe_outcome(probe(writing$spell), data),
+        bare,
+        info = paste(entry$family, writing$label)
+      )
+    }
+    # And the gate really is what the agreement above rests on: a qualifier
+    # naming a package that owns none of these names does not open it, so those
+    # writings must not agree.
+    foreign <- contextual_writings(contextual_foreign_spellings(entry$name))
+    for (writing in foreign) {
+      expect_false(
+        identical(contextual_probe_outcome(probe(writing$spell), data), bare),
+        info = paste(entry$family, writing$label)
+      )
+    }
+  }
+})
+
 test_that("the refusal names the helper and keeps its opening", {
   data <- contextual_probe_data()
   # The opening phrase six other assertions match by regular expression. It is
@@ -483,5 +700,185 @@ test_that("the refusal names the helper and keeps its opening", {
       .by = region
     ),
     "These spellings are reserved"
+  )
+  # A prohibited context is a Package condition, and parentheses do not turn it
+  # into one of R's. Before #178 `(cur_group_id)()` reached the data mask and
+  # failed there with `object 'cur_group_id' not found`, which is an untyped
+  # condition of the class ADR 0015 separates -- and `(grouping_id)(region)`
+  # reached the exported stub, which reports that the helper can only be used
+  # inside the verb the caller is already inside.
+  parenthesized <- expect_error(
+    summarize_with_margins(data, k = (cur_group_id)(), .by = region),
+    "^`summarize_with_margins\\(\\)` does not support `cur_group_id\\(\\)`\\."
+  )
+  expect_s3_class(parenthesized, "marginplyr_error")
+  expect_identical(
+    summarize_with_margins(
+      data,
+      k = (grouping_id(region)),
+      j = (grouping_bit)(region),
+      .grouping = rollup(region),
+      .sort = "last"
+    ),
+    summarize_with_margins(
+      data,
+      k = grouping_id(region),
+      j = grouping_bit(region),
+      .grouping = rollup(region),
+      .sort = "last"
+    )
+  )
+})
+
+test_that("parentheses do not let a selection reach a grouping column", {
+  # The grouping-column exclusion is checked against the call the rewrite
+  # recognizes and applied by resolving the selection against a proxy the
+  # dimensions are not in, so a writing recognition missed would resolve
+  # somewhere else -- or, before #178, fail in the data mask with `object
+  # 'pick' not found`. `everything()` is what makes this an assertion rather
+  # than a restatement: a selection excluding nothing would take the grouping
+  # dimensions with it.
+  data <- contextual_probe_data()
+  selections <- list(
+    across = list(
+      probe = function(spell) {
+        rlang::expr(summarize_with_margins(
+          .probe_data,
+          !!spell(list(
+            quote(dplyr::everything()),
+            quote(sum),
+            .names = "{.col}_s"
+          )),
+          .grouping = rollup(region, grade),
+          .sort = "last"
+        ))
+      },
+      selected = function(outcome) names(outcome$value)
+    ),
+    pick = list(
+      probe = function(spell) {
+        rlang::expr(summarize_with_margins(
+          .probe_data,
+          k = ncol(!!spell(list(quote(dplyr::everything())))),
+          .grouping = rollup(region, grade),
+          .sort = "last"
+        ))
+      },
+      selected = function(outcome) outcome$value$k[[1L]]
+    )
+  )
+  expected <- list(
+    across = c("region", "grade", "units_s", "qty_s"),
+    pick = 2L
+  )
+  for (name in names(selections)) {
+    selection <- selections[[name]]
+    spellings <- contextual_owned_spellings("selection", name)
+    for (writing in contextual_writings(spellings)) {
+      outcome <- contextual_probe_outcome(selection$probe(writing$spell), data)
+      expect_identical(
+        selection$selected(outcome),
+        expected[[name]],
+        info = writing$label
+      )
+    }
+  }
+})
+
+test_that("a share `.fns` reference is the helper through parentheses", {
+  # The end-to-end half of the reference reading above, and the position whose
+  # refusal names what it is refusing: a `.fns` this does not recognize is
+  # reported as a formula, an anonymous function, or a function list, none of
+  # which `(share_of_total)` is.
+  data <- contextual_probe_data()
+  share_across <- function(fns) {
+    rlang::inject(summarize_with_margins(
+      data,
+      t = sum(units),
+      dplyr::across(t, !!fns, .names = "{.col}_share"),
+      .grouping = rollup(region),
+      .sort = "last"
+    ))
+  }
+  bare <- share_across(quote(share_of_total))
+  expect_identical(share_across(quote((share_of_total))), bare)
+  expect_identical(share_across(quote(((share_of_total)))), bare)
+  expect_identical(share_across(quote((marginplyr::share_of_total))), bare)
+  # And the reference really is read rather than run: a qualifier naming a
+  # package that does not own the helper is refused in the same position.
+  expect_error(
+    share_across(quote((stats::share_of_total))),
+    "`across\\(\\)` `.fns` must be"
+  )
+})
+
+test_that("a pair around an ordinary call changes nothing it evaluates", {
+  # The readers unwrap a redundant pair for every node, not only for a
+  # recognized one, and the rewrites rebuild each call they descend into from
+  # the node the readers gave them -- so a caller's pair does not survive into
+  # the staged expression. What has to survive is the value, and the reason it
+  # does is that R's parser has already recorded the grouping in the tree: a
+  # pair that is doing work is not a redundant pair, and unwrapping the node
+  # cannot move an operand from one operator to another.
+  data <- contextual_probe_data()
+  summarize <- function(expr) {
+    rlang::inject(summarize_with_margins(
+      data,
+      k = !!expr,
+      .grouping = rollup(region),
+      .sort = "last"
+    ))
+  }
+  expect_identical(
+    summarize(quote(sum((units + qty)))),
+    summarize(quote(sum(units + qty)))
+  )
+  expect_identical(summarize(quote((sum(units))))$k, c(3, 7, 10))
+  # A pair the parser needed keeps its meaning, and the assertion is that the
+  # two groupings still differ: `(units + qty) * 2` is not `units + qty * 2`.
+  expect_identical(summarize(quote(sum((units + qty) * 2)))$k, c(24, 40, 64))
+  expect_false(identical(
+    summarize(quote(sum((units + qty) * 2))),
+    summarize(quote(sum(units + qty * 2)))
+  ))
+})
+
+test_that("parentheses leave an injected quosure its own environment", {
+  # A quosure a caller injects carries the environment its expression resolves
+  # in, and the rewrites rebuild every call they descend into. Parentheses put
+  # one more node between the summary and the quosure, and unwrapping a node
+  # means rebuilding it: `rebuild_static_call()` takes the attributes of the
+  # node it was given, so unwrapping the pair *around* a quosure would rebuild
+  # a bare `~` call and hand dplyr a formula where the caller injected a
+  # quosure. That is the identity loss #165 removed, and #178 is where it could
+  # have come back.
+  data <- contextual_probe_data()
+  multiplier <- 10
+  injected <- rlang::quo(sum(units) * multiplier)
+  expect_identical(
+    rlang::inject(summarize_with_margins(
+      data,
+      k = (!!injected),
+      .grouping = rollup(region),
+      .sort = "last"
+    )),
+    rlang::inject(summarize_with_margins(
+      data,
+      k = !!injected,
+      .grouping = rollup(region),
+      .sort = "last"
+    ))
+  )
+  # And the environment really was needed: `multiplier` is bound nowhere the
+  # summary would find it without the quosure.
+  expect_false(exists("multiplier", envir = rlang::ns_env("marginplyr")))
+  expect_identical(
+    rlang::inject(summarize_with_margins(
+      data,
+      k = (!!injected),
+      .grouping = rollup(region),
+      .sort = "last"
+    ))$k,
+    c(30, 70, 100)
   )
 })

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2607,6 +2607,16 @@ test_that("`do.call()` of a reflective primitive is an unresolved lookup", {
     expression_data_symbols(quote(do.call(get, list("share")))),
     c("get", unresolved_lookup_name())
   )
+  # Qualified, which is the one position left where a `::` names the primitive
+  # to the walk rather than to the call's own name read: a `base::get()` *call*
+  # is named `get` by the shared reader, through the parentheses #178 made
+  # transparent as well as without them, so it never reaches the callee
+  # reading. Handed to `do.call()` it is a value, and reading it is what makes
+  # this an unresolved lookup rather than a `do.call()` of something ordinary.
+  expect_identical(
+    expression_data_symbols(quote(do.call(base::get, list("share")))),
+    unresolved_lookup_name()
+  )
   # A `do.call()` of anything else is left alone: its arguments are values by
   # the time it runs, and the walk has reported the expressions that built
   # them.
@@ -2793,6 +2803,16 @@ test_that("a name the recovery can read is read, however it is spelled", {
   expect_identical(
     expression_data_symbols(quote((base::get)("share"))),
     "share"
+  )
+  # The name itself may be written inside parentheses, which is the value half
+  # of the reading #178 gives a head: `("share")` is the string it wraps, so
+  # the lookup resolves rather than being reported as a read of every alias in
+  # scope, which is what an unreadable name answers.
+  expect_identical(expression_data_symbols(quote(get(("share")))), "share")
+  expect_identical(expression_data_symbols(quote(get((("share"))))), "share")
+  expect_identical(
+    expression_data_symbols(quote(get((c("sha", "re"))))),
+    c("sha", "re")
   )
   # A string is not a language object: `eval()` answers the string itself and
   # looks nothing up.

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -3003,6 +3003,31 @@ test_that("a capture the walk cannot name plainly is analyzed, not assumed", {
     expression_data_symbols(quote((quote)(share))),
     c("quote", "share")
   )
+  # It stays that answer under the parenthesis reading #178 added, and that is
+  # the one place two static rules read the same pair of parentheses
+  # differently. A Contextual helper is recognized through them because its
+  # meaning never comes from the calling environment; a capture is refused
+  # through them because its meaning does -- `(quote)` is evaluated as a value,
+  # so R's function lookup never runs and any binding wins, which is the head
+  # this walk may not claim.
+  expect_identical(
+    static_spelling_name(quote((pick)(units)), "selection"),
+    "pick"
+  )
+  expect_identical(
+    expression_data_symbols(quote(((base::quote))(share))),
+    "share"
+  )
+  expect_identical(
+    expression_data_symbols(quote((base::quote)(share))),
+    "share"
+  )
+  # And the pair around the *call* is not a head at all, so the capture inside
+  # it is still a capture.
+  expect_identical(
+    expression_data_symbols(quote((quote(share)))),
+    character()
+  )
   # A call carrying more arguments than the primitive takes is not the shape
   # this recognizes either: R refuses `quote(a, b)` when it runs, and the walk
   # reports the argument beyond the captured one rather than claiming it is

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -369,6 +369,30 @@ test_that("the assignment scan detects the shape it is written to forbid", {
   expect_false(binds_call_parts_by_assign(quote(sum(value[]))))
 })
 
+test_that("every shared reader answers an empty call part", {
+  # The scans above forbid binding a call part to a local; this is the same
+  # rule read from the other end, at the readers a walk hands one to. An empty
+  # argument is a call part like any other -- `x[, "col"]` is everyday R that
+  # `dplyr::summarize()` accepts -- so each of these has to answer it rather
+  # than raise base R's untyped `missingArgError` from inside itself (#168,
+  # #174). The name readers are the ones this can be lost at: both unwrap the
+  # parentheses #178 made transparent, and unwrapping before the shape test
+  # binds the missing marker.
+  #
+  # Read by subscript throughout, since the parts being read are exactly the
+  # parts that may be empty.
+  parts <- static_call_args(quote(f(x, )))
+  expect_true(rlang::is_missing(parts[[2L]]))
+  expect_null(static_call_name(parts[[2L]]))
+  expect_null(static_call_ns(parts[[2L]]))
+  expect_null(static_spelling_name(parts[[2L]], "selection"))
+  expect_null(static_spelling_reference_name(parts[[2L]], "share"))
+  expect_null(static_character_value(parts[[2L]]))
+  expect_null(static_callee_name(parts[[2L]]))
+  expect_false(is_parenthesized(parts[[2L]]))
+  expect_identical(expression_data_symbols(parts[[2L]]), character())
+})
+
 test_that("lazy-table assertions use the package condition seam", {
   skip_if_backend_absent("arrow")
 

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -651,8 +651,10 @@ what marginplyr rewrites them into rather than what they are bound to:
 `across()`, `if_any()`, `if_all()`, `pick()`, `where()`, and the
 `cur_group*()` family are recognized bare or qualified with the package that
 owns them, and a binding of the same name in your own environment never
-changes what a Margin verb does with one. For `cur_group_id()` that is
-stricter than `dplyr::summarize()`, which resolves it by ordinary lookup;
+changes what a Margin verb does with one. Redundant parentheses are
+transparent to that, so `(pick)(units)` and `(pick(units))` ask for what
+`pick(units)` asks for. For `cur_group_id()` that is stricter than
+`dplyr::summarize()`, which resolves it by ordinary lookup;
 here it stays refused, because reading the binding would mean resolving a call
 head against the calling environment. Every other name, `n()` included,
 follows ordinary lookup.


### PR DESCRIPTION
Closes #178.

## What was wrong

Semantically identical calls had different static meanings. Measured on `be37c35`:

| written | before | after |
| --- | --- | --- |
| `(grouping_id)(region)` | reached the exported stub: "can only be used inside `summarize_with_margins()`" | the per-branch identifier |
| `(pick)(units)` | `object 'pick' not found`, from the data mask | dplyr's `pick()` |
| `(cur_group_id)()` | `object 'cur_group_id' not found` — an untyped condition | the Package condition the spelling is reserved by |
| `grouping_sets((rollup)(region))` | offered to tidyselect: "Can't select columns with `(rollup)(region)`" | the nested specification |
| `(share_of_total(units))` | refused for not being the complete right-hand side | a Total share |
| `across(units, (share_of_total))` | refused as a formula, lambda, or function list | the helper |

Four families each recognized whichever spellings someone had written out.

## The change

`(` is the identity function, so `(f)(x)`, `(f(x))`, and `f(x)` are one call written three ways. The reading is **one rule in the shared readers of `R/utils.R`** — the name, the namespace, the head, and the arguments — so every analysis inherits it rather than each family being taught the demonstrated forms: the registry's recognition sites, the constructor gate, the data-frame output-name prediction, the share dependency walk, and both rewrites. Name and operands are read through the same unwrapping, so no node is named as its content and subscripted as its wrapper.

Sites that read a call's parts without going through the shared reader are brought under it, since that is where such a split would appear: `call_formal_argument()`, `call_supplies_other_argument()`, `static_character_value()`, `parse_across_arguments()`, `validate_share_direct_syntax()`, `removal_retained_bound()`, `is_name_only_expr()`. `static_callee_name()` carried a pair-of-parentheses rule of its own from #130, written with a different arity test; it now reads the shared one.

## The boundary held

Identity stays syntactic, which is what ADR 0019 fixed in advance for this ticket. A head is unwrapped only down to a name, so `("sum")(1)` — which R refuses to apply, while a bare `"sum"(1)` is parsed as the symbol — and a literal function head carry no spelling, and `get("pick")(units)` stays unresolved under #130's conservative policy.

One place reads the same pair the other way, and it is the asymmetry the registry already records. A language capture answers to the calling environment, so `(quote)(share)` claims no capture at all: R evaluates that head as a value, any binding wins, and the walk keeps reporting the read it would otherwise hide.

## Tests

Derived from the rule, as the spellings are derived from the registry. Every registered spelling is exercised bare and under each owner, and each of those with a pair around the head, two pairs around it, and a pair around the whole call — locally, on a lazy input, with and without a caller binding of the same name, comparing condition classes as well as messages. The foreign-qualifier writings are asserted to *differ* and the unresolvable heads to stay unrecognized, so neither half can pass by recognizing nothing.

Also covered: the grouping-column exclusion through every writing, the nested-constructor gate over the whole constructor family, an injected quosure keeping its environment through a wrapping pair, and every shared reader answering R's empty argument.

## Recorded consequences

Both are in the ADR amendment rather than avoided:

- A caller's redundant pair does not survive into the staged expression, so `sum((a + b))` echoes as `sum(a + b)` in a diagnostic dplyr raises about that argument. What is evaluated is unchanged, and this is the normalization the package already performs far more visibly, since `across(v, mean)` reaches the same diagnostics as `dplyr::across(dplyr::all_of("v"), mean)`.
- `get(("share"))` now resolves to the read it names instead of being reported as a read of every alias in scope.

`DESCRIPTION`'s `Config/marginplyr/cran-status` reads `unpublished`, and every writing this makes recognized was previously an error, so no result changes into a different result.

## Documentation

ADR 0019 gains an amendment; `CONTEXT.md`, `design/architecture.md`, `NEWS.md`, `?summarize_with_margins`, and `get_started.qmd` state the rule.

## Checks run locally

- full testthat suite green (`NOT_CRAN=true`)
- `lintr::lint_package()` clean
- `roxygen2::roxygenise()` committed
- every `man/*.Rd` example runs
- `.github/scripts/verify-suite-coverage.R`: all 510 tests execute under a single-backend configuration