### PR TITLE
Ask before reading a lazy input's data

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -374,7 +374,12 @@ markers <- list(
     "Missing fixed and included keys",
     "where(is.numeric)",
     ".unpack = TRUE",
-    "runtime-only incompatibilities"
+    "runtime-only incompatibility",
+    # What a general dbplyr backend does instead of reading the caller's data
+    # (ADR 0020). This page is the canonical reference for both helpers'
+    # source contract, so it is the page that has to carry the count, and the
+    # count is the part a later edit is most likely to drift back to "one".
+    "at most two queries"
   ),
   "docs/man/nest_with_margins.html" = c(
     "Relationship to tidyr and dplyr",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,6 +493,28 @@ one job body also closed #73, which asked for an assertion that every job
 withholding optional backends checks a tarball: with a single body there is no
 second shape for such a job to have.
 
+### Queries against a lazy input
+
+marginplyr sends no query that reads a lazy input's data unless the caller
+asked for one, with the two exemptions ADR 0020 enumerates. A change that adds
+a `collect()`, `compute()`, or any other execution entry point to `R/` is
+therefore a change to a public contract, not an implementation detail, and is
+justified against that ADR in the same commit — or made conditional on an
+argument the caller sets.
+
+The snapshots in `test-query-policy.R` are what make such a change visible
+rather than assumed: one records the internal functions that reach an execution
+entry point, one records the set of entry points scanned for, and one records
+which backend kinds hold `collect_selection_proxy`. A scan that stopped
+covering an entry point would otherwise report a clean result, which reads
+exactly like a package that added none. They run only where `NOT_CRAN` is set.
+
+Deciding by billing model is the option that was rejected, and
+`investigation/query-cost-across-lazy-backends.md` records why: four models are
+in use across the backends dbplyr reaches, two of them appear under one
+`grouping_backend()` kind, and `is.data.frame()` is the only predicate that
+answers whether an external system is involved at all.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,14 @@ label represented by `NULL` use a typed missing value instead of a synthetic
 factor level.
 _Avoid_: Total value, missing-value replacement
 
+**Margin label collision**:
+A grouping dimension holding, as one of its own values, the Margin label
+chosen for it — so that a margin row and a row of the source data cannot be
+told apart by that column. A collision is *declared* when the colliding value
+is a factor level, which the column's type records, and *observed* when it
+appears only among the column's values.
+_Avoid_: Duplicate label, ambiguous margin
+
 **Margin order**:
 The row order a Margin operation produces when it is asked to order its
 result. Within each fixed key, every grouping dimension contributes its

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,20 @@ fixed `.by` group, so a fixed key never contributes to another partition's
 denominator.
 _Avoid_: Percent of total, root share, grand total percentage
 
+**Converting dialect**:
+A SQL dialect that answers an aggregate over a value of the wrong type by
+converting it to a number rather than raising. Its opposite is a *refusing*
+dialect, which rejects the same aggregate. Which of the two a dialect is
+decides whether the eligible-type rule for a share source can be left to the
+database: a refusing dialect applies it and reports an ineligible source in
+its own diagnostic, while a converting dialect applies nothing and returns a
+number whatever the source held, so a share over one is refused unless the
+caller establishes the source themselves. It is a property of the dialect and
+not of one connection, so it is established once and reused for every later
+connection carrying that dialect. A dialect that could not be asked is neither,
+and is refused as a converting one is.
+_Avoid_: Coercing backend, lenient database, permissive SQL
+
 **Contextual helper**:
 A spelling whose meaning inside a Margin summary arises only through static
 rewriting, and which is therefore recognized by spelling and never resolved

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,8 +19,11 @@
   dtplyr are supported, and lazy inputs stay lazy; Arrow rejects Parent shares
   before a query is built. A share source must be a plain integer or double on
   every backend: where the type is not readable without asking, marginplyr
-  reads the ordinary summaries over one input row rather than leaving the rule
-  to the dialect.
+  asks each SQL dialect once, with a query that reads none of your data,
+  whether it converts a non-numeric value to a number instead of refusing it,
+  and refuses the share rather than calculate one from a source nothing has
+  checked. `.check_share_source = FALSE` opts out for a source you have
+  established yourself (#195, #196).
 * Added the contextual `share_of_total()` summary helper, which divides the
   same kind of source summary by the Grand total set within each fixed `.by`
   partition. It shares every rule of `share_of_parent()` except the
@@ -52,6 +55,18 @@
 * Added explicit duplicate-set policies: `"error"`, `"drop"`, and `"keep"`.
 * Changed the default display label to `"Total"`; `.margin_label = NULL`
   preserves grouping-column types and typed missing values.
+* `.check_margin_label` controls only the half of the Margin label collision
+  check that reads the data: whether an actual value of a Margin dimension
+  equals its display label. It defaults to `TRUE` for local data frames and
+  `FALSE` for lazy inputs, which are read only when asked. A label equal to a
+  declared factor level is rejected on every backend whatever this argument
+  says, because the level is already known from the column's metadata and
+  finding it sends no query (#122).
+* Added `.check_share_source` to `summarize_with_margins()`, `TRUE` by
+  default on every backend, including lazy ones, for the same reason: a share
+  source's eligibility can be established without reading your data, so the
+  check runs unless you opt out. See `share_of_parent()` and
+  `share_of_total()` above.
 * DuckDB and PostgreSQL use native `GROUPING SETS`; other backends use the
   portable `UNION ALL` adapter.
 * `summarize_with_margins()`, `summarise_with_margins()`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,11 +19,11 @@
   dtplyr are supported, and lazy inputs stay lazy; Arrow rejects Parent shares
   before a query is built. A share source must be a plain integer or double on
   every backend: where the type is not readable without asking, marginplyr
-  asks each SQL dialect once, with a query that reads none of your data,
-  whether it converts a non-numeric value to a number instead of refusing it,
-  and refuses the share rather than calculate one from a source nothing has
-  checked. `.check_share_source = FALSE` opts out for a source you have
-  established yourself (#195, #196).
+  asks each SQL dialect once, with at most two queries that read none of your
+  data, whether it converts a non-numeric value to a number instead of
+  refusing it, and refuses the share rather than calculate one from a source
+  nothing has checked. `.check_share_source = FALSE` opts out for a source you
+  have established yourself (#195, #196).
 * Added the contextual `share_of_total()` summary helper, which divides the
   same kind of source summary by the Grand total set within each fixed `.by`
   partition. It shares every rule of `share_of_parent()` except the

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -32,6 +32,7 @@
 #' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Database backend coverage
+#' @inheritSection summarize_with_margins When marginplyr queries your data
 #' @inheritSection summarize_with_margins Backend extension design
 #' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its
 #'   class and attributes follow [dplyr::mutate()] combined with

--- a/R/factor.R
+++ b/R/factor.R
@@ -38,18 +38,25 @@ reconstruct_factor_vector <- function(x,
 }
 
 margin_factor_levels <- function(info, .margin_name, position) {
-  other_levels <- info$levels[vapply(
-    info$levels,
-    function(level) !identical(level, .margin_name),
-    logical(1)
-  )]
+  # An invariant, not a Package condition (ADR-0015). A label equal to a
+  # declared level is rejected before anything executes and whatever
+  # `.check_margin_label` says (ADR 0020): every Margin verb calls
+  # `validate_margin_operation()` before the `finalize_margin_operation()` that
+  # calls `restore_margin_factors()`, which is the only caller of this. A level
+  # equal to the label would otherwise be deduplicated away and re-appended,
+  # moving it to the end of the levels for no reason a caller could see.
+  stopifnot(
+    "A Margin label equal to a declared factor level reached execution." =
+      !(.margin_name %in% info$levels)
+  )
+
   # The assignment is this function's return value, which codetools reads as a
   # dead store.
   # nolint start: object_usage_linter.
   new_levels <- if (identical(position, "first")) {
-    c(.margin_name, other_levels)
+    c(.margin_name, info$levels)
   } else {
-    c(other_levels, .margin_name)
+    c(info$levels, .margin_name)
   }
   # nolint end
 }

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -142,51 +142,78 @@ validate_margin_label <- function(.data,
     }
   }
 
+  # A declared collision is read off the levels ADR 0002 already acquired, so
+  # finding it sends no query and nothing had to be asked for (ADR 0020). It
+  # sits above the gate for the reason the NA-level check above it does.
+  check_declared_label_collision(
+    margin_labels = margin_labels,
+    factor_info = factor_info
+  )
+
   if (!.check_margin_label) {
     return(invisible(NULL))
   }
 
-  check_margin_label_collision(
+  check_observed_label_collision(
     .data,
     margin_labels = margin_labels,
     factor_info = factor_info
   )
 }
 
-check_margin_label_collision <- function(data,
-                                         margin_labels,
-                                         factor_info = list()) {
-  col_names <- names(margin_labels)
-  stopifnot(is.character(col_names), !anyNA(col_names))
+check_declared_label_collision <- function(margin_labels,
+                                           factor_info = list()) {
+  stopifnot(is.character(names(margin_labels)), !anyNA(names(margin_labels)))
 
-  checked_labels <- Filter(function(label) !is.null(label), margin_labels)
-  if (length(checked_labels) == 0L) {
+  if (length(factor_info) == 0L) {
     return(invisible(NULL))
   }
 
-  factor_cols <- vapply(factor_info, function(info) info$col, character(1))
-  factor_levels <- stats::setNames(rep(FALSE, length(col_names)), col_names)
-  for (info in factor_info) {
-    label <- margin_labels[[info$col]]
-    if (!is.null(label) && !is.na(label)) {
-      factor_levels[[info$col]] <- label %in% info$levels
-    }
-  }
-  if (any(factor_levels)) {
-    abort_margin_label_collision(margin_labels, factor_levels)
+  declared <- vapply(
+    factor_info,
+    function(info) {
+      label <- margin_labels[[info$col]]
+      !is_missing_margin_label(label) && label %in% info$levels
+    },
+    logical(1)
+  )
+  names(declared) <- vapply(factor_info, function(info) info$col, character(1))
+  if (!any(declared)) {
+    return(invisible(NULL))
   }
 
-  data <- dplyr::select(.data = data, dplyr::all_of(col_names))
+  abort_margin_label_collision(margin_labels, declared, kind = "declared")
+}
+
+check_observed_label_collision <- function(data,
+                                           margin_labels,
+                                           factor_info = list()) {
+  col_names <- names(margin_labels)
+  stopifnot(is.character(col_names), !anyNA(col_names))
+
+  factor_cols <- vapply(factor_info, function(info) info$col, character(1))
+  # A factor dimension states its values in its levels, and a label equal to
+  # one of them was rejected above, so reading its column could only find a
+  # value the levels do not contain. A missing label is the exception: whether
+  # the column holds a missing value is not something the levels record.
+  read_cols <- Filter(
+    function(col) {
+      label <- margin_labels[[col]]
+      !is.null(label) && !(col %in% factor_cols && !is.na(label))
+    },
+    col_names
+  )
+  # No column left to read is no query, rather than a query selecting nothing:
+  # a lazy input is not contacted to aggregate a set of constants.
+  if (length(read_cols) == 0L) {
+    return(invisible(NULL))
+  }
+
+  data <- dplyr::select(.data = data, dplyr::all_of(read_cols))
   checks <- lapply(
-    col_names,
+    read_cols,
     function(col) {
       margin_label <- margin_labels[[col]]
-      if (
-        is.null(margin_label) ||
-          (col %in% factor_cols && !is.na(margin_label))
-      ) {
-        return(rlang::expr(0L))
-      }
       column <- rlang::sym(col)
       condition <- if (is.na(margin_label)) {
         rlang::expr(is.na(!!column))
@@ -201,10 +228,10 @@ check_margin_label_collision <- function(data,
       )
     }
   )
-  names(checks) <- col_names
+  names(checks) <- read_cols
   found <- dplyr::collect(dplyr::summarize(data, !!!checks))
   found <- vapply(
-    col_names,
+    read_cols,
     function(col) {
       nrow(found) > 0L && isTRUE(found[[col]][[1L]] > 0)
     },
@@ -215,11 +242,15 @@ check_margin_label_collision <- function(data,
     return(invisible(NULL))
   }
 
-  abort_margin_label_collision(margin_labels, found)
+  abort_margin_label_collision(margin_labels, found, kind = "observed")
 }
 
-abort_margin_label_collision <- function(margin_labels, found) {
-  stopifnot(is.logical(found), any(found))
+abort_margin_label_collision <- function(margin_labels, found, kind) {
+  stopifnot(
+    is.logical(found),
+    any(found),
+    identical(kind, "declared") || identical(kind, "observed")
+  )
 
   bad_cols <- paste0("`", names(found)[found], "`", collapse = ", ")
   bad_labels <- margin_labels[names(found)[found]]
@@ -230,15 +261,31 @@ abort_margin_label_collision <- function(margin_labels, found) {
   )
   one_label <- length(unique(label_values)) == 1L
   label <- if (one_label) unique(label_values) else "Margin labels"
+  verb <- if (one_label) " is" else " are"
+  presence <- if (identical(kind, "declared")) {
+    if (one_label) " a factor level in" else " factor levels in"
+  } else {
+    " present in"
+  }
+  # `.check_margin_label = FALSE` is offered only where it is a remedy. It
+  # turns off the read, and a declared collision is not found by reading, so
+  # naming it there would send a caller to an argument that changes nothing.
+  remedy <- if (identical(kind, "declared")) {
+    "Choose another `.margin_label`."
+  } else {
+    "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+  }
   abort_marginplyr(
     paste0(
       label,
-      if (one_label) " is" else " are",
-      " already present in grouping column",
+      verb,
+      " already",
+      presence,
+      " grouping column",
       if (sum(found) == 1L) " " else "s ",
       bad_cols,
-      ". Choose another `.margin_label` or set ",
-      "`.check_margin_label = FALSE`."
+      ". ",
+      remedy
     )
   )
 }

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -9,6 +9,7 @@
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
+#' @inheritSection summarize_with_margins When marginplyr queries your data
 #' @inheritSection summarize_with_margins Backend extension design
 #' @inheritSection nest_with_margins Relationship to tidyr and dplyr
 #' @param .key A non-missing string naming the list column. Unlike

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -10,6 +10,7 @@
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
+#' @inheritSection summarize_with_margins When marginplyr queries your data
 #' @inheritSection summarize_with_margins Backend extension design
 #' @param .data A local data frame or a `dtplyr` step. Other lazy tables are
 #'   not supported because nesting creates list columns.

--- a/R/share.R
+++ b/R/share.R
@@ -2059,34 +2059,75 @@ share_dialect_can_be_asked <- function(con) {
 }
 
 # Only the two outcomes the investigation measured are read as answers: a
-# number came back, which is the conversion, or executing the query raised,
-# which is the refusal the rule is then left to. Everything else -- a query
-# that cannot be built against this connection at all, an empty result, a
-# result of another shape or type -- is no reading of the dialect, and falls
+# number came back, which is the conversion, or the dialect rejected summing a
+# string, which is the refusal the rule is then left to. Everything else -- a
+# query that cannot be built against this connection at all, an empty result,
+# a result of another shape or type -- is no reading of the dialect, and falls
 # to "unknown", which refuses the share. Falling the other way would switch
 # the protection off wherever the question went unanswered and say nothing
 # about having done so.
 #
-# `vars` is what keeps this to the one query the answer needs: without it
-# dbplyr asks the connection for the query's fields before it can build a
-# `tbl`, which is a second query for a schema this frame already knows.
+# A raised query is not by itself the refusal, and reading it as one is how
+# the protection came to be switched off exactly where it was needed. The
+# scaffolding `SELECT 1 AS z` reaches the database verbatim -- `dbplyr::sql()`
+# is passed through untranslated -- and it has no `FROM`, which is a syntax
+# error on Oracle, which requires `FROM DUAL`, and on SAP HANA, which requires
+# `FROM DUMMY`. A dropped connection or a permissions failure raises just the
+# same. Every one of those would have been recorded as "this dialect refuses
+# an ineligible summary", which is the verdict that proceeds, so a share on
+# such a dialect was calculated with the rule silently off and the answer
+# cached for every later connection carrying it.
+#
+# The refusal is therefore only read from a query that raised where the same
+# scaffolding demonstrably works. The control asks the one thing no dialect
+# can refuse -- summing the number the scaffolding already selects -- so a
+# control that does not come back with that number says the question could
+# not be put here, whatever the reason, and "unknown" refuses the share. It is
+# only sent when the probe raised, so a dialect that converts still answers in
+# one query and the second is the price of telling the two failures apart.
+#
+# `vars` is what keeps each of them to the one query its answer needs: without
+# it dbplyr asks the connection for the query's fields before it can build a
+# `tbl`, which is a further query for a schema this frame already knows.
 probe_share_dialect <- function(con) {
-  probe <- tryCatch(
+  probe <- probe_share_dialect_answer(con, quote(sum("x", na.rm = TRUE)))
+  if (identical(probe$status, "unbuildable")) {
+    return("unknown")
+  }
+  if (identical(probe$status, "raised")) {
+    control <- probe_share_dialect_answer(con, quote(sum(z, na.rm = TRUE)))
+    if (!identical(control$status, "answered")) {
+      return("unknown")
+    }
+    return("refuses")
+  }
+  if (!identical(probe$status, "answered")) {
+    return("unknown")
+  }
+  "converts"
+}
+
+# One table-free question, and which of the three things happened to it: it
+# could not be built against this connection, executing it raised, or it came
+# back with exactly one number. Any other shape is not an answer, so it is not
+# reported as one.
+probe_share_dialect_answer <- function(con, expr) {
+  query <- tryCatch(
     dplyr::summarize(
       dplyr::tbl(con, dbplyr::sql("SELECT 1 AS z"), vars = "z"),
-      p = sum("x", na.rm = TRUE)
+      p = !!expr
     ),
     error = function(cnd) NULL
   )
-  if (is.null(probe)) {
-    return("unknown")
+  if (is.null(query)) {
+    return(list(status = "unbuildable"))
   }
   answer <- tryCatch(
-    list(value = suppressMessages(suppressWarnings(dplyr::collect(probe)))),
+    list(value = suppressMessages(suppressWarnings(dplyr::collect(query)))),
     error = function(cnd) NULL
   )
   if (is.null(answer)) {
-    return("refuses")
+    return(list(status = "raised"))
   }
   value <- answer$value
   if (
@@ -2095,9 +2136,9 @@ probe_share_dialect <- function(con) {
       ncol(value) != 1L ||
       !is_share_source_type(value[[1L]])
   ) {
-    return("unknown")
+    return(list(status = "unreadable"))
   }
-  "converts"
+  list(status = "answered", value = value[[1L]])
 }
 
 # The refusal names whichever helpers the caller wrote, as the Arrow one does

--- a/R/share.R
+++ b/R/share.R
@@ -375,16 +375,16 @@
 #' Syntax, source-name, written-order, and `across()` errors are always
 #' reported locally, before execution, on every backend. The eligible-type
 #' rule is also enforced on every backend, and no backend calculates a share
-#' from a source it has shown to be ineligible. What differs is when the
-#' source's type becomes readable, and whether the exactly-one-value
-#' cardinality rule can be read with it:
+#' from a source it has shown to be ineligible. None of it reads a row of your
+#' data. What differs is what establishes the rule, and whether the
+#' exactly-one-value cardinality rule is established with it:
 #'
-#' | Backend | Where source type and cardinality are checked |
+#' | Backend | What establishes the source rules |
 #' |---|---|
-#' | Local data frame | Before any share is calculated |
-#' | `dtplyr` step | At explicit execution, before an invalid row is emitted |
-#' | Arrow | Not reached; shares are rejected outright |
-#' | General dbplyr | Type only, from one input row, before the query returns |
+#' | Local data frame | Both, from the result, before any share |
+#' | `dtplyr` step | Both, at execution, before an invalid row |
+#' | Arrow | Neither; shares are rejected outright |
+#' | General dbplyr | Type only, by asking the dialect once |
 #'
 #' Arrow inputs reject both helpers after expression planning and common
 #' Margin-operation validation but before constructing a summary query. The
@@ -398,26 +398,30 @@
 #' diagnostics keep the share's output name, the source summary name, and
 #' the original public call, so they read like the local ones.
 #'
-#' A general dbplyr backend evaluates the source summary in the database, so
-#' its type is readable only from a value the database returns. marginplyr
-#' reads one: when a share is requested, it collects the ordinary summaries
-#' over a single input row and rejects an ineligible source before returning
-#' the query. The read is bounded in rows requested and returned, not in the
-#' work the input may have to do to produce that one row. It is the staged
-#' query that stays lazy — nothing else is executed, [dplyr::show_query()]
-#' remains non-executing, and no further query is run to improve an error.
+#' A general dbplyr backend evaluates the source summary itself, so the rule
+#' is the dialect's to apply rather than marginplyr's to read. Nothing of
+#' yours is read to establish it: the staged query stays lazy,
+#' [dplyr::show_query()] remains non-executing, and no query is run over your
+#' data to improve an error.
 #'
-#' A source the read cannot type is left alone rather than rejected. A dialect
-#' that types values rather than columns says nothing about a summary whose
-#' one sampled value is missing, and a summary the database refuses is
-#' reported by the database when [dplyr::collect()] executes the staged
-#' query, where its own diagnostic is the useful one. Cardinality is not read
-#' this way at all: a SQL aggregate returns one value per grouping row by
-#' construction, so there is nothing for the sample to disprove. What the
-#' sample cannot type and every non-scalar summary therefore remain
-#' runtime-only incompatibilities: errors the database reports for itself at
-#' [dplyr::collect()] rather than ones marginplyr raises before returning the
-#' query.
+#' Which of two things a dialect does is what decides the case, and it is
+#' settled by asking that dialect once, with a query referencing none of your
+#' tables. Where it refuses an ineligible summary, that refusal is the answer
+#' and reaches you as the database's own diagnostic when [dplyr::collect()]
+#' executes the staged query; the internal denominator column is named after
+#' the summary to rewrite so that diagnostic is actionable. Where it converts
+#' a value of another type to a number instead, it applies no rule at all and
+#' no reading of your data would recover one, so the share is refused rather
+#' than calculated from values nothing has checked —
+#' `.check_share_source = FALSE` calculates it from sources you have
+#' established yourself. A backend that cannot be asked, such as a
+#' `dbplyr::simulate_*()` connection, is refused the same way.
+#'
+#' Cardinality is not established this way at all: a SQL aggregate returns one
+#' value per grouping row by construction, so there is nothing for a dialect
+#' to convert. A non-scalar summary therefore remains a runtime-only
+#' incompatibility, reported by the database at [dplyr::collect()] rather than
+#' raised by marginplyr before the query is returned.
 #'
 #' The portable value guarantee covers finite numbers, missing values, and
 #' zero denominators. Infinite values and backend-specific `NaN`
@@ -639,19 +643,11 @@ abort_arrow_shares <- function(kinds) {
   abort_marginplyr(
     paste0(
       "Arrow backends do not support ",
-      paste(
-        vapply(kinds, function(kind) {
-          paste0(share_kind_label(kind), "s")
-        }, character(1)),
-        collapse = " and "
-      ),
+      share_kind_labels_phrase(kinds),
       " because marginplyr cannot enforce their scalar-summary contract ",
       "safely before an Arrow query is constructed. Other Arrow Margin ",
       "operations remain supported. Omit ",
-      paste(
-        vapply(kinds, share_kind_call, character(1)),
-        collapse = " and "
-      ),
+      share_kind_calls_phrase(kinds),
       " or explicitly collect the data before calling ",
       "`summarize_with_margins()`."
     )
@@ -2011,8 +2007,22 @@ share_dialect_verdict <- function(data, backend) {
     return(cached)
   }
   verdict <- probe_share_dialect(con)
+  # An invariant, not a Package condition (ADR 0015). Four sites branch on
+  # this string and none of them has a default, so one this frame does not
+  # recognise would reach the caller as `"unknown"`'s diagnostic -- that their
+  # backend could not be asked -- for a dialect that was asked and answered.
+  # Caching it would then repeat that for every later connection.
+  stopifnot(verdict %in% share_dialect_verdict_names())
   share_dialect_verdicts[[key]] <- verdict
   verdict
+}
+
+# The three answers the dialect question can have. `"refuses"` and
+# `"converts"` are the two outcomes
+# `investigation/share-source-eligibility-on-coercing-dialects.md` measured;
+# `"unknown"` is every case that read neither, and refuses the share.
+share_dialect_verdict_names <- function() {
+  c("refuses", "converts", "unknown")
 }
 
 # One entry per dialect class, written the first time a share is requested on a
@@ -2098,15 +2108,16 @@ probe_share_dialect <- function(con) {
 # answered by finding out why.
 abort_share_source_dialect <- function(kinds, verdict, call) {
   kinds <- intersect(share_kind_names(), kinds)
+  # An invariant, not a Package condition (ADR 0015), and the reason this
+  # branch is written as a check rather than an `else`: `"refuses"` never
+  # reaches here, so the only alternative to `"converts"` is `"unknown"`. An
+  # unrecognised verdict would otherwise be described to the caller as a
+  # backend that could not be asked, which is a different fact.
+  stopifnot(identical(verdict, "converts") || identical(verdict, "unknown"))
   abort_marginplyr(
     paste0(
       "marginplyr cannot establish that the source summaries of ",
-      paste(
-        vapply(kinds, function(kind) {
-          paste0(share_kind_label(kind), "s")
-        }, character(1)),
-        collapse = " and "
-      ),
+      share_kind_labels_phrase(kinds),
       " are plain integer or double scalars on this backend, because ",
       if (identical(verdict, "converts")) {
         paste0(
@@ -2122,14 +2133,32 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
         )
       },
       ". Set `.check_share_source = FALSE` to calculate ",
-      paste(
-        vapply(kinds, share_kind_call, character(1)),
-        collapse = " and "
-      ),
+      share_kind_calls_phrase(kinds),
       " from sources you have established yourself, or explicitly collect ",
       "the data before calling `summarize_with_margins()`."
     ),
     call = call
+  )
+}
+
+# The two list phrases every share refusal builds from the kinds a call used:
+# the pluralised labels it names the helpers by, and the calls it tells the
+# caller to omit or opt out of. Both refusals -- this file's dialect one and
+# the Arrow one -- assemble the same two, so they are written once here rather
+# than kept in step by eye.
+share_kind_labels_phrase <- function(kinds) {
+  paste(
+    vapply(kinds, function(kind) {
+      paste0(share_kind_label(kind), "s")
+    }, character(1)),
+    collapse = " and "
+  )
+}
+
+share_kind_calls_phrase <- function(kinds) {
+  paste(
+    vapply(kinds, share_kind_call, character(1)),
+    collapse = " and "
   )
 }
 

--- a/R/share.R
+++ b/R/share.R
@@ -882,8 +882,8 @@ share_cardinality_records <- function(analyses, requests) {
 # The backends whose ordinary summaries evaluate R code, so
 # `wrap_share_sources()` below can put the eligible-type and cardinality rules
 # inside the summary itself. The planner reads it to decide whether to wrap,
-# and `unsampled_share_sources()` asserts it: a kind may only be left unsampled
-# because it carries the rule in its own summary.
+# and `check_wrapped_share_sources()` asserts it: a kind is asked nothing at
+# execution only because it carries the rule in its own summary.
 wraps_share_sources_in_summary <- function(backend_kind) {
   backend_kind %in% c("local", "dtplyr")
 }
@@ -1787,7 +1787,7 @@ check_total_grouping_kind <- function(plan) {
 execute_shares <- function(operation,
                            staged_result,
                            requests,
-                           summary_dots) {
+                           check_share_source) {
   check_margin_operation(operation)
   check_margin_summary_stage(staged_result)
   if (length(requests) == 0L) {
@@ -1805,16 +1805,12 @@ execute_shares <- function(operation,
   # The eligible-type rule is a property of the source summary, not of the
   # join that follows, so it is settled once here rather than inside the
   # adapter that happens to run. Only where its answer comes from is a backend
-  # question, and that is what the sampler below decides.
-  check_share_source_types(
-    sample_share_sources(
-      operation,
-      result = result,
-      requests = requests,
-      summary_dots = summary_dots
-    ),
+  # question, and that is what the checker below decides.
+  check_share_sources(
+    operation,
+    result = result,
     requests = requests,
-    call = operation$call
+    check_share_source = check_share_source
   )
   adapter <- share_adapter(operation$backend$kind)
   # One adapter pass per requested kind. Every pass reads the same staged
@@ -1902,131 +1898,266 @@ execute_dbplyr_shares <- function(operation,
   )
 }
 
-# Where the eligible-type rule reads its source values, chosen from the
-# prepared backend kind exactly as the adapter above is. The samplers share
-# the adapters' signature and, like them, the lookup has no default: an
+# How the eligible-type rule is settled, chosen from the prepared backend kind
+# exactly as the adapter above is. Every entry enforces the same rule and none
+# of them reads a row of the caller's data, which is what ADR 0020 requires of
+# each of them separately. Like the adapters, the lookup has no default: an
 # unrecognized kind is a marginplyr defect rather than something a caller can
 # rewrite.
-share_source_sampler <- function(backend_kind) {
-  samplers <- list(
-    local = sample_materialized_sources,
-    duckdb = probe_share_sources,
-    postgres = probe_share_sources,
-    sql = probe_share_sources,
-    dtplyr = unsampled_share_sources,
-    other = probe_share_sources
+share_source_checker <- function(backend_kind) {
+  checkers <- list(
+    local = check_typed_share_sources,
+    duckdb = check_dialect_share_sources,
+    postgres = check_dialect_share_sources,
+    sql = check_dialect_share_sources,
+    dtplyr = check_wrapped_share_sources,
+    other = check_dialect_share_sources
   )
-  sampler <- samplers[[backend_kind]]
-  if (is.null(sampler)) {
+  checker <- checkers[[backend_kind]]
+  if (is.null(checker)) {
     stop(
-      "Unknown contextual-share source-sampler backend kind: ", backend_kind,
+      "Unknown contextual-share source-checker backend kind: ", backend_kind,
       call. = FALSE
     )
   }
-  sampler
+  checker
 }
 
-sample_share_sources <- function(operation,
-                                 result,
-                                 requests,
-                                 summary_dots) {
-  sampler <- share_source_sampler(operation$backend$kind)
-  sampler(
+check_share_sources <- function(operation,
+                                result,
+                                requests,
+                                check_share_source) {
+  checker <- share_source_checker(operation$backend$kind)
+  checker(
     operation,
     result = result,
     requests = requests,
-    summary_dots = summary_dots
+    check_share_source = check_share_source
   )
 }
 
-# A materialized result carries the summaries' own types, so the staged result
-# is the sample and nothing is read.
-sample_materialized_sources <- function(operation,
-                                        result,
-                                        requests,
-                                        summary_dots) {
+# A materialized result carries the summaries' own types, so the rule is read
+# off the result the operation already produced and nothing is asked of
+# anybody.
+check_typed_share_sources <- function(operation,
+                                      result,
+                                      requests,
+                                      check_share_source) {
   values <- as.list(result)
-  values[intersect(share_source_names(requests), names(values))]
+  check_share_source_types(
+    values[intersect(share_source_names(requests), names(values))],
+    requests = requests,
+    call = operation$call
+  )
 }
 
 # `wrap_share_sources()` put the same rule inside the ordinary summary for the
 # backends that evaluate summaries in R and stay lazy, where it raises at
-# execution with the caller's own call. Sampling here would collect their
-# input on the caller's behalf to say what they already say themselves.
-unsampled_share_sources <- function(operation,
-                                    result,
-                                    requests,
-                                    summary_dots) {
+# execution with the caller's own call. Asking here would collect their input
+# on the caller's behalf to say what they already say themselves.
+check_wrapped_share_sources <- function(operation,
+                                        result,
+                                        requests,
+                                        check_share_source) {
   stopifnot(wraps_share_sources_in_summary(operation$backend$kind))
-  list()
+  invisible(NULL)
 }
 
-# One bounded read: the planned ordinary summaries over a single input row,
-# collected so each share source comes back with the type the backend gives
-# it. It is the only way to learn that type in a dialect that types values
-# rather than columns -- a zero-row read there answers every computed column
-# with no type at all -- and it is bounded in rows read and returned, though
-# not in the work the lazy input may still have to do to produce that one row.
+# A database evaluates the source summary itself, so the rule is the dialect's
+# to apply rather than marginplyr's to read. Where the dialect refuses an
+# ineligible summary, that refusal is the answer, and it reaches the caller as
+# the database's own diagnostic when they execute the query.
 #
-# Anything the probe cannot answer leaves the source unsampled rather than
-# rejected. A query that fails here fails again for the caller at collection,
-# where its own diagnostic is the useful one, and a missing value carries no
-# type in a weakly typed dialect, so it is not evidence of an ineligible
-# source. Warnings are already the staged query's, which was built first.
-probe_share_sources <- function(operation,
-                                result,
-                                requests,
-                                summary_dots) {
-  # The one row is read as if it were a row of the most detailed grouping set.
-  # `grouping_bit()` and `grouping_id()` only ever become integer constants, so
-  # which set that is cannot change a source's type -- but leaving them for a
-  # backend that has no such functions would fail the whole read, and a call
-  # that identifies its Margin levels would lose the check for its measures.
-  probed_dots <- rewrite_grouping_dots(
-    share_source_dots(summary_dots, share_source_names(requests)),
-    plan = operation$plan,
-    grouping_set = operation$plan$dimensions
+# Where the dialect converts a value of another type to a number instead, it
+# applies no rule at all, and no reading of the caller's data recovers one:
+# every source comes back a number whatever it holds, which is what
+# `investigation/share-source-eligibility-on-coercing-dialects.md` measured on
+# the dialect #106 was filed about. The share is therefore refused rather than
+# calculated from values nothing has checked, and `.check_share_source = FALSE`
+# is how a caller who knows their own sources calculates it anyway.
+check_dialect_share_sources <- function(operation,
+                                        result,
+                                        requests,
+                                        check_share_source) {
+  if (!isTRUE(check_share_source)) {
+    return(invisible(NULL))
+  }
+  verdict <- share_dialect_verdict(operation$data, backend = operation$backend)
+  if (identical(verdict, "refuses")) {
+    return(invisible(NULL))
+  }
+  abort_share_source_dialect(
+    share_request_kinds(requests),
+    verdict = verdict,
+    call = operation$call
   )
+}
+
+# One question per dialect: does it convert a value of another type to a number
+# rather than refusing it? It is asked with a query referencing no table of the
+# caller's -- `SELECT SUM('x') FROM (SELECT 1 AS z)` -- so asking it reads none
+# of their data, which is what ADR 0020's second exemption rests on. What it
+# establishes is a property of the dialect and not of one connection, so it is
+# asked once and the answer is reused for every later connection carrying the
+# same dialect.
+share_dialect_verdict <- function(data, backend) {
+  con <- share_dialect_connection(data)
+  if (!share_dialect_can_be_asked(con)) {
+    return("unknown")
+  }
+  key <- paste(class(backend$dialect), collapse = "\n")
+  cached <- share_dialect_verdicts[[key]]
+  if (!is.null(cached)) {
+    return(cached)
+  }
+  verdict <- probe_share_dialect(con)
+  share_dialect_verdicts[[key]] <- verdict
+  verdict
+}
+
+# One entry per dialect class, written the first time a share is requested on a
+# connection carrying that dialect.
+share_dialect_verdicts <- new.env(parent = emptyenv())
+
+share_dialect_connection <- function(data) {
+  if (!inherits(data, "tbl_lazy")) {
+    return(NULL)
+  }
+  dbplyr::remote_con(data)
+}
+
+# Whether the question below can be put to this connection at all, asked before
+# it is put rather than read out of the answer. A connection that executes
+# nothing -- `dbplyr::simulate_sqlite()` and its siblings, or one already
+# disconnected -- raises whatever it is sent, and a raised query is how a
+# dialect that refuses an ineligible summary is recognized. Reading a simulated
+# connection's failure as that refusal would record it against the dialect's
+# own class, where a later live connection carrying the same dialect would find
+# it: the SQLite dialect would answer "refuses" because a simulator was built
+# first, and the protection would be off with nothing said about it.
+#
+# `DBI::dbIsValid()` is a question about the connection and sends no query. It
+# needs no availability guard: reaching here means the input is a `tbl_lazy`,
+# so dbplyr is loaded, and dbplyr imports DBI (the `DBI = FALSE` case in
+# `AGENTS.md`'s dependency metadata). A connection with no method for it is one
+# nothing can be asked of, which is the answer this wants.
+share_dialect_can_be_asked <- function(con) {
+  if (is.null(con)) {
+    return(FALSE)
+  }
+  isTRUE(tryCatch(DBI::dbIsValid(con), error = function(cnd) FALSE))
+}
+
+# Only the two outcomes the investigation measured are read as answers: a
+# number came back, which is the conversion, or executing the query raised,
+# which is the refusal the rule is then left to. Everything else -- a query
+# that cannot be built against this connection at all, an empty result, a
+# result of another shape or type -- is no reading of the dialect, and falls
+# to "unknown", which refuses the share. Falling the other way would switch
+# the protection off wherever the question went unanswered and say nothing
+# about having done so.
+#
+# `vars` is what keeps this to the one query the answer needs: without it
+# dbplyr asks the connection for the query's fields before it can build a
+# `tbl`, which is a second query for a schema this frame already knows.
+probe_share_dialect <- function(con) {
   probe <- tryCatch(
-    suppressMessages(suppressWarnings(
-      dplyr::collect(dplyr::summarize(
-        utils::head(operation$data, n = 1L),
-        !!!probed_dots
-      ))
-    )),
+    dplyr::summarize(
+      dplyr::tbl(con, dbplyr::sql("SELECT 1 AS z"), vars = "z"),
+      p = sum("x", na.rm = TRUE)
+    ),
     error = function(cnd) NULL
   )
   if (is.null(probe)) {
-    return(list())
+    return("unknown")
   }
-  values <- as.list(probe)
-  values <- values[intersect(share_source_names(requests), names(values))]
-  Filter(share_probe_carries_a_type, values)
+  answer <- tryCatch(
+    list(value = suppressMessages(suppressWarnings(dplyr::collect(probe)))),
+    error = function(cnd) NULL
+  )
+  if (is.null(answer)) {
+    return("refuses")
+  }
+  value <- answer$value
+  if (
+    !is.data.frame(value) ||
+      nrow(value) != 1L ||
+      ncol(value) != 1L ||
+      !is_share_source_type(value[[1L]])
+  ) {
+    return("unknown")
+  }
+  "converts"
 }
 
-share_probe_carries_a_type <- function(value) {
-  !(is.logical(value) && all(is.na(value)))
+# The refusal names whichever helpers the caller wrote, as the Arrow one does
+# and for the same reason: what cannot be established belongs to the source
+# summary they share. Which of the two unestablished cases it is stays in the
+# message, because the rewrite differs -- a dialect that converts is answered
+# by knowing your own sources, and a backend that could not be asked is
+# answered by finding out why.
+abort_share_source_dialect <- function(kinds, verdict, call) {
+  kinds <- intersect(share_kind_names(), kinds)
+  abort_marginplyr(
+    paste0(
+      "marginplyr cannot establish that the source summaries of ",
+      paste(
+        vapply(kinds, function(kind) {
+          paste0(share_kind_label(kind), "s")
+        }, character(1)),
+        collapse = " and "
+      ),
+      " are plain integer or double scalars on this backend, because ",
+      if (identical(verdict, "converts")) {
+        paste0(
+          "its SQL dialect converts a value of another type to a number ",
+          "rather than refusing it, so an ineligible source summary is ",
+          "indistinguishable from an eligible one"
+        )
+      } else {
+        paste0(
+          "it could not be asked whether its SQL dialect converts a value of ",
+          "another type to a number rather than refusing it, and a dialect ",
+          "that converts rejects nothing"
+        )
+      },
+      ". Set `.check_share_source = FALSE` to calculate ",
+      paste(
+        vapply(kinds, share_kind_call, character(1)),
+        collapse = " and "
+      ),
+      " from sources you have established yourself, or explicitly collect ",
+      "the data before calling `summarize_with_margins()`."
+    ),
+    call = call
+  )
 }
 
-# Only the summaries a share reads. Reading the rest would let a summary no
-# share depends on decide whether the rule runs at all: one expression the
-# backend refuses fails the whole read, and the sources it was never asked
-# about would go unchecked with it.
+# The internal column carrying each source summary's denominator, named after
+# that summary because the name reaches the caller. A dialect that refuses an
+# ineligible source refuses it while casting this column, and it is the column
+# its diagnostic quotes rather than the summary the caller wrote — which is
+# what left #106's DuckDB half reading as `..marginplyr_share_value_1`, a
+# marginplyr temporary a reader can do nothing with. Naming the summary makes
+# the same diagnostic actionable without marginplyr adding one of its own.
 #
-# There is nothing to follow past the named source. `validate_share_request()`
-# refuses a source that depends on an earlier summary alias, so a source
-# summary is self-contained and carries no dependency to keep with it.
-#
-# A summary the caller did not name is kept rather than guessed at. Its outputs
-# are the names an `across()` expands to, which the planner resolved and this
-# frame did not, and reading one summary too many costs a column while dropping
-# one costs the source it defines.
-share_source_dots <- function(dots, sources) {
-  dot_names <- names(dots)
-  if (is.null(dot_names)) {
-    dot_names <- rep("", length(dots))
+# Everything else is `new_margin_internal_names()`'s collision rule unchanged,
+# one call per source with the names allocated so far added to `used_names`, so
+# that two sources cannot be handed one name.
+share_denominator_names <- function(sources, used_names) {
+  denominator_names <- character()
+  for (source in sources) {
+    denominator_names <- c(
+      denominator_names,
+      new_margin_internal_names(
+        1L,
+        used_names = c(used_names, denominator_names),
+        prefix = paste0("..marginplyr_denominator_of_", source, "_")
+      )
+    )
   }
-  dots[!nzchar(dot_names) | dot_names %in% sources]
+  names(denominator_names) <- sources
+  denominator_names
 }
 
 apply_joined_shares <- function(result,
@@ -2041,12 +2172,10 @@ apply_joined_shares <- function(result,
   pairs <- share_pairs(requests)
   sources <- share_source_names(requests)
   result_names <- get_col_names(result, dplyr::everything())
-  denominator_names <- new_margin_internal_names(
-    length(sources),
-    used_names = result_names,
-    prefix = "..marginplyr_share_value_"
+  denominator_names <- share_denominator_names(
+    sources,
+    used_names = result_names
   )
-  names(denominator_names) <- sources
 
   # The cleanup at the end of this function drops whatever internal columns
   # were added, so empty is what it needs when every occurrence is its own
@@ -2385,16 +2514,16 @@ add_lazy_parent_join_keys <- function(result,
   dplyr::mutate(result, !!!join_key_exprs)
 }
 
-# `values` is whatever the backend's sampler could say about the source
-# summaries, keyed by source name. A source it does not name went unsampled,
-# which is not a verdict: the rule is what an eligible type is, never how many
-# backends can be asked.
+# `values` is what a backend holding its summaries' own types can say about the
+# source summaries, keyed by source name. A source it does not name is one the
+# result does not carry, which is not a verdict: the rule is what an eligible
+# type is, never how many backends can be asked.
 check_share_source_types <- function(values, requests, call) {
-  sampled <- names(values)
+  typed <- names(values)
 
   for (pair in share_pairs(requests)) {
     source <- pair$source
-    if (!source %in% sampled) {
+    if (!source %in% typed) {
       next
     }
     value <- values[[source]]

--- a/R/share.R
+++ b/R/share.R
@@ -384,7 +384,7 @@
 #' | Local data frame | Both, from the result, before any share |
 #' | `dtplyr` step | Both, at execution, before an invalid row |
 #' | Arrow | Neither; shares are rejected outright |
-#' | General dbplyr | Type only, by asking the dialect once |
+#' | General dbplyr | Type only, by asking the dialect itself |
 #'
 #' Arrow inputs reject both helpers after expression planning and common
 #' Margin-operation validation but before constructing a summary query. The
@@ -405,8 +405,11 @@
 #' data to improve an error.
 #'
 #' Which of two things a dialect does is what decides the case, and it is
-#' settled by asking that dialect once, with a query referencing none of your
-#' tables. Where it refuses an ineligible summary, that refusal is the answer
+#' settled once per dialect, with at most two queries referencing none of your
+#' tables: a probe, and — only when the probe is rejected — a control, which is
+#' what tells a dialect that genuinely refuses apart from one whose connection
+#' or SQL scaffolding failed and could not answer at all. Where it refuses an
+#' ineligible summary, that refusal is the answer
 #' and reaches you as the database's own diagnostic when [dplyr::collect()]
 #' executes the staged query; the internal denominator column is named after
 #' the summary to rewrite so that diagnostic is actionable. Where it converts
@@ -1990,12 +1993,13 @@ check_dialect_share_sources <- function(operation,
 }
 
 # One question per dialect: does it convert a value of another type to a number
-# rather than refusing it? It is asked with a query referencing no table of the
-# caller's -- `SELECT SUM('x') FROM (SELECT 1 AS z)` -- so asking it reads none
-# of their data, which is what ADR 0020's second exemption rests on. What it
-# establishes is a property of the dialect and not of one connection, so it is
-# asked once and the answer is reused for every later connection carrying the
-# same dialect.
+# rather than refusing it? It is asked with at most two queries, neither
+# referencing a table of the caller's -- `SELECT SUM('x') FROM (SELECT 1 AS z)`
+# and, only where that is rejected, the control below -- so asking it reads
+# none of their data, which is what ADR 0020's second exemption rests on. What
+# it establishes is a property of the dialect and not of one connection, so it
+# is asked once and the answer is reused for every later connection carrying
+# the same dialect.
 share_dialect_verdict <- function(data, backend) {
   con <- share_dialect_connection(data)
   if (!share_dialect_can_be_asked(con)) {
@@ -2091,26 +2095,32 @@ share_dialect_can_be_asked <- function(con) {
 # `tbl`, which is a further query for a schema this frame already knows.
 probe_share_dialect <- function(con) {
   probe <- probe_share_dialect_answer(con, quote(sum("x", na.rm = TRUE)))
-  if (identical(probe$status, "unbuildable")) {
-    return("unknown")
-  }
-  if (identical(probe$status, "raised")) {
+  if (identical(probe, "raised")) {
     control <- probe_share_dialect_answer(con, quote(sum(z, na.rm = TRUE)))
-    if (!identical(control$status, "answered")) {
-      return("unknown")
+    if (identical(control, "answered")) {
+      return("refuses")
     }
-    return("refuses")
-  }
-  if (!identical(probe$status, "answered")) {
     return("unknown")
   }
-  "converts"
+  if (identical(probe, "answered")) {
+    return("converts")
+  }
+  "unknown"
 }
 
-# One table-free question, and which of the three things happened to it: it
-# could not be built against this connection, executing it raised, or it came
-# back with exactly one number. Any other shape is not an answer, so it is not
-# reported as one.
+# One table-free question, and which of three things happened to it: executing
+# it raised, it came back with exactly one number, or neither -- it could not
+# be built against this connection at all, or what came back was not one
+# number. The last two are one answer here because the only two callers treat
+# them alike: neither is a reading of the dialect.
+#
+# This vocabulary gets no guard, where `share_dialect_verdict_names()` does,
+# and the difference is what each mistake would cost. A wrong verdict is
+# cached under the dialect and described to the caller, so it misreports and
+# keeps misreporting. A status is read once, by the frame above, which sends
+# every value it does not recognise to `"unknown"` -- the answer that refuses
+# the share. An unrecognised status therefore fails closed by construction,
+# and that is the property worth writing down rather than asserting.
 probe_share_dialect_answer <- function(con, expr) {
   query <- tryCatch(
     dplyr::summarize(
@@ -2120,14 +2130,14 @@ probe_share_dialect_answer <- function(con, expr) {
     error = function(cnd) NULL
   )
   if (is.null(query)) {
-    return(list(status = "unbuildable"))
+    return("unanswerable")
   }
   answer <- tryCatch(
     list(value = suppressMessages(suppressWarnings(dplyr::collect(query)))),
     error = function(cnd) NULL
   )
   if (is.null(answer)) {
-    return(list(status = "raised"))
+    return("raised")
   }
   value <- answer$value
   if (
@@ -2136,9 +2146,9 @@ probe_share_dialect_answer <- function(con, expr) {
       ncol(value) != 1L ||
       !is_share_source_type(value[[1L]])
   ) {
-    return(list(status = "unreadable"))
+    return("unanswerable")
   }
-  list(status = "answered", value = value[[1L]])
+  "answered"
 }
 
 # The refusal names whichever helpers the caller wrote, as the Arrow one does

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -448,12 +448,14 @@
 #'   decomposition loses. It references your table but reads none of it, and
 #'   it is not a shape marginplyr introduced: [dplyr::tbl()] already sends an
 #'   equivalent zero-row read for any table reference, on any dbplyr backend.
-#' - **One query per SQL dialect**, sent once per dialect, the first time a
-#'   share is requested there with `.check_share_source` at its default of
-#'   `TRUE`, asking whether the dialect converts a non-numeric value to a
-#'   number rather than refusing it. It references none of your tables, so
-#'   reading it touches none of your data, and the answer is a property of
-#'   the dialect, reused for every later connection that shares it. A
+#' - **At most two queries per SQL dialect**, sent once per dialect, the first
+#'   time a share is requested there with `.check_share_source` at its default
+#'   of `TRUE`, asking whether the dialect converts a non-numeric value to a
+#'   number rather than refusing it. Neither references any of your tables, so
+#'   reading them touches none of your data, and the answer is a property of
+#'   the dialect, reused for every later connection that shares it. The second
+#'   is a control, sent only when the first is rejected, and it distinguishes
+#'   a dialect that refuses from one that could not be asked at all. A
 #'   connection that cannot be asked -- one built with a
 #'   `dbplyr::simulate_*()` constructor, which executes nothing -- is treated
 #'   as unable to answer, which refuses the share by default the same way a

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -365,12 +365,12 @@
 #'
 #' Non-missing labels convert ordinary grouping dimensions to character. A
 #' factor or ordered factor is reconstructed after the Margin operation,
-#' preserving ordered status and placing the synthetic level last by default
-#' or first when `.margin_label_position = "first"`. With collision checking
-#' enabled, the complete factor domain is checked, including unused levels.
-#' With checking disabled, an existing level may be reused and is moved to the
-#' requested position. Reconstruction preserves the distinction between an
-#' observation that uses a factor NA level and an actually missing factor code.
+#' preserving ordered status and placing a new synthetic level last by default
+#' or first when `.margin_label_position = "first"`. A label equal to any
+#' declared level, used or unused, is rejected before any grouping set is
+#' built, whatever `.check_margin_label` says: see that argument above.
+#' Reconstruction preserves the distinction between an observation that uses a
+#' factor NA level and an actually missing factor code.
 #'
 #' `NA_character_` and `NULL` both create a typed missing Margin value and do
 #' not create a synthetic factor level. Position is therefore a no-op for
@@ -397,10 +397,12 @@
 #' identically, so keep a structural identity column when the difference
 #' matters: `.id` is available from every Margin verb, and
 #' [summarize_with_margins()] can additionally write [grouping_bit()] or
-#' [grouping_id()] as summaries. The eager default
-#' `.check_margin_label = TRUE` detects
-#' collisions for local data. Lazy tables default to `FALSE` because checking
-#' would execute an extra query; opt in when that scan is appropriate.
+#' [grouping_id()] as summaries. `.check_margin_label` controls only the
+#' observed row of this table -- whether `NA_character_` collides with an
+#' actual missing value when no NA level is declared; the declared rows above
+#' it are checked whatever this argument says. See `.check_margin_label`
+#' above for its default and *When marginplyr queries your data* for why the
+#' two halves differ.
 #'
 #' @section Backend extension design:
 #' Unlike [dplyr::summarize()], the public margin verbs are intentionally not
@@ -427,6 +429,51 @@
 #'
 #' Arrow and dtplyr are also tested lazy backends, but they are not SQL
 #' database connections.
+#'
+#' @section When marginplyr queries your data:
+#' Every Margin verb applied to a lazy input builds a query and returns it
+#' unexecuted. [dplyr::show_query()] runs nothing, and no row is read until
+#' you execute the query yourself -- [nest_by_with_margins()] excepted,
+#' because its row-wise return shape exists only locally; see its own
+#' documentation for when it collects.
+#'
+#' Two queries reach your connection without being asked for, and neither
+#' reads a row of your data:
+#'
+#' - **A zero-row read of the input**, sent only to a backend whose factor
+#'   columns marginplyr must decompose and later restore -- currently
+#'   `dtplyr` and DuckDB -- to recover the levels and column prototypes that
+#'   decomposition loses. It references your table but reads none of it, and
+#'   it is not a shape marginplyr introduced: [dplyr::tbl()] already sends an
+#'   equivalent zero-row read for any table reference, on any dbplyr backend.
+#' - **One query per SQL dialect**, sent once per dialect, the first time a
+#'   share is requested there with `.check_share_source` at its default of
+#'   `TRUE`, asking whether the dialect converts a non-numeric value to a
+#'   number rather than refusing it. It references none of your tables, so
+#'   reading it touches none of your data, and the answer is a property of
+#'   the dialect, reused for every later connection that shares it. A
+#'   connection that cannot be asked -- one built with a
+#'   `dbplyr::simulate_*()` constructor, which executes nothing -- is treated
+#'   as unable to answer, which refuses the share by default the same way a
+#'   dialect known to convert does; see `.check_share_source` on
+#'   [summarize_with_margins()].
+#'
+#' Neither query is safe merely because it returns no rows. A read bounded in
+#' rows is not bounded in what it costs: BigQuery states plainly that a
+#' `LIMIT` does not reduce the bytes billed for a non-clustered table, and no
+#' vendor documentation exempts `LIMIT 0` from that rule.
+#'
+#' marginplyr does not try to tell whether a backend bills for a query,
+#' because nothing it can read distinguishes a free connection from a billed
+#' one of the same kind -- a local DuckDB file from a hosted DuckDB service,
+#' or RDS PostgreSQL from Aurora Standard. `is.data.frame(.data)` is the only
+#' predicate that answers "no external system is involved" exactly rather
+#' than approximately, and it is what sets the default of every check that
+#' reads your data: a check that reads it is asked for, and a check that does
+#' not is not. `.check_margin_label` scans the grouping columns, so every
+#' Margin verb defaults it to `is.data.frame(.data)`.
+#' [summarize_with_margins()]'s `.check_share_source` reads nothing on any
+#' backend, so it defaults to `TRUE` there.
 #'
 #' @family summarize and expand data with margins
 #' @export
@@ -506,8 +553,9 @@
 #' ) |>
 #'   dplyr::as_tibble()
 #'
-#' # Ordered factors remain ordered. A disabled collision check can reuse an
-#' # unused level and move it to the requested position.
+#' # Ordered factors remain ordered, and a new label is placed by
+#' # `.margin_label_position`. An existing level -- used or unused -- is never
+#' # available for reuse: it is rejected whatever `.check_margin_label` says.
 #' priority_data <- data.frame(
 #'   priority = ordered(
 #'     c("standard", "premium"),
@@ -519,18 +567,42 @@
 #'   .data = priority_data,
 #'   total = sum(value),
 #'   .grouping = rollup(priority),
-#'   .margin_label = "unused"
+#'   .margin_label = "unused",
+#'   .check_margin_label = FALSE
 #' ))
 #' priority_result <- summarize_with_margins(
 #'   .data = priority_data,
 #'   total = sum(value),
 #'   .grouping = rollup(priority),
-#'   .margin_label = "unused",
-#'   .margin_label_position = "first",
-#'   .check_margin_label = FALSE
+#'   .margin_label = "All priorities",
+#'   .margin_label_position = "first"
 #' )
 #' is.ordered(priority_result$priority)
 #' levels(priority_result$priority)
+#'
+#' # `.check_margin_label = FALSE` still controls only the observed half of
+#' # the check: whether a missing value already in the column collides with
+#' # `NA_character_` when no NA level is declared. Disabled, the margin row
+#' # and the real missing-value row print alike; `grouping_bit()` tells them
+#' # apart.
+#' status_data <- data.frame(
+#'   status = factor(c("active", NA), levels = c("active", "inactive")),
+#'   value = c(1, 2)
+#' )
+#' try(summarize_with_margins(
+#'   .data = status_data,
+#'   total = sum(value),
+#'   .grouping = rollup(status),
+#'   .margin_label = NA_character_
+#' ))
+#' summarize_with_margins(
+#'   .data = status_data,
+#'   total = sum(value),
+#'   is_total = grouping_bit(status),
+#'   .grouping = rollup(status),
+#'   .margin_label = NA_character_,
+#'   .check_margin_label = FALSE
+#' )
 #'
 #' # A direct Parent share, multiple measures through two ordered across()
 #' # expressions, and a post-summary calculation.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -41,6 +41,16 @@
 #'   contract. Every Margin verb uses the same default: `TRUE` for local data
 #'   frames and `FALSE` for lazy inputs, where checking would require an
 #'   additional query.
+#' @param .check_share_source A logical scalar, `TRUE` by default on every
+#'   backend, including lazy ones: establishing that a share's source summary
+#'   is an eligible type reads none of your data. `FALSE` calculates a
+#'   requested [share_of_parent()] or [share_of_total()] from a source whose
+#'   eligibility marginplyr could not establish, which is a SQL dialect that
+#'   converts a value of another type to a number rather than refusing it, and
+#'   a backend that could not be asked which of those it does. It changes
+#'   nothing where the rule can be applied — a local data frame, a `dtplyr`
+#'   step, and a database that refuses an ineligible summary itself all apply
+#'   it whatever this argument says. See *Contextual shares*.
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
 #'   duplicate grouping sets after expansion.
 #' @param .sort One of `"none"` (the default), `"last"`, or `"first"`. `"none"`
@@ -625,6 +635,7 @@ summarize_with_margins <- function(.data,
                                    .margin_label = "Total",
                                    .margin_label_position = c("last", "first"),
                                    .check_margin_label = is.data.frame(.data),
+                                   .check_share_source = TRUE,
                                    .duplicates = c("error", "drop", "keep"),
                                    .id = NULL,
                                    .sort = c("none", "last", "first")) {
@@ -646,6 +657,7 @@ summarize_with_margins <- function(.data,
         duplicates_choices = margin_duplicates_choices,
         .id = .id
       )
+      assert_logical_scalar(.check_share_source)
       check_option_named_summaries(dots)
       check_summary_context_helpers(dots)
       preflight_shares(dots)
@@ -667,11 +679,15 @@ summarize_with_margins <- function(.data,
     validate_grouping = share_grouping_spec_validator(share_kinds),
     call = call
   )
-  execution <- execute_margin_summary(operation, dots)
+  execution <- execute_margin_summary(
+    operation,
+    dots,
+    check_share_source = .check_share_source
+  )
   finalize_margin_operation(operation, execution)
 }
 
-execute_margin_summary <- function(operation, dots) {
+execute_margin_summary <- function(operation, dots, check_share_source) {
   check_margin_operation(operation)
   with_margin_error_call(
     {
@@ -736,7 +752,7 @@ execute_margin_summary <- function(operation, dots) {
             operation,
             staged_result = staged_result,
             requests = summary_plan$requests,
-            summary_dots = dots
+            check_share_source = check_share_source
           ),
           sort_id = margin_summary_stage_sort_id(staged_result)
         ))

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -34,13 +34,19 @@
 #'   This controls the position of a non-missing synthetic label in factor and
 #'   ordered-factor levels. It does not sort result rows and has no effect for
 #'   `NA_character_` or `NULL`.
-#' @param .check_margin_label A logical scalar. If `TRUE`, check each Margin
-#'   dimension independently for a value or factor level that collides with its
-#'   display label. `.margin_label = NULL` opts out of these checks. See
-#'   *Display labels and grouping identity* for the factor missing-value
-#'   contract. Every Margin verb uses the same default: `TRUE` for local data
-#'   frames and `FALSE` for lazy inputs, where checking would require an
-#'   additional query.
+#' @param .check_margin_label A logical scalar controlling the half of the
+#'   Margin label collision check that reads the data: whether any *value* of a
+#'   Margin dimension is equal to that dimension's display label. Each
+#'   dimension is checked independently, and `.margin_label = NULL` opts out.
+#'   Every Margin verb uses the same default: `TRUE` for local data frames and
+#'   `FALSE` for lazy inputs, which are read only when the caller asks. A label
+#'   equal to a declared factor *level* is rejected on every backend whatever
+#'   this argument says, because the levels are already known and finding it
+#'   sends no query. Left unchecked, a colliding value gives the result a
+#'   margin row and a source row that no grouping column tells apart; keeping
+#'   [grouping_bit()] or [grouping_id()] in the result distinguishes them at no
+#'   added cost. See *Display labels and grouping identity* for the factor
+#'   missing-value contract.
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
 #'   duplicate grouping sets after expansion.
 #' @param .sort One of `"none"` (the default), `"last"`, or `"first"`. `"none"`

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -440,7 +440,10 @@
 #' documentation for when it collects.
 #'
 #' Two queries reach your connection without being asked for, and neither
-#' reads a row of your data:
+#' reads a row of your data. This is the rule for every Margin verb, so each
+#' is described against the inputs that can produce it: a verb accepting no
+#' lazy table, or no contextual share, simply never reaches the one that
+#' depends on it.
 #'
 #' - **A zero-row read of the input**, sent only to a backend whose factor
 #'   columns marginplyr must decompose and later restore -- currently

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -347,8 +347,10 @@
 #' Local data frames reject an ineligible source before any share is
 #' calculated. `dtplyr` steps stay lazy and report the same conditions during
 #' explicit execution, before an invalid grouping row is emitted. General
-#' dbplyr backends read the ordinary summaries over one input row and reject
-#' an ineligible source with the same condition; cardinality remains a
+#' dbplyr backends read none of your data to apply the rule: the dialect is
+#' asked once whether it converts a value of another type to a number rather
+#' than refusing it, and where it converts, the share is refused unless
+#' `.check_share_source = FALSE` asks for it anyway. Cardinality remains a
 #' local-and-`dtplyr` rule, because a SQL aggregate returns one value per
 #' grouping row by construction.
 #'

--- a/design/adr/0003-validate-margin-labels-before-execution.md
+++ b/design/adr/0003-validate-margin-labels-before-execution.md
@@ -7,3 +7,16 @@ execution. The Margin operation module still owns backend, factor, and
 collision validation; delaying them preserves the existing error and query
 order so an invalid summary is rejected before label validation can fail or
 an opt-in collision query contacts a lazy backend.
+
+## Amendment: one half of the collision check contacts nothing
+
+The order above is unchanged. What changed is that "an opt-in collision query
+contacts a lazy backend" now describes only half of the collision check.
+
+A Margin label equal to a declared factor level is found in the typed metadata
+ADR 0002 already acquires, so that collision is rejected on every backend
+whatever `.check_margin_label` says, and no query is issued to find it. Only a
+label equal to an observed value requires reading, and that read is what
+`.check_margin_label` opts into. Both halves still run after the schema-aware
+preflight and immediately before low-level execution, for the reason stated
+above. See ADR 0020.

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -508,6 +508,7 @@ available and the share is refused rather than calculated —
 is measured once per dialect by at most two queries that reference none of the
 caller's tables — a probe, and a control sent only when the probe is rejected,
 so that a dialect which refuses is told apart from one whose scaffolding or
-connection failed — and the internal denominator column is named so that a
-database's own diagnostic reads without exposing an internal identifier, which
+connection failed — and the internal denominator column is named after the
+summary to rewrite, so that a database's own diagnostic names something the
+caller wrote rather than an internal identifier alone, which
 was #106's DuckDB half.

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -472,3 +472,40 @@ parent-selection model exists. That deferral is about selecting a parent, and
 why it does not reach a denominator that is not selected: `share_of_total()`
 accepts any plan containing a Grand total set, while this restriction on
 `share_of_parent()` still stands.
+
+## Amendment: the eligible-type rule is established without reading a row
+
+The decision above stands: the eligible-type rule is enforced on every backend,
+and no backend calculates a share from a source shown to be ineligible. What is
+withdrawn is the read that established it and the reasoning that admitted the
+read.
+
+"One read bounded in rows requested and returned" was offered as a cost
+argument and is not one.
+`investigation/query-cost-across-lazy-backends.md` records that a `LIMIT` does
+not reduce the bytes BigQuery bills for a non-clustered table, that a one-row
+query starting a Snowflake warehouse costs a minute of credits, that every read
+on Aurora Standard is a billable I/O request, and that Athena bills a failed
+query like a successful one — and the read was wrapped in a handler that
+discards its error, so a query the caller pays for could produce nothing at
+all. ADR 0020 replaces the reasoning with a rule that does not price backends.
+
+The read also did not establish what it was taken to establish.
+`investigation/share-source-eligibility-on-coercing-dialects.md` measures
+`sum(<text column>)` returning a genuine `0` on RSQLite where DuckDB raises, so
+the eligible-type rule receives an eligible type for an ineligible source and
+accepts it; `share_of_total()` over such a source reproduces #106's own symptom
+on the dialect #106 was filed about. A read of one row cannot answer the
+question on a dialect that converts, and on a dialect that refuses, the
+database's own refusal already answers it.
+
+Eligibility is therefore established without reading a row of the caller's
+data. Where the backend evaluates the summary and refuses an ineligible one,
+that refusal is the answer and reaches the caller as the database's diagnostic
+at collection. Where the dialect converts instead of refusing, no answer is
+available and the share is refused rather than calculated —
+`.check_share_source = FALSE` calculates it anyway. Which case a dialect is in
+is measured once per dialect by a query that references none of the caller's
+tables, and the internal denominator column is named so that a database's own
+diagnostic reads without exposing an internal identifier, which was #106's
+DuckDB half.

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -505,7 +505,9 @@ that refusal is the answer and reaches the caller as the database's diagnostic
 at collection. Where the dialect converts instead of refusing, no answer is
 available and the share is refused rather than calculated —
 `.check_share_source = FALSE` calculates it anyway. Which case a dialect is in
-is measured once per dialect by a query that references none of the caller's
-tables, and the internal denominator column is named so that a database's own
-diagnostic reads without exposing an internal identifier, which was #106's
-DuckDB half.
+is measured once per dialect by at most two queries that reference none of the
+caller's tables — a probe, and a control sent only when the probe is rejected,
+so that a dialect which refuses is told apart from one whose scaffolding or
+connection failed — and the internal denominator column is named so that a
+database's own diagnostic reads without exposing an internal identifier, which
+was #106's DuckDB half.

--- a/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
+++ b/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
@@ -21,7 +21,7 @@ Three things below therefore no longer describe the code:
   "reads the summaries a share reads … over one row of the input". Nothing
   reads a row of the caller's data to apply the eligible-type rule. Those
   kinds now reach `check_dialect_share_sources()`, which asks the dialect
-  itself, with a query referencing none of the caller's tables.
+  itself, with at most two queries referencing none of the caller's tables.
 - `unsampled_share_sources()`, now `check_wrapped_share_sources()`. Its
   assertion is unchanged and still load-bearing for the same reason: a kind
   may only be left unasked because `wrap_share_sources()` put the rule inside

--- a/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
+++ b/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
@@ -6,6 +6,36 @@ chosen by looking up the backend kind that the Margin operation already
 prepared — never by inspecting the class of the staged ordinary-summary
 result, and never by a chain of capability predicates rebuilt at this seam.
 
+## Amendment: the samplers are source checkers, and none of them samples
+
+The decision above stands in full: there are still two lookups keyed on the
+prepared backend kind, still with no default, and the adapter table is
+unchanged. What is withdrawn is the second table's subject. It selected a
+*sampler*, whose job was to obtain source values to judge, and ADR 0020
+removed the reading those values came from.
+
+Three things below therefore no longer describe the code:
+
+- The sampler table's `Bounded probe` row — `duckdb`, `postgres`, `sql`,
+  `other`, reading "One input row" — and the paragraph explaining that it
+  "reads the summaries a share reads … over one row of the input". Nothing
+  reads a row of the caller's data to apply the eligible-type rule. Those
+  kinds now reach `check_dialect_share_sources()`, which asks the dialect
+  itself, with a query referencing none of the caller's tables.
+- `unsampled_share_sources()`, now `check_wrapped_share_sources()`. Its
+  assertion is unchanged and still load-bearing for the same reason: a kind
+  may only be left unasked because `wrap_share_sources()` put the rule inside
+  its ordinary summary.
+- The sampler signature's final argument. It was "the planned ordinary
+  summaries", which a sampler needed to build its read; a checker does not
+  read, and takes the verb's `.check_share_source` instead. The rule that
+  every entry shares one signature is unchanged, and is still what lets an
+  entry ignore an argument it has no use for.
+
+`share_source_sampler()` is `share_source_checker()`, and the lookup's shape,
+its lack of a default, and its grouping of kinds are all as decided above.
+See ADR 0020, which also withdraws ADR 0010's cost justification for the read.
+
 ## Decision
 
 Parent mapping, ratio calculation, and temporary-name cleanup are shared by

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -21,12 +21,23 @@ justification covering both would be false of one of them:
    `investigation/query-cost-across-lazy-backends.md` records that no vendor
    documentation exempts `LIMIT 0` from BigQuery's rule that a `LIMIT` does not
    reduce the bytes a non-clustered table is billed for.
-2. **One query per SQL dialect**, sent the first time a share is requested on
-   that dialect, asking whether the dialect converts non-numeric values to
-   numbers rather than refusing them. It references no table of the caller's —
-   `SELECT SUM('x') FROM (SELECT 1 AS z)` — so no reading of it touches their
-   data, and the answer is a property of the dialect and is reused for every
-   later connection sharing it.
+2. **At most two queries per SQL dialect**, sent the first time a share is
+   requested on that dialect, asking whether the dialect converts non-numeric
+   values to numbers rather than refusing them. Neither references a table of
+   the caller's — `SELECT SUM('x') FROM (SELECT 1 AS z)` — so no reading of
+   either touches their data, and the answer is a property of the dialect and
+   is reused for every later connection sharing it.
+
+   The second is a control, and it is sent only when the first raises. A
+   raised query is how a refusing dialect is recognized, but it is also what a
+   dialect whose scaffolding is invalid produces — `SELECT 1 AS z` has no
+   `FROM`, which Oracle and SAP HANA both reject — and what a dropped
+   connection or a permissions failure produces. Reading any of those as the
+   refusal records the verdict that *proceeds*, so the rule would be switched
+   off for the whole dialect precisely where it could not be applied. The
+   control asks the one thing no dialect can refuse, summing the number the
+   scaffolding already selects; a control that does not answer means the
+   question could not be put here, and the share is refused.
 
 The predicate for "no external system is involved" is `is.data.frame(.data)`,
 and it is exact rather than an approximation of cheapness. Nothing
@@ -112,7 +123,9 @@ obtain. ADR 0003 orders label validation relative to execution and is amended
 by this decision only in what it may run without asking. ADR 0010 introduced
 the one-row share-source read and is amended separately, since its decision
 stands and only its cost justification is withdrawn. ADR 0012's factor contract
-is what exemption 1 protects.
+is what exemption 1 protects. ADR 0014 selects the per-kind entry that reads
+the source, and is amended separately too: its two lookups stand, but the
+second no longer selects a sampler, because there is nothing left to sample.
 
 Evidence: `investigation/query-cost-across-lazy-backends.md` and
 `investigation/share-source-eligibility-on-coercing-dialects.md`.

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -3,7 +3,11 @@
 marginplyr sends no query that reads a lazy input's data unless the caller
 asked for one. A Margin verb applied to a lazy input builds a query and returns
 it unexecuted; `dplyr::show_query()` runs nothing, and no row is read until the
-caller executes the query themselves.
+caller executes the query themselves. `nest_by_with_margins()` is the one
+exception, and it is one by its return type rather than by this decision: a
+row-wise data frame is a local object, so the verb collects to build one at
+all. It is documented as collecting, and it is not a lazy result that reads
+without being asked.
 
 Two queries are exempt, enumerated rather than derived from a shape. Neither
 reads the caller's data, and each is justified separately because a single

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -1,0 +1,118 @@
+# Ask before reading a lazy input
+
+marginplyr sends no query that reads a lazy input's data unless the caller
+asked for one. A Margin verb applied to a lazy input builds a query and returns
+it unexecuted; `dplyr::show_query()` runs nothing, and no row is read until the
+caller executes the query themselves.
+
+Two queries are exempt, enumerated rather than derived from a shape. Neither
+reads the caller's data, and each is justified separately because a single
+justification covering both would be false of one of them:
+
+1. **The zero-row read of the input**, `collect(head(.data, 0L))` in
+   `grouping_selection_proxy()`, sent only to backends whose
+   `collect_selection_proxy` capability grants it. Granting that capability to
+   a further backend extends this exemption and is justified per backend at
+   that point. Its warrant is that marginplyr decomposed the factors it
+   restores — combining grouping sets by union forces one common type across
+   branches, so a factor dimension is converted to text — and the levels and
+   column prototypes it is rebuilt from have no other source. Returning no rows
+   is not the warrant: a zero-row read still references the caller's table, and
+   `investigation/query-cost-across-lazy-backends.md` records that no vendor
+   documentation exempts `LIMIT 0` from BigQuery's rule that a `LIMIT` does not
+   reduce the bytes a non-clustered table is billed for.
+2. **One query per SQL dialect**, sent the first time a share is requested on
+   that dialect, asking whether the dialect converts non-numeric values to
+   numbers rather than refusing them. It references no table of the caller's —
+   `SELECT SUM('x') FROM (SELECT 1 AS z)` — so no reading of it touches their
+   data, and the answer is a property of the dialect and is reused for every
+   later connection sharing it.
+
+The predicate for "no external system is involved" is `is.data.frame(.data)`,
+and it is exact rather than an approximation of cheapness. Nothing
+`grouping_backend()` reads distinguishes a local DuckDB file from a hosted
+DuckDB service, an in-memory Arrow table from a dataset in object storage, RDS
+PostgreSQL from Aurora Standard, or SQLite from BigQuery; the first of each
+pair charges nothing per query and the second may charge for every read.
+
+One rule sets every default: **a check that reads the caller's data is asked
+for, and a check that does not is not.**
+
+- `.check_margin_label` scans the grouping columns, so it defaults to
+  `is.data.frame(.data)`.
+- `.check_share_source` reads nothing on any backend, so it defaults to `TRUE`.
+
+The same rule splits the Margin-label collision check in two. A label equal to
+a *declared* factor level is found in metadata that ADR 0002 already acquires,
+so that collision is rejected on every backend whatever `.check_margin_label`
+says. A label equal to an *observed* value is found only by reading, so that
+collision is what `.check_margin_label` controls.
+
+## Considered options
+
+**A capability for backends whose queries are cheap.** Rejected: it cannot be
+computed. `kind = "duckdb"` covers a hosted service reached through the same
+driver, `kind = "arrow"` covers a dataset in object storage, and `kind = "sql"`
+covers both SQLite and BigQuery. A capability table encoding cost would be a
+table of guesses about which product a connection addresses.
+
+**Pricing the backends.** Rejected on maintenance grounds before correctness.
+`investigation/query-cost-across-lazy-backends.md` records four billing models
+in use across the backends dbplyr reaches — per byte scanned, per unit of time,
+per provisioned capacity with no per-query charge, and per I/O request — with
+two of them appearing under a single `grouping_backend()` kind. A rule that
+prices backends is a rule that tracks four vendors' pricing pages; a rule that
+asks the caller before reading their data tracks nothing.
+
+**An absolute rule with no exemption.** Rejected: withdrawing the zero-row read
+withdraws factor levels and column prototypes on every lazy backend that has
+them, so ADR 0012's factor contract stops holding on DuckDB and dtplyr by
+default, and the declared-collision rejection above stops being free there. The
+cost of the exemption is one query per operation that reads no rows; the cost of
+removing it is a contract.
+
+**Bounding reads by the rows they request.** Rejected as a cost argument, and
+recorded here because ADR 0010 rests on it. A read bounded in rows is not
+bounded in what it costs: a `LIMIT` does not reduce BigQuery's bytes billed on
+a non-clustered table, a one-row query that starts a Snowflake warehouse costs
+a minute of credits, every read on Aurora Standard is a billable I/O request,
+and Athena bills a failed query like a successful one. Rows are the wrong unit.
+
+## Documentation consequences
+
+The reference carries a *When marginplyr queries your data* section stating
+what is sent unrequested and what is not, because a caller cannot read it off
+the argument list: the two exemptions are invisible at the call site, and the
+differing defaults of the two `.check_*` arguments read as arbitrary without
+the rule that produces them.
+
+`vignettes/database_backends.qmd` states plainly what is given up when
+`.check_margin_label` is left at its lazy default: a grouping column holding
+the label yields two rows that cannot be told apart, and neither a reader nor
+downstream code can recover which is the margin. It also names the two things
+that reduce the exposure at no cost — the declared-level rejection, and keeping
+`grouping_bit()` or `grouping_id()` in the result.
+
+## Test strategy
+
+The rule is not readable from any one file, so it is asserted rather than
+described. A snapshot records the internal functions that reach an execution
+entry point, and a second snapshot records the set of entry points scanned for,
+so a scan that stopped covering `compute()` fails rather than reporting a clean
+result. A third records which backend kinds hold `collect_selection_proxy`, so
+extending exemption 1 is visible in a diff.
+
+Snapshots run only where `NOT_CRAN` is set, which is the `structure` job and
+the `backend` jobs; a plain CRAN check does not execute this gate.
+
+## Related decisions
+
+ADR 0002 acquires the typed metadata this decision's first exemption exists to
+obtain. ADR 0003 orders label validation relative to execution and is amended
+by this decision only in what it may run without asking. ADR 0010 introduced
+the one-row share-source read and is amended separately, since its decision
+stands and only its cost justification is withdrawn. ADR 0012's factor contract
+is what exemption 1 protects.
+
+Evidence: `investigation/query-cost-across-lazy-backends.md` and
+`investigation/share-source-eligibility-on-coercing-dialects.md`.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -295,9 +295,12 @@ The responsibilities divide as follows:
   rule itself and reports an ineligible summary at collection, unless its
   dialect converts a value of another type to a number instead of refusing it,
   in which case nothing applies the rule and the share is refused;
-  `share_dialect_verdict()` decides which, once per dialect, with a query
-  referencing none of the caller's tables, and `.check_share_source = FALSE`
-  calculates the share anyway. Arrow is rejected before any of this.
+  `share_dialect_verdict()` decides which, once per dialect, with at most two
+  queries referencing none of the caller's tables — a probe, and a control
+  sent only when the probe is rejected, so that a dialect which refuses is
+  told apart from one whose scaffolding or connection failed — and
+  `.check_share_source = FALSE` calculates the share anyway. Arrow is rejected
+  before any of this.
 - **Mapping** is the one responsibility a kind supplies for itself, through
   `share_denominator_rule()`: which occurrence each row's denominator comes
   from, and the denominator rows with the columns they are matched on. A

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -257,11 +257,9 @@ points, and no other:
   execute; and
 - `execute_shares()`, called by `execute_margin_summary()`, which
   receives the prepared Margin operation, the staged ordinary-summary result,
-  all planned requests, and the planned ordinary summaries together. It takes
-  the summaries as well as the result they produced because a backend that
-  evaluates them in the database can only be told their types by a value it
-  returns, which `probe_share_sources()` reads by running them over one input
-  row.
+  all planned requests, and the verb's `.check_share_source`. It needs the
+  argument because whether a backend can establish an eligible source is
+  settled here, and a backend that cannot is refused rather than read.
 
 Planning and wrapping are two calls rather than one because the summary
 selections have to be resolved between them: the plan names which summaries a
@@ -285,18 +283,21 @@ The responsibilities divide as follows:
   output-name collisions against fixed keys, dimensions, ordinary summaries,
   the Grouping set identifier, and other contextual shares.
 - **Validation** applies one eligible-type rule to every backend, and only
-  where its source values come from is a backend question.
-  `check_share_source_types()` runs once above adapter selection, over
-  whatever `share_source_sampler()` could sample: the staged result itself
-  when it is materialized, one bounded read of the ordinary summaries over a
-  single input row when the backend evaluates them elsewhere, and nothing for
-  the lazy backends that carry the rule inside the summary. Local and dtplyr
-  operations wrap the referenced source summaries in a type-and-cardinality
-  validator inside the ordinary summary itself, so validation costs no extra
-  pass over the input and no validation-only query, and cardinality stays
-  theirs alone — a SQL aggregate returns one value per grouping row by
-  construction. A sample that answers nothing rejects nothing. Arrow is
-  rejected before any of this.
+  where its answer comes from is a backend question — never from a row of the
+  caller's data, which is ADR 0020. `share_source_checker()` chooses among
+  three answers, once above adapter selection. A materialized result carries
+  its summaries' own types, so `check_share_source_types()` reads them off it.
+  Local and dtplyr operations additionally wrap the referenced source
+  summaries in a type-and-cardinality validator inside the ordinary summary
+  itself, so validation costs no extra pass over the input and no
+  validation-only query, and cardinality stays theirs alone — a SQL aggregate
+  returns one value per grouping row by construction. A database applies the
+  rule itself and reports an ineligible summary at collection, unless its
+  dialect converts a value of another type to a number instead of refusing it,
+  in which case nothing applies the rule and the share is refused;
+  `share_dialect_verdict()` decides which, once per dialect, with a query
+  referencing none of the caller's tables, and `.check_share_source = FALSE`
+  calculates the share anyway. Arrow is rejected before any of this.
 - **Mapping** is the one responsibility a kind supplies for itself, through
   `share_denominator_rule()`: which occurrence each row's denominator comes
   from, and the denominator rows with the columns they are matched on. A
@@ -405,20 +406,21 @@ Direct field reads are confined to:
 - the three dedicated verb executors, for their schema-aware preflight and
   calls into low-level adapters;
 - `execute_shares()`, which reads the prepared backend kind to select an
-  adapter and a source sampler, and the caller-visible Grouping set identifier
+  adapter and a source checker, and the caller-visible Grouping set identifier
   name to restore it after the join;
-- the contextual-share source samplers, which read the input the operation
-  prepared and, for the one that asserts it may sample nothing, the backend
-  kind; and
+- the contextual-share source checkers, which read the prepared backend — its
+  kind, for the one that asserts it may check nothing, and its dialect, for
+  the one that asks whether that dialect converts — and the input it prepared;
+  and
 - the two contextual-share adapters, which read the Grouping plan and
   nothing else.
 
 The native and portable Grouping adapters receive the specific derived values
 they need, not the Margin operation itself. The contextual-share adapters and
-samplers take it whole because they are dispatch targets of one signature
-rather than independent entry points. This boundary lets the operation,
-Grouping plan, and backend representations change without spreading field
-access through public verbs or adapters.
+source checkers take it whole because they are dispatch targets of one
+signature rather than independent entry points. This boundary lets the
+operation, Grouping plan, and backend representations change without spreading
+field access through public verbs or adapters.
 
 ## Test seams
 
@@ -537,8 +539,8 @@ A backend change should:
 3. reuse the existing portable adapter unless native `GROUPING SETS` support
    is confirmed and covered by the native adapter contract;
 4. name the new backend kind in `share_adapter()` and in
-   `share_source_sampler()`, choosing one of the existing contextual-share
-   adapters and one of the existing source samplers, or adding one. Neither
+   `share_source_checker()`, choosing one of the existing contextual-share
+   adapters and one of the existing source checkers, or adding one. Neither
    lookup has a default: an unnamed kind stops the operation rather than
    falling through to a plausible-looking join. Answer
    `wraps_share_sources_in_summary()` for it as well — it is the third

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,6 +2,7 @@ ADR
 CMD
 Codecov
 DuckDB
+DuckDB's
 HANA
 ODBC
 Pre

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -34,6 +34,7 @@ tibble
 tidyr
 tidyselect
 unclamped
+unexecuted
 ungrouped
 vctrs
 yaml

--- a/investigation/query-cost-across-lazy-backends.md
+++ b/investigation/query-cost-across-lazy-backends.md
@@ -1,0 +1,173 @@
+# What a query costs on a lazy backend
+
+Investigated: 2026-08-16
+
+`.check_margin_label` defaults to `is.data.frame(.data)`, and the reason
+recorded in the sources was that checking "would require an additional query"
+(`R/summarize_with_margins.R`) and that the extra scan should be opted into
+(`vignettes/database_backends.qmd`). Both read as performance notes. The
+design intent behind the argument was avoiding unintended billing and database
+load, and #122 proposed changing the default without that intent being
+recorded anywhere a reader could find it.
+
+This note records what the vendors' own documentation says a query costs, what
+could not be found in it, and what was measured locally. It was prompted by
+#122 and by the `probe_share_sources()` read that `share_of_parent()` issues.
+
+## Billing models found
+
+Four models, established from vendor documentation read on 2026-08-16.
+
+### Per byte scanned
+
+**BigQuery** (on-demand) charges for the bytes in the columns a query
+references, not for the rows it returns.
+
+> For non-clustered tables, applying a `LIMIT` clause to a query doesn't
+> affect the amount of data that is read.
+
+— *Estimate and control costs*, https://cloud.google.com/bigquery/docs/best-practices-costs
+
+The same page states that a clustered table is the exception, where a `LIMIT`
+can reduce the bytes scanned because scanning stops once enough blocks are
+read. The pricing page adds a minimum of 10 MiB of processed data per
+referenced table and 10 MiB per query, and states that queries returning an
+error or served from cache are not charged.
+
+**Athena** charges $5 per TB scanned from S3, for successful and unsuccessful
+queries alike, with a 10 MB minimum per query
+(https://aws.amazon.com/athena/pricing/).
+
+**Redshift Spectrum** charges $5.00/TB scanned, rounded up to the next
+megabyte, with a 10 MB minimum per query
+(https://aws.amazon.com/redshift/pricing/).
+
+### Per unit of time
+
+**Snowflake** bills warehouse credits per second, with a 60-second minimum
+each time a warehouse starts
+(https://docs.snowflake.com/en/user-guide/cost-understanding-compute). A query
+that wakes a suspended warehouse therefore has a floor of one minute of
+credits regardless of what it reads.
+
+**Redshift Serverless** bills RPU-hours per second with a 60-second minimum,
+and **Aurora Serverless v2** bills ACU per second.
+
+### Per provisioned capacity — no per-query charge
+
+**Amazon RDS** (non-Aurora) charges DB instance-hours, billed per second with
+a 10-minute minimum, plus provisioned storage per GB-month. For gp3 and
+Provisioned IOPS storage the IOPS are charged as provisioned, regardless of
+IOPS consumed; only the legacy magnetic storage class is charged per million
+I/O requests (https://aws.amazon.com/rds/pricing/,
+https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/User_DBInstanceBilling.html).
+
+An extra query against RDS therefore costs instance CPU and contention with
+other work, and no money per query.
+
+### Per I/O request
+
+**Aurora Standard** charges per million I/O requests, and read operations
+count. **Aurora I/O-Optimized** removes I/O charges in exchange for a higher
+storage rate ($0.225 vs $0.10 per GB-month)
+(https://aws.amazon.com/rds/aurora/pricing/).
+
+## What could not be found
+
+Searched for on 2026-08-16 and not located in vendor documentation. Each is
+recorded because the absence is the finding: an argument that assumes any of
+these is resting on something no document states.
+
+- **Whether `LIMIT 0` is exempt from BigQuery's rule.** The rule quoted above
+  names `LIMIT` without qualification and no carve-out for zero was found. No
+  statement about `WHERE FALSE` was found either. What BigQuery does document
+  for this purpose is *dry run*, which returns the schema and an estimate of
+  bytes processed and is stated to incur no charge
+  (https://cloud.google.com/bigquery/docs/estimate-costs). That a vendor
+  exposed to scan billing built a free path for schema and validation
+  questions is the strongest available evidence that paying to scan for a type
+  is not the expected practice.
+- **Whether a query referencing no table is subject to BigQuery's 10 MiB
+  per-query minimum.** The pricing page states the minimum per query without
+  qualifying it by whether a table is referenced.
+- **Whether a `LIMIT` reduces bytes scanned on Athena's native S3 path.** Two
+  Athena performance pages were read in full
+  (`performance-tuning-data-optimization-techniques`,
+  `performance-tuning-query-optimization-techniques`); neither relates `LIMIT`
+  to data scanned. Athena's *federated connector* pages do state it — "A
+  `LIMIT N` statement reduces the data scanned by the query. With `LIMIT N`
+  pushdown, the connector returns only `N` rows to Athena"
+  (https://docs.aws.amazon.com/athena/latest/ug/connectors-redshift.html) —
+  but that is the connector path, not the S3 path Athena is normally used
+  through.
+
+## What was measured locally
+
+Against duckdb 1.5.5 and RSQLite in this environment, through dbplyr 2.6.0.
+Commands are quoted so each result can be reproduced; the scripts were
+throwaway.
+
+### `dplyr::tbl()` issues an unrequested zero-row read
+
+```r
+trace(DBI::dbSendQuery, tracer = quote(print(statement)))
+t1 <- dplyr::tbl(con, "d")
+#> "SELECT *\nFROM `d` AS `q01`\nWHERE (0 = 1)"
+```
+
+Creating a table reference sends a query before the caller has asked for
+anything. A lazy `summarize()` and a `colnames()` call on the result sent
+none. A zero-row read of the input is therefore not a shape marginplyr
+introduced; it is what the layer below already does per table reference.
+
+### The collision scan costs ~28% on duckdb, in its worst shape
+
+5,000,000 rows, three character grouping dimensions under `rollup()` — the
+shape where no dimension's answer is available from metadata, so the scan is
+unavoidable:
+
+```
+.check_margin_label = FALSE  median 0.074s
+.check_margin_label = TRUE   median 0.095s   (+0.021s, +28%)
+```
+
+The cost that decides the default is not this one. It is the round trip and
+the billing models above, neither of which is visible in an in-process
+measurement.
+
+### Backend kind does not determine whether a query leaves the machine
+
+`grouping_backend()` classifies by input class and SQL dialect
+(`R/grouping-backend.R`). Nothing it reads distinguishes:
+
+- a local DuckDB file from a hosted DuckDB service — both reach
+  `dbConnect(duckdb::duckdb(), ...)` and classify as `kind = "duckdb"`;
+- an in-memory Arrow `Table` from a `FileSystemDataset` over object storage —
+  both classify as `kind = "arrow"`, though `q$.data` does distinguish the two
+  classes, and a `FileSystemDataset` does not distinguish local disk from
+  object storage;
+- RDS PostgreSQL, which has no per-query charge, from Aurora Standard, which
+  charges per I/O request — both classify as `kind = "postgres"`;
+- SQLite from BigQuery — both fall into the generic `kind = "sql"`.
+
+`is.data.frame()` is the only predicate available that answers "no external
+system is involved", and it answers it exactly rather than approximately.
+
+## What this establishes
+
+A read bounded in the rows it requests and returns is not bounded in what it
+costs. On BigQuery a `LIMIT` does not reduce the bytes billed on a
+non-clustered table; on Snowflake a one-row query that starts a warehouse
+costs a minute of credits; on Aurora Standard every read is a billable I/O
+request; on Athena a query that fails is billed like one that succeeds. The
+justification recorded in ADR 0010 for the one-row `probe_share_sources()`
+read — "one read bounded in rows requested and returned" — is accurate about
+rows and says nothing about cost, and cost is what it was offered as an answer
+to.
+
+Conversely, three of the four models charge nothing per query, or nothing that
+scales with a zero-row read: RDS and provisioned Redshift charge for capacity,
+and Aurora I/O-Optimized removes the I/O charge. No single statement covers
+all four, and no property `grouping_backend()` can read tells them apart. A
+design that tries to price backends is a design that must track four vendors'
+pricing pages; one that asks the caller before reading their data does not.

--- a/investigation/share-source-eligibility-on-coercing-dialects.md
+++ b/investigation/share-source-eligibility-on-coercing-dialects.md
@@ -1,0 +1,132 @@
+# Share-source eligibility on a dialect that converts rather than refuses
+
+Investigated: 2026-08-16
+
+`investigation/share-source-schema-vs-data-read.md` (2026-08-08) established
+that on RSQLite no method reports a computed expression's real type without
+the backend computing at least one row, and it framed the choice as zero rows
+or real types.
+
+This note revisits the premise underneath that framing: that the real type,
+once obtained, establishes whether a share source is eligible. On a dialect
+that converts a non-numeric value to a number instead of refusing it, it does
+not. Measured against RSQLite and duckdb 1.5.5 through dbplyr 2.6.0 on
+2026-08-16, with marginplyr loaded from the working tree via
+`pkgload::load_all()`. Scripts were throwaway; commands are quoted inline.
+
+## The type is real and is not evidence
+
+```r
+d <- data.frame(g = c("a","a","b"), txt = c("x","y","z"), v = c(1,2,3))
+collect(summarize(db, t = sum(txt, na.rm = TRUE)))
+```
+
+| backend | result |
+|---|---|
+| RSQLite | `numeric`, value `0` |
+| duckdb | error: `Binder Error: No function matches the given name and argument types` |
+
+SQLite's answer is a genuine double. `is_share_source_type()` (`R/share.R`)
+asks `typeof(value) %in% c("integer", "double") && !is.object(value)`, and a
+double is what it receives. The eligible-type rule reads the type of the value
+the database returned, and on this dialect that type carries no information
+about whether the summary meant anything.
+
+End to end, with marginplyr:
+
+```r
+collect(summarize_with_margins(
+  db, t = sum(txt, na.rm = TRUE), s = share_of_total(t), .grouping = rollup(g)
+))
+#>   g         t     s
+#>   a         0    NA
+#>   b         0    NA
+#>   Total     0     1
+```
+
+The local backend raises a `marginplyr_error` for the same call. The SQLite
+result is the symptom #106 described: an all-missing share column carrying the
+grand total's own-denominator `1`, which reads as 100%.
+
+## #106's own reproduction is fixed; the class of bug is not
+
+```r
+collect(summarize_with_margins(
+  db, lab = max(txt), p = share_of_total(lab), .grouping = rollup(g)
+))
+#> Error: Total share `p` requires source summary `lab` to be a plain integer
+#>   or double scalar; detected type ...
+```
+
+`max(txt)` returns `character` on SQLite as it does elsewhere, so the one-row
+probe added in `e08c3fa` catches it and the diagnostic matches the local one.
+What the probe cannot catch is a summary the dialect converts, because there is
+no wrong type to detect. The gap is not in the probe's implementation but in
+the question it asks.
+
+## A dialect can be asked whether it converts, reading nothing
+
+The property that decides the case is a property of the dialect, not of the
+caller's data, and it can be measured with a query that references no table of
+theirs:
+
+```r
+probe <- dplyr::summarize(
+  dplyr::tbl(con, dbplyr::sql("SELECT 1 AS z")),
+  p = sum("x", na.rm = TRUE)
+)
+```
+
+Both dialects rendered the same SQL and answered differently:
+
+```sql
+SELECT SUM('x') AS p FROM (SELECT 1 AS z) AS q01
+```
+
+| backend | result | reading |
+|---|---|---|
+| RSQLite | `0`, no error | converts |
+| duckdb | `Binder Error` | refuses |
+
+The signal is whether the backend raises, not what value it returns. The
+character literal reaches SQL through dbplyr's ordinary translation —
+`sum("x")` renders as `SUM('x')` — so the only dialect-specific text is
+`SELECT 1 AS z`.
+
+The same distinction was reproduced with the caller's own table as the source,
+under both `utils::head(.data, 0L)` and `dplyr::filter(.data, FALSE)`; duckdb
+raised a binder error in every shape, because binding precedes execution and
+does not depend on rows. The table-free form was preferred for what it avoids
+rather than for what it adds: it makes the unresolved question about
+`LIMIT 0` billing in `investigation/query-cost-across-lazy-backends.md`
+irrelevant to this read.
+
+## Zero-row spellings are not interchangeable across dplyr backends
+
+```r
+collect(filter(arrow::as_arrow_table(d), FALSE))
+#> Error: filter expressions must be either an expression or a list of expressions
+collect(filter(dtplyr::lazy_dt(d), FALSE))
+#> 0 rows, classes factor / numeric
+collect(head(arrow::as_arrow_table(d), 0))
+#> 0 rows
+```
+
+Arrow rejected a bare `FALSE` in `filter()`. `head(x, 0)` returned zero rows on
+every backend tried. Any zero-row read intended to be portable across the
+dplyr backends marginplyr accepts is therefore spelled `head(x, 0)`, whatever
+SQL a given dialect renders it as.
+
+## What this establishes
+
+On a dialect that converts non-numeric values to numbers, reading a row of the
+caller's data cannot establish that a share source is eligible, because every
+source reports an eligible type. The 2026-08-08 note's conclusion stands as
+stated — zero rows or real types, not both — but the real type is not the
+evidence the eligible-type rule needs on such a dialect, so obtaining it does
+not settle the question the rule exists to answer.
+
+The property that does settle it is whether the dialect converts, and that is
+answerable by one query per dialect that reads none of the caller's data and
+references none of their tables. Whether a dialect converts is a property of
+the dialect, so the answer is reusable for every connection sharing it.

--- a/investigation/share-source-schema-vs-data-read.md
+++ b/investigation/share-source-schema-vs-data-read.md
@@ -1,6 +1,7 @@
 # Schema reads vs. data reads for share-source typing
 
 Investigated: 2026-08-08
+Revised: 2026-08-16 — investigation/share-source-eligibility-on-coercing-dialects.md
 
 This note follows up on `git show e08c3fa` (the one-row `probe_share_sources()`
 read) and the handoff that reopened it. The open question was whether some
@@ -180,3 +181,28 @@ return zero rows (cheap, no data computed, no data read by any reasonable
 reading of that phrase) or it can be made to report real computed-expression
 types (only by computing — and, on the methods tried, fully materializing —
 at least one row). No measured method gets both on this dialect.
+
+## Revisions (2026-08-16)
+
+`investigation/share-source-eligibility-on-coercing-dialects.md` establishes
+that the premise underneath the tradeoff above does not hold on RSQLite: the
+real computed-expression type, once obtained, is not evidence that a share
+source is eligible on that dialect.
+
+Measured there: `sum(txt)` over a text column returns a genuine `numeric` `0`
+on RSQLite and raises a binder error on DuckDB, so `is_share_source_type()`
+receives an eligible type for an ineligible source and accepts it. End to end,
+`share_of_total()` over such a source returns the #106 symptom — an all-missing
+share column with `1` on the grand total row — while the local backend raises.
+#106's own reproduction, `max(region)`, remains fixed, because a character
+result is a wrong type and this is not.
+
+Both branches of the tradeoff stated above therefore fail to answer the
+question the eligible-type rule exists to answer, on the one dialect this note
+was written about. The successor note records the question that is answerable
+instead — whether the dialect converts rather than refuses — which needs one
+query per dialect that reads none of the caller's data and references none of
+their tables.
+
+Nothing measured in this note was contradicted. What changed is what the
+measurements were taken to be evidence for.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -45,13 +45,19 @@ This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
 
-\item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
-dimension independently for a value or factor level that collides with its
-display label. \code{.margin_label = NULL} opts out of these checks. See
-\emph{Display labels and grouping identity} for the factor missing-value
-contract. Every Margin verb uses the same default: \code{TRUE} for local data
-frames and \code{FALSE} for lazy inputs, where checking would require an
-additional query.}
+\item{.check_margin_label}{A logical scalar controlling the half of the
+Margin label collision check that reads the data: whether any \emph{value} of a
+Margin dimension is equal to that dimension's display label. Each
+dimension is checked independently, and \code{.margin_label = NULL} opts out.
+Every Margin verb uses the same default: \code{TRUE} for local data frames and
+\code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+equal to a declared factor \emph{level} is rejected on every backend whatever
+this argument says, because the levels are already known and finding it
+sends no query. Left unchecked, a colliding value gives the result a
+margin row and a source row that no grouping column tells apart; keeping
+\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
+added cost. See \emph{Display labels and grouping identity} for the factor
+missing-value contract.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
 duplicate grouping sets after expansion.}

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -346,7 +346,10 @@ because its row-wise return shape exists only locally; see its own
 documentation for when it collects.
 
 Two queries reach your connection without being asked for, and neither
-reads a row of your data:
+reads a row of your data. This is the rule for every Margin verb, so each
+is described against the inputs that can produce it: a verb accepting no
+lazy table, or no contextual share, simply never reaches the one that
+depends on it.
 \itemize{
 \item \strong{A zero-row read of the input}, sent only to a backend whose factor
 columns marginplyr must decompose and later restore -- currently

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -354,12 +354,14 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
-share is requested there with \code{.check_share_source} at its default of
-\code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. It references none of your tables, so
-reading it touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. A
+\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
+time a share is requested there with \code{.check_share_source} at its default
+of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. Neither references any of your tables, so
+reading them touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. The second
+is a control, sent only when the first is rejected, and it distinguishes
+a dialect that refuses from one that could not be asked at all. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -280,12 +280,12 @@ are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
 factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing the synthetic level last by default
-or first when \code{.margin_label_position = "first"}. With collision checking
-enabled, the complete factor domain is checked, including unused levels.
-With checking disabled, an existing level may be reused and is moved to the
-requested position. Reconstruction preserves the distinction between an
-observation that uses a factor NA level and an actually missing factor code.
+preserving ordered status and placing a new synthetic level last by default
+or first when \code{.margin_label_position = "first"}. A label equal to any
+declared level, used or unused, is rejected before any grouping set is
+built, whatever \code{.check_margin_label} says: see that argument above.
+Reconstruction preserves the distinction between an observation that uses a
+factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
@@ -312,10 +312,12 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
-\code{.check_margin_label = TRUE} detects
-collisions for local data. Lazy tables default to \code{FALSE} because checking
-would execute an extra query; opt in when that scan is appropriate.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
+observed row of this table -- whether \code{NA_character_} collides with an
+actual missing value when no NA level is declared; the declared rows above
+it are checked whatever this argument says. See \code{.check_margin_label}
+above for its default and \emph{When marginplyr queries your data} for why the
+two halves differ.
 }
 
 \section{Database backend coverage}{
@@ -333,6 +335,54 @@ SQL generation, not execution against every database server.
 
 Arrow and dtplyr are also tested lazy backends, but they are not SQL
 database connections.
+}
+
+\section{When marginplyr queries your data}{
+
+Every Margin verb applied to a lazy input builds a query and returns it
+unexecuted. \code{\link[dplyr:show_query]{dplyr::show_query()}} runs nothing, and no row is read until
+you execute the query yourself -- \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} excepted,
+because its row-wise return shape exists only locally; see its own
+documentation for when it collects.
+
+Two queries reach your connection without being asked for, and neither
+reads a row of your data:
+\itemize{
+\item \strong{A zero-row read of the input}, sent only to a backend whose factor
+columns marginplyr must decompose and later restore -- currently
+\code{dtplyr} and DuckDB -- to recover the levels and column prototypes that
+decomposition loses. It references your table but reads none of it, and
+it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
+equivalent zero-row read for any table reference, on any dbplyr backend.
+\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
+share is requested there with \code{.check_share_source} at its default of
+\code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. It references none of your tables, so
+reading it touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. A
+connection that cannot be asked -- one built with a
+\verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
+as unable to answer, which refuses the share by default the same way a
+dialect known to convert does; see \code{.check_share_source} on
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}.
+}
+
+Neither query is safe merely because it returns no rows. A read bounded in
+rows is not bounded in what it costs: BigQuery states plainly that a
+\code{LIMIT} does not reduce the bytes billed for a non-clustered table, and no
+vendor documentation exempts \verb{LIMIT 0} from that rule.
+
+marginplyr does not try to tell whether a backend bills for a query,
+because nothing it can read distinguishes a free connection from a billed
+one of the same kind -- a local DuckDB file from a hosted DuckDB service,
+or RDS PostgreSQL from Aurora Standard. \code{is.data.frame(.data)} is the only
+predicate that answers "no external system is involved" exactly rather
+than approximately, and it is what sets the default of every check that
+reads your data: a check that reads it is asked for, and a check that does
+not is not. \code{.check_margin_label} scans the grouping columns, so every
+Margin verb defaults it to \code{is.data.frame(.data)}.
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
+backend, so it defaults to \code{TRUE} there.
 }
 
 \section{Backend extension design}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -329,7 +329,10 @@ because its row-wise return shape exists only locally; see its own
 documentation for when it collects.
 
 Two queries reach your connection without being asked for, and neither
-reads a row of your data:
+reads a row of your data. This is the rule for every Margin verb, so each
+is described against the inputs that can produce it: a verb accepting no
+lazy table, or no contextual share, simply never reaches the one that
+depends on it.
 \itemize{
 \item \strong{A zero-row read of the input}, sent only to a backend whose factor
 columns marginplyr must decompose and later restore -- currently

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -48,13 +48,19 @@ This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
 
-\item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
-dimension independently for a value or factor level that collides with its
-display label. \code{.margin_label = NULL} opts out of these checks. See
-\emph{Display labels and grouping identity} for the factor missing-value
-contract. Every Margin verb uses the same default: \code{TRUE} for local data
-frames and \code{FALSE} for lazy inputs, where checking would require an
-additional query.}
+\item{.check_margin_label}{A logical scalar controlling the half of the
+Margin label collision check that reads the data: whether any \emph{value} of a
+Margin dimension is equal to that dimension's display label. Each
+dimension is checked independently, and \code{.margin_label = NULL} opts out.
+Every Margin verb uses the same default: \code{TRUE} for local data frames and
+\code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+equal to a declared factor \emph{level} is rejected on every backend whatever
+this argument says, because the levels are already known and finding it
+sends no query. Left unchecked, a colliding value gives the result a
+margin row and a source row that no grouping column tells apart; keeping
+\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
+added cost. See \emph{Display labels and grouping identity} for the factor
+missing-value contract.}
 
 \item{.duplicates}{\code{"error"} or \code{"drop"}. Nesting does not support the
 \code{"keep"} policy available in \code{\link[=summarize_with_margins]{summarize_with_margins()}} and

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -280,12 +280,12 @@ are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
 factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing the synthetic level last by default
-or first when \code{.margin_label_position = "first"}. With collision checking
-enabled, the complete factor domain is checked, including unused levels.
-With checking disabled, an existing level may be reused and is moved to the
-requested position. Reconstruction preserves the distinction between an
-observation that uses a factor NA level and an actually missing factor code.
+preserving ordered status and placing a new synthetic level last by default
+or first when \code{.margin_label_position = "first"}. A label equal to any
+declared level, used or unused, is rejected before any grouping set is
+built, whatever \code{.check_margin_label} says: see that argument above.
+Reconstruction preserves the distinction between an observation that uses a
+factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
@@ -312,10 +312,60 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
-\code{.check_margin_label = TRUE} detects
-collisions for local data. Lazy tables default to \code{FALSE} because checking
-would execute an extra query; opt in when that scan is appropriate.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
+observed row of this table -- whether \code{NA_character_} collides with an
+actual missing value when no NA level is declared; the declared rows above
+it are checked whatever this argument says. See \code{.check_margin_label}
+above for its default and \emph{When marginplyr queries your data} for why the
+two halves differ.
+}
+
+\section{When marginplyr queries your data}{
+
+Every Margin verb applied to a lazy input builds a query and returns it
+unexecuted. \code{\link[dplyr:show_query]{dplyr::show_query()}} runs nothing, and no row is read until
+you execute the query yourself -- \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} excepted,
+because its row-wise return shape exists only locally; see its own
+documentation for when it collects.
+
+Two queries reach your connection without being asked for, and neither
+reads a row of your data:
+\itemize{
+\item \strong{A zero-row read of the input}, sent only to a backend whose factor
+columns marginplyr must decompose and later restore -- currently
+\code{dtplyr} and DuckDB -- to recover the levels and column prototypes that
+decomposition loses. It references your table but reads none of it, and
+it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
+equivalent zero-row read for any table reference, on any dbplyr backend.
+\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
+share is requested there with \code{.check_share_source} at its default of
+\code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. It references none of your tables, so
+reading it touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. A
+connection that cannot be asked -- one built with a
+\verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
+as unable to answer, which refuses the share by default the same way a
+dialect known to convert does; see \code{.check_share_source} on
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}.
+}
+
+Neither query is safe merely because it returns no rows. A read bounded in
+rows is not bounded in what it costs: BigQuery states plainly that a
+\code{LIMIT} does not reduce the bytes billed for a non-clustered table, and no
+vendor documentation exempts \verb{LIMIT 0} from that rule.
+
+marginplyr does not try to tell whether a backend bills for a query,
+because nothing it can read distinguishes a free connection from a billed
+one of the same kind -- a local DuckDB file from a hosted DuckDB service,
+or RDS PostgreSQL from Aurora Standard. \code{is.data.frame(.data)} is the only
+predicate that answers "no external system is involved" exactly rather
+than approximately, and it is what sets the default of every check that
+reads your data: a check that reads it is asked for, and a check that does
+not is not. \code{.check_margin_label} scans the grouping columns, so every
+Margin verb defaults it to \code{is.data.frame(.data)}.
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
+backend, so it defaults to \code{TRUE} there.
 }
 
 \section{Backend extension design}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -337,12 +337,14 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
-share is requested there with \code{.check_share_source} at its default of
-\code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. It references none of your tables, so
-reading it touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. A
+\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
+time a share is requested there with \code{.check_share_source} at its default
+of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. Neither references any of your tables, so
+reading them touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. The second
+is a control, sent only when the first is rejected, and it distinguishes
+a dialect that refuses from one that could not be asked at all. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -373,7 +373,10 @@ because its row-wise return shape exists only locally; see its own
 documentation for when it collects.
 
 Two queries reach your connection without being asked for, and neither
-reads a row of your data:
+reads a row of your data. This is the rule for every Margin verb, so each
+is described against the inputs that can produce it: a verb accepting no
+lazy table, or no contextual share, simply never reaches the one that
+depends on it.
 \itemize{
 \item \strong{A zero-row read of the input}, sent only to a backend whose factor
 columns marginplyr must decompose and later restore -- currently

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -324,12 +324,12 @@ are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
 factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing the synthetic level last by default
-or first when \code{.margin_label_position = "first"}. With collision checking
-enabled, the complete factor domain is checked, including unused levels.
-With checking disabled, an existing level may be reused and is moved to the
-requested position. Reconstruction preserves the distinction between an
-observation that uses a factor NA level and an actually missing factor code.
+preserving ordered status and placing a new synthetic level last by default
+or first when \code{.margin_label_position = "first"}. A label equal to any
+declared level, used or unused, is rejected before any grouping set is
+built, whatever \code{.check_margin_label} says: see that argument above.
+Reconstruction preserves the distinction between an observation that uses a
+factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
@@ -356,10 +356,60 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
-\code{.check_margin_label = TRUE} detects
-collisions for local data. Lazy tables default to \code{FALSE} because checking
-would execute an extra query; opt in when that scan is appropriate.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
+observed row of this table -- whether \code{NA_character_} collides with an
+actual missing value when no NA level is declared; the declared rows above
+it are checked whatever this argument says. See \code{.check_margin_label}
+above for its default and \emph{When marginplyr queries your data} for why the
+two halves differ.
+}
+
+\section{When marginplyr queries your data}{
+
+Every Margin verb applied to a lazy input builds a query and returns it
+unexecuted. \code{\link[dplyr:show_query]{dplyr::show_query()}} runs nothing, and no row is read until
+you execute the query yourself -- \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} excepted,
+because its row-wise return shape exists only locally; see its own
+documentation for when it collects.
+
+Two queries reach your connection without being asked for, and neither
+reads a row of your data:
+\itemize{
+\item \strong{A zero-row read of the input}, sent only to a backend whose factor
+columns marginplyr must decompose and later restore -- currently
+\code{dtplyr} and DuckDB -- to recover the levels and column prototypes that
+decomposition loses. It references your table but reads none of it, and
+it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
+equivalent zero-row read for any table reference, on any dbplyr backend.
+\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
+share is requested there with \code{.check_share_source} at its default of
+\code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. It references none of your tables, so
+reading it touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. A
+connection that cannot be asked -- one built with a
+\verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
+as unable to answer, which refuses the share by default the same way a
+dialect known to convert does; see \code{.check_share_source} on
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}.
+}
+
+Neither query is safe merely because it returns no rows. A read bounded in
+rows is not bounded in what it costs: BigQuery states plainly that a
+\code{LIMIT} does not reduce the bytes billed for a non-clustered table, and no
+vendor documentation exempts \verb{LIMIT 0} from that rule.
+
+marginplyr does not try to tell whether a backend bills for a query,
+because nothing it can read distinguishes a free connection from a billed
+one of the same kind -- a local DuckDB file from a hosted DuckDB service,
+or RDS PostgreSQL from Aurora Standard. \code{is.data.frame(.data)} is the only
+predicate that answers "no external system is involved" exactly rather
+than approximately, and it is what sets the default of every check that
+reads your data: a check that reads it is asked for, and a check that does
+not is not. \code{.check_margin_label} scans the grouping columns, so every
+Margin verb defaults it to \code{is.data.frame(.data)}.
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
+backend, so it defaults to \code{TRUE} there.
 }
 
 \section{Backend extension design}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -48,13 +48,19 @@ This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
 
-\item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
-dimension independently for a value or factor level that collides with its
-display label. \code{.margin_label = NULL} opts out of these checks. See
-\emph{Display labels and grouping identity} for the factor missing-value
-contract. Every Margin verb uses the same default: \code{TRUE} for local data
-frames and \code{FALSE} for lazy inputs, where checking would require an
-additional query.}
+\item{.check_margin_label}{A logical scalar controlling the half of the
+Margin label collision check that reads the data: whether any \emph{value} of a
+Margin dimension is equal to that dimension's display label. Each
+dimension is checked independently, and \code{.margin_label = NULL} opts out.
+Every Margin verb uses the same default: \code{TRUE} for local data frames and
+\code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+equal to a declared factor \emph{level} is rejected on every backend whatever
+this argument says, because the levels are already known and finding it
+sends no query. Left unchecked, a colliding value gives the result a
+margin row and a source row that no grouping column tells apart; keeping
+\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
+added cost. See \emph{Display labels and grouping identity} for the factor
+missing-value contract.}
 
 \item{.duplicates}{\code{"error"} or \code{"drop"}. Nesting does not support the
 \code{"keep"} policy available in \code{\link[=summarize_with_margins]{summarize_with_margins()}} and

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -381,12 +381,14 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
-share is requested there with \code{.check_share_source} at its default of
-\code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. It references none of your tables, so
-reading it touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. A
+\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
+time a share is requested there with \code{.check_share_source} at its default
+of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. Neither references any of your tables, so
+reading them touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. The second
+is a control, sent only when the first is rejected, and it distinguishes
+a dialect that refuses from one that could not be asked at all. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -395,14 +395,14 @@ are requested.
 Syntax, source-name, written-order, and \code{across()} errors are always
 reported locally, before execution, on every backend. The eligible-type
 rule is also enforced on every backend, and no backend calculates a share
-from a source it has shown to be ineligible. What differs is when the
-source's type becomes readable, and whether the exactly-one-value
-cardinality rule can be read with it:\tabular{ll}{
-   Backend \tab Where source type and cardinality are checked \cr
-   Local data frame \tab Before any share is calculated \cr
-   \code{dtplyr} step \tab At explicit execution, before an invalid row is emitted \cr
-   Arrow \tab Not reached; shares are rejected outright \cr
-   General dbplyr \tab Type only, from one input row, before the query returns \cr
+from a source it has shown to be ineligible. None of it reads a row of your
+data. What differs is what establishes the rule, and whether the
+exactly-one-value cardinality rule is established with it:\tabular{ll}{
+   Backend \tab What establishes the source rules \cr
+   Local data frame \tab Both, from the result, before any share \cr
+   \code{dtplyr} step \tab Both, at execution, before an invalid row \cr
+   Arrow \tab Neither; shares are rejected outright \cr
+   General dbplyr \tab Type only, by asking the dialect once \cr
 }
 
 
@@ -418,26 +418,30 @@ added and nothing is collected on your behalf. Its execution-time
 diagnostics keep the share's output name, the source summary name, and
 the original public call, so they read like the local ones.
 
-A general dbplyr backend evaluates the source summary in the database, so
-its type is readable only from a value the database returns. marginplyr
-reads one: when a share is requested, it collects the ordinary summaries
-over a single input row and rejects an ineligible source before returning
-the query. The read is bounded in rows requested and returned, not in the
-work the input may have to do to produce that one row. It is the staged
-query that stays lazy — nothing else is executed, \code{\link[dplyr:show_query]{dplyr::show_query()}}
-remains non-executing, and no further query is run to improve an error.
+A general dbplyr backend evaluates the source summary itself, so the rule
+is the dialect's to apply rather than marginplyr's to read. Nothing of
+yours is read to establish it: the staged query stays lazy,
+\code{\link[dplyr:show_query]{dplyr::show_query()}} remains non-executing, and no query is run over your
+data to improve an error.
 
-A source the read cannot type is left alone rather than rejected. A dialect
-that types values rather than columns says nothing about a summary whose
-one sampled value is missing, and a summary the database refuses is
-reported by the database when \code{\link[dplyr:collect]{dplyr::collect()}} executes the staged
-query, where its own diagnostic is the useful one. Cardinality is not read
-this way at all: a SQL aggregate returns one value per grouping row by
-construction, so there is nothing for the sample to disprove. What the
-sample cannot type and every non-scalar summary therefore remain
-runtime-only incompatibilities: errors the database reports for itself at
-\code{\link[dplyr:collect]{dplyr::collect()}} rather than ones marginplyr raises before returning the
-query.
+Which of two things a dialect does is what decides the case, and it is
+settled by asking that dialect once, with a query referencing none of your
+tables. Where it refuses an ineligible summary, that refusal is the answer
+and reaches you as the database's own diagnostic when \code{\link[dplyr:collect]{dplyr::collect()}}
+executes the staged query; the internal denominator column is named after
+the summary to rewrite so that diagnostic is actionable. Where it converts
+a value of another type to a number instead, it applies no rule at all and
+no reading of your data would recover one, so the share is refused rather
+than calculated from values nothing has checked —
+\code{.check_share_source = FALSE} calculates it from sources you have
+established yourself. A backend that cannot be asked, such as a
+\verb{dbplyr::simulate_*()} connection, is refused the same way.
+
+Cardinality is not established this way at all: a SQL aggregate returns one
+value per grouping row by construction, so there is nothing for a dialect
+to convert. A non-scalar summary therefore remains a runtime-only
+incompatibility, reported by the database at \code{\link[dplyr:collect]{dplyr::collect()}} rather than
+raised by marginplyr before the query is returned.
 
 The portable value guarantee covers finite numbers, missing values, and
 zero denominators. Infinite values and backend-specific \code{NaN}

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -402,7 +402,7 @@ exactly-one-value cardinality rule is established with it:\tabular{ll}{
    Local data frame \tab Both, from the result, before any share \cr
    \code{dtplyr} step \tab Both, at execution, before an invalid row \cr
    Arrow \tab Neither; shares are rejected outright \cr
-   General dbplyr \tab Type only, by asking the dialect once \cr
+   General dbplyr \tab Type only, by asking the dialect itself \cr
 }
 
 
@@ -425,8 +425,11 @@ yours is read to establish it: the staged query stays lazy,
 data to improve an error.
 
 Which of two things a dialect does is what decides the case, and it is
-settled by asking that dialect once, with a query referencing none of your
-tables. Where it refuses an ineligible summary, that refusal is the answer
+settled once per dialect, with at most two queries referencing none of your
+tables: a probe, and — only when the probe is rejected — a control, which is
+what tells a dialect that genuinely refuses apart from one whose connection
+or SQL scaffolding failed and could not answer at all. Where it refuses an
+ineligible summary, that refusal is the answer
 and reaches you as the database's own diagnostic when \code{\link[dplyr:collect]{dplyr::collect()}}
 executes the staged query; the internal denominator column is named after
 the summary to rewrite so that diagnostic is actionable. Where it converts

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -13,6 +13,7 @@ summarize_with_margins(
   .margin_label = "Total",
   .margin_label_position = c("last", "first"),
   .check_margin_label = is.data.frame(.data),
+  .check_share_source = TRUE,
   .duplicates = c("error", "drop", "keep"),
   .id = NULL,
   .sort = c("none", "last", "first")
@@ -26,6 +27,7 @@ summarise_with_margins(
   .margin_label = "Total",
   .margin_label_position = c("last", "first"),
   .check_margin_label = is.data.frame(.data),
+  .check_share_source = TRUE,
   .duplicates = c("error", "drop", "keep"),
   .id = NULL,
   .sort = c("none", "last", "first")
@@ -71,6 +73,17 @@ display label. \code{.margin_label = NULL} opts out of these checks. See
 contract. Every Margin verb uses the same default: \code{TRUE} for local data
 frames and \code{FALSE} for lazy inputs, where checking would require an
 additional query.}
+
+\item{.check_share_source}{A logical scalar, \code{TRUE} by default on every
+backend, including lazy ones: establishing that a share's source summary
+is an eligible type reads none of your data. \code{FALSE} calculates a
+requested \code{\link[=share_of_parent]{share_of_parent()}} or \code{\link[=share_of_total]{share_of_total()}} from a source whose
+eligibility marginplyr could not establish, which is a SQL dialect that
+converts a value of another type to a number rather than refusing it, and
+a backend that could not be asked which of those it does. It changes
+nothing where the rule can be applied — a local data frame, a \code{dtplyr}
+step, and a database that refuses an ineligible summary itself all apply
+it whatever this argument says. See \emph{Contextual shares}.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
 duplicate grouping sets after expansion.}

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -512,12 +512,14 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
-share is requested there with \code{.check_share_source} at its default of
-\code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. It references none of your tables, so
-reading it touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. A
+\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
+time a share is requested there with \code{.check_share_source} at its default
+of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. Neither references any of your tables, so
+reading them touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. The second
+is a control, sent only when the first is rejected, and it distinguishes
+a dialect that refuses from one that could not be asked at all. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -64,13 +64,19 @@ This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
 
-\item{.check_margin_label}{A logical scalar. If \code{TRUE}, check each Margin
-dimension independently for a value or factor level that collides with its
-display label. \code{.margin_label = NULL} opts out of these checks. See
-\emph{Display labels and grouping identity} for the factor missing-value
-contract. Every Margin verb uses the same default: \code{TRUE} for local data
-frames and \code{FALSE} for lazy inputs, where checking would require an
-additional query.}
+\item{.check_margin_label}{A logical scalar controlling the half of the
+Margin label collision check that reads the data: whether any \emph{value} of a
+Margin dimension is equal to that dimension's display label. Each
+dimension is checked independently, and \code{.margin_label = NULL} opts out.
+Every Margin verb uses the same default: \code{TRUE} for local data frames and
+\code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+equal to a declared factor \emph{level} is rejected on every backend whatever
+this argument says, because the levels are already known and finding it
+sends no query. Left unchecked, a colliding value gives the result a
+margin row and a source row that no grouping column tells apart; keeping
+\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
+added cost. See \emph{Display labels and grouping identity} for the factor
+missing-value contract.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
 duplicate grouping sets after expansion.}

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -504,7 +504,10 @@ because its row-wise return shape exists only locally; see its own
 documentation for when it collects.
 
 Two queries reach your connection without being asked for, and neither
-reads a row of your data:
+reads a row of your data. This is the rule for every Margin verb, so each
+is described against the inputs that can produce it: a verb accepting no
+lazy table, or no contextual share, simply never reaches the one that
+depends on it.
 \itemize{
 \item \strong{A zero-row read of the input}, sent only to a backend whose factor
 columns marginplyr must decompose and later restore -- currently

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -403,8 +403,10 @@ metadata before returning the requested column order.
 Local data frames reject an ineligible source before any share is
 calculated. \code{dtplyr} steps stay lazy and report the same conditions during
 explicit execution, before an invalid grouping row is emitted. General
-dbplyr backends read the ordinary summaries over one input row and reject
-an ineligible source with the same condition; cardinality remains a
+dbplyr backends read none of your data to apply the rule: the dialect is
+asked once whether it converts a value of another type to a number rather
+than refusing it, and where it converts, the share is refused unless
+\code{.check_share_source = FALSE} asks for it anyway. Cardinality remains a
 local-and-\code{dtplyr} rule, because a SQL aggregate returns one value per
 grouping row by construction.
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -423,12 +423,12 @@ are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
 factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing the synthetic level last by default
-or first when \code{.margin_label_position = "first"}. With collision checking
-enabled, the complete factor domain is checked, including unused levels.
-With checking disabled, an existing level may be reused and is moved to the
-requested position. Reconstruction preserves the distinction between an
-observation that uses a factor NA level and an actually missing factor code.
+preserving ordered status and placing a new synthetic level last by default
+or first when \code{.margin_label_position = "first"}. A label equal to any
+declared level, used or unused, is rejected before any grouping set is
+built, whatever \code{.check_margin_label} says: see that argument above.
+Reconstruction preserves the distinction between an observation that uses a
+factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
@@ -455,10 +455,12 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. The eager default
-\code{.check_margin_label = TRUE} detects
-collisions for local data. Lazy tables default to \code{FALSE} because checking
-would execute an extra query; opt in when that scan is appropriate.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
+observed row of this table -- whether \code{NA_character_} collides with an
+actual missing value when no NA level is declared; the declared rows above
+it are checked whatever this argument says. See \code{.check_margin_label}
+above for its default and \emph{When marginplyr queries your data} for why the
+two halves differ.
 }
 
 \section{Backend extension design}{
@@ -489,6 +491,54 @@ SQL generation, not execution against every database server.
 
 Arrow and dtplyr are also tested lazy backends, but they are not SQL
 database connections.
+}
+
+\section{When marginplyr queries your data}{
+
+Every Margin verb applied to a lazy input builds a query and returns it
+unexecuted. \code{\link[dplyr:show_query]{dplyr::show_query()}} runs nothing, and no row is read until
+you execute the query yourself -- \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} excepted,
+because its row-wise return shape exists only locally; see its own
+documentation for when it collects.
+
+Two queries reach your connection without being asked for, and neither
+reads a row of your data:
+\itemize{
+\item \strong{A zero-row read of the input}, sent only to a backend whose factor
+columns marginplyr must decompose and later restore -- currently
+\code{dtplyr} and DuckDB -- to recover the levels and column prototypes that
+decomposition loses. It references your table but reads none of it, and
+it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
+equivalent zero-row read for any table reference, on any dbplyr backend.
+\item \strong{One query per SQL dialect}, sent once per dialect, the first time a
+share is requested there with \code{.check_share_source} at its default of
+\code{TRUE}, asking whether the dialect converts a non-numeric value to a
+number rather than refusing it. It references none of your tables, so
+reading it touches none of your data, and the answer is a property of
+the dialect, reused for every later connection that shares it. A
+connection that cannot be asked -- one built with a
+\verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
+as unable to answer, which refuses the share by default the same way a
+dialect known to convert does; see \code{.check_share_source} on
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}.
+}
+
+Neither query is safe merely because it returns no rows. A read bounded in
+rows is not bounded in what it costs: BigQuery states plainly that a
+\code{LIMIT} does not reduce the bytes billed for a non-clustered table, and no
+vendor documentation exempts \verb{LIMIT 0} from that rule.
+
+marginplyr does not try to tell whether a backend bills for a query,
+because nothing it can read distinguishes a free connection from a billed
+one of the same kind -- a local DuckDB file from a hosted DuckDB service,
+or RDS PostgreSQL from Aurora Standard. \code{is.data.frame(.data)} is the only
+predicate that answers "no external system is involved" exactly rather
+than approximately, and it is what sets the default of every check that
+reads your data: a check that reads it is asked for, and a check that does
+not is not. \code{.check_margin_label} scans the grouping columns, so every
+Margin verb defaults it to \code{is.data.frame(.data)}.
+\code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
+backend, so it defaults to \code{TRUE} there.
 }
 
 \examples{
@@ -567,8 +617,9 @@ summarize_with_margins(
 ) |>
   dplyr::as_tibble()
 
-# Ordered factors remain ordered. A disabled collision check can reuse an
-# unused level and move it to the requested position.
+# Ordered factors remain ordered, and a new label is placed by
+# `.margin_label_position`. An existing level -- used or unused -- is never
+# available for reuse: it is rejected whatever `.check_margin_label` says.
 priority_data <- data.frame(
   priority = ordered(
     c("standard", "premium"),
@@ -580,18 +631,42 @@ try(summarize_with_margins(
   .data = priority_data,
   total = sum(value),
   .grouping = rollup(priority),
-  .margin_label = "unused"
+  .margin_label = "unused",
+  .check_margin_label = FALSE
 ))
 priority_result <- summarize_with_margins(
   .data = priority_data,
   total = sum(value),
   .grouping = rollup(priority),
-  .margin_label = "unused",
-  .margin_label_position = "first",
-  .check_margin_label = FALSE
+  .margin_label = "All priorities",
+  .margin_label_position = "first"
 )
 is.ordered(priority_result$priority)
 levels(priority_result$priority)
+
+# `.check_margin_label = FALSE` still controls only the observed half of
+# the check: whether a missing value already in the column collides with
+# `NA_character_` when no NA level is declared. Disabled, the margin row
+# and the real missing-value row print alike; `grouping_bit()` tells them
+# apart.
+status_data <- data.frame(
+  status = factor(c("active", NA), levels = c("active", "inactive")),
+  value = c(1, 2)
+)
+try(summarize_with_margins(
+  .data = status_data,
+  total = sum(value),
+  .grouping = rollup(status),
+  .margin_label = NA_character_
+))
+summarize_with_margins(
+  .data = status_data,
+  total = sum(value),
+  is_total = grouping_bit(status),
+  .grouping = rollup(status),
+  .margin_label = NA_character_,
+  .check_margin_label = FALSE
+)
 
 # A direct Parent share, multiple measures through two ordered across()
 # expressions, and a post-summary calculation.

--- a/tests/testthat/_snaps/query-policy.md
+++ b/tests/testthat/_snaps/query-policy.md
@@ -1,0 +1,32 @@
+# the scanned entry-point set is the ADR 0020 execution catalog
+
+    Code
+      lazy_execution_entry_points()
+    Output
+      [1] "dplyr::collect"       "dplyr::compute"       "dplyr::pull"         
+      [4] "as.data.frame"        "DBI::dbGetQuery"      "DBI::dbSendQuery"    
+      [7] "DBI::dbSendStatement" "DBI::dbFetch"         "DBI::dbReadTable"    
+
+# marginplyr functions reaching an execution entry point
+
+    Code
+      reach
+    Output
+       [1] "check_dialect_share_sources"    "check_observed_label_collision"
+       [3] "execute_margin_expand"          "execute_margin_nest"           
+       [5] "execute_margin_summary"         "expand_with_margins"           
+       [7] "grouping_selection_proxy"       "inspect_grouping"              
+       [9] "nest_by_with_margins"           "nest_margin_pipeline"          
+      [11] "nest_with_margins"              "prepare_grouping_plan"         
+      [13] "prepare_margin_operation"       "probe_share_dialect"           
+      [15] "share_dialect_verdict"          "summarise_with_margins"        
+      [17] "summarize_with_margins"         "validate_margin_label"         
+      [19] "validate_margin_operation"     
+
+# backend kinds granted the collect_selection_proxy capability
+
+    Code
+      kinds_with_proxy
+    Output
+      [1] "dtplyr" "duckdb"
+

--- a/tests/testthat/_snaps/query-policy.md
+++ b/tests/testthat/_snaps/query-policy.md
@@ -19,9 +19,9 @@
        [9] "nest_by_with_margins"           "nest_margin_pipeline"          
       [11] "nest_with_margins"              "prepare_grouping_plan"         
       [13] "prepare_margin_operation"       "probe_share_dialect"           
-      [15] "share_dialect_verdict"          "summarise_with_margins"        
-      [17] "summarize_with_margins"         "validate_margin_label"         
-      [19] "validate_margin_operation"     
+      [15] "probe_share_dialect_answer"     "share_dialect_verdict"         
+      [17] "summarise_with_margins"         "summarize_with_margins"        
+      [19] "validate_margin_label"          "validate_margin_operation"     
 
 # backend kinds granted the collect_selection_proxy capability
 

--- a/tests/testthat/_snaps/share-backends.md
+++ b/tests/testthat/_snaps/share-backends.md
@@ -19,6 +19,14 @@
     Output
       [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because it could not be asked whether its SQL dialect converts a value of another type to a number rather than refusing it, and a dialect that converts rejects nothing. Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
 
+# DuckDB reports an ineligible share source against its summary
+
+    Code
+      unique(unlist(regmatches(message, gregexpr("[.][.]marginplyr_[A-Za-z0-9_]+",
+        message))))
+    Output
+      [1] "..marginplyr_denominator_of_lab_1"
+
 # Arrow rejects Total shares before constructing a query
 
     Code

--- a/tests/testthat/_snaps/share-backends.md
+++ b/tests/testthat/_snaps/share-backends.md
@@ -5,6 +5,20 @@
     Output
       [1] "Arrow backends do not support Parent shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed. Other Arrow Margin operations remain supported. Omit `share_of_parent()` or explicitly collect the data before calling `summarize_with_margins()`."
 
+# RSQLite refuses a share its dialect cannot establish
+
+    Code
+      conditionMessage(refusal)
+    Output
+      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because its SQL dialect converts a value of another type to a number rather than refusing it, so an ineligible source summary is indistinguishable from an eligible one. Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
+
+# a lazy backend that answers nothing refuses to establish a share
+
+    Code
+      conditionMessage(refusal)
+    Output
+      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because it could not be asked whether its SQL dialect converts a value of another type to a number rather than refusing it, and a dialect that converts rejects nothing. Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
+
 # Arrow rejects Total shares before constructing a query
 
     Code

--- a/tests/testthat/test-factor.R
+++ b/tests/testthat/test-factor.R
@@ -1,10 +1,14 @@
+# `x4` carries a level no value uses, which reconstruction has to keep. It used
+# to carry the Margin name itself, which `margin_factor_levels()` deduplicated
+# away and re-appended; that state is now rejected before anything executes
+# (ADR 0020), and the function asserts its absence rather than handling it.
 test_that("reconstruct_factor() works with data.frame", {
   x <- c("a", "b", "c", NA_character_)
   data <- data.frame(
     x1 = factor(x),
     x2 = factor(x, ordered = TRUE),
     x3 = factor(x, exclude = NULL),
-    x4 = factor(x, levels = c("a", "b", "c", "aaa"))
+    x4 = factor(x, levels = c("a", "b", "c", "d"))
   )
 
   l_info <- lapply(
@@ -53,7 +57,7 @@ test_that("reconstruct_factor() works with data.frame", {
       ),
       x4 = factor(
         c("a", "b", "c", NA),
-        levels = c("a", "b", "c", "aaa")
+        levels = c("a", "b", "c", "d", "aaa")
       )
     )
   )
@@ -67,7 +71,7 @@ test_that("reconstruct_factor() works with duckdb", {
     x1 = factor(x),
     x2 = factor(x, ordered = TRUE),
     x3 = factor(x, exclude = NULL),
-    x4 = factor(x, levels = c("a", "b", "c", "aaa"))
+    x4 = factor(x, levels = c("a", "b", "c", "d"))
   )
 
   con <- duckdb_test_connection()
@@ -115,7 +119,7 @@ test_that("reconstruct_factor() works with duckdb", {
       x1 = factor(c("a", "b", "c", NA), levels = c("a", "b", "c", "aaa")),
       x2 = factor(c("a", "b", "c", NA), levels = c("a", "b", "c", "aaa")),
       x3 = factor(c("a", "b", "c", NA), levels = c("a", "b", "c", "aaa")),
-      x4 = factor(c("a", "b", "c", NA), levels = c("a", "b", "c", "aaa"))
+      x4 = factor(c("a", "b", "c", NA), levels = c("a", "b", "c", "d", "aaa"))
     )
   )
 })
@@ -128,7 +132,7 @@ test_that("reconstruct_factor() works with dtplyr_step", {
     x1 = factor(x),
     x2 = factor(x, ordered = TRUE),
     x3 = factor(x, exclude = NULL),
-    x4 = factor(x, levels = c("a", "b", "c", "aaa"))
+    x4 = factor(x, levels = c("a", "b", "c", "d"))
   )
 
   data <- dtplyr::lazy_dt(data)
@@ -182,7 +186,7 @@ test_that("reconstruct_factor() works with dtplyr_step", {
       ),
       x4 = factor(
         c("a", "b", "c", NA),
-        levels = c("a", "b", "c", "aaa")
+        levels = c("a", "b", "c", "d", "aaa")
       )
     )
   )

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -398,6 +398,8 @@ test_that("margin label checks handle missing and non-syntactic columns", {
     "grouping columns `first group`, `second group`"
   )
 
+  # A value of a factor column is a level of it, so this collision is declared
+  # and is reported as one.
   factors <- data.frame(
     group = factor(c("Total", "x")),
     value = 1:2
@@ -408,7 +410,7 @@ test_that("margin label checks handle missing and non-syntactic columns", {
       n = dplyr::n(),
       .grouping = rollup(group)
     ),
-    "already present"
+    "already a factor level"
   )
 
   empty <- missing[0, , drop = FALSE]

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -212,16 +212,219 @@ test_that("factor collisions include unused levels and stay column-specific", {
     fixed = TRUE
   )
 
-  result <- summarize_with_margins(
-    data,
-    n = dplyr::n(),
-    .grouping = rollup(first, second),
-    .margin_label = c(first = "All first", second = "All second"),
-    .margin_label_position = "first",
-    .check_margin_label = FALSE
+  both <- expect_error(
+    summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = rollup(first, second),
+      .margin_label = c(first = "All first", second = "All second")
+    ),
+    "grouping columns `first`, `second`"
   )
-  expect_identical(levels(result$first), c("All first", "a", "b"))
-  expect_identical(levels(result$second), c("All second", "x", "y"))
+  expect_match(conditionMessage(both), "are already factor levels")
+})
+
+# The other half of the check reads the data and is what `.check_margin_label`
+# opts into; this half reads the levels marginplyr already holds, so there is
+# nothing to opt into and the argument does not reach it (ADR 0020).
+test_that("a declared collision is rejected however the label check is set", {
+  data <- data.frame(
+    group = factor(c("a", "b"), levels = c("a", "b", "All")),
+    value = 1:2
+  )
+
+  for (check in list(TRUE, FALSE)) {
+    error <- expect_error(
+      summarize_with_margins(
+        data,
+        n = dplyr::n(),
+        .grouping = rollup(group),
+        .margin_label = "All",
+        .check_margin_label = check
+      ),
+      "already a factor level in grouping column `group`",
+      fixed = TRUE
+    )
+    expect_s3_class(error, "marginplyr_error")
+    # Turning the read off is not a remedy for a collision no read found, so
+    # the diagnostic must not send a caller to that argument.
+    expect_no_match(
+      conditionMessage(error),
+      ".check_margin_label",
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("a check with no column left to read contacts nothing", {
+  factor_info <- list(
+    list(
+      col = "group",
+      levels = c("a", "b"),
+      ordered = FALSE,
+      has_na_in_level = FALSE,
+      preserve_missing_value = TRUE
+    )
+  )
+  # A sentinel with no dplyr methods: any attempt to read it fails rather than
+  # aggregating a set of constants, which is what a factor-only check used to
+  # send to a lazy backend.
+  unreadable <- structure(list(), class = "marginplyr_unreadable_input")
+
+  expect_error(dplyr::select(unreadable, dplyr::all_of("group")))
+  expect_no_error(check_observed_label_collision(
+    unreadable,
+    margin_labels = list(group = "All"),
+    factor_info = factor_info
+  ))
+  expect_no_error(check_observed_label_collision(
+    unreadable,
+    margin_labels = list(group = NULL),
+    factor_info = list()
+  ))
+  # A missing label asks whether the column holds a missing value, which the
+  # levels do not record, so that one still reads.
+  expect_error(check_observed_label_collision(
+    unreadable,
+    margin_labels = list(group = NA_character_),
+    factor_info = factor_info
+  ))
+})
+
+test_that("dtplyr rejects a declared collision and stays silent on a value", {
+  skip_if_backend_absent("dtplyr")
+  data <- data.frame(
+    declared = factor(c("a", "b"), levels = c("a", "b", "Total")),
+    observed = c("Total", "x"),
+    value = 1:2
+  )
+
+  # `.check_margin_label` defaults to `FALSE` here, because the input is lazy.
+  error <- expect_error(
+    summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      n = dplyr::n(),
+      .grouping = rollup(declared)
+    ),
+    "already a factor level in grouping column `declared`",
+    fixed = TRUE
+  )
+  expect_s3_class(error, "marginplyr_error")
+
+  expect_no_error(
+    query <- summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      n = dplyr::n(),
+      bit = grouping_bit(observed),
+      .grouping = rollup(observed)
+    )
+  )
+  result <- dplyr::collect(query)
+  colliding <- result[result$observed == "Total", , drop = FALSE]
+  expect_identical(nrow(colliding), 2L)
+  expect_setequal(colliding$bit, c(0L, 1L))
+
+  expect_error(
+    summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      n = dplyr::n(),
+      .grouping = rollup(observed),
+      .check_margin_label = TRUE
+    ),
+    "already present in grouping column `observed`",
+    fixed = TRUE
+  )
+})
+
+# The reproduction #122 was filed with, on the backend it was filed against.
+# DuckDB carries a factor as an `ENUM`, so its levels arrive through the
+# zero-row read ADR 0020 exempts rather than as a factor column, which is a
+# different route to the same rejection than the one dtplyr takes above.
+test_that("DuckDB rejects a declared collision without being asked", {
+  skip_if_backend_absent("duckdb", "DBI")
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data.frame(
+      g = factor(c("a", "(all)", "b"), levels = c("a", "(all)", "b")),
+      v = c(1, 2, 3)
+    ),
+    "margin_label_declared",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+
+  expect_error(
+    summarize_with_margins(
+      remote,
+      t = sum(v, na.rm = TRUE),
+      .grouping = rollup(g),
+      .margin_label = "(all)"
+    ),
+    "already a factor level in grouping column `g`",
+    fixed = TRUE
+  )
+
+  # A label that collides with nothing leaves the genuine level where it was.
+  result <- dplyr::collect(summarize_with_margins(
+    remote,
+    t = sum(v, na.rm = TRUE),
+    .grouping = rollup(g),
+    .margin_label = "Total"
+  ))
+  expect_identical(levels(result$g), c("a", "(all)", "b", "Total"))
+})
+
+# The silence is the contract, so it is asserted rather than left to the
+# absence of a failing expectation: a later change to `.check_margin_label`'s
+# default has to fail here instead of passing quietly. SQLite is where the
+# whole collision is observed -- it carries no factor type, so the level that
+# is declared in the source data frame reaches the database as text and the
+# check above it has nothing to read the collision off.
+test_that("RSQLite leaves an observed collision silent until it is asked", {
+  skip_if_backend_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data.frame(
+      group = factor(c("Total", "x"), levels = c("Total", "x")),
+      value = 1:2
+    ),
+    "margin_label_silence",
+    temporary = TRUE
+  )
+
+  expect_no_error(
+    query <- summarize_with_margins(
+      remote,
+      total = sum(value, na.rm = TRUE),
+      bit = grouping_bit(group),
+      .grouping = rollup(group)
+    )
+  )
+  result <- dplyr::collect(query)
+  colliding <- result[result$group == "Total", , drop = FALSE]
+
+  # What the silence costs: two rows the grouping column cannot tell apart,
+  # and a Grouping bit that can.
+  expect_identical(nrow(colliding), 2L)
+  expect_setequal(colliding$bit, c(0L, 1L))
+  expect_setequal(as.numeric(colliding$total), c(1, 3))
+
+  expect_error(
+    summarize_with_margins(
+      remote,
+      total = sum(value, na.rm = TRUE),
+      .grouping = rollup(group),
+      .check_margin_label = TRUE
+    ),
+    "already present in grouping column `group`",
+    fixed = TRUE
+  )
 })
 
 test_that("dtplyr applies mixed named labels lazily and restores factors", {

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -1,0 +1,164 @@
+# ADR 0020 says marginplyr sends no query that reads a lazy input's data
+# unless the caller asked for one, with two enumerated exemptions. That rule
+# is not readable from any one file -- it is a property of the call graph
+# from the public verbs down to whatever function actually executes a query
+# -- so this file asserts it structurally instead of describing it.
+#
+# `R/` is not installed, so scanning the shipped package would find nothing
+# to grep. The helpers below walk `body()` of every function bound in the
+# loaded marginplyr namespace instead, which is why every test here needs the
+# package loaded via `pkgload::load_all()` or an installed dev build, not a
+# CRAN-style installed copy of a release.
+
+# A parsed call can hold the missing-argument placeholder as one of its own
+# elements -- a `switch()` fallthrough branch such as
+# `switch(x, a = , b = foo())`, or a subsetting call such as `x[i, ]` both
+# produce one. Reading that placeholder through an ordinary `for` loop raises
+# "argument is missing, with no default" the moment the loop variable is
+# looked up, even though nothing about the walk is actually missing an
+# argument: a `for` loop's own assignment preserves the internal missing flag,
+# and normal symbol lookup checks for it. Binding the same value through a
+# function argument does not carry the flag forward, which is why the
+# recursion below goes through `lapply()` and never through a bare `for` over
+# a call's elements.
+call_targets <- function(expr) {
+  targets <- character()
+  walk <- function(e) {
+    if (!is.call(e)) {
+      return(invisible(NULL))
+    }
+    head <- e[[1]]
+    if (is.name(head)) {
+      head_chr <- as.character(head)
+      if (
+        (identical(head_chr, "::") || identical(head_chr, ":::")) &&
+          length(e) == 3
+      ) {
+        targets[[length(targets) + 1L]] <<- paste0(
+          as.character(e[[2]]), "::", as.character(e[[3]])
+        )
+      } else {
+        targets[[length(targets) + 1L]] <<- head_chr
+      }
+    } else {
+      walk(head)
+    }
+    lapply(as.list(e)[-1], walk)
+    invisible(NULL)
+  }
+  walk(expr)
+  unique(targets)
+}
+
+# `backend_capabilities()` (`R/grouping-backend.R`) is the one place the
+# backend-kind universe and the `collect_selection_proxy` grant are recorded,
+# in a local `enabled <- list(...)` assignment. It is a self-contained
+# literal, so finding that assignment's right-hand side and evaluating it
+# reads the same table the package reads, rather than a copy of it kept here
+# by hand.
+find_local_assignment <- function(fn, var_name) {
+  found <- NULL
+  walk <- function(e) {
+    if (!is.call(e)) {
+      return(invisible(NULL))
+    }
+    if (
+      identical(as.character(e[[1]]), "<-") &&
+        length(e) == 3 &&
+        is.symbol(e[[2]]) &&
+        identical(as.character(e[[2]]), var_name)
+    ) {
+      found <<- e[[3]]
+      return(invisible(NULL))
+    }
+    lapply(as.list(e), walk)
+    invisible(NULL)
+  }
+  walk(body(fn))
+  found
+}
+
+marginplyr_internal_functions <- function(ns = asNamespace("marginplyr")) {
+  all_names <- ls(ns, all.names = TRUE)
+  Filter(function(name) is.function(get(name, envir = ns)), all_names)
+}
+
+# Enumerated rather than derived from a shape, exactly as ADR 0020 enumerates
+# its two exemptions rather than deriving them: an execution entry point is
+# whatever a vendor's client library exposes for running a query and reading
+# a result, and no static property of a function distinguishes one from an
+# ordinary query-building call. `dplyr::show_query()` is deliberately absent
+# -- ADR 0020 states that it runs nothing.
+lazy_execution_entry_points <- function() {
+  c(
+    "dplyr::collect",
+    "dplyr::compute",
+    "dplyr::pull",
+    "as.data.frame",
+    "DBI::dbGetQuery",
+    "DBI::dbSendQuery",
+    "DBI::dbSendStatement",
+    "DBI::dbFetch",
+    "DBI::dbReadTable"
+  )
+}
+
+# The functions reaching an entry point directly, plus every function calling
+# one of those, to a fixed point -- the call graph is not asserted to be
+# acyclic, so growing the reachable set once is not enough.
+functions_reaching_entry_point <- function(call_graph, entry_points) {
+  reaches <- function(targets, allowed) any(targets %in% allowed)
+  reach <- names(call_graph)[
+    vapply(call_graph, reaches, logical(1), allowed = entry_points)
+  ]
+  repeat {
+    grown <- names(call_graph)[
+      vapply(call_graph, reaches, logical(1), allowed = reach)
+    ]
+    grown <- union(reach, grown)
+    if (setequal(grown, reach)) {
+      break
+    }
+    reach <- grown
+  }
+  sort(reach)
+}
+
+test_that("the scanned entry-point set is the ADR 0020 execution catalog", {
+  expect_snapshot(lazy_execution_entry_points())
+})
+
+test_that("marginplyr functions reaching an execution entry point", {
+  ns <- asNamespace("marginplyr")
+  internal_functions <- marginplyr_internal_functions(ns)
+  call_graph <- stats::setNames(
+    lapply(internal_functions, function(name) {
+      call_targets(body(get(name, envir = ns)))
+    }),
+    internal_functions
+  )
+
+  reach <- functions_reaching_entry_point(
+    call_graph,
+    lazy_execution_entry_points()
+  )
+
+  expect_snapshot(reach)
+})
+
+test_that("backend kinds granted the collect_selection_proxy capability", {
+  ns <- asNamespace("marginplyr")
+  enabled_expr <- find_local_assignment(
+    get("backend_capabilities", envir = ns),
+    "enabled"
+  )
+  enabled <- eval(enabled_expr, envir = baseenv())
+
+  kinds_with_proxy <- sort(names(enabled)[
+    vapply(enabled, function(capabilities) {
+      "collect_selection_proxy" %in% capabilities
+    }, logical(1))
+  ])
+
+  expect_snapshot(kinds_with_proxy)
+})

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1158,6 +1158,70 @@ test_that("a connection that answers nothing records nothing for its dialect", {
   expect_identical(ls(share_dialect_verdicts, all.names = TRUE), character())
 })
 
+# `share_source_checker()` routes the `other` backend kind to the dialect
+# checker as well, and an input of that kind carries no connection to put the
+# question to. Answering "unknown" is what refuses the share there; failing
+# instead would turn a backend marginplyr merely does not recognize into a
+# crash. Each helper is asserted beside the verdict because each answers for a
+# different absence: no lazy table at all, and no connection behind one.
+test_that("an input carrying no connection is asked nothing", {
+  data <- data.frame(group = c("x", "y"), value = c(1, 3))
+  backend <- grouping_backend(data)
+  recorded <- ls(share_dialect_verdicts, all.names = TRUE)
+
+  expect_null(share_dialect_connection(data))
+  expect_false(share_dialect_can_be_asked(NULL))
+  expect_identical(share_dialect_verdict(data, backend = backend), "unknown")
+  expect_identical(ls(share_dialect_verdicts, all.names = TRUE), recorded)
+})
+
+# The verdict is read from whether executing the probe raised, so a connection
+# no query can be built against at all has raised nothing to read. Falling to
+# "unknown" is what keeps that from being recorded as the refusal a live
+# dialect would have earned, which would switch the protection off for every
+# later connection carrying that dialect.
+test_that("a connection no query can be built against answers nothing", {
+  expect_identical(
+    probe_share_dialect(structure(list(), class = "not_a_connection")),
+    "unknown"
+  )
+})
+
+# Only a one-row, one-column number is the conversion. Any other answer --
+# more columns, no rows, a value of another type, or something that is not a
+# data frame -- is no reading of the dialect, and "unknown" refuses the share
+# rather than accept a shape nothing interpreted. The converting answer is
+# asserted in the same block as a control: without it, a mock that stopped
+# reaching `probe_share_dialect()` would report every shape unknown and pass.
+test_that("an answer of an unexpected shape is not read as a verdict", {
+  verdict_for_answer <- function(answer) {
+    local_mocked_bindings(
+      collect = function(x, ...) answer,
+      .package = "dplyr"
+    )
+    probe_share_dialect(dbplyr::simulate_postgres())
+  }
+
+  expect_identical(verdict_for_answer(data.frame(p = 0)), "converts")
+  expect_identical(verdict_for_answer(data.frame(a = 1, b = 2)), "unknown")
+  expect_identical(verdict_for_answer(data.frame(p = numeric(0))), "unknown")
+  expect_identical(verdict_for_answer(data.frame(p = "x")), "unknown")
+  expect_identical(verdict_for_answer(list(p = 1)), "unknown")
+})
+
+# An unrecognized kind is a marginplyr defect and not something a caller can
+# rewrite, so it stops bare rather than raising a Package condition
+# (ADR 0015). The class assertion is the load-bearing half: a defect caught by
+# `tryCatch(marginplyr_error = )` would reach a caller as though their own call
+# were the thing to fix.
+test_that("the source checker refuses an unrecognized backend kind", {
+  error <- expect_error(
+    share_source_checker("nonexistent"),
+    "Unknown contextual-share source-checker backend kind: nonexistent"
+  )
+  expect_false(inherits(error, "marginplyr_error"))
+})
+
 # #106's DuckDB half. This dialect refuses an ineligible summary itself, so
 # marginplyr calculates the share and the database reports the refusal when the
 # caller executes the query — which is why the column it casts carries the name

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1264,6 +1264,65 @@ test_that("an answer of an unexpected shape is not read as a verdict", {
   expect_identical(verdict_for_answer(list(p = 1)), "unknown")
 })
 
+# Reading any raised query as the dialect's refusal is how the protection came
+# to be off exactly where it was needed: `"refuses"` is the verdict that
+# proceeds, so every unrelated reason a query can raise switched the rule off
+# and cached that for the dialect. The scaffolding `SELECT 1 AS z` reaches the
+# database verbatim and has no `FROM`, which Oracle and SAP HANA both reject,
+# and a dropped connection raises the same way. None of those may read as a
+# refusal.
+test_that("a query that raises for another reason is not read as a refusal", {
+  verdict_when_collect <- function(fn) {
+    local_mocked_bindings(collect = fn, .package = "dplyr")
+    probe_share_dialect(dbplyr::simulate_postgres())
+  }
+
+  # Nothing executes here, so the control cannot come back either.
+  expect_identical(
+    verdict_when_collect(function(x, ...) {
+      stop("ORA-00923: FROM keyword not found where expected")
+    }),
+    "unknown"
+  )
+  expect_identical(
+    verdict_when_collect(function(x, ...) stop("could not connect to server")),
+    "unknown"
+  )
+
+  # Rejecting the string while answering the control is the one shape that is
+  # a refusal, and it is what DuckDB does.
+  raised_first <- local({
+    calls <- 0L
+    function(x, ...) {
+      calls <<- calls + 1L
+      if (calls == 1L) {
+        stop("Binder Error: No function matches SUM(VARCHAR)")
+      }
+      data.frame(p = 1)
+    }
+  })
+  expect_identical(verdict_when_collect(raised_first), "refuses")
+})
+
+# The control is only the price of telling two failures apart, so a dialect
+# that answers the first question is never asked a second one.
+test_that("a converting dialect is asked exactly one query", {
+  queries <- 0L
+  verdict_counting <- function() {
+    local_mocked_bindings(
+      collect = function(x, ...) {
+        queries <<- queries + 1L
+        data.frame(p = 0)
+      },
+      .package = "dplyr"
+    )
+    probe_share_dialect(dbplyr::simulate_postgres())
+  }
+
+  expect_identical(verdict_counting(), "converts")
+  expect_identical(queries, 1L)
+})
+
 # An unrecognized kind is a marginplyr defect and not something a caller can
 # rewrite, so it stops bare rather than raising a Package condition
 # (ADR 0015). The class assertion is the load-bearing half: a defect caught by

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1022,6 +1022,61 @@ test_that("RSQLite refuses a share its dialect cannot establish", {
   expect_identical(local_error$source_summary, "lab")
 })
 
+# This test's predecessor guarded a probe query that no longer exists. That
+# probe collected the caller's own summaries, so `grouping_id()` and
+# `grouping_bit()` -- marginplyr's spellings, which no backend has functions
+# for -- failed it as a whole and the rule was lost for the measures written
+# beside them. The probe is gone, but the guarantee it protected is not: a call
+# that identifies its Margin levels must still reach the rule for its measures,
+# and must still calculate them once the caller takes that rule on themselves.
+test_that("RSQLite keeps the share rule beside Margin level helpers", {
+  skip_if_backend_absent("RSQLite", "DBI")
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    store = c("s1", "s2", "s3"),
+    revenue = c(1, 3, 2)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_source_level_sqlite_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source, ...) {
+    summarize_with_margins(
+      source,
+      level = grouping_id(region, store),
+      bit = grouping_bit(store),
+      total = sum(revenue),
+      p = share_of_parent(total),
+      .grouping = rollup(region, store),
+      ...
+    )
+  }
+
+  refusal <- expect_error(summarize(remote), class = "marginplyr_error")
+  expect_match(conditionMessage(refusal), "cannot establish")
+
+  # Taken on by the caller, the helpers and the share are calculated together,
+  # and against the local result rather than against another backend, so this
+  # cannot pass by being self-consistently wrong.
+  expect_equal(
+    as.data.frame(dplyr::collect(dplyr::arrange(
+      summarize(remote, .check_share_source = FALSE),
+      region,
+      store
+    ))),
+    as.data.frame(dplyr::arrange(
+      summarize(data, .check_share_source = FALSE),
+      region,
+      store
+    ))
+  )
+})
+
 test_that("RSQLite calculates eligible shares a caller has established", {
   skip_if_backend_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
@@ -1263,6 +1318,22 @@ test_that("DuckDB reports an ineligible share source against its summary", {
     conditionMessage(remote_error),
     "denominator_of_lab",
     fixed = TRUE
+  )
+
+  # #196 asks for this diagnostic to be snapshotted, and what is snapshotted is
+  # the internal names it exposes rather than the message carrying them.
+  # DuckDB's own text is its version's wording, a `DECIMAL` precision, and a
+  # `LINE` marker with column offsets, none of which this assertion is about --
+  # snapshotting it whole would fail on a DuckDB upgrade while saying nothing
+  # about the property. The property is which marginplyr identifier a reader is
+  # left holding, and the whole of #106's DuckDB half was that it read
+  # `..marginplyr_share_value_1`, which names nothing the caller wrote.
+  message <- conditionMessage(remote_error)
+  expect_snapshot(
+    unique(unlist(regmatches(
+      message,
+      gregexpr("[.][.]marginplyr_[A-Za-z0-9_]+", message)
+    )))
   )
 })
 

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1,3 +1,13 @@
+# `.check_share_source = FALSE` appears throughout this file wherever a share
+# is requested of a connection that executes nothing -- every `simulate_*()`
+# one, and every live SQLite one. Neither can establish that a share source is
+# eligible: a simulator answers no query at all, and SQLite's dialect converts
+# a value of another type to a number rather than refusing it, so it would
+# accept any source whatever. What each of those tests is about is the SQL the
+# staged share produces, or the values it produces from sources the test
+# itself defines, so opting out of the establishing rule is what leaves them
+# testing that. The rule itself is covered where it belongs, in the two tests
+# named for it below.
 test_that("Parent shares preserve columns, grouping, and laziness", {
   data <- data.frame(
     fixed = c("a", "a", "b"),
@@ -13,7 +23,8 @@ test_that("Parent shares preserve columns, grouping, and laziness", {
       .by = fixed,
       .grouping = rollup(group),
       .id = "set",
-      .margin_label = NULL
+      .margin_label = NULL,
+      .check_share_source = FALSE
     )
   }
   expected_names <- c("fixed", "group", "set", "total", "share", "rows")
@@ -644,7 +655,8 @@ test_that("PostgreSQL renders one staged Parent-share join for all measures", {
     revenue = sum(revenue),
     revenue_share = share_of_parent(revenue),
     .grouping = rollup(region, store),
-    .margin_label = NULL
+    .margin_label = NULL,
+    .check_share_source = FALSE
   )
   many <- summarize_with_margins(
     remote,
@@ -653,7 +665,8 @@ test_that("PostgreSQL renders one staged Parent-share join for all measures", {
     revenue_share = share_of_parent(revenue),
     units_share = share_of_parent(units),
     .grouping = rollup(region, store),
-    .margin_label = NULL
+    .margin_label = NULL,
+    .check_share_source = FALSE
   )
   one_sql <- dbplyr::sql_render(one)
   many_sql <- dbplyr::sql_render(many)
@@ -668,38 +681,44 @@ test_that("PostgreSQL renders one staged Parent-share join for all measures", {
   expect_match(many_sql, "CAST(", fixed = TRUE)
 })
 
-# This connection cannot collect at all, so it stands for a backend the type
-# sample learns nothing from: the read fails, the source goes unsampled, and
-# the staged query is returned for the caller to execute. The counters are
-# what hold the rest of the contract — nothing asks this connection for the
-# staged query's fields, its row count, or its results.
-test_that("general dbplyr leaves a source it cannot sample to execution", {
+# The counters are the contract: requesting a share reads none of the caller's
+# data, so nothing asks this connection for the staged query's fields, its row
+# count, or its results — whichever way `.check_share_source` is set, and
+# whether the call is answered with a query or with a refusal. The ineligible
+# source is what shows the second half: the share is not calculated from a
+# value marginplyr checked, it is left to the database, and this connection is
+# never asked to type it.
+test_that("general dbplyr builds a share without reading the caller's data", {
   remote <- new_parent_lazy_probe(
     data.frame(group = "x", label = "value")
   )
+  summarize <- function(...) {
+    summarize_with_margins(
+      remote,
+      label = min(label),
+      share = share_of_parent(label),
+      .grouping = rollup(group),
+      .margin_label = NULL,
+      ...
+    )
+  }
+  unread <- c(result_type = 0L, cardinality = 0L, collection = 0L)
 
-  query <- summarize_with_margins(
-    remote,
-    label = min(label),
-    share = share_of_parent(label),
-    .grouping = rollup(group),
-    .margin_label = NULL
-  )
+  query <- summarize(.check_share_source = FALSE)
   expect_s3_class(query, "tbl_lazy")
-  expect_identical(parent_lazy_probe_counts(), c(
-    result_type = 0L,
-    cardinality = 0L,
-    collection = 0L
-  ))
+  expect_identical(parent_lazy_probe_counts(), unread)
 
   sql <- dbplyr::sql_render(query)
-  expect_identical(parent_lazy_probe_counts(), c(
-    result_type = 0L,
-    cardinality = 0L,
-    collection = 0L
-  ))
+  expect_identical(parent_lazy_probe_counts(), unread)
   expect_match(sql, "CAST(", fixed = TRUE)
   expect_match(sql, "LEFT JOIN", fixed = TRUE)
+
+  # A connection that answers nothing cannot say whether its dialect converts,
+  # so the default refuses the share rather than calculating one nothing
+  # stands behind — and it refuses without reading the caller's data either.
+  refusal <- expect_error(summarize(), class = "marginplyr_error")
+  expect_match(conditionMessage(refusal), "could not be asked", fixed = TRUE)
+  expect_identical(parent_lazy_probe_counts(), unread)
 })
 
 test_that("general dbplyr reports static Parent-share errors without probing", {
@@ -790,7 +809,8 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
       share = share_of_parent(total),
       .by = fixed,
       .grouping = rollup(group),
-      .margin_label = NULL
+      .margin_label = NULL,
+      .check_share_source = FALSE
     )
     sql <- dbplyr::sql_render(query)
 
@@ -847,7 +867,8 @@ test_that("RSQLite executes portable Parent shares end to end", {
       .by = fixed,
       .grouping = rollup(group),
       .id = "set",
-      .margin_label = "Margin"
+      .margin_label = "Margin",
+      .check_share_source = FALSE
     )
   }
   arrange_result <- function(result) {
@@ -913,7 +934,8 @@ test_that("RSQLite Parent shares preserve runtime backend conditions", {
     bad = no_such_function(value),
     share = share_of_parent(bad),
     .grouping = rollup(group),
-    .margin_label = NULL
+    .margin_label = NULL,
+    .check_share_source = FALSE
   )
 
   expect_s3_class(query, "tbl_lazy")
@@ -923,12 +945,15 @@ test_that("RSQLite Parent shares preserve runtime backend conditions", {
   expect_false(inherits(error, "marginplyr_error"))
 })
 
-# The reproduction from #106. A weakly typed dialect used to answer it with an
-# all-missing share column plus the grand total's own-denominator `1`, because
-# the eligible-type rule was reached only from the local adapter. Comparing the
-# condition against the local one is what makes "the same rejection" checkable
-# without a second backend in this test.
-test_that("RSQLite rejects an ineligible share source like the local backend", {
+# The reproduction from #195, on the dialect #106 was filed about. SQLite
+# answers `sum(<text column>)` with a genuine `0` rather than refusing it, so
+# no reading of the result distinguishes an ineligible source from an eligible
+# one, and the share it used to produce — an all-missing column beside the
+# grand total's own-denominator `1` — reads as 100%. What is asserted here is
+# that the eligible source is refused too: eligibility is a question about the
+# dialect, and this dialect answers it the same way whatever the call
+# summarizes.
+test_that("RSQLite refuses a share its dialect cannot establish", {
   skip_if_backend_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -944,110 +969,60 @@ test_that("RSQLite rejects an ineligible share source like the local backend", {
     overwrite = TRUE,
     temporary = TRUE
   )
-  summarize <- function(source) {
+  summarize <- function(source, ...) {
     summarize_with_margins(
       source,
       lab = max(region),
       p = share_of_parent(lab),
-      .grouping = rollup(region, store)
+      .grouping = rollup(region, store),
+      ...
+    )
+  }
+  eligible <- function(source, ...) {
+    summarize_with_margins(
+      source,
+      total = sum(revenue),
+      p = share_of_total(total),
+      .grouping = rollup(region, store),
+      ...
     )
   }
 
-  local_error <- expect_error(summarize(data), "plain integer or double scalar")
-  remote_error <- expect_error(
-    summarize(remote),
-    "plain integer or double scalar"
-  )
-
-  expect_s3_class(remote_error, "marginplyr_error")
+  refusal <- expect_error(summarize(remote), class = "marginplyr_error")
+  expect_snapshot(conditionMessage(refusal))
   expect_identical(
-    conditionMessage(remote_error),
-    conditionMessage(local_error)
-  )
-  expect_identical(remote_error$share_output, "p")
-  expect_identical(remote_error$source_summary, "lab")
-  expect_identical(
-    rlang::call_name(conditionCall(remote_error)),
+    rlang::call_name(conditionCall(refusal)),
     "summarize_with_margins"
   )
-  # The internal denominator and match columns are marginplyr's own names for
-  # temporaries the caller never wrote and cannot act on.
-  expect_false(grepl(
-    "..marginplyr",
-    conditionMessage(remote_error),
-    fixed = TRUE
-  ))
-})
+  expect_error(eligible(remote), class = "marginplyr_error")
 
-test_that("RSQLite rejects an ineligible source beside a Margin level", {
-  skip_if_backend_absent("RSQLite", "DBI")
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
-  remote <- dplyr::copy_to(
-    con,
-    data.frame(
-      region = c("E", "E", "W"),
-      store = c("s1", "s2", "s3"),
-      revenue = c(1, 3, 2)
-    ),
-    "share_source_level_sqlite_data",
-    overwrite = TRUE,
-    temporary = TRUE
+  # Forced, the ineligible source is calculated from what the dialect converted
+  # it to, which is the answer #195 reported and is now the caller's own
+  # request. The eligible one agrees with the local result.
+  forced <- dplyr::collect(summarize(remote, .check_share_source = FALSE))
+  expect_true(all(is.na(forced$p[forced$lab != "W"]) | forced$p == 1))
+  expect_equal(
+    as.data.frame(dplyr::collect(
+      eligible(remote, .check_share_source = FALSE) |>
+        dplyr::arrange(region, store)
+    )),
+    as.data.frame(dplyr::arrange(
+      eligible(data, .check_share_source = FALSE),
+      region,
+      store
+    ))
   )
-
-  # `grouping_bit()` and `grouping_id()` are marginplyr's own summary-context
-  # helpers, so the backend has no such functions and the read that types the
-  # source summaries would fail on them as a whole. A call that identifies its
-  # Margin levels must not lose the rule for its measures.
-  error <- expect_error(
-    summarize_with_margins(
-      remote,
-      level = grouping_id(region, store),
-      bit = grouping_bit(store),
-      lab = max(region),
-      p = share_of_parent(lab),
-      .grouping = rollup(region, store)
-    ),
+  # The local backend holds its summaries' own types, so the rule applies there
+  # whatever this argument says, and it is the eligible-type diagnostic rather
+  # than this refusal that a local caller gets.
+  local_error <- expect_error(
+    summarize(data, .check_share_source = FALSE),
     "plain integer or double scalar"
   )
-  expect_s3_class(error, "marginplyr_error")
-  expect_identical(error$source_summary, "lab")
+  expect_identical(local_error$source_summary, "lab")
 })
 
-test_that("RSQLite types a share source past an unrelated failing summary", {
-  skip_if_backend_absent("RSQLite", "DBI")
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
-  remote <- dplyr::copy_to(
-    con,
-    data.frame(
-      region = c("E", "E", "W"),
-      store = c("s1", "s2", "s3"),
-      revenue = c(1, 3, 2)
-    ),
-    "share_source_scope_sqlite_data",
-    overwrite = TRUE,
-    temporary = TRUE
-  )
-
-  # A summary no share reads must not decide whether the rule runs. Reading it
-  # too would fail the whole read on this expression the backend refuses, and
-  # the source it was never asked about would go unchecked with it.
-  error <- expect_error(
-    summarize_with_margins(
-      remote,
-      unrelated = no_such_aggregate(revenue),
-      lab = max(region),
-      p = share_of_parent(lab),
-      .grouping = rollup(region, store)
-    ),
-    "plain integer or double scalar"
-  )
-  expect_s3_class(error, "marginplyr_error")
-  expect_identical(error$source_summary, "lab")
-})
-
-test_that("RSQLite keeps eligible share sources working after the probe", {
+test_that("RSQLite calculates eligible shares a caller has established", {
   skip_if_backend_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -1055,15 +1030,14 @@ test_that("RSQLite keeps eligible share sources working after the probe", {
     group = c("x", "x", "y"),
     revenue = c(1, 3, 2),
     units = c(1L, 3L, 0L),
-    # The first input row is missing, so a weakly typed dialect answers the
-    # type probe with a value carrying no type at all. That is not evidence of
-    # an ineligible source, and rejecting on it would break a working call.
+    # A source whose first values are missing is still a source: what the
+    # dialect converts is the type of a value, and a missing one carries none.
     sparse = c(NA_real_, 4, 5)
   )
   remote <- dplyr::copy_to(
     con,
     data,
-    "share_source_probe_sqlite_data",
+    "share_source_forced_sqlite_data",
     overwrite = TRUE,
     temporary = TRUE
   )
@@ -1077,7 +1051,8 @@ test_that("RSQLite keeps eligible share sources working after the probe", {
       units_share = share_of_total(units_total),
       sparse_share = share_of_parent(sparse_total),
       .grouping = rollup(group),
-      .margin_label = NULL
+      .margin_label = NULL,
+      .check_share_source = FALSE
     ) |>
       dplyr::arrange(is.na(group), group)
   }
@@ -1092,28 +1067,103 @@ test_that("RSQLite keeps eligible share sources working after the probe", {
   )
 })
 
-test_that("a lazy backend that answers nothing keeps its share source", {
+test_that("a lazy backend that answers nothing refuses to establish a share", {
   skip_if_no_sqlite_simulation()
-  # A simulated connection executes no query, so the type probe learns nothing
-  # and the call must stay lazy rather than reject a source it cannot read.
+  # A simulated connection executes no query, so it can say nothing about what
+  # its dialect does with an ineligible summary. Reading its failure as the
+  # refusal a live database of that dialect would make is what the default
+  # declines to do; asked to, it stays lazy and renders as any other.
   remote <- dbplyr::tbl_lazy(
     data.frame(group = c("x", "y"), value = 1:2),
     con = dbplyr::simulate_sqlite()
   )
+  summarize <- function(...) {
+    summarize_with_margins(
+      remote,
+      total = sum(value),
+      share = share_of_parent(total),
+      .grouping = rollup(group),
+      .margin_label = NULL,
+      ...
+    )
+  }
 
-  query <- summarize_with_margins(
-    remote,
-    total = sum(value),
-    share = share_of_parent(total),
-    .grouping = rollup(group),
-    .margin_label = NULL
-  )
+  refusal <- expect_error(summarize(), class = "marginplyr_error")
+  expect_snapshot(conditionMessage(refusal))
 
+  query <- summarize(.check_share_source = FALSE)
   expect_s3_class(query, "tbl_lazy")
   expect_match(dbplyr::sql_render(query), "UNION ALL", fixed = TRUE)
 })
 
-test_that("DuckDB rejects an ineligible share source like the local backend", {
+# What the dialect does with an ineligible summary is a property of the
+# dialect, so it is asked once and reused — which is only observable across
+# calls, and only from an empty cache. The second half is why the question is
+# asked of the connection before it is put to it: a connection that executes
+# nothing answers for itself and not for its dialect, so nothing it does is
+# recorded where a live connection carrying that dialect would find it.
+test_that("a dialect is asked whether it converts at most once", {
+  remote <- dbplyr::tbl_lazy(
+    data.frame(group = c("x", "y"), value = c(1, 3)),
+    con = dbplyr::simulate_postgres()
+  )
+  backend <- grouping_backend(remote)
+  saved <- as.list(share_dialect_verdicts, all.names = TRUE)
+  empty_verdicts <- function() {
+    rm(
+      list = ls(share_dialect_verdicts, all.names = TRUE),
+      envir = share_dialect_verdicts
+    )
+  }
+  on.exit(
+    {
+      empty_verdicts()
+      list2env(saved, envir = share_dialect_verdicts)
+    },
+    add = TRUE
+  )
+  probes <- 0L
+  local_mocked_bindings(
+    probe_share_dialect = function(con) {
+      probes <<- probes + 1L
+      "refuses"
+    }
+  )
+
+  empty_verdicts()
+  local_mocked_bindings(share_dialect_can_be_asked = function(con) TRUE)
+  expect_identical(share_dialect_verdict(remote, backend = backend), "refuses")
+  expect_identical(share_dialect_verdict(remote, backend = backend), "refuses")
+  expect_identical(probes, 1L)
+  expect_identical(
+    ls(share_dialect_verdicts, all.names = TRUE),
+    paste(class(backend$dialect), collapse = "\n")
+  )
+})
+
+test_that("a connection that answers nothing records nothing for its dialect", {
+  remote <- dbplyr::tbl_lazy(
+    data.frame(group = c("x", "y"), value = c(1, 3)),
+    con = dbplyr::simulate_postgres()
+  )
+  backend <- grouping_backend(remote)
+  saved <- as.list(share_dialect_verdicts, all.names = TRUE)
+  on.exit(list2env(saved, envir = share_dialect_verdicts), add = TRUE)
+  rm(
+    list = ls(share_dialect_verdicts, all.names = TRUE),
+    envir = share_dialect_verdicts
+  )
+
+  expect_identical(share_dialect_verdict(remote, backend = backend), "unknown")
+  expect_identical(ls(share_dialect_verdicts, all.names = TRUE), character())
+})
+
+# #106's DuckDB half. This dialect refuses an ineligible summary itself, so
+# marginplyr calculates the share and the database reports the refusal when the
+# caller executes the query — which is why the column it casts carries the name
+# of the summary to rewrite. Nothing here is a marginplyr condition: the
+# diagnostic is the database's own, and the assertion is that it is usable.
+test_that("DuckDB reports an ineligible share source against its summary", {
   skip_if_backend_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1139,25 +1189,17 @@ test_that("DuckDB rejects an ineligible share source like the local backend", {
   }
 
   local_error <- expect_error(summarize(data), "plain integer or double scalar")
-  remote_error <- expect_error(
-    summarize(remote),
-    "plain integer or double scalar"
-  )
+  expect_identical(local_error$source_summary, "lab")
 
-  expect_s3_class(remote_error, "marginplyr_error")
-  expect_identical(
+  query <- summarize(remote)
+  expect_s3_class(query, "tbl_lazy")
+  remote_error <- expect_error(dplyr::collect(query))
+  expect_false(inherits(remote_error, "marginplyr_error"))
+  expect_match(
     conditionMessage(remote_error),
-    conditionMessage(local_error)
-  )
-  expect_identical(remote_error$share_output, "p")
-  expect_identical(remote_error$source_summary, "lab")
-  # The backend used to raise its own error here, naming the internal
-  # denominator column the join reserved.
-  expect_false(grepl(
-    "..marginplyr",
-    conditionMessage(remote_error),
+    "denominator_of_lab",
     fixed = TRUE
-  ))
+  )
 })
 
 test_that("DuckDB Parent shares agree across native, portable, local paths", {
@@ -1425,8 +1467,12 @@ test_that("DuckDB Parent shares skip duplicate grouping-set occurrences", {
 
 test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
   group_name <- "..marginplyr_parent_key_1"
-  value_name <- "..marginplyr_share_value_1"
-  summary_name <- "..marginplyr_share_value_1_"
+  value_name <- "value"
+  summary_name <- "total"
+  # The name the join reserves for `total`'s denominator, written here as a
+  # summary of the caller's own so that it is already in the staged result when
+  # the allocator asks for it.
+  denominator_name <- "..marginplyr_denominator_of_total_1"
   share_name <- "..marginplyr_set_id_1_"
   id_name <- "..marginplyr_share_match_1_"
   data <- data.frame(
@@ -1447,10 +1493,12 @@ test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
     rlang::inject(summarize_with_margins(
       source,
       !!summary_name := sum(.data[[value_name]]),
+      !!denominator_name := sum(.data[[value_name]]),
       !!share_name := share_of_parent(!!rlang::sym(summary_name)),
       .grouping = rollup(dplyr::all_of(group_name)),
       .margin_label = group_name,
       .check_margin_label = FALSE,
+      .check_share_source = FALSE,
       .id = id_name
     )) |>
       dplyr::arrange(.data[[id_name]], .data[[group_name]])
@@ -1524,7 +1572,8 @@ test_that("RSQLite executes portable Total shares end to end", {
       .by = fixed,
       .grouping = rollup(group, item),
       .id = "set",
-      .margin_label = "Margin"
+      .margin_label = "Margin",
+      .check_share_source = FALSE
     )
   }
   arrange_result <- function(result) {

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -1946,27 +1946,79 @@ test_that("Total-share staging avoids adversarial user-name collisions", {
   # The fixed-key stand-in a Total share joins on when `.by` is empty is the
   # one internal name Parent shares never allocate.
   partition_name <- "..marginplyr_total_key_1"
-  denominator_name <- "..marginplyr_share_value_1"
+  # The name the join reserves for `total`'s denominator, written here as a
+  # summary output of the caller's own so that it is already in the result when
+  # the allocator asks for it.
+  denominator_name <- "..marginplyr_denominator_of_total_1"
   data <- data.frame(
     c("x", "y"),
     c(1, 3),
     c(2, 2),
     check.names = FALSE
   )
-  names(data) <- c("group", partition_name, denominator_name)
+  names(data) <- c("group", partition_name, "shadow")
 
-  result <- summarize_with_margins(
+  result <- rlang::inject(summarize_with_margins(
     data,
     total = sum(.data[[partition_name]]),
-    shadow = sum(.data[[denominator_name]]),
+    !!denominator_name := sum(shadow),
     whole = share_of_total(total),
     .grouping = rollup(group),
     .margin_label = NULL
-  )
+  ))
 
-  expect_identical(names(result), c("group", "total", "shadow", "whole"))
+  expect_identical(
+    names(result),
+    c("group", "total", denominator_name, "whole")
+  )
   expect_equal(result$whole, c(0.25, 0.75, 1))
-  expect_equal(result$shadow, c(2, 2, 4))
+  expect_equal(result[[denominator_name]], c(2, 2, 4))
+})
+
+# The denominator column is the one internal name a database quotes back at the
+# caller: a dialect that refuses an ineligible source refuses it while casting
+# this column, and #106's DuckDB half was that diagnostic naming
+# `..marginplyr_share_value_1`. Naming the summary is what makes it actionable,
+# so the names are asserted here rather than only through a backend that
+# happens to quote one.
+test_that("a share denominator is named after the summary it comes from", {
+  expect_identical(
+    share_denominator_names(
+      c("revenue", "units"),
+      used_names = c("region", "revenue", "units")
+    ),
+    c(
+      revenue = "..marginplyr_denominator_of_revenue_1",
+      units = "..marginplyr_denominator_of_units_1"
+    )
+  )
+  # A caller who already wrote the name gets the collision rule, not the name.
+  expect_identical(
+    share_denominator_names(
+      "revenue",
+      used_names = c("revenue", "..marginplyr_denominator_of_revenue_1")
+    ),
+    c(revenue = "..marginplyr_denominator_of_revenue_1_")
+  )
+})
+
+test_that("`.check_share_source` admits only a logical scalar", {
+  data <- data.frame(group = c("x", "y"), value = c(1, 3))
+  summarize <- function(check) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      whole = share_of_total(total),
+      .grouping = rollup(group),
+      .check_share_source = check
+    )
+  }
+
+  expect_error(summarize("yes"), class = "marginplyr_error")
+  expect_error(summarize(NA), "`.check_share_source` must be a logical scalar")
+  # A local data frame holds its summaries' own types, so the eligible-type
+  # rule is applied there whichever way this is set.
+  expect_identical(summarize(TRUE), summarize(FALSE))
 })
 
 test_that("share_of_total reports its required context", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -3252,12 +3252,17 @@ test_that("a lazy plan reads a quoted expression as data too", {
   # `quote()` holds rather than carrying it, so a name no column has fails at
   # build time. Round-tripping language is a local guarantee; what holds on
   # every backend is that this package's analysis leaves the expression alone.
+  # A simulated connection answers no query, so it cannot say what its dialect
+  # does with an ineligible share source and the default refuses the share.
+  # What this asserts is the planning either side of that, so it asks for the
+  # share the connection cannot vouch for.
   shared <- summarize_with_margins(
     postgres,
     units = sum(value),
     share = share_of_total(units),
     label = deparse1(quote(value)),
-    .grouping = rollup(region)
+    .grouping = rollup(region),
+    .check_share_source = FALSE
   )
   expect_s3_class(shared, "tbl_lazy")
   expect_match(
@@ -3278,7 +3283,8 @@ test_that("a lazy plan reads a quoted expression as data too", {
       units = sum(value),
       share = share_of_total(units),
       label = deparse1(quote(share)),
-      .grouping = rollup(region)
+      .grouping = rollup(region),
+      .check_share_source = FALSE
     ),
     error = function(cnd) cnd
   )

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -373,9 +373,11 @@ Where the dialect converts a value of another type to a number instead of
 refusing it — SQLite answers `sum()` of a text column with `0` rather than an
 error — nothing applies the rule at all, and marginplyr refuses the share
 rather than calculating one from values nothing has checked. Which of the two
-a dialect does is asked once per dialect, with a query referencing none of
-your tables. A connection that executes nothing, such as the simulators used
-above, cannot be asked and is refused for the same reason;
+a dialect does is asked once per dialect, with at most two queries referencing
+none of your tables: a probe, and — only when the probe is rejected — a
+control, which is what tells a dialect that genuinely refuses apart from one
+that could not answer at all. A connection that executes nothing, such as the
+simulators used above, cannot be asked and is refused for the same reason;
 `.check_share_source = FALSE` calculates the share from sources you have
 established yourself.
 

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -212,6 +212,69 @@ leaves the omitted dimension as a typed SQL `NULL`; it never attempts to add
 an NA enum label. A non-missing label is added as an enum level and is placed
 last by default or first with `.margin_label_position = "first"`.
 
+## `.check_margin_label` on lazy inputs
+
+Lazy inputs default to `.check_margin_label = FALSE`, and what that default
+gives up is not free: an *observed* collision — a real value already in the
+data equal to `.margin_label` — goes undetected, so the result carries one
+row for that value and one row for the margin, and neither the row itself nor
+code reading the result afterward can tell which is which. *When marginplyr
+queries your data* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+states the rule this default follows and its two exemptions.
+
+Two protections hold regardless of `.check_margin_label`, at no added query.
+
+A label equal to a *declared* factor level is rejected on every backend,
+because the level is already known from the column's metadata and finding
+the collision reads nothing. The enum preservation above is what makes this
+visible on DuckDB: `region` below declares `"Total"` as an unused level, and
+`.margin_label = "Total"` is rejected before any query is built, even though
+`.check_margin_label` is left at its lazy default:
+
+```{r}
+#| eval: !expr has_duckdb
+
+con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+region_data <- data.frame(
+  region = factor(c("East", "West"), levels = c("East", "West", "Total")),
+  revenue = c(10, 20)
+)
+region_db <- copy_to(
+  con,
+  region_data,
+  name = "region_data",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+```
+
+```{r}
+#| label: declared-level-rejected
+#| eval: !expr has_duckdb
+#| must_error: marginplyr_error
+
+region_db |>
+  summarize_with_margins(
+    total = sum(revenue),
+    .grouping = rollup(region)
+  )
+```
+
+```{r}
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(con)
+```
+
+Keeping `grouping_bit()` or `grouping_id()` in the result is the other free
+protection: either identifies every margin row structurally, so a source row
+and a margin row that print alike still stay distinguishable by position,
+whatever `.check_margin_label` finds or misses.
+
+Opt into `.check_margin_label = TRUE` when the extra scan for an observed
+collision is worth the query for your backend and workload.
+
 ## Portable fallback SQL
 
 marginplyr does not assume that every SQL dialect supports native grouping
@@ -318,7 +381,10 @@ established yourself.
 
 A refusing dialect is therefore shown against a live DuckDB table rather than
 the simulator used above. The diagnostic is DuckDB's own, and the column it
-names carries the name of the summary to rewrite:
+names carries the name of the summary to rewrite. It reaches you as a plain
+`rlang_error` with no marginplyr class in its `parent` chain — nothing here
+reads the row that used to make it a `marginplyr_error` — so the chunk below
+accepts any error rather than naming one:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -500,9 +566,10 @@ names every verified backend.
   one. Ask for a Margin order with `.sort`, or call `arrange()` for any other
   presentation order.
 
-- Lazy inputs default to `.check_margin_label = FALSE` because detecting an
-  existing label would require an additional query. Opt in only when that
-  extra scan is appropriate.
+- Lazy inputs default to `.check_margin_label = FALSE`, which skips only the
+  *observed* half of the collision check; a label equal to a *declared*
+  factor level is rejected either way. See *`.check_margin_label` on lazy
+  inputs* above.
 
 - A fallback query may repeat the source relation once per grouping set.
   Inspect the generated SQL and the database query plan for large workloads;

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -259,14 +259,18 @@ sqlite_sales |>
 `share_of_parent()` needs a denominator from another Grouping-set row, so it
 cannot be translated as one ordinary aggregate expression. marginplyr first
 forms the ordinary Margin summaries, then builds one Parent mapping shared by
-every requested measure:
+every requested measure. `.check_share_source = FALSE` appears here because
+the simulated connection executes nothing and therefore cannot be asked what
+its dialect does with an ineligible source; the rule it opts out of is
+described below.
 
 ```{r}
 parent_query <- postgres_sales |>
   summarize_with_margins(
     revenue = sum(revenue, na.rm = TRUE),
     revenue_share = share_of_parent(revenue),
-    .grouping = rollup(region, store)
+    .grouping = rollup(region, store),
+    .check_share_source = FALSE
   )
 
 show_query(parent_query)
@@ -288,22 +292,33 @@ postgres_sales |>
   summarize_with_margins(
     revenue = sum(revenue, na.rm = TRUE),
     revenue_of_total = share_of_total(revenue),
-    .grouping = rollup(region, store)
+    .grouping = rollup(region, store),
+    .check_share_source = FALSE
   ) |>
   show_query()
 ```
 
 Syntax, source-name, written-order, and `across()` errors are validated before
 execution. A share source must still be a plain integer or double, and that
-rule holds here too. A general dbplyr backend exposes no metadata for an
-arbitrary aggregate's result type, so marginplyr reads the summaries a share
-reads over a single input row and rejects an ineligible source before
-returning the query. That read is bounded in the rows it asks for and gets
-back, not in the work the input may have to do to produce one row — the staged
-query above is still not executed, and `show_query()` runs nothing.
+rule holds here too — but marginplyr reads no row of your data to establish
+it. A database evaluates the source summary itself, so where the dialect
+refuses an ineligible summary that refusal is the answer, and it reaches you
+as the database's own diagnostic when you execute the query. The staged
+queries above are still not executed, and `show_query()` runs nothing.
 
-Sampling one row needs a connection that can execute one, so this refusal is
-shown against a live DuckDB table rather than the simulator used above:
+Where the dialect converts a value of another type to a number instead of
+refusing it — SQLite answers `sum()` of a text column with `0` rather than an
+error — nothing applies the rule at all, and marginplyr refuses the share
+rather than calculating one from values nothing has checked. Which of the two
+a dialect does is asked once per dialect, with a query referencing none of
+your tables. A connection that executes nothing, such as the simulators used
+above, cannot be asked and is refused for the same reason;
+`.check_share_source = FALSE` calculates the share from sources you have
+established yourself.
+
+A refusing dialect is therefore shown against a live DuckDB table rather than
+the simulator used above. The diagnostic is DuckDB's own, and the column it
+names carries the name of the summary to rewrite:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -321,14 +336,15 @@ sample_sales <- copy_to(
 ```{r}
 #| label: duckdb-ineligible-share-source
 #| eval: !expr has_duckdb
-#| must_error: marginplyr_error
+#| must_error: true
 
 sample_sales |>
   summarize_with_margins(
     last_channel = max(channel),
     last_channel_share = share_of_parent(last_channel),
     .grouping = rollup(region, store)
-  )
+  ) |>
+  collect()
 ```
 
 ```{r}
@@ -337,10 +353,10 @@ sample_sales |>
 DBI::dbDisconnect(sample_con)
 ```
 
-A source the sample cannot type is left alone rather than rejected — which is
-what the simulator above falls under, since it executes nothing at all. So a
-runtime-only incompatibility, and any non-scalar summary, can still surface
-from the database when the staged query executes.
+Cardinality is not established this way at all: a SQL aggregate returns one
+value per grouping row by construction, so there is nothing for a dialect to
+convert. A non-scalar summary, and any other runtime-only incompatibility,
+therefore still surfaces from the database when the staged query executes.
 
 The portable value contract covers finite numbers, missing values, and zero
 denominators. Backend-specific non-finite representations are outside that

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -492,9 +492,10 @@ retail_sales |>
   dplyr::as_tibble()
 ```
 
-`.margin_label = NULL` bypasses collision checks. `NA_character_` requests
-the same typed missing output but still checks for source missing values and
-factor NA levels when `.check_margin_label = TRUE`.
+`.margin_label = NULL` bypasses collision checks entirely. `NA_character_`
+requests the same typed missing output, but an existing factor NA level is
+always a structural conflict, and whether an actual missing value collides is
+checked only when `.check_margin_label = TRUE`.
 
 A factor NA level and a missing factor code are different even though both
 can print as `<NA>`. Here the second value uses the NA level and the third is
@@ -533,8 +534,9 @@ when `.check_margin_label = FALSE`.
 
 For local data, `.check_margin_label = TRUE` prevents an existing value such
 as `"Total"` from becoming visually ambiguous. Lazy inputs default to
-`.check_margin_label = FALSE` because checking would execute an additional
-query. Result row order is unspecified for both local and lazy inputs unless
+`.check_margin_label = FALSE` for that same check; a label equal to a
+declared factor level is rejected on every backend either way. Result row
+order is unspecified for both local and lazy inputs unless
 `.sort` asks for a Margin order; use `arrange()` for any other presentation
 order. [Put each subtotal with the rows it
 summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html)


### PR DESCRIPTION
Implements ADR 0020: marginplyr sends no query that reads a lazy input's data
unless the caller asked for one, with two enumerated exemptions (a zero-row
read for factor levels/prototypes on backends granting
`collect_selection_proxy`, and one per-dialect share-eligibility query that
references none of the caller's tables). See
`design/adr/0020-ask-before-reading-a-lazy-input.md` for the decision and
`investigation/query-cost-across-lazy-backends.md` and
`investigation/share-source-eligibility-on-coercing-dialects.md` for the
evidence behind it.

Three sessions:

- **A** — rejects a declared Margin-label collision without reading, on
  every backend, whatever `.check_margin_label` says.
- **B** — establishes a contextual share's source eligibility without
  reading a row: the one-row `probe_share_sources()` read is replaced by one
  query per SQL dialect that references none of the caller's tables.
- **C** (this finishing pass) — documents the rule in a new
  `@section When marginplyr queries your data` on every Margin verb, gates it
  structurally with `tests/testthat/test-query-policy.R` (a snapshot of the
  internal functions reaching an execution entry point, the entry-point
  catalog itself, and the backend kinds granted `collect_selection_proxy`,
  all derived from the loaded namespace rather than hardcoded), corrects
  vignette and NEWS prose that predated the declared/observed split and had
  gone stale, and reconciles ADR 0020 and AGENTS.md against the finished
  code.

Closes #122, closes #195, closes #196.