### PR TITLE
State what a nested specification position recognizes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,6 +15,21 @@ The semantic form of one node in a Grouping specification: grouping set,
 grouping-set union, rollup, cube, or Cartesian product.
 _Avoid_: Grouping specification type
 
+**Nested specification position**:
+An argument of a Grouping specification constructor, where a nested Grouping
+specification and a column selection are both allowed. Which one is meant is
+decided by how the argument is written: a call to a constructor, or a name
+bound to a specification, is a nested specification, and every other argument
+is a column selection. The position never evaluates an argument to find out,
+because a selection such as `starts_with("re")` has no meaning outside a
+selection context. A specification a caller's own function returns is
+therefore refused there, in marginplyr's own words and with the binding that
+works, while the same call is accepted as `.grouping` itself. The position
+answers for its own argument and not for a part of one: a specification
+written inside a selection is the wrong kind of object where it sits, and
+keeps the selection's own report.
+_Avoid_: Nested grouping, nested slot
+
 **Grouping plan**:
 The backend-independent grouping semantics obtained by fully expanding a
 grouping specification.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@
 * Added `grouping_set()`, `grouping_sets()`, `rollup()`, `cube()`, and
   `grouping_spec()` for arbitrary SQL-style grouping plans, including empty
   sets, nesting, Cartesian products, and composite dimensions.
+* A nested Grouping specification is recognized by how it is written: a call to
+  one of those constructors, or a name bound to a specification. Anything else
+  is a column selection, which is why a function of your own returning a
+  specification is accepted as `.grouping` itself and refused inside another
+  specification. That refusal is now marginplyr's own diagnostic, naming the
+  recognized forms and the binding that works — `s <- my_spec(region)`, then
+  `grouping_sets(s, grade)` — rather than tidyselect reporting the
+  specification as an unusable column selection.
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -735,8 +735,71 @@ grouping_arg_spec <- function(arg, data_vars) {
   NULL
 }
 
+# The gate above reads spellings, so a specification a caller's own function
+# returns arrives here, where a column selection is expected. tidyselect then
+# reports a `margin_grouping_spec` as the wrong kind of object for a position
+# where a specification is exactly what belongs, which is a diagnostic that
+# contradicts itself (#190). The contract the position actually has -- a
+# constructor spelling or a name -- is what the caller needs told, together
+# with the binding that makes their call work.
+#
+# The refused value is read from the condition rather than by evaluating the
+# quosure again to identify it: tidyselect has already evaluated it once, and
+# ADR 0008 fixes how often a caller's quosure runs. This is marginplyr's own
+# report about a position of its own, so it stays parentless, as
+# `abort_share_source_name()` does for the same reason. Every other failure is
+# an External condition and is re-raised as it arrived, class and provenance
+# intact.
 resolve_grouping_selection <- function(arg, data_proxy) {
-  resolve_column_selection(arg, data_proxy, labels = grouping_rename_labels())
+  tryCatch(
+    resolve_column_selection(
+      arg,
+      data_proxy,
+      labels = grouping_rename_labels()
+    ),
+    error = function(cnd) {
+      label <- rlang::as_label(rlang::quo_get_expr(arg))
+      if (!is_grouping_spec_subscript(cnd, label)) {
+        stop(cnd)
+      }
+      abort_nested_grouping_spec(label)
+    }
+  )
+}
+
+# The refused subscript travels in the condition's `i` field, and tidyselect
+# wraps a failure raised inside a selection helper, so the chain is walked as
+# `share_selection_missing_names()` walks it for the same reason.
+#
+# What the position can speak for is its own argument, so the refusal has to
+# name that argument and not a part of it: tidyselect reports the sub-selection
+# it refused, and in `c(spec, region)` a specification is genuinely the wrong
+# kind of object where it sits. Saying otherwise there would claim the whole
+# argument is a specification, which is false, and send a caller to a binding
+# they have already made. Comparing the labels is what separates the two, and
+# both are written by `rlang::as_label()` from the same expression when the
+# argument as a whole is what was refused.
+is_grouping_spec_subscript <- function(cnd, label) {
+  if (
+    inherits(cnd$i, "margin_grouping_spec") &&
+      identical(cnd$subscript_arg, label)
+  ) {
+    return(TRUE)
+  }
+  parent <- cnd$parent
+  inherits(parent, "condition") && is_grouping_spec_subscript(parent, label)
+}
+
+abort_nested_grouping_spec <- function(label) {
+  abort_marginplyr(
+    paste0(
+      "`", label, "` is a grouping specification, but a nested position ",
+      "recognizes one only when it is a call to ",
+      format_grouping_constructors(), ", or a name bound to a specification. ",
+      "Anything else is read as a column selection. Assign the specification ",
+      "to a name first, then use that name here."
+    )
+  )
 }
 
 # tidyselect reports a selection under the names the caller gave it, so

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -38,6 +38,15 @@
 #'   valid nested Grouping specification, and with no arguments represents the
 #'   identity product (the empty grouping set).
 #'
+#'   A nested Grouping specification is recognized by how it is written: a
+#'   call to one of these constructors, or a name bound to a specification.
+#'   Any other argument is a column selection, so a call of your own that
+#'   returns a specification is refused where it is nested even though it is
+#'   accepted as `.grouping` itself. Assign what it returns to a name and use
+#'   that name: `s <- my_spec(region)`, then `grouping_sets(s, grade)`. A
+#'   specification written inside a selection, as in `c(s, grade)`, is a
+#'   selection containing something it cannot select, and is refused as one.
+#'
 #'   A dimension is a column of the input, so a selection cannot rename it:
 #'   `c(area = region)` is an error rather than a dimension named `area`.
 #'   Rename the result afterwards with [dplyr::rename()].

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -13,7 +13,10 @@
 #'   [dplyr::rename()].
 #' @param .grouping A Grouping specification created by [grouping_set()],
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
-#'   represents the empty grouping set.
+#'   represents the empty grouping set. Any expression returning a
+#'   specification can be written here, while a specification nested inside
+#'   another must be a constructor call or a name bound to one; see
+#'   [grouping_set()].
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
 #'   duplicate grouping-set occurrences.
 #' @param .format `"text"` for compact display values or `"list"` for exact

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -20,7 +20,10 @@
 #'   named `area`. Rename the result afterwards with [dplyr::rename()].
 #' @param .grouping A grouping specification made with [grouping_set()],
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
-#'   represents one empty grouping set.
+#'   represents one empty grouping set. Any expression returning a
+#'   specification can be written here, while a specification nested inside
+#'   another must be a constructor call or a name bound to one; see
+#'   [grouping_set()].
 #' @param .margin_label A display label for dimensions omitted from a grouping
 #'   set. An unnamed character scalar applies to every resolved Margin
 #'   dimension. A named character vector must name every resolved Margin

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -91,6 +91,23 @@ specifications are validated before their parent-child relationship. The
 registry is used only while compiling; neither it nor the source specification
 is retained in the resulting Grouping plan.
 
+A Nested specification position reads its argument by spelling, because the
+alternative reading is a column selection and evaluating every nested call
+would run a selection helper outside a selection context. A specification a
+caller's own function returns therefore reaches selection resolution, where
+tidyselect refuses it as an unusable subscript, and that one refusal is
+replaced by a Package condition naming the recognized forms and the binding
+that works. Being marginplyr's own report about a position of its own, it is
+parentless, as a share selection naming something ineligible is. The refused
+value is read from the condition rather than by evaluating the argument a
+second time to identify it, which is what keeps the number and timing of
+caller-quosure evaluations fixed. The replacement covers the argument the
+position owns and not a part of one: a specification written inside a
+selection keeps tidyselect's report, which names the sub-selection and is
+accurate about it. Every other selection failure is re-raised as it arrived,
+so an External condition still reaches the caller with its own class and
+provenance.
+
 ### Margin label (`R/margin-label.R`)
 
 Owns label normalization, factor/backend restrictions, optional collision

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -28,7 +28,10 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
-represents one empty grouping set.}
+represents one empty grouping set. Any expression returning a
+specification can be written here, while a specification nested inside
+another must be a constructor call or a name bound to one; see
+\code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -33,6 +33,15 @@ nested Grouping specification, and requires at least one argument.
 valid nested Grouping specification, and with no arguments represents the
 identity product (the empty grouping set).
 
+A nested Grouping specification is recognized by how it is written: a
+call to one of these constructors, or a name bound to a specification.
+Any other argument is a column selection, so a call of your own that
+returns a specification is refused where it is nested even though it is
+accepted as \code{.grouping} itself. Assign what it returns to a name and use
+that name: \code{s <- my_spec(region)}, then \code{grouping_sets(s, grade)}. A
+specification written inside a selection, as in \code{c(s, grade)}, is a
+selection containing something it cannot select, and is refused as one.
+
 A dimension is a column of the input, so a selection cannot rename it:
 \code{c(area = region)} is an error rather than a dimension named \code{area}.
 Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -24,7 +24,10 @@ fixed key named \code{area}. Rename the result afterwards with
 
 \item{.grouping}{A Grouping specification created by \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
-represents the empty grouping set.}
+represents the empty grouping set. Any expression returning a
+specification can be written here, while a specification nested inside
+another must be a constructor call or a name bound to one; see
+\code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
 duplicate grouping-set occurrences.}

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -31,7 +31,10 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
-represents one empty grouping set.}
+represents one empty grouping set. Any expression returning a
+specification can be written here, while a specification nested inside
+another must be a constructor call or a name bound to one; see
+\code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -31,7 +31,10 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
-represents one empty grouping set.}
+represents one empty grouping set. Any expression returning a
+specification can be written here, while a specification nested inside
+another must be a constructor call or a name bound to one; see
+\code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -47,7 +47,10 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 
 \item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
-represents one empty grouping set.}
+represents one empty grouping set. Any expression returning a
+specification can be written here, while a specification nested inside
+another must be a constructor call or a name bound to one; see
+\code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -163,6 +163,70 @@ test_that("Grouping tidyselect conditions retain their provenance", {
   expect_match(conditionMessage(error), "Column `unknown` doesn't exist")
 })
 
+test_that("a nested specification from a caller's function names its verb", {
+  data <- data.frame(a = c("x", "y"), value = 1:2)
+  spec_from_caller <- function(...) rollup(...)
+  calls <- list(
+    summarize_with_margins = quote(
+      summarize_with_margins(
+        data,
+        n = dplyr::n(),
+        .grouping = grouping_sets(spec_from_caller(a), a)
+      )
+    ),
+    expand_with_margins = quote(
+      expand_with_margins(
+        data,
+        .grouping = grouping_sets(spec_from_caller(a), a)
+      )
+    ),
+    nest_with_margins = quote(
+      nest_with_margins(
+        data,
+        .grouping = grouping_sets(spec_from_caller(a), a)
+      )
+    ),
+    nest_by_with_margins = quote(
+      nest_by_with_margins(
+        data,
+        .grouping = grouping_sets(spec_from_caller(a), a)
+      )
+    )
+  )
+
+  for (verb in names(calls)) {
+    error <- expect_error(eval(calls[[verb]]))
+    expect_s3_class(error, "marginplyr_error")
+    expect_match(
+      conditionMessage(error),
+      paste0(
+        "`spec_from_caller(a)` is a grouping specification, but a nested ",
+        "position recognizes one only when it is a call to"
+      ),
+      fixed = TRUE
+    )
+    expect_identical(rlang::call_name(conditionCall(error)), verb)
+  }
+
+  # The workaround the diagnostic names executes, and it is the same plan the
+  # constructor spelling builds.
+  bound <- spec_from_caller(a)
+  expect_equal(
+    summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = grouping_sets(bound, a),
+      .duplicates = "drop"
+    ),
+    summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = grouping_sets(rollup(a), a),
+      .duplicates = "drop"
+    )
+  )
+})
+
 test_that("fixed .by columns are never replaced", {
   data <- data.frame(
     year = c(2024L, 2024L, 2025L),

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -136,6 +136,173 @@ test_that("grouping specification kinds enforce the nesting grammar", {
   }
 })
 
+test_that("a nested specification position recognizes a spelling or a name", {
+  data_vars <- c("region", "grade", "value")
+  spec_from_caller <- function(...) rollup(...)
+  compile <- function(spec) {
+    compile_grouping_spec(
+      spec,
+      data_vars,
+      .duplicates = "keep",
+      duplicates_choices = margin_duplicates_choices
+    )
+  }
+
+  # The two recognized forms resolve to the same family, so the name is a
+  # complete substitute for the spelling and not a narrower one.
+  from_spelling <- compile(grouping_sets(rollup(region), grade))
+  bound <- rollup(region)
+  expect_equal(compile(grouping_sets(bound, grade))$sets, from_spelling$sets)
+
+  # A caller's own function is neither, so the value it returns arrives where a
+  # column selection is expected. The position says so itself rather than
+  # leaving tidyselect to report a specification as an unusable selection.
+  refused <- expect_error(
+    compile(grouping_sets(spec_from_caller(region), grade))
+  )
+  expect_s3_class(refused, "marginplyr_error")
+  expect_identical(
+    conditionMessage(refused),
+    paste0(
+      "`spec_from_caller(region)` is a grouping specification, but a nested ",
+      "position recognizes one only when it is a call to `grouping_set()`, ",
+      "`grouping_sets()`, `rollup()`, `cube()`, or `grouping_spec()`, or a ",
+      "name bound to a specification. Anything else is read as a column ",
+      "selection. Assign the specification to a name first, then use that ",
+      "name here."
+    )
+  )
+
+  # The workaround the diagnostic names is the one that works.
+  from_caller <- spec_from_caller(region)
+  expect_equal(
+    compile(grouping_sets(from_caller, grade))$sets,
+    from_spelling$sets
+  )
+
+  # Every constructor position reports the same rule, `grouping_set()`
+  # included, where the binding the diagnostic asks for then reaches the
+  # grammar error that position really has.
+  constructors <- c(
+    "grouping_set",
+    "grouping_sets",
+    "rollup",
+    "cube",
+    "grouping_spec"
+  )
+  for (constructor in constructors) {
+    error <- expect_error(compile(eval(rlang::call2(
+      constructor,
+      quote(spec_from_caller(region))
+    ))))
+    expect_s3_class(error, "marginplyr_error")
+    expect_match(
+      conditionMessage(error),
+      "is a grouping specification, but a nested position",
+      fixed = TRUE
+    )
+  }
+  bound_in_set <- expect_error(compile(grouping_set(from_caller)))
+  expect_identical(
+    conditionMessage(bound_in_set),
+    paste0(
+      "A `grouping_set()` can contain columns, not another ",
+      "grouping family."
+    )
+  )
+})
+
+test_that("a nested column selection is unaffected by the specification rule", {
+  data_vars <- c("region", "region_code", "grade", "value")
+  compile <- function(spec) {
+    compile_grouping_spec(
+      spec,
+      data_vars,
+      .duplicates = "keep",
+      duplicates_choices = margin_duplicates_choices
+    )
+  }
+  selected <- c("region", "grade")
+
+  expect_equal(
+    compile(grouping_sets(tidyselect::starts_with("region"), grade))$sets,
+    list(c("region", "region_code"), "grade")
+  )
+  expect_equal(
+    compile(grouping_sets(tidyselect::all_of(selected)))$sets,
+    list(c("region", "grade"))
+  )
+  expect_equal(
+    compile(grouping_sets(-c(region_code, value), grade))$sets,
+    list(c("region", "grade"), "grade")
+  )
+  expect_equal(
+    compile(grouping_spec(c(region, grade), tidyselect::last_col()))$sets,
+    list(c("region", "grade", "value"))
+  )
+
+  # A selection that fails is still tidyselect's own report, unchanged.
+  unknown <- expect_error(compile(grouping_sets(unknown, grade)))
+  expect_false(inherits(unknown, "marginplyr_error"))
+  expect_match(conditionMessage(unknown), "Column `unknown` doesn't exist")
+
+  # A specification inside a selection is not a nested specification, and the
+  # position does not speak for a part of an argument it did not refuse: a
+  # specification really is the wrong kind of object where `c()` puts it, and a
+  # caller who bound it to a name has already done what this rule would ask.
+  # tidyselect deprecates the bare external vector these three write, and it is
+  # not what they are here to show, so its warning is suppressed rather than
+  # asserted.
+  bound <- rollup(region)
+  embedded <- expect_error(
+    suppressWarnings(compile(grouping_sets(c(bound, grade), region)))
+  )
+  expect_false(inherits(embedded, "marginplyr_error"))
+  expect_match(conditionMessage(embedded), "Can't select columns with `bound`")
+  for (selection in list(quote(-bound), quote(tidyselect::all_of(bound)))) {
+    spec <- eval(rlang::call2("grouping_sets", selection, rlang::sym("grade")))
+    embedded_error <- expect_error(suppressWarnings(compile(spec)))
+    expect_false(inherits(embedded_error, "marginplyr_error"))
+  }
+})
+
+test_that("recognizing a nested specification adds no caller evaluation", {
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    grade = c("a", "b", "a"),
+    units = c(1, 3, 6)
+  )
+
+  # ADR 0008 fixes how often a caller's quosure is evaluated. The refused
+  # specification is read from the failed selection rather than evaluated a
+  # second time to identify it, so the caller's function still runs once.
+  refused_calls <- 0L
+  spec_from_caller <- function(...) {
+    refused_calls <<- refused_calls + 1L
+    rollup(...)
+  }
+  expect_error(summarize_with_margins(
+    data,
+    t = sum(units),
+    .grouping = grouping_sets(spec_from_caller(region), grade)
+  ))
+  expect_identical(refused_calls, 1L)
+
+  # A name-only selection is resolved once per compilation pass, and both
+  # passes run when the whole specification is settled by name alone.
+  selection_calls <- 0L
+  counted <- function(x) {
+    selection_calls <<- selection_calls + 1L
+    x
+  }
+  summarize_with_margins(
+    data,
+    t = sum(units),
+    .grouping = grouping_sets(tidyselect::all_of(counted("region")), grade)
+  )
+  expect_identical(selection_calls, 2L)
+})
+
 test_that("empty grouping rules preserve their phase and error precedence", {
   expect_equal(
     compile_grouping_spec(


### PR DESCRIPTION
Closes #190.

## What was wrong

A caller's own function returning a genuine `margin_grouping_spec` was accepted
as `.grouping` and refused when nested, by a diagnostic that contradicts
itself. Measured on `508d798`:

| written | before | after |
| --- | --- | --- |
| `.grouping = my_spec(region)` | works | works |
| `grouping_sets(my_spec(region), grade)` | "Can't select columns with `my_spec(region)`. `my_spec(region)` must be numeric or character, not a `<margin_grouping_spec>` object" | the contract the position has, and the binding that works |
| `s <- my_spec(region); grouping_sets(s, grade)` | works, and nothing said so | works, and the diagnostic names it |

## The change

The gate is not the defect and is untouched. A nested argument is ambiguous
between a column selection and a nested specification, and evaluating every
nested call would run `starts_with("re")` outside a selection context, so the
spelling is what separates the two. What was missing is the contract:

> A nested specification is a constructor call or a name bound to one, and
> every other argument is a column selection.

`resolve_grouping_selection()` now states it, naming the recognized forms from
`grouping_kind_rules()` rather than a second list of constructors:

```
`my_spec(region)` is a grouping specification, but a nested position recognizes
one only when it is a call to `grouping_set()`, `grouping_sets()`, `rollup()`,
`cube()`, or `grouping_spec()`, or a name bound to a specification. Anything
else is read as a column selection. Assign the specification to a name first,
then use that name here.
```

`grouping_set()` reaches the same diagnostic, and the binding it asks for then
reaches the grammar error that position really has — that a grouping set
contains columns and not another grouping family. The tests follow the caller
through both steps rather than stopping at the first.

## The boundaries held

**ADR 0008.** The refused value is read from the subscript condition's `i`
field rather than by evaluating the quosure again to identify it, so the number
and timing of caller-quosure evaluations is unchanged. tidyselect has already
evaluated it once; that is how the value is available at all. A test counts the
caller's function calls and the selection's evaluations rather than a comment
claiming it.

**ADR 0015.** Every other selection failure is re-raised as it arrived, so an
External condition still reaches the caller with its own class, message, and
provenance — the existing "Grouping tidyselect conditions retain their
provenance" assertion covers that direction. The replacement is marginplyr's
own report about a position of its own, so it is parentless, as
`abort_share_source_name()` is for the same reason and unlike
`abort_share_selection_error()`, which parents a genuine tidyselect failure.

**The argument the position owns.** tidyselect reports the *sub-selection* it
refused, so the labels are compared before the refusal is replaced. In
`c(s, region)` a specification is genuinely the wrong kind of object where it
sits: claiming the whole argument is a specification would be false, and would
send a caller to a binding they have already made. `c(s, region)`, `-s`, and
`all_of(s)` therefore keep tidyselect's report, which names `s` and is accurate
about it.

## Tests

Regression cases cover a constructor spelling, a symbol, a caller's function,
and a selection in a nested position, across all five constructors and all four
Margin verbs:

- the two recognized forms resolve to the same family, so a name is a complete
  substitute for a spelling and not a narrower one;
- the workaround the diagnostic names executes, and builds the plan the
  spelling builds;
- `starts_with()`, `all_of()`, `last_col()`, a negation, and an unknown column
  are unaffected, the last still answering with tidyselect's own condition;
- a specification embedded in a selection keeps tidyselect's report;
- the evaluation counts are asserted, one for the refused specification and two
  for a name-only selection, which is both compilation passes.

## Documentation

The contract is written where a reader meets it: the constructors' `...`, both
`.grouping` parameters (inherited by the four verbs), `CONTEXT.md` as the
*Nested specification position* term, `design/architecture.md` for the
interception and its one allowed departure from untouched External conditions,
and `NEWS.md`. `DESCRIPTION`'s `Config/marginplyr/cran-status` reads
`unpublished`, and the writing this changes was an error before, so no result
changes into a different result.

## Follow-up filed

#193 — `share_selection_missing_names()` and the walk added here read the same
condition chain, and neither derives from the other. Deliberately not done in
this PR: it is a cross-module edit to a tested function for no change a caller
can see.

## Checks run locally

- full testthat suite green: `FAIL 0 | WARN 0 | SKIP 0 | PASS 4269`
- `lintr::lint_package()` clean, after `pkgload::load_all(".")`
- `roxygen2::roxygenise()` committed
- `spelling::spell_check_package()` clean
- `.github/scripts/verify-suite-coverage.R`: all 514 tests execute under a
  single-backend configuration

Not run locally, and left to CI: `R CMD check` including
`_R_CHECK_DEPENDS_ONLY_=true`, and the site build. Neither optional-dependency
guards nor vignettes are touched by this change.
