### PR TITLE
Report a repeated execution condition once, in the caller's names

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -180,7 +180,7 @@ _Avoid_: Error context, provenance, backtrace
 One External condition reported once per grouping set, because a Margin
 operation evaluates the caller's summary expression once per grouping set
 although the caller wrote it once. Two occurrences are repetitions of one
-condition when they agree on cause — the class, the diagnostic, and the
+condition when they agree on identity — the class, the diagnostic, and the
 argument they are attributed to — and are distinct conditions otherwise. Which
 grouping set produced an occurrence is never part of that identity, since it
 is the part that necessarily differs. A Margin verb reports a Repeated

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -152,10 +152,40 @@ _Avoid_: Contextual function, masked helper, reserved argument
 **Package condition**:
 An error marginplyr itself raises, inheriting the `marginplyr_error` base
 class. It reports something the caller can avoid by rewriting the call within
-the documented public interface.
+the documented public interface. It is always an error: marginplyr states what
+it will not do by refusing, and raises no warning of its own.
 _Avoid_: Package error, internal error, user-facing error
 
 **External condition**:
-An error raised by a user summary expression, tidyselect, dplyr, or a backend
-and propagated with its original class and provenance intact.
+A condition raised by a user summary expression, tidyselect, dplyr, or a
+backend, and propagated with its own class, its own diagnostic, and its own
+cause intact. Warnings and errors are alike External conditions. What a Margin
+verb may adjust is the Condition context; the condition itself is the caller's
+to receive unchanged.
 _Avoid_: Third-party error, foreign error
+
+**Condition context**:
+The lines an External condition carries naming where it arose — the argument
+it is attributed to, the grouping values in force when it did, and the call
+blamed for it. It is distinct from the condition's class and diagnostic. A
+Margin verb owes the caller a context written in names the caller can act on,
+so a grouping value is reported under the column the caller named and the
+blamed call is the Margin verb the caller wrote, rather than the columns and
+the calls marginplyr allocated to compute the grouping sets. A context it
+cannot restate in those terms it leaves as it found it, because a context that
+misdirects is still worth more than none.
+_Avoid_: Error context, provenance, backtrace
+
+**Repeated condition**:
+One External condition reported once per grouping set, because a Margin
+operation evaluates the caller's summary expression once per grouping set
+although the caller wrote it once. Two occurrences are repetitions of one
+condition when they agree on cause — the class, the diagnostic, and the
+argument they are attributed to — and are distinct conditions otherwise. Which
+grouping set produced an occurrence is never part of that identity, since it
+is the part that necessarily differs. A Margin verb reports a Repeated
+condition once, and says how many further grouping sets raised it. It answers
+only for the occurrences raised while it runs: a lazy input evaluates the
+caller's expression when the caller later collects the result, and that is the
+collecting call's to report.
+_Avoid_: Duplicate warning, redundant condition, repeated diagnostic

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,7 +177,7 @@ misdirects is still worth more than none.
 _Avoid_: Error context, provenance, backtrace
 
 **Repeated condition**:
-One External condition reported once per grouping set, because a Margin
+One External condition raised once per grouping set, because a Margin
 operation evaluates the caller's summary expression once per grouping set
 although the caller wrote it once. Two occurrences are repetitions of one
 condition when they agree on identity — the class, the diagnostic, and the

--- a/NEWS.md
+++ b/NEWS.md
@@ -125,9 +125,10 @@
   summary. A warning every grouping set raises is reported once and says how
   many further grouping sets raised it, in place of one identical warning per
   set — `2^k` of them for a `cube()` of `k` dimensions — while warnings that
-  differ from each other are still reported one by one. The condition itself is
-  untouched, and a lazy input is unaffected, because its summary expressions
-  run when you collect the result rather than while the verb runs (#141, #108).
+  differ from each other are still reported one by one. Only that context
+  changes: the class, the diagnostic, and the cause you receive are the ones
+  raised. A lazy input is unaffected, because its summary expressions run when
+  you collect the result rather than while the verb runs (#141, #108).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/NEWS.md
+++ b/NEWS.md
@@ -120,9 +120,9 @@
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were
-  those of internal `..marginplyr_key_N` columns and the call it blamed was an
-  internal summary; both now name the columns you wrote and the Margin verb you
-  called. A warning every grouping set raises is reported once and says how
+  those of internal `..marginplyr_key_N` columns; they now name the columns you
+  wrote, and an error blames the Margin verb you called rather than an internal
+  summary. A warning every grouping set raises is reported once and says how
   many further grouping sets raised it, in place of one identical warning per
   set — `2^k` of them for a `cube()` of `k` dimensions — while warnings that
   differ from each other are still reported one by one. The condition itself is

--- a/NEWS.md
+++ b/NEWS.md
@@ -114,8 +114,20 @@
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording
   remain implementation details. Errors from your summary expressions,
-  tidyselect, dplyr, or a backend keep their original class and call, and so do
-  internal invariant checks that no change to the call can avoid.
+  tidyselect, dplyr, or a backend keep their original class, diagnostic, and
+  cause, and so do internal invariant checks that no change to the call can
+  avoid.
+* A condition raised while your summary expression runs now reports its
+  context in names you can act on. A margin operation summarizes that
+  expression once per grouping set, so the grouping values it reported were
+  those of internal `..marginplyr_key_N` columns and the call it blamed was an
+  internal summary; both now name the columns you wrote and the Margin verb you
+  called. A warning every grouping set raises is reported once and says how
+  many further grouping sets raised it, in place of one identical warning per
+  set — `2^k` of them for a `cube()` of `k` dimensions — while warnings that
+  differ from each other are still reported one by one. The condition itself is
+  untouched, and a lazy input is unaffected, because its summary expressions
+  run when you collect the result rather than while the verb runs (#141, #108).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -74,28 +74,35 @@ with_branch_conditions <- function(expr, conditions) {
 # run in sequence, so the first error aborts the operation and no second
 # occurrence is ever raised.
 restate_branch_error <- function(cnd, conditions) {
-  if (is.character(cnd$message)) {
-    cnd$message <- restate_margin_keys(cnd$message, conditions$keys)
-  }
-  # `$body` is a character vector of bullets here, but rlang also admits a
-  # function that renders them, which nothing can substitute into.
-  if (is.character(cnd$body)) {
-    cnd$body <- restate_margin_keys(cnd$body, conditions$keys)
-  }
+  cnd <- restate_condition_names(cnd, conditions$keys)
   if (!is.null(conditions$call)) {
     cnd$call <- conditions$call
   }
   cnd
 }
 
+# The grouping-value bullet is `$body` for an error and part of the rendered
+# `$message` for a warning, so both are rewritten in place rather than one
+# being rendered into the other: replacing a structured condition's `$message`
+# with everything `conditionMessage()` rendered would print its body and its
+# cause twice.
+restate_condition_names <- function(cnd, keys) {
+  if (is.character(cnd$message)) {
+    cnd$message <- restate_margin_keys(cnd$message, keys)
+  }
+  # `$body` is a character vector of bullets here, but rlang also admits a
+  # function that renders them, which nothing can substitute into.
+  if (is.character(cnd$body)) {
+    cnd$body <- restate_margin_keys(cnd$body, keys)
+  }
+  cnd
+}
+
 # A warning arrives as one condition per branch whose message dplyr has already
 # aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
-# `$body`, so the text is all there is to restate and all there is to compare.
+# `$body`, so the text is all there is to compare.
 buffer_branch_warning <- function(cnd, conditions) {
-  cnd$message <- restate_margin_keys(
-    paste(conditionMessage(cnd), collapse = "\n"),
-    conditions$keys
-  )
+  cnd <- restate_condition_names(cnd, conditions$keys)
   cause <- branch_warning_cause(cnd)
 
   buffered <- conditions$warnings
@@ -112,58 +119,47 @@ buffer_branch_warning <- function(cnd, conditions) {
 # Two occurrences are repetitions of one condition when they agree on cause:
 # the class, the diagnostic, and the argument the warning is attributed to. The
 # class is read from the condition; the other two are what is left of the
-# message once the parts that necessarily differ between grouping sets are
-# removed -- which groups raised the warning, how many of that branch's groups
-# did, and dplyr's pointer at the store holding the rest.
+# rendered message once the parts that necessarily differ between grouping sets
+# are removed -- which groups raised the warning, how many of that branch's
+# groups did, and dplyr's pointer at the store holding the rest.
 #
-# The text half reads a format dplyr does not promise, and is chosen for which
+# The comparison runs on the message with every run of whitespace collapsed,
+# because how the message is laid out is not part of what it says: cli wraps a
+# bullet it cannot fit, indenting the continuation of one it recognizes and not
+# the continuation of dplyr's opening sentence, so matching by line made the
+# console width and the length of the grouping values decide whether a Repeated
+# condition was one condition. Measured on the ticket's own reproduction, whose
+# values are one and four characters long: three reports at 60 columns, four at
+# 40, and two anywhere in 15 to 24.
+#
+# What is left reads a format dplyr does not promise, and is chosen for which
 # way it fails: wording dplyr changes stops matching, the causes stay distinct,
 # and every occurrence is reported, which is what happens today. It can never
 # collapse a warning that genuinely differs. Both bullet spellings are matched
 # because the leading symbol is cli's and follows `cli.unicode`.
 branch_warning_cause <- function(cnd) {
-  lines <- unwrap_message_lines(
-    strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
+  bullet <- "(?:i|\u2139) "
+  text <- gsub("[[:space:]]+", " ", conditionMessage(cnd))
+  # A grouping-value bullet runs to whatever opens the next part of the
+  # message, which after collapsing is the only boundary left to read.
+  text <- gsub(
+    paste0(bullet, "In group .*?(?=", bullet, "|! |Caused by |$)"),
+    "",
+    text,
+    perl = TRUE
   )
-  bullet <- "^[i\u2139] "
-  varying <- grepl(paste0(bullet, "In group "), lines) |
-    grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines) |
-    lines == "The first warning was:" |
-    # The count sentence opens the message, and only there is it dplyr's rather
-    # than something the caller's own diagnostic happens to say. Indexing by
-    # the whole sequence rather than the first element is what leaves a message
-    # of no lines at all -- which dplyr's aggregation does not produce, but
-    # nothing outside it promises either -- a cause rather than an error.
-    (seq_along(lines) == 1L & grepl("^There (were|was) ", lines))
-  paste(c(class(cnd), lines[!varying]), collapse = "\n")
-}
-
-# Every bullet as the one line it was written as. cli wraps a bullet it cannot
-# fit onto continuation lines indented by two spaces, so which lines a message
-# holds is a function of the console width and of how long the grouping values
-# are -- and a group bullet matched line by line then survives the removal
-# above from its second line on.
-#
-# Without this, the console width decides whether a Repeated condition is one
-# condition. Measured on the ticket's own `cube(region, grade)` reproduction,
-# whose values are one and four characters long: one warning at width 80,
-# three at 60, and four at 40. A `.by` key or a realistic value produces it at
-# any width.
-#
-# Rejoining can only lose text that cli indented under the line above it, which
-# is what a wrap is; a caller's own indented line is rejoined into the
-# diagnostic it follows and stays part of the cause.
-unwrap_message_lines <- function(lines) {
-  wrapped <- grepl("^  ", lines) & seq_along(lines) > 1L
-  if (!any(wrapped)) {
-    return(lines)
-  }
-  unname(vapply(
-    split(sub("^ +", "", lines), cumsum(!wrapped)),
-    paste,
-    character(1),
-    collapse = " "
-  ))
+  text <- sub(
+    paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`.*$"),
+    "",
+    text,
+    perl = TRUE
+  )
+  # Only the count is dropped from the opening sentence; the call it names is
+  # the same in every branch, and dropping the sentence whole would take a
+  # caller's own diagnostic with it whenever dplyr raised exactly one warning.
+  text <- sub("^There (?:was|were) [0-9]+ warnings? in ", "", text, perl = TRUE)
+  text <- sub("The first warning was: ", "", text, fixed = TRUE)
+  paste(c(class(cnd), trimws(text)), collapse = "\n")
 }
 
 # Replays what the branches withheld: one report per distinct cause, each

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -103,12 +103,12 @@ restate_condition_names <- function(cnd, keys) {
 # `$body`, so the text is all there is to compare.
 buffer_branch_warning <- function(cnd, conditions) {
   cnd <- restate_condition_names(cnd, conditions$keys)
-  identity <- branch_warning_identity(cnd)
+  key <- branch_warning_identity(cnd)
 
   buffered <- conditions$warnings
-  seen <- match(identity, names(buffered))
+  seen <- match(key, names(buffered))
   if (is.na(seen)) {
-    buffered[[identity]] <- list(condition = cnd, count = 1L)
+    buffered[[key]] <- list(condition = cnd, count = 1L)
   } else {
     buffered[[seen]]$count <- buffered[[seen]]$count + 1L
   }
@@ -123,11 +123,14 @@ buffer_branch_warning <- function(cnd, conditions) {
 # are removed -- which groups raised the warning, how many of that branch's
 # groups did, and dplyr's pointer at the store holding the rest.
 #
-# Removal is anchored to the start of a line, because a bullet is only a bullet
-# there. An unanchored marker is found inside a grouping value as readily: a
-# region named `Hawaii Region` carries `i `, and a caller diagnostic reading
-# `i In group A is bad` carries the whole marker, so either would decide what
-# gets removed and the second would be removed itself.
+# Removal is confined to where dplyr writes those parts, and not merely to what
+# they say, because everything they say is also something a caller's own
+# diagnostic can say. A marker is only a marker at the start of a line, so an
+# unanchored match would find one inside a grouping value -- a region named
+# `Hawaii Region` carries `i `. A line is only dplyr's before its `Caused by`
+# line, since what follows that is the caller's diagnostic, whose second line
+# cli renders at column zero exactly as it renders a bullet. And the pointer at
+# the store is only dplyr's as the last line of the message.
 #
 # What is left reads a format dplyr does not promise, and is chosen for which
 # way it fails: wording dplyr changes stops matching, the identities stay
@@ -139,9 +142,19 @@ branch_warning_identity <- function(cnd) {
     strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
   ))
   bullet <- "^[i\u2139] "
-  varying <- grepl(paste0(bullet, "In group "), lines) |
+  causes <- which(grepl("^Caused by ", lines))
+  # No `Caused by` line is a message this cannot locate dplyr's own context in,
+  # so nothing is removed and the message is compared whole -- the reading that
+  # reports every occurrence rather than the one that collapses them.
+  attributed <- if (length(causes) == 0L) {
+    rep(FALSE, length(lines))
+  } else {
+    seq_along(lines) < causes[[1L]]
+  }
+  groups <- attributed & grepl(paste0(bullet, "In group "), lines)
+  pointer <- seq_along(lines) == length(lines) &
     grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines)
-  paste(c(class(cnd), lines[!varying]), collapse = "\n")
+  paste(c(class(cnd), lines[!(groups | pointer)]), collapse = "\n")
 }
 
 # Every bullet as the one line it was written as. cli wraps a bullet it cannot

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -103,12 +103,12 @@ restate_condition_names <- function(cnd, keys) {
 # `$body`, so the text is all there is to compare.
 buffer_branch_warning <- function(cnd, conditions) {
   cnd <- restate_condition_names(cnd, conditions$keys)
-  cause <- branch_warning_cause(cnd)
+  identity <- branch_warning_identity(cnd)
 
   buffered <- conditions$warnings
-  seen <- match(cause, names(buffered))
+  seen <- match(identity, names(buffered))
   if (is.na(seen)) {
-    buffered[[cause]] <- list(condition = cnd, count = 1L)
+    buffered[[identity]] <- list(condition = cnd, count = 1L)
   } else {
     buffered[[seen]]$count <- buffered[[seen]]$count + 1L
   }
@@ -116,53 +116,92 @@ buffer_branch_warning <- function(cnd, conditions) {
   invisible(NULL)
 }
 
-# Two occurrences are repetitions of one condition when they agree on cause:
+# Two occurrences are repetitions of one condition when they agree on identity:
 # the class, the diagnostic, and the argument the warning is attributed to. The
 # class is read from the condition; the other two are what is left of the
 # rendered message once the parts that necessarily differ between grouping sets
 # are removed -- which groups raised the warning, how many of that branch's
 # groups did, and dplyr's pointer at the store holding the rest.
 #
-# The comparison runs on the message with every run of whitespace collapsed,
-# because how the message is laid out is not part of what it says: cli wraps a
-# bullet it cannot fit, indenting the continuation of one it recognizes and not
-# the continuation of dplyr's opening sentence, so matching by line made the
-# console width and the length of the grouping values decide whether a Repeated
-# condition was one condition. Measured on the ticket's own reproduction, whose
-# values are one and four characters long: three reports at 60 columns, four at
-# 40, and two anywhere in 15 to 24.
+# Removal is anchored to the start of a line, because a bullet is only a bullet
+# there. An unanchored marker is found inside a grouping value as readily: a
+# region named `Hawaii Region` carries `i `, and a caller diagnostic reading
+# `i In group A is bad` carries the whole marker, so either would decide what
+# gets removed and the second would be removed itself.
 #
 # What is left reads a format dplyr does not promise, and is chosen for which
-# way it fails: wording dplyr changes stops matching, the causes stay distinct,
-# and every occurrence is reported, which is what happens today. It can never
-# collapse a warning that genuinely differs. Both bullet spellings are matched
-# because the leading symbol is cli's and follows `cli.unicode`.
-branch_warning_cause <- function(cnd) {
-  bullet <- "(?:i|\u2139) "
-  text <- gsub("[[:space:]]+", " ", conditionMessage(cnd))
-  # A grouping-value bullet runs to whatever opens the next part of the
-  # message, which after collapsing is the only boundary left to read.
-  text <- gsub(
-    paste0(bullet, "In group .*?(?=", bullet, "|! |Caused by |$)"),
-    "",
-    text,
-    perl = TRUE
-  )
-  text <- sub(
-    paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`.*$"),
-    "",
-    text,
-    perl = TRUE
-  )
-  # Only the count is dropped from the opening sentence; the call it names is
-  # the same in every branch, and dropping the sentence whole would take a
-  # caller's own diagnostic with it whenever dplyr raised exactly one warning.
-  text <- sub("^There (?:was|were) [0-9]+ warnings? in ", "", text, perl = TRUE)
-  text <- sub("The first warning was: ", "", text, fixed = TRUE)
-  paste(c(class(cnd), trimws(text)), collapse = "\n")
+# way it fails: wording dplyr changes stops matching, the identities stay
+# distinct, and every occurrence is reported, which is what happens today. It
+# can never collapse a warning that genuinely differs. Both bullet spellings
+# are matched because the leading symbol is cli's and follows `cli.unicode`.
+branch_warning_identity <- function(cnd) {
+  lines <- drop_aggregation_preamble(unwrap_message_lines(
+    strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
+  ))
+  bullet <- "^[i\u2139] "
+  varying <- grepl(paste0(bullet, "In group "), lines) |
+    grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines)
+  paste(c(class(cnd), lines[!varying]), collapse = "\n")
 }
 
-# Replays what the branches withheld: one report per distinct cause, each
+# Every bullet as the one line it was written as. cli wraps a bullet it cannot
+# fit onto continuation lines indented by two spaces, so which lines a message
+# holds is a function of the console width and of how long the grouping values
+# are -- and a group bullet matched line by line would then survive the removal
+# above from its second line on. Measured on the ticket's own reproduction,
+# whose values are one and four characters long: three reports of one condition
+# at 60 columns, and four at 40.
+#
+# Rejoining can only lose text that cli indented under the line above it, which
+# is what a wrap is; a caller's own indented line is rejoined into the
+# diagnostic it follows and stays part of the identity.
+unwrap_message_lines <- function(lines) {
+  wrapped <- grepl("^  ", lines) & seq_along(lines) > 1L
+  if (!any(wrapped)) {
+    return(lines)
+  }
+  unname(vapply(
+    split(sub("^ +", "", lines), cumsum(!wrapped)),
+    paste,
+    character(1),
+    collapse = " "
+  ))
+}
+
+# dplyr's aggregation header: how many warnings that branch raised, in which
+# call, and -- where there was more than one -- that what follows is the first
+# of them. All of it precedes the first bullet, and the count is the part that
+# necessarily differs between grouping sets.
+#
+# It is dropped whole rather than edited because it is the one part of the
+# message cli wraps onto lines it does not indent, so unwrapping cannot restore
+# it and there is no reliable line to edit: at any width from 15 to 24 columns
+# the ticket's own reproduction wrapped it into `There were 3` against `There
+# was 1`, leaving `warnings in` against `in`, and reported two conditions for a
+# plan that raises one. What goes with the count is the call, which every
+# branch names identically.
+#
+# A message that does not open with the header, or that holds no bullet to stop
+# at, is left alone and compared whole -- the reading that reports every
+# occurrence rather than the one that collapses them.
+drop_aggregation_preamble <- function(lines) {
+  bullets <- which(grepl("^[i\u2139!] ", lines))
+  if (length(bullets) == 0L || bullets[[1L]] == 1L) {
+    return(lines)
+  }
+  # Read as one sentence however it was broken up, so that the match does not
+  # become another thing the width decides.
+  preamble <- paste(
+    sub("^ +", "", lines[seq_len(bullets[[1L]] - 1L)]),
+    collapse = " "
+  )
+  if (!grepl("^There (were|was) [0-9]+ warnings? in ", preamble)) {
+    return(lines)
+  }
+  lines[seq(bullets[[1L]], length(lines))]
+}
+
+# Replays what the branches withheld: one report per distinct identity, each
 # saying how many further grouping sets raised it. The conditions are replayed
 # in the order the branches raised them, and the reported occurrence is the
 # first, so a plan that raises nothing new reads as one branch's report.
@@ -188,7 +227,7 @@ report_branch_warnings <- function(conditions) {
 # Rewrites the internal grouping-column names dplyr built the context from into
 # the names the caller wrote. Finding one is a search for a literal marginplyr
 # planted rather than a parse of dplyr's format, which is why this half carries
-# none of the fragility `branch_warning_cause()` above does.
+# none of the fragility `branch_warning_identity()` above does.
 #
 # One pass over the text rather than one `gsub()` per key, so that no token can
 # be found inside another: a fixed replacement of `..marginplyr_key_1` corrupts

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -55,7 +55,7 @@ with_branch_conditions <- function(expr, conditions) {
     withCallingHandlers(
       expr,
       warning = function(cnd) {
-        buffer_branch_warning(conditions, cnd)
+        buffer_branch_warning(cnd, conditions)
         invokeRestart("muffleWarning")
       }
     ),
@@ -91,17 +91,17 @@ restate_branch_error <- function(cnd, conditions) {
 # A warning arrives as one condition per branch whose message dplyr has already
 # aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
 # `$body`, so the text is all there is to restate and all there is to compare.
-buffer_branch_warning <- function(conditions, cnd) {
+buffer_branch_warning <- function(cnd, conditions) {
   cnd$message <- restate_margin_keys(
     paste(conditionMessage(cnd), collapse = "\n"),
     conditions$keys
   )
-  identity <- branch_warning_identity(cnd$message)
+  cause <- branch_warning_cause(cnd)
 
   buffered <- conditions$warnings
-  seen <- match(identity, names(buffered))
+  seen <- match(cause, names(buffered))
   if (is.na(seen)) {
-    buffered[[identity]] <- list(condition = cnd, count = 1L)
+    buffered[[cause]] <- list(condition = cnd, count = 1L)
   } else {
     buffered[[seen]]$count <- buffered[[seen]]$count + 1L
   }
@@ -109,27 +109,31 @@ buffer_branch_warning <- function(conditions, cnd) {
   invisible(NULL)
 }
 
-# The identity of a Repeated condition is its cause, so what this removes is
-# exactly the parts that necessarily differ between grouping sets: which groups
-# raised the warning, how many of that branch's groups did, and dplyr's pointer
-# at the store holding the rest. What survives is the argument the warning is
-# attributed to and the diagnostic itself.
+# Two occurrences are repetitions of one condition when they agree on cause:
+# the class, the diagnostic, and the argument the warning is attributed to. The
+# class is read from the condition; the other two are what is left of the
+# message once the parts that necessarily differ between grouping sets are
+# removed -- which groups raised the warning, how many of that branch's groups
+# did, and dplyr's pointer at the store holding the rest.
 #
-# This reads a format dplyr does not promise, and is chosen for which way it
-# fails: wording dplyr changes stops matching, the keys stay distinct, and
-# every occurrence is reported, which is what happens today. It can never
+# The text half reads a format dplyr does not promise, and is chosen for which
+# way it fails: wording dplyr changes stops matching, the causes stay distinct,
+# and every occurrence is reported, which is what happens today. It can never
 # collapse a warning that genuinely differs. Both bullet spellings are matched
 # because the leading symbol is cli's and follows `cli.unicode`.
-branch_warning_identity <- function(message) {
-  lines <- strsplit(message, "\n", fixed = TRUE)[[1L]]
+branch_warning_cause <- function(cnd) {
+  lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
   bullet <- "^[i\u2139] "
   varying <- grepl(paste0(bullet, "In group "), lines) |
     grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines) |
-    lines == "The first warning was:"
-  # The count sentence opens the message, and only there is it dplyr's rather
-  # than something the caller's own diagnostic happens to say.
-  varying[[1L]] <- varying[[1L]] | grepl("^There (were|was) ", lines[[1L]])
-  paste(lines[!varying], collapse = "\n")
+    lines == "The first warning was:" |
+    # The count sentence opens the message, and only there is it dplyr's rather
+    # than something the caller's own diagnostic happens to say. Indexing by
+    # the whole sequence rather than the first element is what leaves a message
+    # of no lines at all -- which dplyr's aggregation does not produce, but
+    # nothing outside it promises either -- a cause rather than an error.
+    (seq_along(lines) == 1L & grepl("^There (were|was) ", lines))
+  paste(c(class(cnd), lines[!varying]), collapse = "\n")
 }
 
 # Replays what the branches withheld: one report per distinct cause, each
@@ -137,10 +141,7 @@ branch_warning_identity <- function(message) {
 # in the order the branches raised them, and the reported occurrence is the
 # first, so a plan that raises nothing new reads as one branch's report.
 report_branch_warnings <- function(conditions) {
-  buffered <- conditions$warnings
-  conditions$warnings <- list()
-
-  for (entry in buffered) {
+  for (entry in conditions$warnings) {
     cnd <- entry$condition
     if (entry$count > 1L) {
       cnd$message <- paste0(

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -122,7 +122,9 @@ buffer_branch_warning <- function(cnd, conditions) {
 # collapse a warning that genuinely differs. Both bullet spellings are matched
 # because the leading symbol is cli's and follows `cli.unicode`.
 branch_warning_cause <- function(cnd) {
-  lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
+  lines <- unwrap_message_lines(
+    strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
+  )
   bullet <- "^[i\u2139] "
   varying <- grepl(paste0(bullet, "In group "), lines) |
     grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines) |
@@ -134,6 +136,34 @@ branch_warning_cause <- function(cnd) {
     # nothing outside it promises either -- a cause rather than an error.
     (seq_along(lines) == 1L & grepl("^There (were|was) ", lines))
   paste(c(class(cnd), lines[!varying]), collapse = "\n")
+}
+
+# Every bullet as the one line it was written as. cli wraps a bullet it cannot
+# fit onto continuation lines indented by two spaces, so which lines a message
+# holds is a function of the console width and of how long the grouping values
+# are -- and a group bullet matched line by line then survives the removal
+# above from its second line on.
+#
+# Without this, the console width decides whether a Repeated condition is one
+# condition. Measured on the ticket's own `cube(region, grade)` reproduction,
+# whose values are one and four characters long: one warning at width 80,
+# three at 60, and four at 40. A `.by` key or a realistic value produces it at
+# any width.
+#
+# Rejoining can only lose text that cli indented under the line above it, which
+# is what a wrap is; a caller's own indented line is rejoined into the
+# diagnostic it follows and stays part of the cause.
+unwrap_message_lines <- function(lines) {
+  wrapped <- grepl("^  ", lines) & seq_along(lines) > 1L
+  if (!any(wrapped)) {
+    return(lines)
+  }
+  unname(vapply(
+    split(sub("^ +", "", lines), cumsum(!wrapped)),
+    paste,
+    character(1),
+    collapse = " "
+  ))
 }
 
 # Replays what the branches withheld: one report per distinct cause, each
@@ -162,16 +192,13 @@ report_branch_warnings <- function(conditions) {
 # Rewrites the internal grouping-column names dplyr built the context from into
 # the names the caller wrote. Finding one is a search for a literal marginplyr
 # planted rather than a parse of dplyr's format, which is why this half carries
-# none of the fragility `branch_warning_identity()` above does.
+# none of the fragility `branch_warning_cause()` above does.
 #
-# One pass over the text rather than one `gsub()` per key, so that neither
-# token can be found inside another's substitution: a fixed replacement of
-# `..marginplyr_key_1` corrupts the `..marginplyr_key_10` a plan of ten
-# grouping columns allocates, and a caller column whose own name looks like a
-# key -- which `new_margin_internal_names()` allocates around rather than
-# refuses -- would otherwise be substituted a second time. Longest token first,
-# because a Perl-compatible alternation matches the first branch that fits
-# rather than the longest.
+# One pass over the text rather than one `gsub()` per key, so that no token can
+# be found inside another: a fixed replacement of `..marginplyr_key_1` corrupts
+# the `..marginplyr_key_10` a plan of ten grouping columns allocates. Longest
+# token first, because a Perl-compatible alternation matches the first branch
+# that fits rather than the longest.
 restate_margin_keys <- function(text, keys) {
   if (length(keys) == 0L || length(text) == 0L) {
     return(text)

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -106,11 +106,11 @@ buffer_branch_warning <- function(cnd, conditions) {
   key <- branch_warning_identity(cnd)
 
   buffered <- conditions$warnings
-  seen <- match(key, names(buffered))
-  if (is.na(seen)) {
-    buffered[[key]] <- list(condition = cnd, count = 1L)
+  seen <- buffered[[key]]
+  buffered[[key]] <- if (is.null(seen)) {
+    list(condition = cnd, count = 1L)
   } else {
-    buffered[[seen]]$count <- buffered[[seen]]$count + 1L
+    list(condition = seen$condition, count = seen$count + 1L)
   }
   conditions$warnings <- buffered
   invisible(NULL)

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -19,3 +19,172 @@ abort_marginplyr <- function(message,
     call = call
   )
 }
+
+# What an External condition raised while one grouping-set branch runs is
+# reported with. `keys` maps each `..marginplyr_key_N` column the branch
+# grouped by to the column the caller named, and `call` is the Margin verb the
+# caller wrote -- `NULL` where there is no verb to name, which is how a direct
+# call to an adapter leaves the blamed call as it found it.
+#
+# The buffer is what makes a Repeated condition one report: a branch warning is
+# withheld as it is raised and every branch's warnings are replayed together,
+# which cannot be decided one branch at a time. It is an environment because
+# the branches run inside `Map()`, so what they write to has to outlive each
+# call. The decision is recorded in
+# design/adr/0021-report-a-repeated-execution-condition-once.md, and the terms
+# it is stated in -- *Condition context* and *Repeated condition* -- are
+# CONTEXT.md's.
+new_branch_conditions <- function(keys, call = NULL) {
+  stopifnot(
+    is.character(keys),
+    length(keys) == 0L || !is.null(names(keys))
+  )
+  conditions <- new.env(parent = emptyenv())
+  conditions$keys <- keys
+  conditions$call <- call
+  conditions$warnings <- list()
+  conditions
+}
+
+# Runs one branch, withholding the warnings it raises and restating the context
+# of the error that aborts it. Only the caller's own summary expressions are
+# evaluated inside `expr`: a Package condition is raised by the branch builders
+# around it, which is what keeps this from reaching one.
+with_branch_conditions <- function(expr, conditions) {
+  tryCatch(
+    withCallingHandlers(
+      expr,
+      warning = function(cnd) {
+        buffer_branch_warning(conditions, cnd)
+        invokeRestart("muffleWarning")
+      }
+    ),
+    error = function(cnd) {
+      stop(restate_branch_error(cnd, conditions))
+    }
+  )
+}
+
+# An error arrives with its context in addressable fields: `$message` holds the
+# argument bullet, `$body` the grouping-value bullet, and `$call` the internal
+# `dplyr::summarize()` the adapter issued. `$parent` holds the caller's own
+# condition and is never touched, which is what keeps the propagation faithful.
+#
+# Errors are not deduplicated, and there is nothing to deduplicate: branches
+# run in sequence, so the first error aborts the operation and no second
+# occurrence is ever raised.
+restate_branch_error <- function(cnd, conditions) {
+  if (is.character(cnd$message)) {
+    cnd$message <- restate_margin_keys(cnd$message, conditions$keys)
+  }
+  # `$body` is a character vector of bullets here, but rlang also admits a
+  # function that renders them, which nothing can substitute into.
+  if (is.character(cnd$body)) {
+    cnd$body <- restate_margin_keys(cnd$body, conditions$keys)
+  }
+  if (!is.null(conditions$call)) {
+    cnd$call <- conditions$call
+  }
+  cnd
+}
+
+# A warning arrives as one condition per branch whose message dplyr has already
+# aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
+# `$body`, so the text is all there is to restate and all there is to compare.
+buffer_branch_warning <- function(conditions, cnd) {
+  cnd$message <- restate_margin_keys(
+    paste(conditionMessage(cnd), collapse = "\n"),
+    conditions$keys
+  )
+  identity <- branch_warning_identity(cnd$message)
+
+  buffered <- conditions$warnings
+  seen <- match(identity, names(buffered))
+  if (is.na(seen)) {
+    buffered[[identity]] <- list(condition = cnd, count = 1L)
+  } else {
+    buffered[[seen]]$count <- buffered[[seen]]$count + 1L
+  }
+  conditions$warnings <- buffered
+  invisible(NULL)
+}
+
+# The identity of a Repeated condition is its cause, so what this removes is
+# exactly the parts that necessarily differ between grouping sets: which groups
+# raised the warning, how many of that branch's groups did, and dplyr's pointer
+# at the store holding the rest. What survives is the argument the warning is
+# attributed to and the diagnostic itself.
+#
+# This reads a format dplyr does not promise, and is chosen for which way it
+# fails: wording dplyr changes stops matching, the keys stay distinct, and
+# every occurrence is reported, which is what happens today. It can never
+# collapse a warning that genuinely differs. Both bullet spellings are matched
+# because the leading symbol is cli's and follows `cli.unicode`.
+branch_warning_identity <- function(message) {
+  lines <- strsplit(message, "\n", fixed = TRUE)[[1L]]
+  bullet <- "^[i\u2139] "
+  varying <- grepl(paste0(bullet, "In group "), lines) |
+    grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines) |
+    lines == "The first warning was:"
+  # The count sentence opens the message, and only there is it dplyr's rather
+  # than something the caller's own diagnostic happens to say.
+  varying[[1L]] <- varying[[1L]] | grepl("^There (were|was) ", lines[[1L]])
+  paste(lines[!varying], collapse = "\n")
+}
+
+# Replays what the branches withheld: one report per distinct cause, each
+# saying how many further grouping sets raised it. The conditions are replayed
+# in the order the branches raised them, and the reported occurrence is the
+# first, so a plan that raises nothing new reads as one branch's report.
+report_branch_warnings <- function(conditions) {
+  buffered <- conditions$warnings
+  conditions$warnings <- list()
+
+  for (entry in buffered) {
+    cnd <- entry$condition
+    if (entry$count > 1L) {
+      cnd$message <- paste0(
+        cnd$message,
+        "\n",
+        rlang::format_error_bullets(c(i = sprintf(
+          "%d further grouping %s raised this warning.",
+          entry$count - 1L,
+          if (entry$count == 2L) "set" else "sets"
+        )))
+      )
+    }
+    warning(cnd)
+  }
+  invisible(NULL)
+}
+
+# Rewrites the internal grouping-column names dplyr built the context from into
+# the names the caller wrote. Finding one is a search for a literal marginplyr
+# planted rather than a parse of dplyr's format, which is why this half carries
+# none of the fragility `branch_warning_identity()` above does.
+#
+# One pass over the text rather than one `gsub()` per key, so that neither
+# token can be found inside another's substitution: a fixed replacement of
+# `..marginplyr_key_1` corrupts the `..marginplyr_key_10` a plan of ten
+# grouping columns allocates, and a caller column whose own name looks like a
+# key -- which `new_margin_internal_names()` allocates around rather than
+# refuses -- would otherwise be substituted a second time. Longest token first,
+# because a Perl-compatible alternation matches the first branch that fits
+# rather than the longest.
+restate_margin_keys <- function(text, keys) {
+  if (length(keys) == 0L || length(text) == 0L) {
+    return(text)
+  }
+  keys <- keys[order(nchar(names(keys)), decreasing = TRUE)]
+  pattern <- paste0(
+    "(?:",
+    paste0(gsub("([^[:alnum:]_])", "\\\\\\1", names(keys)), collapse = "|"),
+    ")"
+  )
+  matches <- gregexpr(pattern, text, perl = TRUE)
+  regmatches(text, matches) <- lapply(
+    regmatches(text, matches),
+    function(found) unname(keys[found])
+  )
+  text
+}

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -123,95 +123,78 @@ buffer_branch_warning <- function(cnd, conditions) {
 # are removed -- which groups raised the warning, how many of that branch's
 # groups did, and dplyr's pointer at the store holding the rest.
 #
-# Removal is confined to where dplyr writes those parts, and not merely to what
-# they say, because everything they say is also something a caller's own
-# diagnostic can say. A marker is only a marker at the start of a line, so an
-# unanchored match would find one inside a grouping value -- a region named
-# `Hawaii Region` carries `i `. A line is only dplyr's before its `Caused by`
-# line, since what follows that is the caller's diagnostic, whose second line
-# cli renders at column zero exactly as it renders a bullet. And the pointer at
-# the store is only dplyr's as the last line of the message.
+# What identifies a part as dplyr's is where it sits, not what it says, because
+# everything dplyr's aggregation says a caller's own diagnostic can say too: a
+# diagnostic can open `There were 3 warnings in ...`, and cli renders its second
+# line at column zero exactly as it renders a bullet. So the header is what
+# precedes the first bullet, a grouping-value bullet is one written before the
+# `Caused by` line that introduces the caller's own diagnostic, and the pointer
+# at the store is looked for only in a message whose header said there was more
+# than one warning to point at.
+#
+# Each part is matched as the line it was written as -- `message_line_runs()`
+# below -- so that the console width decides nothing, and removed as the lines
+# it was rendered onto. Every line kept is kept as it arrived: nothing a caller
+# wrote is rewritten into what another branch wrote.
 #
 # What is left reads a format dplyr does not promise, and is chosen for which
 # way it fails: wording dplyr changes stops matching, the identities stay
 # distinct, and every occurrence is reported, which is what happens today. It
-# can never collapse a warning that genuinely differs. Both bullet spellings
-# are matched because the leading symbol is cli's and follows `cli.unicode`.
+# can never collapse a warning that genuinely differs.
 branch_warning_identity <- function(cnd) {
-  lines <- drop_aggregation_preamble(unwrap_message_lines(
-    strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
-  ))
-  bullet <- "^[i\u2139] "
-  causes <- which(grepl("^Caused by ", lines))
-  # No `Caused by` line is a message this cannot locate dplyr's own context in,
-  # so nothing is removed and the message is compared whole -- the reading that
-  # reports every occurrence rather than the one that collapses them.
-  attributed <- if (length(causes) == 0L) {
-    rep(FALSE, length(lines))
-  } else {
-    seq_along(lines) < causes[[1L]]
-  }
-  groups <- attributed & grepl(paste0(bullet, "In group "), lines)
-  pointer <- seq_along(lines) == length(lines) &
-    grepl(paste0(bullet, "Run `dplyr::last_dplyr_warnings\\(\\)`"), lines)
-  paste(c(class(cnd), lines[!(groups | pointer)]), collapse = "\n")
-}
-
-# Every bullet as the one line it was written as. cli wraps a bullet it cannot
-# fit onto continuation lines indented by two spaces, so which lines a message
-# holds is a function of the console width and of how long the grouping values
-# are -- and a group bullet matched line by line would then survive the removal
-# above from its second line on. Measured on the ticket's own reproduction,
-# whose values are one and four characters long: three reports of one condition
-# at 60 columns, and four at 40.
-#
-# Rejoining can only lose text that cli indented under the line above it, which
-# is what a wrap is; a caller's own indented line is rejoined into the
-# diagnostic it follows and stays part of the identity.
-unwrap_message_lines <- function(lines) {
-  wrapped <- grepl("^  ", lines) & seq_along(lines) > 1L
-  if (!any(wrapped)) {
-    return(lines)
-  }
-  unname(vapply(
-    split(sub("^ +", "", lines), cumsum(!wrapped)),
-    paste,
-    character(1),
-    collapse = " "
-  ))
-}
-
-# dplyr's aggregation header: how many warnings that branch raised, in which
-# call, and -- where there was more than one -- that what follows is the first
-# of them. All of it precedes the first bullet, and the count is the part that
-# necessarily differs between grouping sets.
-#
-# It is dropped whole rather than edited because it is the one part of the
-# message cli wraps onto lines it does not indent, so unwrapping cannot restore
-# it and there is no reliable line to edit: at any width from 15 to 24 columns
-# the ticket's own reproduction wrapped it into `There were 3` against `There
-# was 1`, leaving `warnings in` against `in`, and reported two conditions for a
-# plan that raises one. What goes with the count is the call, which every
-# branch names identically.
-#
-# A message that does not open with the header, or that holds no bullet to stop
-# at, is left alone and compared whole -- the reading that reports every
-# occurrence rather than the one that collapses them.
-drop_aggregation_preamble <- function(lines) {
-  bullets <- which(grepl("^[i\u2139!] ", lines))
-  if (length(bullets) == 0L || bullets[[1L]] == 1L) {
-    return(lines)
-  }
-  # Read as one sentence however it was broken up, so that the match does not
-  # become another thing the width decides.
-  preamble <- paste(
-    sub("^ +", "", lines[seq_len(bullets[[1L]] - 1L)]),
-    collapse = " "
+  lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
+  runs <- message_line_runs(lines)
+  written <- vapply(
+    runs,
+    function(run) paste(sub("^ +", "", lines[run]), collapse = " "),
+    character(1)
   )
-  if (!grepl("^There (were|was) [0-9]+ warnings? in ", preamble)) {
-    return(lines)
+  # `!` opens the caller's own diagnostic, so a message dplyr attributed to no
+  # argument still has a bullet where its header ends. Both spellings of the
+  # informational one are matched because the symbol is cli's and follows
+  # `cli.unicode`.
+  first_bullet <- match(TRUE, grepl("^[i\u2139!] ", written))
+  cause <- match(TRUE, grepl("^Caused by ", written))
+  removed <- rep(FALSE, length(runs))
+
+  aggregated <- !is.na(first_bullet) &&
+    first_bullet > 1L &&
+    grepl(
+      "^There (were|was) [0-9]+ warnings? in ",
+      paste(written[seq_len(first_bullet - 1L)], collapse = " ")
+    )
+  if (aggregated) {
+    removed[seq_len(first_bullet - 1L)] <- TRUE
   }
-  lines[seq(bullets[[1L]], length(lines))]
+  if (!is.na(cause)) {
+    removed <- removed |
+      (grepl("^[i\u2139] In group ", written) & seq_along(written) < cause)
+  }
+  # The pointer runs to the end of the message, so everything after it goes
+  # with it.
+  pointer <- which(
+    grepl("^[i\u2139] Run `dplyr::last_dplyr_warnings\\(\\)`", written)
+  )
+  if (aggregated && length(pointer) > 0L) {
+    removed[seq(max(pointer), length(runs))] <- TRUE
+  }
+
+  paste(
+    c(class(cnd), lines[unlist(runs[!removed])]),
+    collapse = "\n"
+  )
+}
+
+# The message as the lines it was written as, each one the indices of the lines
+# cli rendered it onto: a line it cannot fit is wrapped onto continuations it
+# indents by two spaces. Reading a part off the rendered lines instead would
+# make the console width and the length of the grouping values decide what gets
+# matched -- the ticket's own reproduction wrapped its grouping-value bullet at
+# 60 columns and dplyr's opening sentence at 24, and reported three and two
+# conditions for a plan that raises one.
+message_line_runs <- function(lines) {
+  wrapped <- grepl("^  ", lines) & seq_along(lines) > 1L
+  unname(split(seq_along(lines), cumsum(!wrapped)))
 }
 
 # Replays what the branches withheld: one report per distinct identity, each

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -148,7 +148,7 @@ summarize_margin_union <- function(.data,
   }
 
   conditions <- new_branch_conditions(
-    keys = rlang::set_names(group_vars, unname(key_names)),
+    keys = rlang::set_names(names(key_names), unname(key_names)),
     call = call
   )
   # On exit rather than after the loop, so that the branches that ran before an

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -116,6 +116,14 @@ add_grouping_set_id <- function(result, set_id_name, set_id) {
   )
 }
 
+# This is the one function in the package that evaluates the caller's own
+# summary expressions more than once, so it is the one that can report an
+# External condition once per grouping set and in names the caller never wrote:
+# the branches group by the `..marginplyr_key_N` columns allocated below, and
+# dplyr builds every context it attaches out of those. `call` is the Margin
+# verb a Condition context is owed instead of the internal `summarize()` the
+# branch issues; a caller that reaches this directly has none to name and
+# leaves the blamed call alone.
 summarize_margin_union <- function(.data,
                                    dots,
                                    plan,
@@ -123,7 +131,8 @@ summarize_margin_union <- function(.data,
                                    column_info,
                                    reserved_names,
                                    set_id_name = NULL,
-                                   set_id_is_internal = FALSE) {
+                                   set_id_is_internal = FALSE,
+                                   call = NULL) {
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
     length(group_vars),
@@ -138,6 +147,16 @@ summarize_margin_union <- function(.data,
     .data <- dplyr::mutate(.data, !!!key_exprs)
   }
 
+  conditions <- new_branch_conditions(
+    keys = rlang::set_names(group_vars, unname(key_names)),
+    call = call
+  )
+  # On exit rather than after the loop, so that the branches that ran before an
+  # error still report what they raised. Withholding a warning and then leaving
+  # by any path but the one that replays it would lose it outright, which no
+  # reading of the contract allows.
+  on.exit(report_branch_warnings(conditions), add = TRUE)
+
   branches <- Map(
     function(grouping_set, set_id) {
       branch_dots <- rewrite_grouping_dots(
@@ -147,10 +166,16 @@ summarize_margin_union <- function(.data,
         sql = FALSE
       )
 
-      result <- summarize_margin_branch(
-        .data = .data,
-        !!!branch_dots,
-        .by = unname(key_names[grouping_set])
+      # Only the caller's expressions are wrapped. The checks and the branch
+      # builders below raise Package conditions, which carry their own context
+      # and are never deduplicated.
+      result <- with_branch_conditions(
+        summarize_margin_branch(
+          .data = .data,
+          !!!branch_dots,
+          .by = unname(key_names[grouping_set])
+        ),
+        conditions = conditions
       )
 
       check_summary_output_names(

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -748,8 +748,8 @@ grouping_arg_spec <- function(arg, data_vars) {
 # ADR 0008 fixes how often a caller's quosure runs. This is marginplyr's own
 # report about a position of its own, so it stays parentless, as
 # `abort_share_source_name()` does for the same reason. Every other failure is
-# an External condition and is re-raised as it arrived, class and provenance
-# intact.
+# an External condition and is re-raised as it arrived, with its own class,
+# diagnostic, and cause.
 resolve_grouping_selection <- function(arg, data_proxy) {
   tryCatch(
     resolve_column_selection(

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -78,12 +78,11 @@ check_margin_operation <- function(operation) {
 }
 
 # Package conditions report the Margin verb the caller wrote rather than the
-# internal frame that raised them. An External condition keeps its own class,
-# diagnostic, and cause here whatever its blamed call says: the one that
-# reaches a caller under an internal call is the one a grouping-set branch
-# raises, and `with_branch_conditions()` restates that Condition context where
-# the branch runs, which is the only frame that knows which columns the names
-# in it stand for.
+# internal frame that raised them. An External condition passes through with
+# its own class, diagnostic, and cause. Its Condition context is restated where
+# a grouping-set branch raises one, by `with_branch_conditions()`, rather than
+# here: the grouping values in that context are reported under internal column
+# names, and the branch is the only frame that knows what they stand for.
 with_margin_error_call <- function(expr, call) {
   tryCatch(
     expr,

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -78,7 +78,12 @@ check_margin_operation <- function(operation) {
 }
 
 # Package conditions report the Margin verb the caller wrote rather than the
-# internal frame that raised them. Everything else keeps its own provenance.
+# internal frame that raised them. An External condition keeps its own class,
+# diagnostic, and cause here whatever its blamed call says: the one that
+# reaches a caller under an internal call is the one a grouping-set branch
+# raises, and `with_branch_conditions()` restates that Condition context where
+# the branch runs, which is the only frame that knows which columns the names
+# in it stand for.
 with_margin_error_call <- function(expr, call) {
   tryCatch(
     expr,

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -34,7 +34,7 @@
 #'   calculate a summary's ratio to its immediate rollup parent, or to the
 #'   grand total.
 #'
-#' @section Errors:
+#' @section Errors and warnings:
 #' Every error marginplyr raises for a call you can correct inherits the
 #' `"marginplyr_error"` class, so one handler catches them all:
 #'
@@ -57,10 +57,22 @@
 #'
 #' Two kinds of error deliberately fall outside the class. Errors raised by
 #' your own summary expressions, by tidyselect, by dplyr, or by a database
-#' backend propagate with their original class and call intact. So do
-#' marginplyr's internal invariant checks, which report a defect no change to
-#' your call can avoid; please report those at
+#' backend propagate with their original class, diagnostic, and cause intact.
+#' So do marginplyr's internal invariant checks, which report a defect no
+#' change to your call can avoid; please report those at
 #' <https://github.com/sayuks/marginplyr/issues>.
+#'
+#' marginplyr itself raises no warning: it states what it will not do by
+#' refusing. What a Margin verb does adjust, for an error and a warning alike,
+#' is the context reported around one, because a margin operation may summarize
+#' your expression once per grouping set. Such a condition reports its grouping
+#' values under the columns you named, and blames the Margin verb you wrote
+#' rather than the internal summary that ran it. A warning that every grouping
+#' set raises is reported once, saying how many further grouping sets raised
+#' it; warnings that differ from each other are reported one by one. A lazy
+#' input is outside this, and visibly so: its summary expressions run when you
+#' collect the result rather than while the verb runs, so what they raise is
+#' the collecting call's to report.
 #'
 #' @section Guides:
 #' - [Get started][g1]

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -66,13 +66,16 @@
 #' refusing. What a Margin verb does adjust, for an error and a warning alike,
 #' is the context reported around one, because a margin operation may summarize
 #' your expression once per grouping set. Such a condition reports its grouping
-#' values under the columns you named, and blames the Margin verb you wrote
-#' rather than the internal summary that ran it. A warning that every grouping
-#' set raises is reported once, saying how many further grouping sets raised
-#' it; warnings that differ from each other are reported one by one. A lazy
-#' input is outside this, and visibly so: its summary expressions run when you
-#' collect the result rather than while the verb runs, so what they raise is
-#' the collecting call's to report.
+#' values under the columns you named rather than under internal ones, and an
+#' error blames the Margin verb you wrote rather than the internal summary that
+#' ran it. A warning still names that internal summary, because the name is
+#' part of a sentence dplyr renders before marginplyr sees the warning at all.
+#'
+#' A warning that every grouping set raises is reported once, saying how many
+#' further grouping sets raised it; warnings that differ from each other are
+#' reported one by one. A lazy input is outside this, and visibly so: its
+#' summary expressions run when you collect the result rather than while the
+#' verb runs, so what they raise is the collecting call's to report.
 #'
 #' @section Guides:
 #' - [Get started][g1]

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -918,7 +918,8 @@ stage_margin_summaries <- function(operation,
           column_info = operation$column_info,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
-          set_id_is_internal = set_id_is_internal
+          set_id_is_internal = set_id_is_internal,
+          call = operation$call
         )
       }
     },

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -55,13 +55,29 @@ That normalisation reads dplyr's rendered format, which is not a stable
 contract, and it is chosen anyway because of which way it fails. If dplyr
 changes its wording the patterns stop matching, the keys stay distinct, and
 every occurrence is reported — today's behaviour. The failure mode is the
-status quo, never a genuinely different warning silently collapsed into another.
+status quo, never a genuinely different rendered warning silently collapsed
+into another.
+
+*Rendered* is the bound, and it is dplyr's bound rather than one this adds. A
+branch that raises several distinct diagnostics has one of them rendered and
+the rest replaced by the pointer at `last_dplyr_warnings()`; the others are
+not conditions the caller ever receives, before this change or after. So two
+branches whose rendered diagnostic agrees are repetitions here even where what
+each hid behind that pointer differs, and the count says how many further
+grouping sets reported the diagnostic rather than how many raised something.
+Reading past the pointer is not available: what is behind it is a count that
+varies with repetition within a branch, which is the one thing an identity may
+not depend on. The reported occurrence keeps the pointer, so a caller reading
+a report that hides something is told so in the same terms dplyr tells them.
 
 ## Rewriting the names is safe for a reason that does not depend on dplyr
 
 The `..marginplyr_key_N` token is a string marginplyr chose, so finding it in a
 rendered message is a search for a planted literal rather than a parse of
-dplyr's format. That holds equally in the flat warning string and in the
+dplyr's format. It is planted as a column name, which
+`new_margin_internal_names()` allocates clear of the caller's columns; a
+grouping *value* spelled the same way is rewritten along with it, which is the
+one thing the search cannot tell apart and is left where it is. That holds equally in the flat warning string and in the
 structured error fields, and it is why this half of the fix carries none of the
 fragility the deduplication key does. Substitution runs longest token first:
 naively replacing `..marginplyr_key_1` first corrupts `..marginplyr_key_10`,

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -1,0 +1,130 @@
+# Report a repeated execution condition once, in the caller's names
+
+A Margin verb reports an External condition raised by the caller's summary
+expression once, however many grouping sets raised it, and writes its Condition
+context in names the caller can act on. Two occurrences are repetitions of one
+condition when they agree on class, diagnostic, and the argument they are
+attributed to; which grouping set produced an occurrence is never part of that
+identity, because it is the part that necessarily differs. The condition itself
+— its class, its diagnostic, its cause — is propagated unchanged, as ADR 0015
+already required. What this decides is the context around it.
+
+The scope is the `UNION ALL` adapter, and only because that is where the
+repetition exists. `summarize_margin_union()` is the one function in the package
+that evaluates the caller's own summary expressions more than once: it renames
+each grouping column to a `..marginplyr_key_N` column and runs one
+`dplyr::summarize()` per grouping set over those names, so dplyr builds every
+context it attaches from marginplyr's names rather than the caller's. The native
+grouping-sets adapter issues one `summarize()` in total and groups by
+`pick(all_of(group_vars))`, so it allocates no key columns and repeats nothing;
+it is exempt by construction rather than by exclusion. The nesting verbs and the
+share module summarize with expressions marginplyr wrote, not the caller's, so
+neither is in scope either.
+
+## The two condition kinds need different mechanisms
+
+They are not one mechanism, and treating them as one was the framing this ADR
+had to reject. What dplyr hands over differs:
+
+An **error** arrives as a structured `rlang_error` whose fields are separately
+addressable: `$message` holds the argument bullet, `$body` holds the group
+bullet as a named character vector, `$call` holds the internal
+`dplyr::summarize(.data = .data, ..., .by = dplyr::all_of(.by))` literal, and
+`$parent` holds the caller's own original condition, untouched. Rewriting the
+first three is a field assignment; `$parent` never moves, which is what keeps
+the propagation faithful. Errors also need no deduplication at all: branches run
+in sequence, so the first error aborts the operation and no second occurrence is
+ever raised.
+
+A **warning** arrives as one condition per branch whose `$message` is a single
+pre-rendered string — `$parent` is `NULL` and there is no `$body`. dplyr has
+already aggregated every warning from that branch, flattened the bullets into
+text, and appended its own count. There is no field to edit and no structure to
+read, so the deduplication key can only be computed from the rendered text.
+
+Comparing the rendered messages verbatim does not work, which is why this is
+written down: measured on the ticket's own reproduction, a `cube(region, grade)`
+produces four warnings whose messages are pairwise distinct, because each embeds
+a different key column in its group bullet and a different occurrence count.
+Normalising away exactly the parts that necessarily differ — the group bullets,
+the leading count sentence, and dplyr's `last_dplyr_warnings()` footer —
+collapses those four to one key, while a plan whose branches raise genuinely
+different diagnostics still yields one key per diagnostic.
+
+That normalisation reads dplyr's rendered format, which is not a stable
+contract, and it is chosen anyway because of which way it fails. If dplyr
+changes its wording the patterns stop matching, the keys stay distinct, and
+every occurrence is reported — today's behaviour. The failure mode is the
+status quo, never a genuinely different warning silently collapsed into another.
+
+## Rewriting the names is safe for a reason that does not depend on dplyr
+
+The `..marginplyr_key_N` token is a string marginplyr chose, so finding it in a
+rendered message is a search for a planted literal rather than a parse of
+dplyr's format. That holds equally in the flat warning string and in the
+structured error fields, and it is why this half of the fix carries none of the
+fragility the deduplication key does. Substitution runs longest token first:
+naively replacing `..marginplyr_key_1` first corrupts `..marginplyr_key_10`,
+which a plan of ten or more grouping columns produces.
+
+## Considered Options
+
+**Stop renaming, and group by the original columns.** The cleanest context, and
+rejected because it changes what a summary expression can see. The rename exists
+so that a dimension omitted from a grouping set stays available to the caller's
+expression as a full vector rather than as a per-group scalar. Removing it to
+improve a diagnostic would alter the data-mask contract, and the Parent-share
+paths read the same branch results.
+
+**Leave it and document it.** The recommendation on #108 for the CRAN
+submission, when the fix looked like it required the option above. It no longer
+does: the deduplication and the name substitution are both confined to one
+function and both degrade to current behaviour, so the risk that justified
+deferring is not the risk actually on offer.
+
+**Suppress the context entirely.** Removes the internal names by removing the
+information. Rejected: the grouping values are the useful half of the context,
+and a caller debugging a summary expression needs to know which group provoked
+it.
+
+**Deduplicate by comparing `conditionMessage()` verbatim.** Rejected on
+measurement rather than on principle — the messages differ per branch, so it
+collapses nothing.
+
+**Read the per-branch conditions from `dplyr::last_dplyr_warnings()`.** It does
+return the structured objects the flat message lacks. Rejected: it is a
+debugging aid rather than an API, and it is reset per `summarize()` call, so it
+holds only the last branch's warnings by the time the loop ends.
+
+**Also restore the caller's spelling of the argument.** dplyr's argument bullet
+quotes marginplyr's rewrite — `dplyr::across(dplyr::all_of(c("units")), ...)`
+where the caller wrote `c(units)`. Rejected for this decision: restoring it
+means deparsing the caller's dots and text-matching them against dplyr's own
+deparse of the rewritten ones, which is the fragile-parse problem again, for the
+part of the context least likely to mislead. The caller wrote the expression;
+seeing it requoted is confusing rather than wrong.
+
+## Consequences
+
+Deduplication is observable, not silent: the surviving occurrence says how many
+further grouping sets raised it, following the precedent dplyr sets when it
+aggregates warnings within one call.
+
+Only eager inputs are covered, and this is a property of the contract rather
+than an unfinished part of it. On a `dtplyr`, Arrow, or non-native SQL input,
+the branch `summarize()` builds a query without evaluating the caller's
+expression; the warning is raised later, inside the caller's own `collect()`,
+where no marginplyr frame is on the stack. There is nothing to intercept, and
+the Repeated-condition contract says so directly by answering only for what a
+Margin verb raises while it runs.
+
+`dplyr::last_dplyr_warnings()` continues to report the last branch's warnings
+under the internal key names. That store belongs to dplyr and is written before
+marginplyr sees anything, so the substitution cannot reach it.
+
+Because the deduplication key is derived from rendered text, a dplyr release can
+change it without failing a test that asserts on structure. The tests therefore
+assert on the rendered message, as #108 anticipated, and a plan whose branches
+raise different diagnostics is asserted alongside the plan whose branches repeat
+one — a test that only checks collapsing would pass just as well if everything
+collapsed.

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -76,8 +76,10 @@ The `..marginplyr_key_N` token is a string marginplyr chose, so finding it in a
 rendered message is a search for a planted literal rather than a parse of
 dplyr's format. It is planted as a column name, which
 `new_margin_internal_names()` allocates clear of the caller's columns; a
-grouping *value* spelled the same way is rewritten along with it, which is the
-one thing the search cannot tell apart and is left where it is. That holds equally in the flat warning string and in the
+grouping *value* spelled the same way is rewritten along with it, as is a
+caller's own diagnostic that spells it. Both are the one thing the search
+cannot tell apart, and both are left where they are: what it takes to reach
+either is writing a name marginplyr allocated for itself. That holds equally in the flat warning string and in the
 structured error fields, and it is why this half of the fix carries none of the
 fragility the deduplication key does. Substitution runs longest token first:
 naively replacing `..marginplyr_key_1` first corrupts `..marginplyr_key_10`,

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -122,6 +122,16 @@ Margin verb raises while it runs.
 under the internal key names. That store belongs to dplyr and is written before
 marginplyr sees anything, so the substitution cannot reach it.
 
+A warning still names `dplyr::summarize()` as the call it arose in, where an
+error now names the Margin verb. The asymmetry follows from the same difference
+the mechanisms do: an error's blamed call is a field, and a warning's is a
+clause inside the sentence dplyr rendered before signalling. Rewriting that
+clause would be a second parse of dplyr's format, and one that fails the wrong
+way — it edits a sentence rather than choosing a key, so a wording change
+leaves it silently naming the wrong thing rather than falling back to what
+happens today. This is the *Condition context* entry's "a context it cannot
+restate in those terms it leaves as it found it".
+
 Because the deduplication key is derived from rendered text, a dplyr release can
 change it without failing a test that asserts on structure. The tests therefore
 assert on the rendered message, as #108 anticipated, and a plan whose branches

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -118,6 +118,14 @@ where no marginplyr frame is on the stack. There is nothing to intercept, and
 the Repeated-condition contract says so directly by answering only for what a
 Margin verb raises while it runs.
 
+A `message()` is outside this, and is the one External condition kind left
+where it was. dplyr attaches no context to one and does not aggregate them, so
+a message from a summary expression is already emitted once per group rather
+than once per grouping set, in plain dplyr as here; there is no context to
+restate and nothing that would make two of them one. The contract is written
+over what a verb can identify, which the *External condition* entry enumerates
+as warnings and errors.
+
 `dplyr::last_dplyr_warnings()` continues to report the last branch's warnings
 under the internal key names. That store belongs to dplyr and is written before
 marginplyr sees anything, so the substitution cannot reach it.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -495,13 +495,19 @@ The test suite divides supporting contracts as follows:
   inspected without executing a Margin operation.
 - `test-execution-conditions.R` covers the Condition context of ADR 0021
   through `summarize_with_margins()`: a warning every grouping set raises
-  reported once with its count, branches raising different diagnostics
-  reported one by one, the caller's columns and verb in an error's context,
-  the propagated class and cause, ten keys substituted without corruption, a
-  Package condition raised beside them left alone, and the lazy non-goal. Its
-  two snapshots carry the rendered messages, because the deduplication key is
-  derived from rendered text and no structural assertion would see dplyr
-  reword it.
+  reported once with its count and under the caller's own column names,
+  branches raising different diagnostics reported one by one, the caller's
+  columns and verb in an error's context, the propagated class and cause, ten
+  keys substituted without corruption, a Package condition raised beside them
+  left alone, and the lazy non-goal. One case runs at four console widths,
+  because cli wraps a bullet it cannot fit and the identity may not depend on
+  where. Its two snapshots carry the rendered messages, because the
+  deduplication key is derived from rendered text and no structural assertion
+  would see dplyr reword it. Its one test of an internal helper is the
+  documented exception: the class half of a Repeated condition's identity, and
+  a message of no lines, are both unreachable through a verb, because dplyr
+  aggregates a branch's warnings into one condition of its own before
+  signalling.
 - `test-get-col-names.R` and `test-factor.R` cover the focused metadata and
   factor backend contracts.
 - `test-grouping-plan.R` covers the backend-independent Grouping

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -105,8 +105,8 @@ caller-quosure evaluations fixed. The replacement covers the argument the
 position owns and not a part of one: a specification written inside a
 selection keeps tidyselect's report, which names the sub-selection and is
 accurate about it. Every other selection failure is re-raised as it arrived,
-so an External condition still reaches the caller with its own class and
-provenance.
+so an External condition still reaches the caller with its own class,
+diagnostic, and cause.
 
 ### Margin label (`R/margin-label.R`)
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -499,13 +499,15 @@ The test suite divides supporting contracts as follows:
   branches raising different diagnostics reported one by one, the caller's
   columns and verb in an error's context, the propagated class and cause, ten
   keys substituted without corruption, a Package condition raised beside them
-  left alone, and the lazy non-goal. One case runs at four console widths,
-  because cli wraps a bullet it cannot fit and the identity may not depend on
-  where. Its two snapshots carry the rendered messages, because the
-  deduplication key is derived from rendered text and no structural assertion
-  would see dplyr reword it. Its one test of an internal helper is the
-  documented exception: the class half of a Repeated condition's identity, and
-  a message of no lines, are both unreachable through a verb, because dplyr
+  left alone, and the lazy non-goal. Two of its cases hold the identity to what
+  a message says rather than to how it was laid out or what a value happens to
+  contain: one runs at five console widths, because cli wraps a bullet it
+  cannot fit, and one uses a grouping value and a caller diagnostic that carry
+  a bullet marker of their own. Its two snapshots carry the rendered messages,
+  because the identity is derived from rendered text and no structural
+  assertion would see dplyr reword it. Its one test of an internal helper is
+  the documented exception: the class half of a Repeated condition's identity,
+  and an empty message, are both unreachable through a verb, because dplyr
   aggregates a branch's warnings into one condition of its own before
   signalling.
 - `test-get-col-names.R` and `test-factor.R` cover the focused metadata and
@@ -525,7 +527,7 @@ Package conditions are not tested in one file. Each module's tests assert the
 package condition seam" tests in `test-grouping-interface.R`,
 `test-margin-label.R`, `test-summarize-operation.R`, `test-nest-operation.R`,
 `test-inspect-grouping.R`, and `test-utils.R` — while the matching
-"retain their provenance" and "preserve user-expression conditions" tests
+"retain their class and cause" and "preserve user-expression conditions" tests
 assert that an External condition keeps its original class. Keeping the two
 halves adjacent is what makes the boundary in ADR 0015 reviewable.
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -354,13 +354,13 @@ source summary, which both helpers share, so it names whichever helpers the
 caller wrote rather than a fixed one. Other Arrow Margin operations continue
 through the ordinary summary, expansion, and nesting paths.
 
-### Package conditions (`R/conditions.R`)
+### Conditions (`R/conditions.R`)
 
-`abort_marginplyr()` is the only constructor for a Package condition and the
-whole of this module. A Package condition is raised exactly when the caller
-can avoid it by rewriting the call within the documented public interface;
-unreachable invariants and upstream defects use bare `stop()` or
-`stopifnot()`, and External conditions propagate untouched. `marginplyr_error`
+`abort_marginplyr()` is the only constructor for a Package condition. A
+Package condition is raised exactly when the caller can avoid it by rewriting
+the call within the documented public interface; unreachable invariants and
+upstream defects use bare `stop()` or `stopifnot()`, and an External condition
+propagates with its class, diagnostic, and cause untouched. `marginplyr_error`
 is the only promised class. See
 [ADR 0015](adr/0015-separate-package-conditions-from-internal-invariants.md).
 
@@ -368,6 +368,16 @@ The rule is not mechanically enforced, so both directions of the boundary are
 review surface: a Package condition demoted to `stop()` silently leaves the
 public contract, and an invariant promoted to `abort_marginplyr()` silently
 enters it.
+
+The rest of the module owns the Condition context around an External condition
+one grouping-set branch raises. `with_branch_conditions()` restates the
+grouping values dplyr reports under the branch's internal key columns, and the
+blamed call, in the names the caller wrote; it withholds a branch warning as it
+is raised so that `report_branch_warnings()` can report a Repeated condition
+once, with a count of the further grouping sets that raised it. Only the
+portable adapter uses it, because it is the only path that evaluates a caller's
+summary expression more than once. See
+[ADR 0021](adr/0021-report-a-repeated-execution-condition-once.md).
 
 ### Native adapter (`R/grouping-adapter-native.R`)
 
@@ -384,6 +394,11 @@ summarizes each grouping set, checks dynamic names, restores visible grouping
 keys, and labels omitted dimensions. Expansion emits one labelled input branch
 per grouping set; nesting builds on that expansion in its verb executor. Like
 the native adapter, it consumes derived inputs and does not own the lifecycle.
+
+Because it is the one path that summarizes the caller's own expressions once
+per grouping set, it is also the one that owes a Condition context: it wraps
+the branch summary alone in `with_branch_conditions()`, so that the checks and
+builders around it keep raising their Package conditions unchanged.
 
 `combine_margin_branches()` is the one place the package combines a branch
 list, and the contextual-share module calls it for its denominator mappings
@@ -478,6 +493,15 @@ The test suite divides supporting contracts as follows:
 - `test-inspect-grouping.R` covers `inspect_grouping()` as an ordinary tibble
   per ADR 0013, including both formats, plan order, and that a lazy input is
   inspected without executing a Margin operation.
+- `test-execution-conditions.R` covers the Condition context of ADR 0021
+  through `summarize_with_margins()`: a warning every grouping set raises
+  reported once with its count, branches raising different diagnostics
+  reported one by one, the caller's columns and verb in an error's context,
+  the propagated class and cause, ten keys substituted without corruption, a
+  Package condition raised beside them left alone, and the lazy non-goal. Its
+  two snapshots carry the rendered messages, because the deduplication key is
+  derived from rendered text and no structural assertion would see dplyr
+  reword it.
 - `test-get-col-names.R` and `test-factor.R` cover the focused metadata and
   factor backend contracts.
 - `test-grouping-plan.R` covers the backend-independent Grouping

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -499,7 +499,8 @@ The test suite divides supporting contracts as follows:
   branches raising different diagnostics reported one by one, the caller's
   columns and verb in an error's context, the propagated class and cause, ten
   keys substituted without corruption, a Package condition raised beside them
-  left alone, and the lazy non-goal. Two of its cases hold the identity to what
+  left alone, a warning a branch raised surviving a later branch's error, and
+  the lazy non-goal. Two of its cases hold the identity to what
   a message says rather than to how it was laid out or what a value happens to
   contain: one runs at five console widths, because cli wraps a bullet it
   cannot fit, and one uses a grouping value and a caller diagnostic that carry

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -233,7 +233,7 @@ ADR, comment, or contributor doc recorded the rule separating the migrated
 sites from the four surviving bare `stop()` calls. *Evidence:* ADR 0015 states
 the avoidability predicate; `R/conditions.R` carries it at the only
 constructor; `?marginplyr` documents the `marginplyr_error` contract for
-users; `design/architecture.md` has a Package conditions section.
+users; `design/architecture.md` has a Conditions section.
 
 **`match_margin_choice()` duplicates each option vocabulary** (Standards).
 **Fixed in #33.** `match.arg(x)` derived choices from the formal default;

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -93,11 +93,11 @@ not inferred to be predicates".
 #32. `test-parent-share.R` "Parent-share execution preserves user-expression
 conditions".
 
-**Package-created errors need a stable base class, external ones their
-provenance** — #31, #32, #33. `test-grouping-interface.R` "the documented
+**Package-created errors need a stable base class, external ones their own
+class and cause** — #31, #32, #33. `test-grouping-interface.R` "the documented
 `marginplyr_error` handler catches conditions" and "Grouping tidyselect
-conditions retain their provenance", plus the "use the package condition seam"
-tests in six files.
+conditions retain their class and cause", plus the "use the package condition
+seam" tests in six files.
 
 **Local cardinality validation rescans the input once per Grouping set** —
 #27. Validation is wrapped into the ordinary summary by
@@ -187,8 +187,8 @@ with a marginplyr message. The criterion the reviewer applied governs
 package-created errors; a propagated tidyselect failure is an External
 condition, which #23 user story 27 and ADR 0015 both require to keep its
 original class. *Evidence:* `test-summarize-operation.R` "summary tidyselect
-conditions retain their provenance" and `test-grouping-interface.R` "Grouping
-tidyselect conditions retain their provenance" assert
+conditions retain their class and cause" and `test-grouping-interface.R`
+"Grouping tidyselect conditions retain their class and cause" assert
 `expect_identical(class(error), class(baseline))`.
 
 **`abort_dbplyr_representation()` should have stayed an internal assertion**

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -77,13 +77,16 @@ marginplyr itself raises no warning: it states what it will not do by
 refusing. What a Margin verb does adjust, for an error and a warning alike,
 is the context reported around one, because a margin operation may summarize
 your expression once per grouping set. Such a condition reports its grouping
-values under the columns you named, and blames the Margin verb you wrote
-rather than the internal summary that ran it. A warning that every grouping
-set raises is reported once, saying how many further grouping sets raised
-it; warnings that differ from each other are reported one by one. A lazy
-input is outside this, and visibly so: its summary expressions run when you
-collect the result rather than while the verb runs, so what they raise is
-the collecting call's to report.
+values under the columns you named rather than under internal ones, and an
+error blames the Margin verb you wrote rather than the internal summary that
+ran it. A warning still names that internal summary, because the name is
+part of a sentence dplyr renders before marginplyr sees the warning at all.
+
+A warning that every grouping set raises is reported once, saying how many
+further grouping sets raised it; warnings that differ from each other are
+reported one by one. A lazy input is outside this, and visibly so: its
+summary expressions run when you collect the result rather than while the
+verb runs, so what they raise is the collecting call's to report.
 }
 
 \section{Guides}{

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -45,7 +45,7 @@ grand total.
 }
 }
 
-\section{Errors}{
+\section{Errors and warnings}{
 
 Every error marginplyr raises for a call you can correct inherits the
 \code{"marginplyr_error"} class, so one handler catches them all:
@@ -68,10 +68,22 @@ message text.
 
 Two kinds of error deliberately fall outside the class. Errors raised by
 your own summary expressions, by tidyselect, by dplyr, or by a database
-backend propagate with their original class and call intact. So do
-marginplyr's internal invariant checks, which report a defect no change to
-your call can avoid; please report those at
+backend propagate with their original class, diagnostic, and cause intact.
+So do marginplyr's internal invariant checks, which report a defect no
+change to your call can avoid; please report those at
 \url{https://github.com/sayuks/marginplyr/issues}.
+
+marginplyr itself raises no warning: it states what it will not do by
+refusing. What a Margin verb does adjust, for an error and a warning alike,
+is the context reported around one, because a margin operation may summarize
+your expression once per grouping set. Such a condition reports its grouping
+values under the columns you named, and blames the Margin verb you wrote
+rather than the internal summary that ran it. A warning that every grouping
+set raises is reported once, saying how many further grouping sets raised
+it; warnings that differ from each other are reported one by one. A lazy
+input is outside this, and visibly so: its summary expressions run when you
+collect the result rather than while the verb runs, so what they raise is
+the collecting call's to report.
 }
 
 \section{Guides}{

--- a/tests/testthat/_snaps/execution-conditions.md
+++ b/tests/testthat/_snaps/execution-conditions.md
@@ -1,0 +1,24 @@
+# the reported conditions read as they are written
+
+    Code
+      cat(conditionMessage(warnings[[1L]]))
+    Output
+      There were 3 warnings in `dplyr::summarize()`.
+      The first warning was:
+      i In argument: `total = sum(as.numeric(grade))`.
+      i In group 1: `region = "East"`, `grade = "a"`.
+      Caused by warning:
+      ! NAs introduced by coercion
+      i Run `dplyr::last_dplyr_warnings()` to see the 2 remaining warnings.
+      i 3 further grouping sets raised this warning.
+
+---
+
+    Code
+      cat(conditionMessage(error))
+    Output
+      i In argument: `x = stop("my error")`.
+      i In group 1: `g = "a"`.
+      Caused by error:
+      ! my error
+

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -74,6 +74,31 @@ test_that("branches raising different diagnostics are reported separately", {
   expect_false(any(grepl("further grouping set", messages, fixed = TRUE)))
 })
 
+# Asserted on the seam rather than through a verb, because neither case can be
+# produced through one: dplyr aggregates a branch's warnings into one condition
+# of its own before signalling, so the class it carries is always
+# `rlang_warning` and its message is never empty. The identity is stated over
+# the class as well as the diagnostic (CONTEXT.md, *Repeated condition*), and a
+# warning that reached this without dplyr's aggregation must get a cause rather
+# than an error -- replacing an External condition with one of marginplyr's own
+# is the one outcome the contract rules out.
+test_that("a warning's cause covers its class and admits an empty message", {
+  text <- "There was 1 warning in `dplyr::summarize()`.\n! NAs introduced"
+
+  expect_false(identical(
+    branch_warning_cause(rlang::warning_cnd("one_class", message = text)),
+    branch_warning_cause(rlang::warning_cnd("other_class", message = text))
+  ))
+  expect_identical(
+    branch_warning_cause(rlang::warning_cnd("one_class", message = text)),
+    branch_warning_cause(rlang::warning_cnd("one_class", message = text))
+  )
+  expect_type(
+    branch_warning_cause(rlang::warning_cnd("one_class", message = "")),
+    "character"
+  )
+})
+
 # #108's reproduction. An error aborts the first branch that raises it, so
 # there is nothing to deduplicate; what it needs is the context.
 test_that("a branch error reports the caller's column, group, and verb", {
@@ -186,8 +211,6 @@ test_that("a lazy input leaves its execution warnings to the caller", {
 })
 
 test_that("the reported conditions read as they are written", {
-  skip_on_cran()
-
   data <- data.frame(g = c("a", "b"), v = c(1, 2))
   warnings <- collect_warnings(summarize_with_margins(
     coercion_frame(),

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -10,6 +10,37 @@ coercion_frame <- function() {
   )
 }
 
+# The ticket's own reproduction: four grouping sets, each raising the same
+# coercion warning. Wrapped in a function so that the tests below share one
+# reading of it; the Margin verb is still the call each condition reports,
+# because a verb captures its own call rather than its caller's.
+summarize_coercion_cube <- function() {
+  # `region` and `grade` are columns of the frame, which codetools reads as
+  # undefined globals wherever a verb's arguments are written inside a
+  # function.
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    coercion_frame(),
+    total = sum(as.numeric(grade)),
+    .grouping = cube(region, grade)
+  )
+  # nolint end
+}
+
+# #108's reproduction: an error from the caller's own expression, which aborts
+# the first branch that raises it.
+summarize_failing_rollup <- function() {
+  # `g` is a column of the frame above it; see the note in
+  # `summarize_coercion_cube()`.
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    data.frame(g = c("a", "b"), v = c(1, 2)),
+    x = stop("my error"),
+    .grouping = rollup(g)
+  )
+  # nolint end
+}
+
 # Every warning a call raises, not just the first: the whole subject here is
 # how many times one condition reaches the caller, which `expect_warning()`
 # cannot report.
@@ -25,12 +56,16 @@ collect_warnings <- function(expr) {
   warnings
 }
 
+# `expr` is forced inside `collect_warnings()`, so it is rendered at the width
+# set here.
+collect_warnings_at_width <- function(width, expr) {
+  original <- options(cli.width = width)
+  on.exit(options(original), add = TRUE)
+  collect_warnings(expr)
+}
+
 test_that("a warning repeated across grouping sets is reported once", {
-  warnings <- collect_warnings(summarize_with_margins(
-    coercion_frame(),
-    total = sum(as.numeric(grade)),
-    .grouping = cube(region, grade)
-  ))
+  warnings <- collect_warnings(summarize_coercion_cube())
 
   expect_length(warnings, 1L)
   message <- conditionMessage(warnings[[1L]])
@@ -42,16 +77,31 @@ test_that("a warning repeated across grouping sets is reported once", {
 })
 
 test_that("a reported warning names the caller's own grouping columns", {
-  warnings <- collect_warnings(summarize_with_margins(
-    coercion_frame(),
-    total = sum(as.numeric(grade)),
-    .grouping = cube(region, grade)
-  ))
+  warnings <- collect_warnings(summarize_coercion_cube())
 
   message <- conditionMessage(warnings[[1L]])
   expect_match(message, "`region = \"East\"`", fixed = TRUE)
   expect_match(message, "`grade = \"a\"`", fixed = TRUE)
   expect_false(grepl("marginplyr_key", message, fixed = TRUE))
+})
+
+# cli wraps a bullet it cannot fit onto continuation lines, so how many lines a
+# warning message holds is a function of the console width and of how long the
+# grouping values are. Which grouping set raised a warning is no more part of
+# its identity when the bullet naming it wrapped: at 60 columns this reproduced
+# three reports of one condition, and at 40 it reproduced four.
+test_that("a repeated warning is one report at any console width", {
+  for (width in c(80L, 60L, 40L, 20L)) {
+    warnings <- collect_warnings_at_width(width, summarize_coercion_cube())
+
+    expect_length(warnings, 1L)
+    expect_match(
+      conditionMessage(warnings[[1L]]),
+      "3 further grouping sets",
+      fixed = TRUE,
+      info = paste("width", width)
+    )
+  }
 })
 
 # A test that only asserted collapsing would pass if everything collapsed, so
@@ -102,13 +152,7 @@ test_that("a warning's cause covers its class and admits an empty message", {
 # #108's reproduction. An error aborts the first branch that raises it, so
 # there is nothing to deduplicate; what it needs is the context.
 test_that("a branch error reports the caller's column, group, and verb", {
-  data <- data.frame(g = c("a", "b"), v = c(1, 2))
-
-  error <- expect_error(summarize_with_margins(
-    data,
-    x = stop("my error"),
-    .grouping = rollup(g)
-  ))
+  error <- expect_error(summarize_failing_rollup())
 
   message <- conditionMessage(error)
   expect_match(message, "In group 1: `g = \"a\"`", fixed = TRUE)
@@ -120,13 +164,7 @@ test_that("a branch error reports the caller's column, group, and verb", {
 })
 
 test_that("a propagated error keeps its class, diagnostic, and cause", {
-  data <- data.frame(g = c("a", "b"), v = c(1, 2))
-
-  error <- expect_error(summarize_with_margins(
-    data,
-    x = stop("my error"),
-    .grouping = rollup(g)
-  ))
+  error <- expect_error(summarize_failing_rollup())
 
   expect_s3_class(error, "rlang_error")
   expect_false(inherits(error, "marginplyr_error"))
@@ -156,7 +194,9 @@ test_that("ten grouping columns substitute without corrupting a name", {
     .grouping = grouping_sets(dplyr::all_of(columns))
   ))
 
-  message <- conditionMessage(error)
+  # Ten grouping values do not fit on one line at any ordinary width, and where
+  # cli wraps the bullet is not what this test is about.
+  message <- gsub("[[:space:]]+", " ", conditionMessage(error))
   expect_false(grepl("marginplyr_key", message, fixed = TRUE))
   for (column in columns) {
     expect_match(message, paste0("`", column, " = \"x\"`"), fixed = TRUE)

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -135,8 +135,8 @@ test_that("branches raising different diagnostics are reported separately", {
 
   messages <- vapply(warnings, conditionMessage, character(1))
   expect_length(warnings, 2L)
-  expect_true(any(grepl("whole table", messages, fixed = TRUE)))
-  expect_true(any(grepl("one region", messages, fixed = TRUE)))
+  expect_match(messages, "whole table", fixed = TRUE, all = FALSE)
+  expect_match(messages, "one region", fixed = TRUE, all = FALSE)
   expect_false(any(grepl("further grouping set", messages, fixed = TRUE)))
 })
 
@@ -186,6 +186,16 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
     collect_warnings(summarize_branch_diagnostics(
       "bad value\ni Run `dplyr::last_dplyr_warnings()` A",
       "bad value\ni Run `dplyr::last_dplyr_warnings()` B"
+    )),
+    2L
+  )
+  # An indented line of the caller's own is what a wrap looks like, so nothing
+  # may rejoin one: rewriting a line that is kept is what turns two diagnostics
+  # into one.
+  expect_length(
+    collect_warnings(summarize_branch_diagnostics(
+      "bad value\n  in data",
+      "bad value in data"
     )),
     2L
   )
@@ -329,11 +339,11 @@ test_that("a lazy input leaves its execution warnings to the caller", {
 
   collected <- collect_warnings(dplyr::collect(query))
   expect_gt(length(collected), 1L)
-  expect_true(all(vapply(
-    collected,
-    function(cnd) grepl("NAs introduced by coercion", conditionMessage(cnd)),
-    logical(1)
-  )))
+  expect_match(
+    vapply(collected, conditionMessage, character(1)),
+    "NAs introduced by coercion",
+    fixed = TRUE
+  )
 })
 
 test_that("the reported conditions read as they are written", {

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -37,6 +37,25 @@ summarize_failing_rollup <- function() {
   )
 }
 
+# One plan whose two grouping sets raise whatever the caller asks them to.
+# `dplyr::n()` is 3 only in the grouping set that groups by nothing, which
+# `rollup()` runs second, so `whole` is the later branch and `fail` makes it
+# abort the operation after the earlier one has already warned.
+summarize_branch_diagnostics <- function(whole, detail, fail = FALSE) {
+  summarize_with_margins(
+    coercion_frame(),
+    total = {
+      if (dplyr::n() == 3L) {
+        if (fail) stop("aborting branch") else warning(whole)
+      } else {
+        warning(detail)
+      }
+      0
+    },
+    .grouping = rollup(dplyr::all_of("region"))
+  )
+}
+
 # Every warning a call raises, not just the first: the whole subject here is
 # how many times one condition reaches the caller, which `expect_warning()`
 # cannot report.
@@ -109,13 +128,9 @@ test_that("a repeated warning is one report at any console width", {
 # the plan whose branches raise genuinely different diagnostics is asserted
 # beside it. `dplyr::n()` is 3 only in the grouping set that groups by nothing.
 test_that("branches raising different diagnostics are reported separately", {
-  warnings <- collect_warnings(summarize_with_margins(
-    coercion_frame(),
-    total = {
-      if (dplyr::n() == 3L) warning("whole table") else warning("one region")
-      0
-    },
-    .grouping = rollup(region)
+  warnings <- collect_warnings(summarize_branch_diagnostics(
+    "whole table",
+    "one region"
   ))
 
   messages <- vapply(warnings, conditionMessage, character(1))
@@ -123,6 +138,60 @@ test_that("branches raising different diagnostics are reported separately", {
   expect_true(any(grepl("whole table", messages, fixed = TRUE)))
   expect_true(any(grepl("one region", messages, fixed = TRUE)))
   expect_false(any(grepl("further grouping set", messages, fixed = TRUE)))
+})
+
+# What a grouping value or a caller diagnostic says is data, and none of it may
+# decide what gets removed from an identity. Each case below reproduced a
+# collapse or a split when the removal read a marker anywhere in the message
+# rather than at the start of a line: `Hawaii Region` carries `i `, and the
+# last pair are two diagnostics that differ only where a marker made the
+# difference invisible.
+test_that("a marker inside a value or a diagnostic decides nothing", {
+  regions <- c("Hawaii Region", "Hawaii Region", "West Region")
+  data <- coercion_frame()
+  data$region <- regions
+
+  expect_length(
+    collect_warnings(summarize_with_margins(
+      data,
+      total = sum(as.numeric(grade)),
+      .grouping = cube(region, grade)
+    )),
+    1L
+  )
+  expect_length(
+    collect_warnings(summarize_branch_diagnostics(
+      "i In group A is bad",
+      "i In group B is bad"
+    )),
+    2L
+  )
+  expect_length(
+    collect_warnings(summarize_branch_diagnostics(
+      "bad value\nin data",
+      "bad value in data"
+    )),
+    2L
+  )
+})
+
+# Withholding a warning and then leaving by a path that never replays it would
+# lose it outright, which is worse than the repetition this ticket is about.
+# `rollup()` runs the detail set before the Grand total set, so the warning is
+# raised and buffered before the error aborts the operation.
+test_that("a warning a branch raised survives a later branch's error", {
+  reported <- NULL
+  error <- expect_error(withCallingHandlers(
+    summarize_branch_diagnostics("unreached", "early warning", fail = TRUE),
+    warning = function(cnd) {
+      reported <<- c(reported, conditionMessage(cnd))
+      invokeRestart("muffleWarning")
+    }
+  ))
+
+  expect_match(conditionMessage(error), "aborting branch", fixed = TRUE)
+  expect_length(reported, 1L)
+  expect_match(reported[[1L]], "early warning", fixed = TRUE)
 })
 
 # Asserted on the seam rather than through a verb, because neither case can be
@@ -133,19 +202,19 @@ test_that("branches raising different diagnostics are reported separately", {
 # warning that reached this without dplyr's aggregation must get a cause rather
 # than an error -- replacing an External condition with one of marginplyr's own
 # is the one outcome the contract rules out.
-test_that("a warning's cause covers its class and admits an empty message", {
+test_that("a warning's identity covers its class and admits an empty message", {
   text <- "There was 1 warning in `dplyr::summarize()`.\n! NAs introduced"
 
   expect_false(identical(
-    branch_warning_cause(rlang::warning_cnd("one_class", message = text)),
-    branch_warning_cause(rlang::warning_cnd("other_class", message = text))
+    branch_warning_identity(rlang::warning_cnd("one_class", message = text)),
+    branch_warning_identity(rlang::warning_cnd("other_class", message = text))
   ))
   expect_identical(
-    branch_warning_cause(rlang::warning_cnd("one_class", message = text)),
-    branch_warning_cause(rlang::warning_cnd("one_class", message = text))
+    branch_warning_identity(rlang::warning_cnd("one_class", message = text)),
+    branch_warning_identity(rlang::warning_cnd("one_class", message = text))
   )
   expect_type(
-    branch_warning_cause(rlang::warning_cnd("one_class", message = "")),
+    branch_warning_identity(rlang::warning_cnd("one_class", message = "")),
     "character"
   )
 })

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -1,0 +1,209 @@
+# The reproduction #141 was filed with. `as.numeric(grade)` is an ordinary
+# coercion warning rather than anything marginplyr or dplyr raises, so what
+# these tests hold is the treatment of an External condition and not the
+# behaviour of one particular diagnostic.
+coercion_frame <- function() {
+  data.frame(
+    region = c("East", "East", "West"),
+    grade = c("a", "b", "a"),
+    units = c(1, 3, 6)
+  )
+}
+
+# Every warning a call raises, not just the first: the whole subject here is
+# how many times one condition reaches the caller, which `expect_warning()`
+# cannot report.
+collect_warnings <- function(expr) {
+  warnings <- list()
+  withCallingHandlers(
+    expr,
+    warning = function(cnd) {
+      warnings[[length(warnings) + 1L]] <<- cnd
+      invokeRestart("muffleWarning")
+    }
+  )
+  warnings
+}
+
+test_that("a warning repeated across grouping sets is reported once", {
+  warnings <- collect_warnings(summarize_with_margins(
+    coercion_frame(),
+    total = sum(as.numeric(grade)),
+    .grouping = cube(region, grade)
+  ))
+
+  expect_length(warnings, 1L)
+  message <- conditionMessage(warnings[[1L]])
+  expect_match(message, "NAs introduced by coercion", fixed = TRUE)
+  # Four grouping sets raise it, so three further ones follow the one reported.
+  expect_match(message, "3 further grouping sets", fixed = TRUE)
+  # The condition itself is the caller's to receive unchanged.
+  expect_s3_class(warnings[[1L]], "rlang_warning")
+})
+
+test_that("a reported warning names the caller's own grouping columns", {
+  warnings <- collect_warnings(summarize_with_margins(
+    coercion_frame(),
+    total = sum(as.numeric(grade)),
+    .grouping = cube(region, grade)
+  ))
+
+  message <- conditionMessage(warnings[[1L]])
+  expect_match(message, "`region = \"East\"`", fixed = TRUE)
+  expect_match(message, "`grade = \"a\"`", fixed = TRUE)
+  expect_false(grepl("marginplyr_key", message, fixed = TRUE))
+})
+
+# A test that only asserted collapsing would pass if everything collapsed, so
+# the plan whose branches raise genuinely different diagnostics is asserted
+# beside it. `dplyr::n()` is 3 only in the grouping set that groups by nothing.
+test_that("branches raising different diagnostics are reported separately", {
+  warnings <- collect_warnings(summarize_with_margins(
+    coercion_frame(),
+    total = {
+      if (dplyr::n() == 3L) warning("whole table") else warning("one region")
+      0
+    },
+    .grouping = rollup(region)
+  ))
+
+  messages <- vapply(warnings, conditionMessage, character(1))
+  expect_length(warnings, 2L)
+  expect_true(any(grepl("whole table", messages, fixed = TRUE)))
+  expect_true(any(grepl("one region", messages, fixed = TRUE)))
+  expect_false(any(grepl("further grouping set", messages, fixed = TRUE)))
+})
+
+# #108's reproduction. An error aborts the first branch that raises it, so
+# there is nothing to deduplicate; what it needs is the context.
+test_that("a branch error reports the caller's column, group, and verb", {
+  data <- data.frame(g = c("a", "b"), v = c(1, 2))
+
+  error <- expect_error(summarize_with_margins(
+    data,
+    x = stop("my error"),
+    .grouping = rollup(g)
+  ))
+
+  message <- conditionMessage(error)
+  expect_match(message, "In group 1: `g = \"a\"`", fixed = TRUE)
+  expect_false(grepl("marginplyr_key", message, fixed = TRUE))
+  expect_identical(
+    rlang::call_name(conditionCall(error)),
+    "summarize_with_margins"
+  )
+})
+
+test_that("a propagated error keeps its class, diagnostic, and cause", {
+  data <- data.frame(g = c("a", "b"), v = c(1, 2))
+
+  error <- expect_error(summarize_with_margins(
+    data,
+    x = stop("my error"),
+    .grouping = rollup(g)
+  ))
+
+  expect_s3_class(error, "rlang_error")
+  expect_false(inherits(error, "marginplyr_error"))
+  expect_s3_class(error$parent, "simpleError")
+  expect_identical(conditionMessage(error$parent), "my error")
+  expect_match(conditionMessage(error), "Caused by error", fixed = TRUE)
+})
+
+# The hazard a fixed `gsub()` per key carries: replacing `..marginplyr_key_1`
+# before `..marginplyr_key_10` leaves the caller's first column name followed
+# by a stray `0`. Ten dimensions in one grouping set is the cheapest plan that
+# allocates both tokens.
+test_that("ten grouping columns substitute without corrupting a name", {
+  columns <- c(
+    "region", "grade", "store", "channel", "segment",
+    "brand", "month", "city", "country", "tier"
+  )
+  data <- as.data.frame(lapply(
+    rlang::set_names(columns),
+    function(column) c("x", "y")
+  ))
+  data$value <- c(1, 2)
+
+  error <- expect_error(summarize_with_margins(
+    data,
+    x = stop("my error"),
+    .grouping = grouping_sets(dplyr::all_of(columns))
+  ))
+
+  message <- conditionMessage(error)
+  expect_false(grepl("marginplyr_key", message, fixed = TRUE))
+  for (column in columns) {
+    expect_match(message, paste0("`", column, " = \"x\"`"), fixed = TRUE)
+  }
+  # A naive replacement leaves `region0` where the tenth column belongs.
+  expect_false(grepl("region0", message, fixed = TRUE))
+})
+
+# What the verb rewrites is the Condition context dplyr built from marginplyr's
+# query. A Package condition carries its own context and is not an External
+# condition at all, so nothing here may reach it.
+test_that("a Package condition raised while branches run is untouched", {
+  error <- expect_error(summarize_with_margins(
+    coercion_frame(),
+    region = sum(units),
+    .grouping = rollup(region)
+  ))
+
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(
+    conditionMessage(error),
+    "Summary results cannot overwrite grouping column `region`."
+  )
+  expect_identical(
+    rlang::call_name(conditionCall(error)),
+    "summarize_with_margins"
+  )
+})
+
+# The non-goal, pinned so that a later reader does not read it as this bug
+# unfixed. A lazy input's branch `summarize()` builds a query without
+# evaluating the caller's expression, so the warning is raised inside the
+# caller's own `collect()` with no marginplyr frame on the stack to intercept
+# it -- and CONTEXT.md's *Repeated condition* says so: a verb answers only for
+# the occurrences raised while it runs.
+test_that("a lazy input leaves its execution warnings to the caller", {
+  skip_if_backend_absent("dtplyr")
+
+  query <- summarize_with_margins(
+    dtplyr::lazy_dt(coercion_frame()),
+    total = sum(as.numeric(grade)),
+    .grouping = cube(region, grade)
+  )
+
+  collected <- collect_warnings(dplyr::collect(query))
+  expect_true(length(collected) > 1L)
+  expect_true(all(vapply(
+    collected,
+    function(cnd) grepl("NAs introduced by coercion", conditionMessage(cnd)),
+    logical(1)
+  )))
+})
+
+test_that("the reported conditions read as they are written", {
+  skip_on_cran()
+
+  data <- data.frame(g = c("a", "b"), v = c(1, 2))
+  warnings <- collect_warnings(summarize_with_margins(
+    coercion_frame(),
+    total = sum(as.numeric(grade)),
+    .grouping = cube(region, grade)
+  ))
+  error <- expect_error(summarize_with_margins(
+    data,
+    x = stop("my error"),
+    .grouping = rollup(g)
+  ))
+
+  # Targeted snapshots: a structural assertion would not catch a dplyr
+  # formatting change, which is the whole reason the deduplication key is
+  # computed from rendered text. Regenerated whenever the wording is
+  # deliberately improved.
+  expect_snapshot(cat(conditionMessage(warnings[[1L]])))
+  expect_snapshot(cat(conditionMessage(error)))
+})

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -173,6 +173,22 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
     )),
     2L
   )
+  # cli renders the second line of a caller's diagnostic at column zero, where
+  # a marker on it is indistinguishable from one dplyr wrote.
+  expect_length(
+    collect_warnings(summarize_branch_diagnostics(
+      "bad value\ni In group A",
+      "bad value\ni In group B"
+    )),
+    2L
+  )
+  expect_length(
+    collect_warnings(summarize_branch_diagnostics(
+      "bad value\ni Run `dplyr::last_dplyr_warnings()` A",
+      "bad value\ni Run `dplyr::last_dplyr_warnings()` B"
+    )),
+    2L
+  )
 })
 
 # Withholding a warning and then leaving by a path that never replays it would

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -30,15 +30,11 @@ summarize_coercion_cube <- function() {
 # #108's reproduction: an error from the caller's own expression, which aborts
 # the first branch that raises it.
 summarize_failing_rollup <- function() {
-  # `g` is a column of the frame above it; see the note in
-  # `summarize_coercion_cube()`.
-  # nolint start: object_usage_linter.
   summarize_with_margins(
     data.frame(g = c("a", "b"), v = c(1, 2)),
     x = stop("my error"),
-    .grouping = rollup(g)
+    .grouping = rollup(dplyr::all_of("g"))
   )
-  # nolint end
 }
 
 # Every warning a call raises, not just the first: the whole subject here is
@@ -57,9 +53,13 @@ collect_warnings <- function(expr) {
 }
 
 # `expr` is forced inside `collect_warnings()`, so it is rendered at the width
-# set here.
+# set here. `cli.condition_width` is the one that has to be set: testthat's own
+# `local_reproducible_output()` sets it to `Inf` so that a snapshot does not
+# depend on the pane it was recorded in, and rlang consults it ahead of
+# `cli.width` -- so a test that set `cli.width` alone would render every case
+# unwrapped and pass whatever the code did.
 collect_warnings_at_width <- function(width, expr) {
-  original <- options(cli.width = width)
+  original <- options(cli.width = width, cli.condition_width = width)
   on.exit(options(original), add = TRUE)
   collect_warnings(expr)
 }
@@ -85,13 +85,14 @@ test_that("a reported warning names the caller's own grouping columns", {
   expect_false(grepl("marginplyr_key", message, fixed = TRUE))
 })
 
-# cli wraps a bullet it cannot fit onto continuation lines, so how many lines a
-# warning message holds is a function of the console width and of how long the
-# grouping values are. Which grouping set raised a warning is no more part of
-# its identity when the bullet naming it wrapped: at 60 columns this reproduced
-# three reports of one condition, and at 40 it reproduced four.
+# cli wraps a bullet it cannot fit, so how a warning message is laid out is a
+# function of the console width and of how long the grouping values are. Which
+# grouping set raised a warning is no more part of its identity when the bullet
+# naming it wrapped: this reproduction gave three reports of one condition at
+# 60 columns, four at 40, and two anywhere in 15 to 24, where dplyr's opening
+# sentence wraps and cli does not indent what it wraps it onto.
 test_that("a repeated warning is one report at any console width", {
-  for (width in c(80L, 60L, 40L, 20L)) {
+  for (width in c(80L, 60L, 40L, 20L, 16L)) {
     warnings <- collect_warnings_at_width(width, summarize_coercion_cube())
 
     expect_length(warnings, 1L)
@@ -242,7 +243,7 @@ test_that("a lazy input leaves its execution warnings to the caller", {
   )
 
   collected <- collect_warnings(dplyr::collect(query))
-  expect_true(length(collected) > 1L)
+  expect_gt(length(collected), 1L)
   expect_true(all(vapply(
     collected,
     function(cnd) grepl("NAs introduced by coercion", conditionMessage(cnd)),
@@ -251,17 +252,8 @@ test_that("a lazy input leaves its execution warnings to the caller", {
 })
 
 test_that("the reported conditions read as they are written", {
-  data <- data.frame(g = c("a", "b"), v = c(1, 2))
-  warnings <- collect_warnings(summarize_with_margins(
-    coercion_frame(),
-    total = sum(as.numeric(grade)),
-    .grouping = cube(region, grade)
-  ))
-  error <- expect_error(summarize_with_margins(
-    data,
-    x = stop("my error"),
-    .grouping = rollup(g)
-  ))
+  warnings <- collect_warnings(summarize_coercion_cube())
+  error <- expect_error(summarize_failing_rollup())
 
   # Targeted snapshots: a structural assertion would not catch a dplyr
   # formatting change, which is the whole reason the deduplication key is

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -143,7 +143,7 @@ test_that("Grouping plan errors use the package condition seam", {
   )
 })
 
-test_that("Grouping tidyselect conditions retain their provenance", {
+test_that("Grouping tidyselect conditions retain their class and cause", {
   data <- data.frame(a = c("x", "y"), value = 1:2)
   selection <- rlang::quo(unknown)
   baseline <- expect_error(

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -305,7 +305,7 @@ test_that("summary selection errors use the package condition seam", {
   }
 })
 
-test_that("summary tidyselect conditions retain their provenance", {
+test_that("summary tidyselect conditions retain their class and cause", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   baseline <- expect_error(
     tidyselect::eval_select(rlang::quo(unknown), data = data["value"])


### PR DESCRIPTION
Closes #141, which #108 was closed into.

A Margin verb runs one `dplyr::summarize()` per grouping set over columns it
renamed to `..marginplyr_key_N`, so a warning the caller's summary expression
raises arrived once per grouping set — `2^k` of them for a `cube()` of `k`
dimensions — and every context dplyr attached, to a warning and an error alike,
named columns and a call the caller never wrote.

## What is here

The first commit is the contract #141 was held open for, already on this
branch: `CONTEXT.md` gains **Condition context** and **Repeated condition**,
widens **External condition** to warnings, and ADR 0021 records the decision.
The rest implements it.

`summarize_margin_union()` wraps the branch `summarize()` alone, so the checks
and builders around it keep raising marginplyr's own conditions untouched.

- **Errors** get `$message`, `$body`, and `$call` restated — the caller's
  column names, and the Margin verb they wrote. `$parent` never moves. No
  deduplication, because branches run in sequence and the first error aborts.
- **Warnings** are withheld per branch, deduplicated, and re-signalled once
  with a count of the further grouping sets that raised it. dplyr hands over
  one pre-rendered string per branch, so the identity is the class plus that
  message with dplyr's own aggregation removed.
- Warnings are replayed from `on.exit()`, so a branch that warned before a
  later branch errored still reports it.

```r
data <- data.frame(
  region = c("East", "East", "West"),
  grade  = c("a", "b", "a"),
  units  = c(1, 3, 6)
)
summarize_with_margins(data, total = sum(as.numeric(grade)),
                       .grouping = cube(region, grade))
```

Before: four warnings, each reporting `..marginplyr_key_1 = "East"`. After: one,
reporting `region = "East"`, `grade = "a"` and `3 further grouping sets raised
this warning.`

## The part worth reviewing closely

The identity is derived from rendered text, which is what ADR 0021 has to
justify. It reads the message as the lines it was *written* as — each bullet
plus the continuations cli indents under it — matches dplyr's parts by where
they sit rather than by what they say, and removes only the rendered lines
those runs cover. Lines that are kept are never rewritten.

That shape is the end of eight review rounds, and each earlier one was a real
defect reproduced first:

- cli's wrapping made the console width decide whether a repeat was a repeat
  (three reports at 60 columns, four at 40, two at widths 15–24);
- collapsing whitespace fixed the width and let a marker inside the *data*
  decide instead — a region named `Hawaii Region` carries `i `;
- line-anchoring fixed that but not a caller diagnostic's own continuation
  lines, which cli renders at column zero exactly like a bullet.

Verified: one report at every width from 5 to 200 in both bullet spellings, two
for a plan whose branches genuinely differ, and two for each adversarial case
above. ADR 0021 bounds its own no-collapse claim to what dplyr *renders*, since
a branch raising several diagnostics has the rest hidden behind
`last_dplyr_warnings()` — those were never conditions the caller received,
before this change or after.

## Documentation this makes untrue

`?marginplyr` and `NEWS.md` said an External condition keeps its original class
*and call*. The blamed call is now the caller's verb, so both say class,
diagnostic, and cause, and both state what a verb does adjust. A warning still
names `dplyr::summarize()`, because that name is inside a sentence dplyr renders
before marginplyr sees the warning; that is recorded as a remainder rather than
claimed as fixed.

## Non-goals, pinned by tests or recorded

- The native grouping-sets adapter issues one `summarize()` and repeats nothing.
- A lazy input evaluates the caller's expression inside their own `collect()`,
  with no marginplyr frame to intercept — pinned by a dtplyr test.
- The argument bullet still quotes marginplyr's rewrite (#199).
- `message()` is left where it was; the ADR says why.

## Checks

`lintr::lint_package()` clean, full suite green (544 tests), `roxygen2` in step,
`.github/scripts/verify-suite-coverage.R` passes — all 544 tests execute in at
least one single-backend configuration.