### PR TITLE
Attach the Grouping set identifier without inventing a row

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,12 +132,19 @@
 * Attaching a Grouping set identifier to a `dtplyr` input with no columns no
   longer invents a row. Because a `data.table` reads its row count from its
   first column, giving a column-less one a column materialized exactly one
-  row, so every verb that adds an identifier reported a row no source row
-  produced: `expand_with_margins(.id = )`, both nesting verbs — which add one
-  internally whatever `.id` says — and any verb asked for a Margin order. A
-  column-less input that reaches the backend with the rows it had — one with
-  no rows either — now expands to the row count the local backend gives it,
-  and the lazy path stays lazy (#184).
+  row, and a verb whose result keeps that column reported it:
+  `expand_with_margins(.id = )`, and both nesting verbs, which add an
+  identifier internally whatever `.id` says. A column-less input that reaches
+  the backend with the rows it had — one with no rows either — now expands to
+  the row count the local backend gives it, and the lazy path stays lazy
+  (#184).
+* Documented the neighboring limit that has the same cause and no fix: a
+  `dtplyr` summary asked for no summaries and given no fixed key or grouping
+  dimension collects to zero rows where the same call on a local data frame
+  returns one, because its result is a single row holding no columns and a
+  `data.table` cannot represent one. It is what `dplyr::summarize()` answers
+  for that lazy input, and one summary, key, dimension, or `.id` in the result
+  ends the disagreement. See the details in `?summarize_with_margins`.
 * A `data.frame` subclass whose `[` is not column selection — a raw
   `data.table` is the case — now reaches every Margin verb that accepts local
   data frames. Factor levels and the prototypes behind an absent Margin label

--- a/NEWS.md
+++ b/NEWS.md
@@ -135,7 +135,8 @@
   row, so every verb that adds an identifier reported a row no source row
   produced: `expand_with_margins(.id = )`, both nesting verbs — which add one
   internally whatever `.id` says — and any verb asked for a Margin order. A
-  column-less input now expands to the row count the local backend gives it,
+  column-less input that reaches the backend with the rows it had — one with
+  no rows either — now expands to the row count the local backend gives it,
   and the lazy path stays lazy (#184).
 * A `data.frame` subclass whose `[` is not column selection — a raw
   `data.table` is the case — now reaches every Margin verb that accepts local

--- a/NEWS.md
+++ b/NEWS.md
@@ -136,15 +136,11 @@
   `expand_with_margins(.id = )`, and both nesting verbs, which add an
   identifier internally whatever `.id` says. A column-less input that reaches
   the backend with the rows it had — one with no rows either — now expands to
-  the row count the local backend gives it, and the lazy path stays lazy
-  (#184).
-* Documented the neighboring limit that has the same cause and no fix: a
-  `dtplyr` summary asked for no summaries and given no fixed key or grouping
-  dimension collects to zero rows where the same call on a local data frame
-  returns one, because its result is a single row holding no columns and a
-  `data.table` cannot represent one. It is what `dplyr::summarize()` answers
-  for that lazy input, and one summary, key, dimension, or `.id` in the result
-  ends the disagreement. See the details in `?summarize_with_margins`.
+  the row count the local backend gives it, and the lazy path stays lazy. The
+  neighboring limit with the same cause has no fix and is documented on
+  `summarize_with_margins()`: a summary asked for no summaries and given no
+  key has no column to be a row of, so `dtplyr` collects zero rows where a
+  local input returns one (#184).
 * A `data.frame` subclass whose `[` is not column selection — a raw
   `data.table` is the case — now reaches every Margin verb that accepts local
   data frames. Factor levels and the prototypes behind an absent Margin label

--- a/NEWS.md
+++ b/NEWS.md
@@ -123,10 +123,20 @@
 * A nesting that leaves no payload column now nests one inner row per source
   row, on detail groups, subtotals, and the Grand total set alike, as
   `dplyr::nest_by()` does, and local and `dtplyr` results agree once collected.
-  An input with no columns at all is outside that agreement, because a
-  `data.table` cannot represent one. The class of such a cell is described
-  rather than promised, as every nested element class is: on both backends it
-  is what `dplyr::tibble()` produced.
+  An input with rows and no columns is outside that agreement, and the limit is
+  on what reaches the backend rather than on nesting: a `data.table` reads its
+  row count from its first column, so `dtplyr::lazy_dt()` cannot carry those
+  rows in and nothing here can restore them. The class of such a cell is
+  described rather than promised, as every nested element class is: on both
+  backends it is what `dplyr::tibble()` produced.
+* Attaching a Grouping set identifier to a `dtplyr` input with no columns no
+  longer invents a row. Because a `data.table` reads its row count from its
+  first column, giving a column-less one a column materialized exactly one
+  row, so every verb that adds an identifier reported a row no source row
+  produced: `expand_with_margins(.id = )`, both nesting verbs — which add one
+  internally whatever `.id` says — and any verb asked for a Margin order. A
+  column-less input now expands to the row count the local backend gives it,
+  and the lazy path stays lazy (#184).
 * A `data.frame` subclass whose `[` is not column selection — a raw
   `data.table` is the case — now reaches every Margin verb that accepts local
   data frames. Factor levels and the prototypes behind an absent Margin label

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -137,7 +137,8 @@ execute_margin_expand <- function(operation) {
       plan = operation$plan,
       margin_labels = operation$margin_labels,
       column_info = operation$column_info,
-      set_id_name = set_id_name
+      set_id_name = set_id_name,
+      backend = operation$backend
     ),
     sort_id = sort_id
   )

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -137,8 +137,8 @@ execute_margin_expand <- function(operation) {
       plan = operation$plan,
       margin_labels = operation$margin_labels,
       column_info = operation$column_info,
-      set_id_name = set_id_name,
-      backend = operation$backend
+      backend = operation$backend,
+      set_id_name = set_id_name
     ),
     sort_id = sort_id
   )

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -104,8 +104,7 @@ summarize_margin_branch <- function(.data,
 add_grouping_set_id <- function(result,
                                 set_id_name,
                                 set_id,
-                                backend,
-                                stands_for_source_rows) {
+                                count_branch_rows) {
   if (is.null(set_id_name)) {
     return(result)
   }
@@ -117,8 +116,7 @@ add_grouping_set_id <- function(result,
   value <- set_id_expr(
     as.integer(set_id),
     result,
-    backend = backend,
-    stands_for_source_rows = stands_for_source_rows
+    count_branch_rows = count_branch_rows
   )
   dplyr::mutate(
     result,
@@ -135,23 +133,16 @@ add_grouping_set_id <- function(result,
 # there -- dtplyr translates `n()` to `.N`, which is zero for that table -- so
 # the identifier lands on as many rows as the branch has and no more.
 #
-# Which branch this is decides whether that row is fabricated at all, and it is
-# the reason the count is asked for rather than always taken. An expansion
-# branch holds one row per source row, so a column-less one standing for no
-# rows must stay empty. A summary branch holds one row per group, and a
-# column-less summary branch is reachable only with no keys and no summaries --
-# one group, the Grand total -- so the single row `mutate()` materialises there
-# is the row local dplyr returns for the same call, and counting would drop it.
+# `count_branch_rows` is what each call site knows and this cannot: whether a
+# row this attachment materialises would be a row the branch does not stand
+# for. Both sites spell it out, because the two answers come from different
+# facts rather than from one being the default.
 #
-# The other two conditions guard the count itself. A backend that recycles
-# correctly must keep the literal: `n()` in a `mutate()` renders a window
-# function on SQL, and on arrow it is an unsupported expression that warns and
-# pulls the data into R -- the collection ADR 0020 forbids. And a branch that
-# has columns keeps it too, since that is every ordinary branch, on dtplyr as
-# much as anywhere.
-set_id_expr <- function(set_id, result, backend, stands_for_source_rows) {
-  needs_count <- stands_for_source_rows &&
-    backend$invents_row_on_column_add &&
+# A branch that has columns keeps the literal whatever the site says, since
+# that is every ordinary branch, on dtplyr as much as anywhere: the count is
+# for the case the literal cannot express, not a second way of writing it.
+set_id_expr <- function(set_id, result, count_branch_rows) {
+  needs_count <- count_branch_rows &&
     length(get_col_names(result, dplyr::everything())) == 0L
 
   if (!needs_count) {
@@ -167,8 +158,7 @@ summarize_margin_union <- function(.data,
                                    column_info,
                                    reserved_names,
                                    set_id_name = NULL,
-                                   set_id_is_internal = FALSE,
-                                   backend = grouping_backend(.data)) {
+                                   set_id_is_internal = FALSE) {
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
     length(group_vars),
@@ -223,12 +213,19 @@ summarize_margin_union <- function(.data,
         factor_info = column_info$factors
       )
 
+      # A summary branch holds one row per group rather than one per source
+      # row, and a column-less summary branch is reachable only with no keys
+      # and no summaries: one group, the Grand total. The row `mutate()`
+      # materialises there while the identifier column lasts is that group's,
+      # so nothing is counted. What a `data.table` still cannot represent is
+      # the result once the column goes away again -- a one-row, zero-column
+      # table -- which is dtplyr's own answer to such a summary and not
+      # something this attachment decides.
       add_grouping_set_id(
         result,
         set_id_name,
         set_id,
-        backend = backend,
-        stands_for_source_rows = FALSE
+        count_branch_rows = FALSE
       )
     },
     plan$sets,
@@ -244,6 +241,12 @@ expand_margin_union <- function(.data,
                                 column_info,
                                 set_id_name = NULL,
                                 backend = grouping_backend(.data)) {
+  # An expansion branch is the input's own rows, so a column-less one standing
+  # for no rows has to stay empty, and only a backend that invents a row when
+  # given a column needs to be told so by counting. Read once rather than per
+  # branch, since the answer is the input's and a cube folds 2^n of them.
+  count_branch_rows <- backend$invents_row_on_column_add
+
   branches <- Map(
     function(grouping_set, set_id) {
       result <- label_margin_branch(
@@ -259,8 +262,7 @@ expand_margin_union <- function(.data,
         result,
         set_id_name,
         set_id,
-        backend = backend,
-        stands_for_source_rows = TRUE
+        count_branch_rows = count_branch_rows
       )
     },
     plan$sets,

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -101,29 +101,6 @@ summarize_margin_branch <- function(.data,
   )
 }
 
-add_grouping_set_id <- function(result,
-                                set_id_name,
-                                set_id,
-                                count_branch_rows) {
-  if (is.null(set_id_name)) {
-    return(result)
-  }
-  # Injected for the same reason as the factor methods: a bare `set_id` here
-  # resolves against the data mask first, so a grouping column of that name
-  # would number every row from its own values instead of the branch's
-  # grouping-set id. The `{set_id_name}` glue is evaluated in this environment
-  # rather than the mask, so only the value needs injecting.
-  value <- set_id_expr(
-    as.integer(set_id),
-    result,
-    count_branch_rows = count_branch_rows
-  )
-  dplyr::mutate(
-    result,
-    "{set_id_name}" := !!value
-  )
-}
-
 # A literal recycles to whatever the branch holds, which is the whole of the
 # attachment on a backend that can say how many rows a column-less branch has.
 # `data.table` cannot: it reads a table's row count from its first column, so
@@ -136,19 +113,30 @@ add_grouping_set_id <- function(result,
 # `count_branch_rows` is what each call site knows and this cannot: whether a
 # row this attachment materialises would be a row the branch does not stand
 # for. Both sites spell it out, because the two answers come from different
-# facts rather than from one being the default.
-#
-# A branch that has columns keeps the literal whatever the site says, since
-# that is every ordinary branch, on dtplyr as much as anywhere: the count is
-# for the case the literal cannot express, not a second way of writing it.
-set_id_expr <- function(set_id, result, count_branch_rows) {
-  needs_count <- count_branch_rows &&
-    length(get_col_names(result, dplyr::everything())) == 0L
-
-  if (!needs_count) {
-    return(set_id)
+# facts rather than from one being the default, and each is a property of the
+# input rather than of a branch, so each is settled once per call.
+add_grouping_set_id <- function(result,
+                                set_id_name,
+                                set_id,
+                                count_branch_rows) {
+  if (is.null(set_id_name)) {
+    return(result)
   }
-  rlang::expr(rep(!!set_id, dplyr::n()))
+  set_id <- as.integer(set_id)
+  value <- if (count_branch_rows) {
+    rlang::expr(rep(!!set_id, dplyr::n()))
+  } else {
+    set_id
+  }
+  # Injected for the same reason as the factor methods: a bare `set_id` here
+  # resolves against the data mask first, so a grouping column of that name
+  # would number every row from its own values instead of the branch's
+  # grouping-set id. The `{set_id_name}` glue is evaluated in this environment
+  # rather than the mask, so only the value needs injecting.
+  dplyr::mutate(
+    result,
+    "{set_id_name}" := !!value
+  )
 }
 
 summarize_margin_union <- function(.data,
@@ -243,9 +231,12 @@ expand_margin_union <- function(.data,
                                 backend = grouping_backend(.data)) {
   # An expansion branch is the input's own rows, so a column-less one standing
   # for no rows has to stay empty, and only a backend that invents a row when
-  # given a column needs to be told so by counting. Read once rather than per
-  # branch, since the answer is the input's and a cube folds 2^n of them.
-  count_branch_rows <- backend$invents_row_on_column_add
+  # given a column needs to be told so by counting. Both halves are read from
+  # the input once rather than from each branch: labelling adds a column only
+  # for a dimension, and a column-less input has none, so every branch of one
+  # is column-less too -- and a cube folds 2^n of them.
+  count_branch_rows <- backend$invents_row_on_column_add &&
+    length(get_col_names(.data, dplyr::everything())) == 0L
 
   branches <- Map(
     function(grouping_set, set_id) {

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -223,12 +223,15 @@ summarize_margin_union <- function(.data,
   combine_margin_branches(branches)
 }
 
+# `backend` is the operation's own, and it sits among the required arguments
+# rather than after the optional one so that no positional call can reach a
+# different arrangement than the two callers write.
 expand_margin_union <- function(.data,
                                 plan,
                                 margin_labels,
                                 column_info,
-                                set_id_name = NULL,
-                                backend) {
+                                backend,
+                                set_id_name = NULL) {
   # An expansion branch is the input's own rows, so a column-less one standing
   # for no rows has to stay empty, and only a backend that invents a row when
   # given a column needs to be told so by counting. Both halves are read from

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -102,11 +102,10 @@ summarize_margin_branch <- function(.data,
 }
 
 # A literal recycles to whatever the branch holds, which is the whole of the
-# attachment on a backend that can say how many rows a column-less branch has.
-# `data.table` cannot: it reads a table's row count from its first column, so
-# giving a zero-column table a column materialises one row, and every
-# expansion branch of a zero-column `dtplyr` input used to arrive carrying a
-# row no source row produced (#184). Counting is what the literal cannot do
+# attachment wherever a column-less branch has a row count to recycle to. The
+# `invents_row_on_column_add` capability in `R/grouping-backend.R` is where a
+# backend says it has none, and every branch of such an input arrived carrying
+# a row no source row produced (#184). Counting is what the literal cannot do
 # there -- dtplyr translates `n()` to `.N`, which is zero for that table -- so
 # the identifier lands on as many rows as the branch has and no more.
 #
@@ -207,8 +206,9 @@ summarize_margin_union <- function(.data,
       # materialises there while the identifier column lasts is that group's,
       # so nothing is counted. What a `data.table` still cannot represent is
       # the result once the column goes away again -- a one-row, zero-column
-      # table -- which is dtplyr's own answer to such a summary and not
-      # something this attachment decides.
+      # table -- which is dtplyr's own answer to such a summary rather than
+      # something this attachment decides, and is documented as a limit on
+      # `summarize_with_margins()` where a caller meets it.
       add_grouping_set_id(
         result,
         set_id_name,
@@ -228,7 +228,7 @@ expand_margin_union <- function(.data,
                                 margin_labels,
                                 column_info,
                                 set_id_name = NULL,
-                                backend = grouping_backend(.data)) {
+                                backend) {
   # An expansion branch is the input's own rows, so a column-less one standing
   # for no rows has to stay empty, and only a backend that invents a row when
   # given a column needs to be told so by counting. Both halves are read from

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -101,7 +101,11 @@ summarize_margin_branch <- function(.data,
   )
 }
 
-add_grouping_set_id <- function(result, set_id_name, set_id) {
+add_grouping_set_id <- function(result,
+                                set_id_name,
+                                set_id,
+                                backend,
+                                stands_for_source_rows) {
   if (is.null(set_id_name)) {
     return(result)
   }
@@ -110,10 +114,50 @@ add_grouping_set_id <- function(result, set_id_name, set_id) {
   # would number every row from its own values instead of the branch's
   # grouping-set id. The `{set_id_name}` glue is evaluated in this environment
   # rather than the mask, so only the value needs injecting.
+  value <- set_id_expr(
+    as.integer(set_id),
+    result,
+    backend = backend,
+    stands_for_source_rows = stands_for_source_rows
+  )
   dplyr::mutate(
     result,
-    "{set_id_name}" := !!as.integer(set_id)
+    "{set_id_name}" := !!value
   )
+}
+
+# A literal recycles to whatever the branch holds, which is the whole of the
+# attachment on a backend that can say how many rows a column-less branch has.
+# `data.table` cannot: it reads a table's row count from its first column, so
+# giving a zero-column table a column materialises one row, and every
+# expansion branch of a zero-column `dtplyr` input used to arrive carrying a
+# row no source row produced (#184). Counting is what the literal cannot do
+# there -- dtplyr translates `n()` to `.N`, which is zero for that table -- so
+# the identifier lands on as many rows as the branch has and no more.
+#
+# Which branch this is decides whether that row is fabricated at all, and it is
+# the reason the count is asked for rather than always taken. An expansion
+# branch holds one row per source row, so a column-less one standing for no
+# rows must stay empty. A summary branch holds one row per group, and a
+# column-less summary branch is reachable only with no keys and no summaries --
+# one group, the Grand total -- so the single row `mutate()` materialises there
+# is the row local dplyr returns for the same call, and counting would drop it.
+#
+# The other two conditions guard the count itself. A backend that recycles
+# correctly must keep the literal: `n()` in a `mutate()` renders a window
+# function on SQL, and on arrow it is an unsupported expression that warns and
+# pulls the data into R -- the collection ADR 0020 forbids. And a branch that
+# has columns keeps it too, since that is every ordinary branch, on dtplyr as
+# much as anywhere.
+set_id_expr <- function(set_id, result, backend, stands_for_source_rows) {
+  needs_count <- stands_for_source_rows &&
+    backend$invents_row_on_column_add &&
+    length(get_col_names(result, dplyr::everything())) == 0L
+
+  if (!needs_count) {
+    return(set_id)
+  }
+  rlang::expr(rep(!!set_id, dplyr::n()))
 }
 
 summarize_margin_union <- function(.data,
@@ -123,7 +167,8 @@ summarize_margin_union <- function(.data,
                                    column_info,
                                    reserved_names,
                                    set_id_name = NULL,
-                                   set_id_is_internal = FALSE) {
+                                   set_id_is_internal = FALSE,
+                                   backend = grouping_backend(.data)) {
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
     length(group_vars),
@@ -178,7 +223,13 @@ summarize_margin_union <- function(.data,
         factor_info = column_info$factors
       )
 
-      add_grouping_set_id(result, set_id_name, set_id)
+      add_grouping_set_id(
+        result,
+        set_id_name,
+        set_id,
+        backend = backend,
+        stands_for_source_rows = FALSE
+      )
     },
     plan$sets,
     plan$set_ids
@@ -191,7 +242,8 @@ expand_margin_union <- function(.data,
                                 plan,
                                 margin_labels,
                                 column_info,
-                                set_id_name = NULL) {
+                                set_id_name = NULL,
+                                backend = grouping_backend(.data)) {
   branches <- Map(
     function(grouping_set, set_id) {
       result <- label_margin_branch(
@@ -203,7 +255,13 @@ expand_margin_union <- function(.data,
         factor_info = column_info$factors
       )
 
-      add_grouping_set_id(result, set_id_name, set_id)
+      add_grouping_set_id(
+        result,
+        set_id_name,
+        set_id,
+        backend = backend,
+        stands_for_source_rows = TRUE
+      )
     },
     plan$sets,
     plan$set_ids

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -54,7 +54,8 @@ backend_capabilities <- function(kind) {
     "can_encode_factor_missing_values",
     "native_grouping_sets",
     "native_duplicate_sets",
-    "records_window_order"
+    "records_window_order",
+    "invents_row_on_column_add"
   )
   enabled <- list(
     local = c(
@@ -66,7 +67,16 @@ backend_capabilities <- function(kind) {
       "collect_selection_proxy",
       "can_read_schema",
       "can_restore_factors",
-      "can_encode_factor_missing_values"
+      "can_encode_factor_missing_values",
+      # `data.table` reads a table's row count from its first column, so a
+      # column-less one is always empty; the consequence in the other
+      # direction is what this names -- giving a zero-column table a column
+      # materialises exactly one row (#184). No other kind does that: a local
+      # frame holds rows without columns natively, an arrow table gives a
+      # column-less one a column and stays empty, and a SQL table with no
+      # columns cannot be constructed at all. `other` is granted nothing, so
+      # an unrecognised backend keeps the ordinary attachment.
+      "invents_row_on_column_add"
     ),
     arrow = "can_read_schema",
     duckdb = c(

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -316,8 +316,8 @@ execute_margin_nest <- function(operation, .key, .keep) {
         plan = plan,
         margin_labels = operation$margin_labels,
         column_info = operation$column_info,
-        set_id_name = set_col,
-        backend = operation$backend
+        backend = operation$backend,
+        set_id_name = set_col
       )
 
       # Nesting always expands through the portable adapter and already carries

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -71,8 +71,10 @@
 #' rather than anything nesting does: a data frame with rows and no columns
 #' loses its rows on the way in, so `dtplyr::lazy_dt(data.frame(row.names =
 #' 1:3))` is already empty before marginplyr reads it and no behavior here can
-#' restore the three rows. Nest an input that has no columns at all locally
-#' when its row count matters.
+#' restore the three rows. Nest an input that has rows and no columns locally
+#' when its row count matters. This is the whole of the difference: a
+#' column-less input that reaches the backend with the rows it had -- one with
+#' no rows either -- nests to the same result on both backends.
 #'
 #' No input column name is reserved for internal bookkeeping. Temporary
 #' grouping-set and `.keep` columns are generated collision-free and removed
@@ -314,7 +316,8 @@ execute_margin_nest <- function(operation, .key, .keep) {
         plan = plan,
         margin_labels = operation$margin_labels,
         column_info = operation$column_info,
-        set_id_name = set_col
+        set_id_name = set_col,
+        backend = operation$backend
       )
 
       # Nesting always expands through the portable adapter and already carries

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -918,8 +918,7 @@ stage_margin_summaries <- function(operation,
           column_info = operation$column_info,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
-          set_id_is_internal = set_id_is_internal,
-          backend = operation$backend
+          set_id_is_internal = set_id_is_internal
         )
       }
     },

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -98,17 +98,13 @@
 #' following [dplyr::summarize()] and [dplyr::summarise()].
 #'
 #' One result a `dtplyr` input cannot carry back is a summary with no columns
-#' in it. Asked for no summaries and given no fixed key or grouping dimension,
-#' the answer is the Grand total set's single row holding nothing, and a
-#' `data.table` cannot represent that -- `dim()` reads its row count from its
-#' first column, so a column-less one is always empty. Such a call collects to
-#' zero rows where the same call on a local data frame returns one, whatever
-#' columns the input itself had. It is what [dplyr::summarize()] answers for
-#' that lazy input rather than anything marginplyr decides, and no behavior
-#' here can restore the row, so summarize locally when it matters. Anything
-#' that puts a column in the result -- one summary, one fixed key, one
-#' grouping dimension, or `.id` -- brings the two backends back into
-#' agreement.
+#' in it: asked for no summaries and given no fixed key or grouping dimension,
+#' the answer is one row holding nothing, whatever the input held, and a
+#' `data.table` reads its row count from its first column. Such a call
+#' collects to zero rows where a local data frame returns one, as
+#' [dplyr::summarize()] itself does for that lazy input. Anything that puts a
+#' column in the result -- one summary, one fixed key, one grouping dimension,
+#' or `.id` -- ends the difference.
 #'
 #' @section Fixed columns and grouping dimensions:
 #' `.by` marks columns that are present in every grouping set, while

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -918,7 +918,8 @@ stage_margin_summaries <- function(operation,
           column_info = operation$column_info,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
-          set_id_is_internal = set_id_is_internal
+          set_id_is_internal = set_id_is_internal,
+          backend = operation$backend
         )
       }
     },

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -97,6 +97,19 @@
 #' [summarize_with_margins()] and [summarise_with_margins()] are synonyms,
 #' following [dplyr::summarize()] and [dplyr::summarise()].
 #'
+#' One result a `dtplyr` input cannot carry back is a summary with no columns
+#' in it. Asked for no summaries and given no fixed key or grouping dimension,
+#' the answer is the Grand total set's single row holding nothing, and a
+#' `data.table` cannot represent that -- `dim()` reads its row count from its
+#' first column, so a column-less one is always empty. Such a call collects to
+#' zero rows where the same call on a local data frame returns one, whatever
+#' columns the input itself had. It is what [dplyr::summarize()] answers for
+#' that lazy input rather than anything marginplyr decides, and no behavior
+#' here can restore the row, so summarize locally when it matters. Anything
+#' that puts a column in the result -- one summary, one fixed key, one
+#' grouping dimension, or `.id` -- brings the two backends back into
+#' agreement.
+#'
 #' @section Fixed columns and grouping dimensions:
 #' `.by` marks columns that are present in every grouping set, while
 #' `.grouping` describes dimensions that can be omitted to form margins.

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -434,8 +434,10 @@ columns at all.
 That last point is also a limit on what an input can carry into \code{dtplyr},
 rather than anything nesting does: a data frame with rows and no columns
 loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
-restore the three rows. Nest an input that has no columns at all locally
-when its row count matters.
+restore the three rows. Nest an input that has rows and no columns locally
+when its row count matters. This is the whole of the difference: a
+column-less input that reaches the backend with the rows it had -- one with
+no rows either -- nests to the same result on both backends.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -151,8 +151,10 @@ columns at all.
 That last point is also a limit on what an input can carry into \code{dtplyr},
 rather than anything nesting does: a data frame with rows and no columns
 loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
-restore the three rows. Nest an input that has no columns at all locally
-when its row count matters.
+restore the three rows. Nest an input that has rows and no columns locally
+when its row count matters. This is the whole of the difference: a
+column-less input that reaches the backend with the rows it had -- one with
+no rows either -- nests to the same result on both backends.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -144,17 +144,13 @@ backends use a portable \verb{UNION ALL} adapter with the same semantics.
 following \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[dplyr:summarise]{dplyr::summarise()}}.
 
 One result a \code{dtplyr} input cannot carry back is a summary with no columns
-in it. Asked for no summaries and given no fixed key or grouping dimension,
-the answer is the Grand total set's single row holding nothing, and a
-\code{data.table} cannot represent that -- \code{dim()} reads its row count from its
-first column, so a column-less one is always empty. Such a call collects to
-zero rows where the same call on a local data frame returns one, whatever
-columns the input itself had. It is what \code{\link[dplyr:summarize]{dplyr::summarize()}} answers for
-that lazy input rather than anything marginplyr decides, and no behavior
-here can restore the row, so summarize locally when it matters. Anything
-that puts a column in the result -- one summary, one fixed key, one
-grouping dimension, or \code{.id} -- brings the two backends back into
-agreement.
+in it: asked for no summaries and given no fixed key or grouping dimension,
+the answer is one row holding nothing, whatever the input held, and a
+\code{data.table} reads its row count from its first column. Such a call
+collects to zero rows where a local data frame returns one, as
+\code{\link[dplyr:summarize]{dplyr::summarize()}} itself does for that lazy input. Anything that puts a
+column in the result -- one summary, one fixed key, one grouping dimension,
+or \code{.id} -- ends the difference.
 }
 \section{Fixed columns and grouping dimensions}{
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -142,6 +142,19 @@ Confirmed SQL backends use one \verb{GROUP BY GROUPING SETS} query. Other lazy
 backends use a portable \verb{UNION ALL} adapter with the same semantics.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} and \code{\link[=summarise_with_margins]{summarise_with_margins()}} are synonyms,
 following \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[dplyr:summarise]{dplyr::summarise()}}.
+
+One result a \code{dtplyr} input cannot carry back is a summary with no columns
+in it. Asked for no summaries and given no fixed key or grouping dimension,
+the answer is the Grand total set's single row holding nothing, and a
+\code{data.table} cannot represent that -- \code{dim()} reads its row count from its
+first column, so a column-less one is always empty. Such a call collects to
+zero rows where the same call on a local data frame returns one, whatever
+columns the input itself had. It is what \code{\link[dplyr:summarize]{dplyr::summarize()}} answers for
+that lazy input rather than anything marginplyr decides, and no behavior
+here can restore the row, so summarize locally when it matters. Anything
+that puts a column in the result -- one summary, one fixed key, one
+grouping dimension, or \code{.id} -- brings the two backends back into
+agreement.
 }
 \section{Fixed columns and grouping dimensions}{
 

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -234,14 +234,16 @@ test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
   )
 
   # Nesting reaches the same attachment through an internal identifier, so it
-  # diverged with no `.id` in sight.
+  # diverged with no `.id` in sight. The whole collected result is compared, as
+  # above: the row count is what the defect changed, but the promise
+  # `nest_with_margins()` documents for a column-less input is the result.
   expect_identical(
-    nrow(dplyr::collect(nest_with_margins(dtplyr::lazy_dt(empty)))),
-    nrow(nest_with_margins(empty))
+    dplyr::collect(nest_with_margins(dtplyr::lazy_dt(empty))),
+    dplyr::as_tibble(nest_with_margins(empty))
   )
   expect_identical(
-    nrow(dplyr::collect(nest_with_margins(dtplyr::lazy_dt(empty), .id = "s"))),
-    nrow(nest_with_margins(empty, .id = "s"))
+    dplyr::collect(nest_with_margins(dtplyr::lazy_dt(empty), .id = "s")),
+    dplyr::as_tibble(nest_with_margins(empty, .id = "s"))
   )
 
   # `nest_by_with_margins()` keeps `dplyr::nest_by()`'s one row for an input
@@ -276,29 +278,47 @@ test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
 })
 
 # The neighbour of the case above, and the boundary it runs into rather than a
-# second instance of the defect. Asked for that same summary with no `.id`,
-# `dtplyr` has no column left to carry the Grand total row on, and a
-# one-row, zero-column `data.table` does not exist -- `dim()` reads the row
-# count from the first column. Nothing in the union adapter decides this: it is
-# what `dplyr::summarize()` already answers for the same lazy input, which is
-# what this compares against, so a dtplyr that gained the shape reports here.
+# second instance of the defect. Asked for no summaries and given no key,
+# `dtplyr` has no column to carry the Grand total row on, and a one-row,
+# zero-column `data.table` does not exist -- `dim()` reads the row count from
+# the first column. Nothing in the union adapter decides it: it is what
+# `dplyr::summarize()` already answers for the same lazy input, which is what
+# this compares against, so a dtplyr that gained the shape reports here.
+#
+# What the result holds decides this and not what the input held, which is why
+# a keyed frame is here beside the column-less one -- and why the limit is
+# documented on `summarize_with_margins()` rather than beside #184's
+# column-less input, whose other verbs now agree.
 test_that("a column-less dtplyr summary keeps dtplyr's own empty answer", {
   skip_if_backend_absent("dtplyr")
 
-  empty <- data.frame()
-  upstream <- dplyr::collect(dplyr::summarize(dtplyr::lazy_dt(empty)))
-  expect_identical(dim(upstream), c(0L, 0L))
+  for (input in list(data.frame(), data.frame(a = 1:3, g = c("x", "x", "y")))) {
+    upstream <- dplyr::collect(dplyr::summarize(dtplyr::lazy_dt(input)))
+    expect_identical(dim(upstream), c(0L, 0L))
+    expect_identical(
+      dim(dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(input)))),
+      dim(upstream)
+    )
+    # The local answer is `dplyr::summarize()`'s there too, and it is one row.
+    expect_identical(
+      dim(summarize_with_margins(input)),
+      dim(dplyr::summarize(input))
+    )
+    expect_identical(nrow(dplyr::summarize(input)), 1L)
+  }
 
+  # Anything that puts a column in the result ends the disagreement, which is
+  # the escape the documentation offers and the reason this stays a boundary
+  # rather than a defect.
+  keyed <- data.frame(a = 1:3, g = c("x", "x", "y"))
   expect_identical(
-    dim(dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(empty)))),
-    dim(upstream)
+    dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(keyed), .by = g)),
+    dplyr::as_tibble(summarize_with_margins(keyed, .by = g))
   )
-  # The local answer is `dplyr::summarize()`'s there too, and it is one row.
   expect_identical(
-    dim(summarize_with_margins(empty)),
-    dim(dplyr::summarize(empty))
+    dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(keyed), .id = "s")),
+    dplyr::as_tibble(summarize_with_margins(keyed, .id = "s"))
   )
-  expect_identical(nrow(dplyr::summarize(empty)), 1L)
 })
 
 # The count-preserving attachment is asked for only where a backend needs it,
@@ -315,7 +335,7 @@ test_that("a zero-column arrow input keeps the local row count", {
     .id = "s"
   )
 
-  expect_warning(result <- dplyr::collect(query), NA)
+  result <- expect_no_warning(dplyr::collect(query))
   expect_identical(
     result,
     dplyr::as_tibble(expand_with_margins(empty, .id = "s"))

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -275,6 +275,32 @@ test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
   )
 })
 
+# The neighbour of the case above, and the boundary it runs into rather than a
+# second instance of the defect. Asked for that same summary with no `.id`,
+# `dtplyr` has no column left to carry the Grand total row on, and a
+# one-row, zero-column `data.table` does not exist -- `dim()` reads the row
+# count from the first column. Nothing in the union adapter decides this: it is
+# what `dplyr::summarize()` already answers for the same lazy input, which is
+# what this compares against, so a dtplyr that gained the shape reports here.
+test_that("a column-less dtplyr summary keeps dtplyr's own empty answer", {
+  skip_if_backend_absent("dtplyr")
+
+  empty <- data.frame()
+  upstream <- dplyr::collect(dplyr::summarize(dtplyr::lazy_dt(empty)))
+  expect_identical(dim(upstream), c(0L, 0L))
+
+  expect_identical(
+    dim(dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(empty)))),
+    dim(upstream)
+  )
+  # The local answer is `dplyr::summarize()`'s there too, and it is one row.
+  expect_identical(
+    dim(summarize_with_margins(empty)),
+    dim(dplyr::summarize(empty))
+  )
+  expect_identical(nrow(dplyr::summarize(empty)), 1L)
+})
+
 # The count-preserving attachment is asked for only where a backend needs it,
 # because `n()` in a `mutate()` is a window function on SQL and an unsupported
 # expression on arrow, where it warns and pulls the data into R. Arrow is the

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -196,6 +196,106 @@ test_that("a union-path query is one flat `UNION ALL` over every branch", {
   expect_equal(remote_result, local_result)
 })
 
+# Attaching the Grouping set identifier is the one place a Margin verb adds a
+# column to the caller's own rows, and on `dtplyr` that used to invent a row
+# when the caller's table had no columns at all (#184): `data.table` reads a
+# table's row count from its first column, so a column-less one is always
+# empty, and giving it a column materialises exactly one row.
+#
+# Every verb is asserted against the local answer rather than against a row
+# count written here, because the defect was a disagreement between backends
+# and the local backend is the one that holds rows without columns natively.
+# Comparing to local also keeps this to one optional backend, as AGENTS.md
+# requires.
+test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
+  skip_if_backend_absent("dtplyr")
+
+  empty <- data.frame()
+  expect_identical(dim(empty), c(0L, 0L))
+
+  # The identifier is what the defect rode in on, so the verb that adds one and
+  # nothing else is where it is visible undisguised.
+  lazy_expanded <- expand_with_margins(dtplyr::lazy_dt(empty), .id = "s")
+  # The fix attaches the identifier to an unexecuted step, and collecting is
+  # still the caller's to ask for.
+  expect_s3_class(lazy_expanded, "dtplyr_step")
+  local_expanded <- expand_with_margins(empty, .id = "s")
+  expect_identical(nrow(local_expanded), 0L)
+  expect_identical(
+    dplyr::collect(lazy_expanded),
+    dplyr::as_tibble(local_expanded)
+  )
+
+  # Without `.id` no identifier column is added, so this half always agreed and
+  # is here to say the fix left it that way.
+  expect_identical(
+    nrow(dplyr::collect(expand_with_margins(dtplyr::lazy_dt(empty)))),
+    nrow(expand_with_margins(empty))
+  )
+
+  # Nesting reaches the same attachment through an internal identifier, so it
+  # diverged with no `.id` in sight.
+  expect_identical(
+    nrow(dplyr::collect(nest_with_margins(dtplyr::lazy_dt(empty)))),
+    nrow(nest_with_margins(empty))
+  )
+  expect_identical(
+    nrow(dplyr::collect(nest_with_margins(dtplyr::lazy_dt(empty), .id = "s"))),
+    nrow(nest_with_margins(empty, .id = "s"))
+  )
+
+  # `nest_by_with_margins()` keeps `dplyr::nest_by()`'s one row for an input
+  # with no keys, so what the fabricated row showed there was the cell: a
+  # `1 x 0` payload standing for a source row that never existed.
+  lazy_by <- nest_by_with_margins(dtplyr::lazy_dt(empty))
+  local_by <- nest_by_with_margins(empty)
+  expect_identical(nrow(lazy_by), nrow(local_by))
+  expect_identical(dim(lazy_by$data[[1L]]), dim(local_by$data[[1L]]))
+  expect_identical(dim(local_by$data[[1L]]), c(0L, 0L))
+
+  # Summarizing agreed by coincidence -- a Grand total set of an empty input is
+  # legitimately one row -- and the count it reports is what says the row is
+  # the grouping set's rather than a fabricated one.
+  lazy_summary <- dplyr::collect(
+    summarize_with_margins(dtplyr::lazy_dt(empty), n = dplyr::n(), .id = "s")
+  )
+  expect_identical(
+    lazy_summary,
+    dplyr::as_tibble(summarize_with_margins(empty, n = dplyr::n(), .id = "s"))
+  )
+  expect_identical(lazy_summary$n, 0L)
+
+  # A summary branch with no summaries either is the one column-less branch
+  # whose row is not fabricated: with no keys and nothing to calculate it is
+  # the Grand total group, which local dplyr also answers with one row. Fixing
+  # the expansion by counting rows would have taken this row away.
+  expect_identical(
+    dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(empty), .id = "s")),
+    dplyr::as_tibble(summarize_with_margins(empty, .id = "s"))
+  )
+})
+
+# The count-preserving attachment is asked for only where a backend needs it,
+# because `n()` in a `mutate()` is a window function on SQL and an unsupported
+# expression on arrow, where it warns and pulls the data into R. Arrow is the
+# other lazy backend that can be handed a zero-column table at all, and it
+# already answered the local count.
+test_that("a zero-column arrow input keeps the local row count", {
+  skip_if_backend_absent("arrow")
+
+  empty <- data.frame()
+  query <- expand_with_margins(
+    arrow::as_arrow_table(empty),
+    .id = "s"
+  )
+
+  expect_warning(result <- dplyr::collect(query), NA)
+  expect_identical(
+    result,
+    dplyr::as_tibble(expand_with_margins(empty, .id = "s"))
+  )
+})
+
 # The third fold site: `build_lazy_parent_mapping()` unions one denominator
 # mapping per grouping set that has a coarser one. A Parent share needs a pure
 # `rollup()`, so that site never sees the branch counts the other two do -- it

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -492,12 +492,13 @@ test_that("zero-column and empty nesting match an independent construction", {
   # A frame with rows and no columns at all: every cell is a payload-free
   # cell, and `dplyr::nest_by()` is the upstream verb that answers it.
   #
-  # Local only, deliberately. A `dtplyr` input cannot reach this case as
-  # itself: `as.data.table()` cannot carry rows without columns, so
-  # `lazy_dt(rows_only)` is already empty, and a zero-column step then gains a
-  # row of its own when the Grouping set identifier is attached. That is the
-  # union adapter rather than nesting, it predates this behavior, and it is
-  # tracked in #184.
+  # Local only, deliberately, and for one reason rather than two now.
+  # `as.data.table()` cannot carry rows without columns, so `lazy_dt(rows_only)`
+  # is already empty before marginplyr reads it and no backend comparison here
+  # is available to make. The zero-column step that used to gain a row of its
+  # own when the Grouping set identifier was attached was the union adapter
+  # rather than nesting, and it is fixed (#184); `test-branch-union.R` is where
+  # the two backends are compared on the input that does reach both.
   rows_only <- data.frame(row.names = 1:3)
   expect_identical(dim(rows_only), c(3L, 0L))
 


### PR DESCRIPTION
Closes #184.

`data.table` reads a table's row count from its first column, so a column-less
one is always empty. The consequence in the other direction is the defect:
giving a zero-column table a column materialises exactly one row. The union
adapter attaches the Grouping set identifier with an ordinary `mutate()`, so
every expansion branch of a zero-column `dtplyr` input arrived carrying a row
no source row produced.

```r
e <- data.frame()  # 0 rows, 0 columns

nrow(expand_with_margins(e, .id = "s"))                                  #> 0
nrow(dplyr::collect(expand_with_margins(dtplyr::lazy_dt(e), .id = "s"))) #> 1  (now 0)
nrow(nest_with_margins(e))                                               #> 0
nrow(dplyr::collect(nest_with_margins(dtplyr::lazy_dt(e))))              #> 1  (now 0)
```

## What is here

`invents_row_on_column_add` is a new backend capability, granted to `dtplyr`
alone. Each of the other kinds was checked rather than reasoned about: arrow
gives a column-less table a column and stays empty, a raw `data.table` routed
as `local` goes through `dplyr_col_modify()` and does not invent a row, and a
zero-column SQL table cannot be constructed at all (duckdb: `Table must have at
least one column!`). `other` is granted nothing, so an unrecognised backend
keeps the attachment it has today.

Where the capability holds, an expansion branch attaches the identifier by
counting its own rows — `rep(id, n())`, which dtplyr translates to
`rep(1L, .N)`. The count is asked for nowhere else: `n()` in a `mutate()`
renders a window function on SQL, and on arrow it is an unsupported expression
that warns and pulls the data into R, which is the collection ADR 0020 forbids.

**A summary branch keeps the literal**, and this is the part that is easy to
get wrong — I did, first time round. A summary branch holds one row per group
rather than one per source row, and a column-less summary branch is reachable
only with no keys and no summaries: the Grand total group, whose single row
local dplyr also returns. Counting there deletes a legitimate row. Each call
site now states which shape it is; neither reads the other's fact.

## The part worth reviewing closely

One cell of the ticket's first acceptance criterion is **not** met, and cannot
be: `summarize_with_margins()` with no summaries and no `.id` gives 0 rows on
`dtplyr` against local's 1. It is pre-existing — `main` answers 0 too — and the
cause is on the result side rather than the input side: the required result is
one row with no columns, which no `data.table` can be. It is what
`dplyr::summarize()` itself answers for the same lazy input, and restoring the
row needs a `collect()` that ADR 0020 forbids and that would break the lazy
return contract besides.

It is documented on `?summarize_with_margins` where a caller meets it, and
pinned in `test-branch-union.R` against upstream's own answer, so a dtplyr that
ever gained the shape reports there. The reasoning and the decision this asks
for are on the ticket:
https://github.com/sayuks/marginplyr/issues/184#issuecomment-5307690706

Two smaller things a reviewer should know were corrected along the way:

- A NEWS claim of mine was false. A Margin order is *not* among the affected
  verbs: on `main`, `expand_with_margins(.sort = "last")` answered 0 rows for a
  column-less input, because the finalizer drops the internal identifier and the
  invented row goes with it. Only a result that keeps a column kept the row.
- #183's NEWS bullet and its `nest_with_margins()` paragraph both said an input
  with *no columns at all* was outside the local/`dtplyr` agreement. After this
  fix only an input with **rows** and no columns is — `lazy_dt()` still cannot
  carry those rows in — so both now carry the qualifier. That is a narrowing of
  a sentence this change made false, not the re-statement #184's triage ruled
  out.

## Verification

Full suite under `NOT_CRAN=true` (534 tests, no failures, no skips),
`lintr::lint_package()`, `spelling::spell_check_package()`,
`roxygen2::roxygenise()` (no drift), and
`.github/scripts/verify-suite-coverage.R` all pass. Each new test requires at
most one member of `optional_backends()` and compares against the **local**
result, per AGENTS.md.

Reviewed with three rounds of a two-axis (standards + spec) review; the fixes
each round asked for are the middle commits, and the last round found nothing.
