### PR TITLE
Read a forwarded name for the name it carries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,7 +140,11 @@ or around the whole call, because `(` is the identity function; a head that
 must be evaluated to know what it calls is not recognized at all. A caller
 binding of the same name never changes what a Margin verb does with it, and
 the rewritten call names the owning package so that what executes is what was
-analyzed. Every other name in a summary expression follows
+analyzed. An argument one reads as a bare name is resolved the same way —
+against the Grouping plan, or among the preceding summaries — so a name
+forwarded by injection is read for the name it carries and the environment
+carried with it is not consulted, there being no lookup for one to answer.
+Every other name in a summary expression follows
 ordinary lexical and data-mask lookup, including `dplyr::n()`. Grouping
 specification constructors are not Contextual helpers: their spelling decides
 only whether a nested argument is evaluated, and the caller's own function

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,8 +144,8 @@ analyzed. An argument one reads as a bare name is resolved the same way —
 against the Grouping plan, or among the preceding summaries — so a name
 forwarded by injection is read for the name it carries and the environment
 carried with it is not consulted, there being no lookup for one to answer.
-Every other name in a summary expression follows
-ordinary lexical and data-mask lookup, including `dplyr::n()`. Grouping
+Every other name in a summary expression follows ordinary lexical and data-mask
+lookup, including `dplyr::n()`. Grouping
 specification constructors are not Contextual helpers: their spelling decides
 only whether a nested argument is evaluated, and the caller's own function
 runs when it is. A diagnostic refusing one tells the caller their spelling is

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,9 @@
   among the preceding summaries, so the environment `rlang::enquo()` captured is
   not consulted, and an injection carrying anything else is refused exactly
   where writing that expression out would be — now saying what was injected
-  (#169).
+  (#169). Asking that question once also settles an empty argument the share
+  helpers had admitted: `share_of_total(x = )` reported an unknown preceding
+  summary named `` , and is now refused for not being a bare name.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level
   up, partitioned by the fixed `.by` keys. Local data frames, dbplyr, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@
   `grouping_sets(s, grade)` — rather than tidyselect reporting the
   specification as an unusable column selection.
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
+* A contextual helper taking a bare name accepts one forwarded by injection, so
+  a function of your own can pass `!!rlang::enquo(col)` where it previously had
+  to reach for `rlang::ensym(col)` and was otherwise told it had not written a
+  bare name. Only the name is read: it is resolved against the Grouping plan or
+  among the preceding summaries, so the environment `rlang::enquo()` captured is
+  not consulted, and an injection carrying anything else is refused exactly
+  where writing that expression out would be — now saying what was injected
+  (#169).
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level
   up, partitioned by the fixed `.by` keys. Local data frames, dbplyr, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@
   where writing that expression out would be — now saying what was injected
   (#169). Asking that question once also settles an empty argument the share
   helpers had admitted: `share_of_total(x = )` reported an unknown preceding
-  summary named `` , and is now refused for not being a bare name.
+  summary whose name was empty, and is now refused for not being a bare name.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level
   up, partitioned by the fixed `.by` keys. Local data frames, dbplyr, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,16 +13,6 @@
   `grouping_sets(s, grade)` — rather than tidyselect reporting the
   specification as an unusable column selection.
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
-* A contextual helper taking a bare name accepts one forwarded by injection, so
-  a function of your own can pass `!!rlang::enquo(col)` where it previously had
-  to reach for `rlang::ensym(col)` and was otherwise told it had not written a
-  bare name. Only the name is read: it is resolved against the Grouping plan or
-  among the preceding summaries, so the environment `rlang::enquo()` captured is
-  not consulted, and an injection carrying anything else is refused exactly
-  where writing that expression out would be — now saying what was injected
-  (#169). Asking that question once also settles an empty argument the share
-  helpers had admitted: `share_of_total(x = )` reported an unknown preceding
-  summary whose name was empty, and is now refused for not being a bare name.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level
   up, partitioned by the fixed `.by` keys. Local data frames, dbplyr, and
@@ -40,6 +30,13 @@
   denominator, so it accepts any Grouping specification whose plan contains a
   Grand total set — `rollup()`, `cube()`, and any `grouping_sets()` including
   an empty `grouping_set()`.
+* Each of those four contextual helpers takes a bare name, and accepts one
+  forwarded by injection: a function of your own can pass either
+  `!!rlang::enquo(col)` or `!!rlang::ensym(col)`. Only the name is read. It is
+  resolved against the Grouping plan or among the preceding summaries, so the
+  environment `rlang::enquo()` captured is not consulted, and an injection
+  carrying anything but a name is refused exactly where writing that expression
+  out would be, saying what was injected (#169).
 * Added `inspect_grouping()` for reading the resolved Grouping plan as an
   ordinary local tibble, without executing a Margin operation.
 * Added `.id` to every Margin verb for one-based Grouping set occurrence

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -235,12 +235,12 @@ grouping_helper_vars <- function(args, helper, plan) {
     abort_marginplyr(not_a_column_message)
   }
 
-  if (identical(helper, "grouping_bit") && length(args) != 1L) {
+  if (identical(helper, "grouping_bit") && length(carried) != 1L) {
     abort_marginplyr(
       "`grouping_bit()` requires exactly one column."
     )
   }
-  if (identical(helper, "grouping_id") && length(args) == 0L) {
+  if (identical(helper, "grouping_id") && length(carried) == 0L) {
     abort_marginplyr(
       "`grouping_id()` requires at least one column."
     )

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -218,7 +218,7 @@ grouping_helper_vars <- function(args, helper, plan) {
   # the wrapper (#169). Only the carried expression decides: a quosure carrying
   # a bare name is one, and a quosure carrying anything else gets exactly the
   # answer that expression gets written without the injection.
-  carried <- lapply(args, unwrap_injected_quosure)
+  carried <- unwrap_injected_args(args)
   not_a_column_message <- paste0(
     sprintf("`%s()` only accepts bare grouping columns.", helper),
     injected_quosure_clause(args)

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -214,10 +214,12 @@ grouping_helper_vars <- function(args, helper, plan) {
   #
   # An argument can also arrive as an injected quosure, which is what a
   # tidy-eval wrapper forwarding a bare column has to hand, so every question
-  # below is asked of what `unwrap_injected_quosure()` carries rather than of
-  # the wrapper (#169). Only the carried expression decides: a quosure carrying
-  # a bare name is one, and a quosure carrying anything else gets exactly the
-  # answer that expression gets written without the injection.
+  # below is asked of what `unwrap_injected_args()` carried out of them rather
+  # than of the wrappers (#169). Only the carried expression decides: a quosure
+  # carrying a bare name is one, and a quosure carrying anything else gets
+  # exactly the answer that expression gets written without the injection. The
+  # message reads the arguments as written, because whether one arrived injected
+  # is the fact the unwrapping discards.
   carried <- unwrap_injected_args(args)
   not_a_column_message <- paste0(
     sprintf("`%s()` only accepts bare grouping columns.", helper),

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -57,6 +57,14 @@
 #'
 #' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
 #'
+#' A function of your own may forward the column its caller wrote by injecting
+#' it: `!!rlang::enquo(col)` is accepted wherever a bare column is, and so is
+#' `!!rlang::ensym(col)`. Only the name is read. It is resolved against the
+#' Grouping plan, as every bare column here is, so the environment
+#' [rlang::enquo()] captured is not consulted and an injection carrying
+#' anything but a name is refused exactly where writing that expression out
+#' would be.
+#'
 #' @param x A bare grouping column.
 #' @param ... Bare grouping columns.
 #'
@@ -203,8 +211,17 @@ grouping_helper_vars <- function(args, helper, plan) {
   # missing from the plan, and `grouping_id(, )` named it a duplicate, because
   # both empty arguments read as the same name (#181). `is_name_part()` is the
   # question actually being asked: a symbol, and not the empty argument.
-  not_a_column_message <- sprintf(
-    "`%s()` only accepts bare grouping columns.", helper
+  #
+  # An argument can also arrive as an injected quosure, which is what a
+  # tidy-eval wrapper forwarding a bare column has to hand, so every question
+  # below is asked of what `unwrap_injected_quosure()` carries rather than of
+  # the wrapper (#169). Only the carried expression decides: a quosure carrying
+  # a bare name is one, and a quosure carrying anything else gets exactly the
+  # answer that expression gets written without the injection.
+  carried <- lapply(args, unwrap_injected_quosure)
+  not_a_column_message <- paste0(
+    sprintf("`%s()` only accepts bare grouping columns.", helper),
+    injected_quosure_clause(args)
   )
 
   # The empty argument is refused ahead of the arity checks so that the answer
@@ -214,7 +231,7 @@ grouping_helper_vars <- function(args, helper, plan) {
   # Nothing else moves: a non-column that is not empty -- `grouping_bit(1, 2)`
   # -- still reaches the arity diagnostic first, which is the one a caller
   # passing two of anything needs.
-  if (any(vapply(args, rlang::is_missing, logical(1)))) {
+  if (any(vapply(carried, rlang::is_missing, logical(1)))) {
     abort_marginplyr(not_a_column_message)
   }
 
@@ -235,11 +252,11 @@ grouping_helper_vars <- function(args, helper, plan) {
   # `is.symbol()` on the grounds that nothing empty survives the pre-check would
   # make the reordering above load-bearing for correctness rather than for which
   # diagnostic a caller reads.
-  if (!all(vapply(args, is_name_part, logical(1)))) {
+  if (!all(vapply(carried, is_name_part, logical(1)))) {
     abort_marginplyr(not_a_column_message)
   }
 
-  vars <- vapply(args, as.character, character(1))
+  vars <- vapply(carried, as.character, character(1))
   if (anyDuplicated(vars)) {
     abort_marginplyr(
       sprintf("`%s()` does not accept duplicate columns.", helper)

--- a/R/share.R
+++ b/R/share.R
@@ -1458,10 +1458,18 @@ validate_share_direct_syntax <- function(expr, output_name) {
   args <- static_call_args(expr)
   # Read through an injected quosure for the reason `unwrap_injected_quosure()`
   # gives, and asked with `is_name_part()` rather than `rlang::is_symbol()` so
-  # that the question here is the same question `grouping_helper_vars()` asks
-  # of a bare grouping column. One answer covers all four helpers, which is what
-  # #169 asks for; the empty argument the second half excludes cannot reach this
-  # arity anyway, since `f(, )` is two arguments to the parser.
+  # that the question here is the same question `grouping_helper_vars()` asks of
+  # a bare grouping column. One answer covers all four helpers, which is what
+  # #169 asks for.
+  #
+  # The second half of that question is not inert here, and the arity is what
+  # makes it reachable: `share_of_total(, )` is two arguments to the parser and
+  # is refused for the count, but `share_of_total(x = )` is *one* argument and
+  # it is empty. `rlang::is_symbol()` answered `TRUE` for it, because the empty
+  # argument is a symbol whose name is `""`, so the call was admitted and
+  # refused one layer on for an unknown preceding summary named `` -- a summary
+  # nobody wrote, which is #181's defect reached in the share family. That is a
+  # change to an un-injected spelling and is recorded as one in ADR 0019.
   carried <- lapply(args, unwrap_injected_quosure)
   if (length(carried) != 1L || !is_name_part(carried[[1L]])) {
     abort_marginplyr(

--- a/R/share.R
+++ b/R/share.R
@@ -1470,7 +1470,7 @@ validate_share_direct_syntax <- function(expr, output_name) {
   # refused one layer on for an unknown preceding summary named `` -- a summary
   # nobody wrote, which is #181's defect reached in the share family. That is a
   # change to an un-injected spelling and is recorded as one in ADR 0019.
-  carried <- lapply(args, unwrap_injected_quosure)
+  carried <- unwrap_injected_args(args)
   if (length(carried) != 1L || !is_name_part(carried[[1L]])) {
     abort_marginplyr(
       paste0(

--- a/R/share.R
+++ b/R/share.R
@@ -432,6 +432,14 @@
 #' do not share one portable finite-value predicate. Normalize potentially
 #' non-finite summaries explicitly with operations supported by the backend.
 #'
+#' A function of your own may forward the name its caller wrote by injecting
+#' it: `!!rlang::enquo(name)` is accepted wherever a bare name is, and so is
+#' `!!rlang::ensym(name)`. Only the name is read. It is resolved among the
+#' preceding summaries, as every bare name here is, so the environment
+#' [rlang::enquo()] captured is not consulted and an injection carrying
+#' anything but a name is refused exactly where writing that expression out
+#' would be.
+#'
 #' @param x The bare name of one preceding eligible ordinary summary.
 #'
 #' @return A double vector when used inside [summarize_with_margins()].
@@ -1448,16 +1456,24 @@ validate_share_direct_syntax <- function(expr, output_name) {
     )
   }
   args <- static_call_args(expr)
-  if (length(args) != 1L || !rlang::is_symbol(args[[1L]])) {
+  # Read through an injected quosure for the reason `unwrap_injected_quosure()`
+  # gives, and asked with `is_name_part()` rather than `rlang::is_symbol()` so
+  # that the question here is the same question `grouping_helper_vars()` asks
+  # of a bare grouping column. One answer covers all four helpers, which is what
+  # #169 asks for; the empty argument the second half excludes cannot reach this
+  # arity anyway, since `f(, )` is two arguments to the parser.
+  carried <- lapply(args, unwrap_injected_quosure)
+  if (length(carried) != 1L || !is_name_part(carried[[1L]])) {
     abort_marginplyr(
       paste0(
         "`", output_name, " = ", helper, "(...)` requires exactly one ",
         "bare name of a preceding ordinary summary. Define the scalar ",
-        "summary first, then pass its name directly to `", helper, "()`."
+        "summary first, then pass its name directly to `", helper, "()`.",
+        injected_quosure_clause(args)
       )
     )
   }
-  args
+  carried
 }
 
 plan_across_share <- function(expr,

--- a/R/utils.R
+++ b/R/utils.R
@@ -397,13 +397,14 @@ unwrap_injected_quosure <- function(part) {
 
 # The same reading over a whole argument list, which is how both validators of
 # a bare name use it -- `grouping_helper_vars()` for the two grouping helpers
-# and `validate_share_direct_syntax()` for the two share helpers. Named rather
-# than spelled `lapply()` at each site so
-# that it is a *reader* like `static_call_args()`, whose result the empty-
-# argument scans in `test-utils.R` recognize by the name that produced it. Spelt
-# out at the call sites, those scans would have to recognize a mapping by the
-# function being mapped -- a listed spelling inside a gate that otherwise
-# derives, and one that says nothing about a list built any other way.
+# and `validate_share_direct_syntax()` for the two share helpers.
+#
+# It is a named function rather than an `lapply()` spelled out at those two
+# sites, and that is load-bearing rather than tidiness: the empty-argument scans
+# in `test-utils.R` recognize a list of a call's parts by the reader that
+# produced it, so inlining this would put both callers outside the gate. Why a
+# mapping cannot be recognized in a reader's place is recorded there, beside the
+# scan that would have to do it.
 unwrap_injected_args <- function(args) {
   lapply(args, unwrap_injected_quosure)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -401,10 +401,21 @@ unwrap_injected_quosure <- function(part) {
 # the property #163 and #165 were each filed over. Naming the injection and
 # what it carries says which of the two spellings is being refused.
 #
-# It takes the whole argument list rather than one part, so it stays silent
-# when the refusal is about something else -- an arity, or an expression
-# written with no injection at all -- and names the first injected quosure that
-# is not a name when it is not.
+# It takes the whole argument list rather than one part, because the part that
+# arrived injected need not be the one a positional message would name. It says
+# nothing where no argument is an injected non-name, which is what keeps it out
+# of a refusal that has nothing to do with an injection.
+#
+# Which messages compose it is each caller's decision and not this function's,
+# and the two callers decide it differently on purpose. The share helper's
+# headline covers the arity and the name-ness together -- "exactly one bare
+# name" -- so a two-argument call carrying an injected non-name is described by
+# both halves and takes the clause. `grouping_bit()` counts columns in a message
+# of its own, deliberately reached before the non-column one (#181), and a
+# caller who passed two of anything needs that count rather than a remark about
+# one of them; so that message does not compose the clause and this cannot add
+# it. What is one answer across the four helpers is which injected forms are
+# accepted, not which diagnostic wins when a caller has made two mistakes.
 injected_quosure_clause <- function(parts) {
   injected <- vapply(
     parts,
@@ -418,18 +429,22 @@ injected_quosure_clause <- function(parts) {
   }
   paste0(
     " The injected quosure carries `",
-    static_part_label(unwrap_injected_quosure(parts[[which(injected)[[1L]]]])),
+    call_part_label(unwrap_injected_quosure(parts[[which(injected)[[1L]]]])),
     "`, which is not a bare name."
   )
 }
 
-# How an expression is written back into a diagnostic that refuses it for not
-# being a name. `rlang::as_label()` is the house spelling elsewhere and is the
-# wrong one here: it reads `.data$region` as `region`, so a message saying the
-# part is not a bare name would quote it as one. `deparse1()` gives back what
-# the caller wrote. The empty argument deparses to nothing at all, and is named
-# as rlang names it rather than as an empty pair of backticks.
-static_part_label <- function(part) {
+# How a call part is written back into a diagnostic that refuses it for not
+# being a name. Named for what it does rather than with the `static_` prefix the
+# readers above carry: those answer what a node *is*, and this one turns one
+# into text.
+#
+# `rlang::as_label()` is the house spelling elsewhere and is the wrong one here:
+# it reads `.data$region` as `region`, so a message saying the part is not a
+# bare name would quote it as one. `deparse1()` gives back what the caller
+# wrote. The empty argument deparses to nothing at all, and is named as rlang
+# names it rather than as an empty pair of backticks.
+call_part_label <- function(part) {
   if (rlang::is_missing(part)) {
     return("<empty>")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -395,8 +395,10 @@ unwrap_injected_quosure <- function(part) {
   unwrap_injected_quosure(rlang::quo_get_expr(part))
 }
 
-# The same reading over a whole argument list, which is how both helpers that
-# take a bare name use it. Named rather than spelled `lapply()` at each site so
+# The same reading over a whole argument list, which is how both validators of
+# a bare name use it -- `grouping_helper_vars()` for the two grouping helpers
+# and `validate_share_direct_syntax()` for the two share helpers. Named rather
+# than spelled `lapply()` at each site so
 # that it is a *reader* like `static_call_args()`, whose result the empty-
 # argument scans in `test-utils.R` recognize by the name that produced it. Spelt
 # out at the call sites, those scans would have to recognize a mapping by the

--- a/R/utils.R
+++ b/R/utils.R
@@ -395,6 +395,17 @@ unwrap_injected_quosure <- function(part) {
   unwrap_injected_quosure(rlang::quo_get_expr(part))
 }
 
+# The same reading over a whole argument list, which is how both helpers that
+# take a bare name use it. Named rather than spelled `lapply()` at each site so
+# that it is a *reader* like `static_call_args()`, whose result the empty-
+# argument scans in `test-utils.R` recognize by the name that produced it. Spelt
+# out at the call sites, those scans would have to recognize a mapping by the
+# function being mapped -- a listed spelling inside a gate that otherwise
+# derives, and one that says nothing about a list built any other way.
+unwrap_injected_args <- function(args) {
+  lapply(args, unwrap_injected_quosure)
+}
+
 # What a diagnostic adds when the part it refuses arrived by injection. The
 # caller wrote a bare name at their own call, so a message that says only what
 # the written spellings say describes a mistake they have not made, which is
@@ -405,6 +416,13 @@ unwrap_injected_quosure <- function(part) {
 # arrived injected need not be the one a positional message would name. It says
 # nothing where no argument is an injected non-name, which is what keeps it out
 # of a refusal that has nothing to do with an injection.
+#
+# And it takes the arguments as they were written rather than what
+# `unwrap_injected_args()` carried out of them, which is the one thing its
+# callers cannot pass instead: whether a part arrived injected is exactly the
+# fact the unwrapping discards, and it is the fact this reports. Unwrapping the
+# one part it names a second time is the price of that, over an argument list
+# whose length a caller typed.
 #
 # Which messages compose it is each caller's decision and not this function's,
 # and the two callers decide it differently on purpose. The share helper's

--- a/R/utils.R
+++ b/R/utils.R
@@ -363,6 +363,79 @@ is_name_part <- function(part) {
   !rlang::is_missing(part) && rlang::is_symbol(part)
 }
 
+# What an injected quosure carries, and the part itself where there is none.
+# `rlang::enquo()` is what the tidy-eval idiom hands the author of a wrapper, so
+# `!!rlang::enquo(col)` is the ordinary spelling for forwarding the bare column
+# that wrapper's own caller wrote. A quosure is not a symbol, so a helper
+# reading a bare name refused one while telling the caller they had not written
+# a bare name -- which they had, one call further out (#169). Read through this
+# before asking what a part is, and the injected spelling gets the answer the
+# written one gets, rather than a second answer of its own.
+#
+# The recursion is not defensive: a quosure can carry another, and one level of
+# unwrapping would hand the test back the shape it was written to see through.
+# It is written as a recursion rather than as a `while` loop for the reason
+# `static_call_args()` gives above: the loop form assigns the carried expression
+# to a name, so a quosure carrying the empty argument raised base R's untyped
+# `missingArgError` naming this function's own parameter. Handed on as an
+# argument the same value forces without error, and returned it stays a value.
+#
+# What this does not carry across is the environment, and that is the decision
+# rather than a limitation. A Contextual helper's argument is resolved against
+# the Grouping plan by spelling and is never looked up in an environment
+# (ADR 0019), so there is no lookup for a quosure's environment to answer. That
+# is the opposite of the answer #165 reached one layer out, where a walk keeps a
+# quosure's environment because a selection inside it really is evaluated there,
+# and both follow the one rule: the environment is honoured wherever evaluation
+# happens, and these arguments are never evaluated.
+unwrap_injected_quosure <- function(part) {
+  if (!rlang::is_quosure(part)) {
+    return(part)
+  }
+  unwrap_injected_quosure(rlang::quo_get_expr(part))
+}
+
+# What a diagnostic adds when the part it refuses arrived by injection. The
+# caller wrote a bare name at their own call, so a message that says only what
+# the written spellings say describes a mistake they have not made, which is
+# the property #163 and #165 were each filed over. Naming the injection and
+# what it carries says which of the two spellings is being refused.
+#
+# It takes the whole argument list rather than one part, so it stays silent
+# when the refusal is about something else -- an arity, or an expression
+# written with no injection at all -- and names the first injected quosure that
+# is not a name when it is not.
+injected_quosure_clause <- function(parts) {
+  injected <- vapply(
+    parts,
+    function(part) {
+      rlang::is_quosure(part) && !is_name_part(unwrap_injected_quosure(part))
+    },
+    logical(1)
+  )
+  if (!any(injected)) {
+    return("")
+  }
+  paste0(
+    " The injected quosure carries `",
+    static_part_label(unwrap_injected_quosure(parts[[which(injected)[[1L]]]])),
+    "`, which is not a bare name."
+  )
+}
+
+# How an expression is written back into a diagnostic that refuses it for not
+# being a name. `rlang::as_label()` is the house spelling elsewhere and is the
+# wrong one here: it reads `.data$region` as `region`, so a message saying the
+# part is not a bare name would quote it as one. `deparse1()` gives back what
+# the caller wrote. The empty argument deparses to nothing at all, and is named
+# as rlang names it rather than as an empty pair of backticks.
+static_part_label <- function(part) {
+  if (rlang::is_missing(part)) {
+    return("<empty>")
+  }
+  deparse1(part)
+}
+
 # `head` defaults to the head the node already has, which is what every walk
 # wants: a rewrite of a call's arguments is not a rewrite of what it calls.
 # Passing one is how a recognized spelling is written back qualified

--- a/R/utils.R
+++ b/R/utils.R
@@ -408,11 +408,14 @@ unwrap_injected_args <- function(args) {
   lapply(args, unwrap_injected_quosure)
 }
 
-# What a diagnostic adds when the part it refuses arrived by injection. The
-# caller wrote a bare name at their own call, so a message that says only what
-# the written spellings say describes a mistake they have not made, which is
-# the property #163 and #165 were each filed over. Naming the injection and
-# what it carries says which of the two spellings is being refused.
+# What a diagnostic adds when the part it refuses arrived by injection. What is
+# refused here really is not a bare name -- the case where it is one is accepted
+# above and reaches no diagnostic at all -- so the headline is accurate and the
+# clause is not there to correct it. It is there because the expression the
+# headline is about does not appear at the call the caller is reading: the
+# source says `grouping_id(!!q)`, and nothing in `only accepts bare grouping
+# columns` says what `q` turned out to hold. The written spellings need no such
+# clause, because there the refused expression is on the page (#169).
 #
 # It takes the whole argument list rather than one part, because the part that
 # arrived injected need not be the one a positional message would name. It says

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -505,13 +505,10 @@ reached by a different route.
 
 `unwrap_injected_args()` is a named reader over a whole argument list rather
 than an `lapply()` spelled out at each call site, and that is what keeps the
-same hazard's gate derived. The scans in `test-utils.R` recognize a list of call
-parts by the reader that produced it; a mapping written at the call sites would
-have to be recognized by the function being mapped instead, and
-`grouping_helper_vars()` is handed its arguments as a parameter, so nothing in
-its body says the list it maps over is a call's arguments at all — the walk with
-#181's own history would have sat outside the gate. Adding a reader to that list
-is how the package says a list of parts came from somewhere new.
+same hazard's gate derived: the scans in `test-utils.R` recognize a list of call
+parts by the reader that produced it, so adding a reader to that list is how
+this package says a list of parts came from somewhere new. Why a mapping cannot
+be recognized in a reader's place is recorded beside that scan.
 
 `injected_quosure_clause()` reads the arguments as written rather than what the
 unwrapping carried out of them, because whether a part arrived injected is

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -551,9 +551,10 @@ would leave the four helpers asking two different questions to preserve it.
 **Test strategy.** The four helpers are derived from `static_spelling_rules()`
 as the registered spellings marginplyr owns *and* declares Contextual, so a
 fifth owned Contextual helper fails the coverage assertion rather than
-inheriting an answer nobody decided. Both halves of that criterion do work: the
-dplyr-owned families take selections, and the constructors are owned but not
-Contextual. Each helper's probe is a function from the argument to the whole
+inheriting an answer nobody decided. Both halves of that criterion do work:
+none of the dplyr-owned families reads a bare name — a selection, a predicate
+function, and nothing at all, across the three — and the constructors are owned
+but not Contextual. Each helper's probe is a function from the argument to the whole
 call, since the argument is the only thing that varies, and the refused shapes
 are derived from the bare name that helper takes rather than written out. The
 acceptance case injects a quosure built on the *empty* environment, so it

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -523,6 +523,10 @@ a better-worded refusal; no result changes into a different result.
 `DESCRIPTION`'s `Config/marginplyr/cran-status` reads `unpublished`, so no
 released version carried the old behaviour.
 
+Two are the rule and the diagnostic above: an injected quosure carrying a bare
+name is now accepted where all four helpers refused it, and one carrying
+anything else is refused with a clause naming the injection.
+
 The third is not about injection, and it is recorded here because it is a
 change to an un-injected spelling, which #169 fenced off as out of scope.
 Asking the name question once meant asking it with `is_name_part()` in the

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -482,19 +482,52 @@ the carried expression with `deparse1()` rather than with `rlang::as_label()`,
 the house spelling elsewhere: `as_label()` reads `.data$region` as `region`, so
 a message saying the part is not a bare name would quote it as one.
 
-**Where the reading lives.** `unwrap_injected_quosure()` and
-`injected_quosure_clause()` sit in `R/utils.R` beside `is_name_part()` and
-`static_call_args()`, which is where the shared readers of a call's parts
-already are, so the four helpers ask one question rather than four. The
-unwrapping is a recursion and not a `while` loop, because the loop form assigns
-the carried expression to a name and a quosure carrying the empty argument then
-raises base R's untyped `missingArgError` — the #168 hazard `static_call_args()`
-already documents, reached by a different route.
+**Where the reading lives.** `unwrap_injected_quosure()`,
+`injected_quosure_clause()`, and `call_part_label()` sit in `R/utils.R` beside
+`is_name_part()` and `static_call_args()`, which is where the shared readers of
+a call's parts already are, so the four helpers ask one question rather than
+four. The unwrapping is a recursion and not a `while` loop, because the loop
+form assigns the carried expression to a name and a quosure carrying the empty
+argument then raises base R's untyped `missingArgError` — the #168 hazard
+`static_call_args()` already documents, reached by a different route. The scan
+in `test-utils.R` that enforces that hazard is extended to follow a list built
+elementwise from a call's arguments, which is what both helpers now read
+through.
 
-**Recorded behaviour change.** Two, both a refusal becoming an acceptance or a
-better-worded refusal; no result changes into a different result.
+**The clause is composed by the message, not by the argument.** A caller can
+make two mistakes at once, and which diagnostic wins is each helper's own
+decision rather than the clause's. The share helpers' headline covers the arity
+and the name-ness together — "exactly one bare name" — so a two-argument call
+carrying an injected non-name takes the clause. `grouping_bit()` counts columns
+in a message of its own, reached before the non-column one deliberately (#181),
+because a caller who passed two of anything needs the count rather than a
+remark about one of them; that message does not compose the clause. What #169
+requires to be one answer across the four helpers is *which injected forms are
+accepted*, and that is one answer.
+
+**Recorded behaviour change.** Three, each a refusal becoming an acceptance or
+a better-worded refusal; no result changes into a different result.
 `DESCRIPTION`'s `Config/marginplyr/cran-status` reads `unpublished`, so no
 released version carried the old behaviour.
+
+The third is not about injection, and it is recorded here because it is a
+change to an un-injected spelling, which #169 fenced off as out of scope.
+Asking the name question once meant asking it with `is_name_part()` in the
+share helpers too, where it had been `rlang::is_symbol()`. That is not
+behaviour-neutral: the empty argument is a symbol whose name is `""`, and
+`share_of_total(x = )` is *one* argument and empty, so it was admitted and
+refused one layer on as
+
+```
+Total share `k` refers to unknown preceding ordinary summary ``.
+```
+
+which names a summary nobody wrote — #181's defect, in the family that ticket
+did not reach. It is now the share helpers' own "exactly one bare name"
+refusal. Restoring `rlang::is_symbol()` on that branch was the alternative and
+was rejected: it would reinstate a diagnostic describing input the caller did
+not write, which is the property this whole amendment exists to remove, and it
+would leave the four helpers asking two different questions to preserve it.
 
 **Test strategy.** The four helpers are derived from `static_spelling_rules()`
 as the registered spellings marginplyr owns *and* declares Contextual, so a
@@ -508,3 +541,7 @@ acceptance case injects a quosure built on the *empty* environment, so it
 asserts the environment answer in the same expectation as the acceptance one,
 and the refusal case asserts message equality with the written spelling plus
 the clause, which is what stops the injected form reporting a different fault.
+A caller's two mistakes at once are a case of their own, since which message
+wins is a per-helper decision that no equality above would notice changing, and
+so is the named empty argument, which is the only writing that reaches the
+un-injected change recorded above.

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -478,6 +478,15 @@ accepts, and a clause is added naming the injection and what it carries:
 carries `.data$region`, which is not a bare name.
 ```
 
+What the clause is for is not correcting the headline, which is accurate here —
+what it refuses really is not a bare name, the case where it is one having been
+accepted above. It is that the expression the headline is about is not on the
+page the caller is reading: the source says `grouping_id(!!q)`, and nothing in
+`only accepts bare grouping columns` says what `q` turned out to hold. The
+written spellings need no clause because there the refused expression is
+written out. The reader who *did* write a bare name is answered by the rule
+rather than by any message, since their call now works.
+
 The clause is absent from a refusal that has nothing to do with an injection,
 which is what stops it describing a mistake in the other direction. It writes
 the carried expression with `deparse1()` rather than with `rlang::as_label()`,

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -414,9 +414,11 @@ The decision above fixes how a Contextual helper's *spelling* is resolved and
 says nothing about the arguments it reads. #169 is that question, asked of the
 four helpers marginplyr owns, each of which takes a bare name —
 `grouping_bit()` and `grouping_id()` a grouping column, `share_of_parent()` and
-`share_of_total()` a preceding ordinary summary. All four tested for one with
-`rlang::is_symbol()`, and a quosure carrying a bare symbol is not a symbol, so
-each refused the standard tidy-eval wrapper:
+`share_of_total()` a preceding ordinary summary. All four asked whether the
+argument was a symbol — the grouping helpers through `is_name_part()`, which
+#181 had already given them, and the share helpers through
+`rlang::is_symbol()` — and a quosure carrying a bare symbol is not one, so each
+refused the standard tidy-eval wrapper:
 
 ```r
 level_by <- function(data, col) {

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -492,7 +492,10 @@ argument then raises base R's untyped `missingArgError` — the #168 hazard
 `static_call_args()` already documents, reached by a different route. The scan
 in `test-utils.R` that enforces that hazard is extended to follow a list built
 elementwise from a call's arguments, which is what both helpers now read
-through.
+through — and it recognizes such a list by the *unwrapper being mapped* as well
+as by the source list, because `grouping_helper_vars()` is handed its arguments
+as a parameter and nothing in its body says where they came from. Matching only
+the source would have left the walk with #181's history outside the gate.
 
 **The clause is composed by the message, not by the argument.** A caller can
 make two mistakes at once, and which diagnostic wins is each helper's own

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -407,3 +407,104 @@ foreign-qualifier writings are asserted to *differ*, which is what stops the
 agreement being two calls that both fail the same way, and the unresolvable
 heads are asserted unrecognized so that the boundary is a case rather than a
 sentence.
+
+## Amendment: an injected name is read for the name it carries
+
+The decision above fixes how a Contextual helper's *spelling* is resolved and
+says nothing about the arguments it reads. #169 is that question, asked of the
+four helpers marginplyr owns, each of which takes a bare name —
+`grouping_bit()` and `grouping_id()` a grouping column, `share_of_parent()` and
+`share_of_total()` a preceding ordinary summary. All four tested for one with
+`rlang::is_symbol()`, and a quosure carrying a bare symbol is not a symbol, so
+each refused the standard tidy-eval wrapper:
+
+```r
+level_by <- function(data, col) {
+  q <- rlang::enquo(col)
+  summarize_with_margins(
+    data,
+    level = grouping_id(!!q),
+    .grouping = rollup(region)
+  )
+}
+level_by(d, region)
+#> Error: `grouping_id()` only accepts bare grouping columns.
+```
+
+The caller did write a bare grouping column, one call further out. That is the
+property #163 and #165 were each filed over: a diagnostic describing the
+caller's input incorrectly. There was a workaround — `!!rlang::ensym(col)`
+injects a symbol and has always worked — which is why the severity was low, and
+nothing in the message said so.
+
+**The rule.** An argument read as a bare name is read through an injected
+quosure, however many deep, and only what it carries decides the answer. A
+quosure carrying a bare name *is* one. A quosure carrying anything else —
+`.data$region`, a string, a call, the empty argument — is refused exactly where
+that expression is refused when it is written out, and by the same diagnostic.
+
+It is one rule for all four helpers, and it mirrors the un-injected spelling
+rather than adding a second grammar for the injected one. Accepting a string
+under injection was the alternative, and was rejected for that reason: it would
+make `share_of_total("t")` a refusal and `share_of_total(!!rlang::quo("t"))` an
+acceptance, which is a difference no caller can be told the reason for.
+
+**The environment is discarded, and that follows from the decision above rather
+than sitting beside it.** A Contextual helper's argument is resolved against
+the Grouping plan, or among the preceding summaries, *by spelling* — never
+looked up in an environment — so there is no lookup for a quosure's environment
+to answer. Consulting it is not declined here; it is not possible, and the
+statement is what stops that reading like an omission.
+
+That is the opposite of the answer #165 reached one layer out, where a walk
+keeps a quosure's environment because a selection inside it really is evaluated
+there, and the two are one rule seen from two sides: **the environment is
+honoured wherever evaluation happens, and these arguments are never
+evaluated.** A caller who injects a quosure built where `region` is bound to
+something else gets the column `region`, exactly as writing `grouping_id(region)`
+does. The Grouping specification constructors are the case that shows the rule
+is about the criterion and not about ownership: they are marginplyr's too, and
+they are not Contextual helpers, so their nested arguments *are* evaluated and
+the caller's environment decides.
+
+**The diagnostic changes for every form that stays refused.** The headline is
+unchanged, because it is still the right thing to say about what the helper
+accepts, and a clause is added naming the injection and what it carries:
+
+```
+`grouping_id()` only accepts bare grouping columns. The injected quosure
+carries `.data$region`, which is not a bare name.
+```
+
+The clause is absent from a refusal that has nothing to do with an injection,
+which is what stops it describing a mistake in the other direction. It writes
+the carried expression with `deparse1()` rather than with `rlang::as_label()`,
+the house spelling elsewhere: `as_label()` reads `.data$region` as `region`, so
+a message saying the part is not a bare name would quote it as one.
+
+**Where the reading lives.** `unwrap_injected_quosure()` and
+`injected_quosure_clause()` sit in `R/utils.R` beside `is_name_part()` and
+`static_call_args()`, which is where the shared readers of a call's parts
+already are, so the four helpers ask one question rather than four. The
+unwrapping is a recursion and not a `while` loop, because the loop form assigns
+the carried expression to a name and a quosure carrying the empty argument then
+raises base R's untyped `missingArgError` — the #168 hazard `static_call_args()`
+already documents, reached by a different route.
+
+**Recorded behaviour change.** Two, both a refusal becoming an acceptance or a
+better-worded refusal; no result changes into a different result.
+`DESCRIPTION`'s `Config/marginplyr/cran-status` reads `unpublished`, so no
+released version carried the old behaviour.
+
+**Test strategy.** The four helpers are derived from `static_spelling_rules()`
+as the registered spellings marginplyr owns *and* declares Contextual, so a
+fifth owned Contextual helper fails the coverage assertion rather than
+inheriting an answer nobody decided. Both halves of that criterion do work: the
+dplyr-owned families take selections, and the constructors are owned but not
+Contextual. Each helper's probe is a function from the argument to the whole
+call, since the argument is the only thing that varies, and the refused shapes
+are derived from the bare name that helper takes rather than written out. The
+acceptance case injects a quosure built on the *empty* environment, so it
+asserts the environment answer in the same expectation as the acceptance one,
+and the refusal case asserts message equality with the written spelling plus
+the clause, which is what stops the injected form reporting a different fault.

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -483,19 +483,29 @@ the house spelling elsewhere: `as_label()` reads `.data$region` as `region`, so
 a message saying the part is not a bare name would quote it as one.
 
 **Where the reading lives.** `unwrap_injected_quosure()`,
-`injected_quosure_clause()`, and `call_part_label()` sit in `R/utils.R` beside
-`is_name_part()` and `static_call_args()`, which is where the shared readers of
-a call's parts already are, so the four helpers ask one question rather than
-four. The unwrapping is a recursion and not a `while` loop, because the loop
-form assigns the carried expression to a name and a quosure carrying the empty
-argument then raises base R's untyped `missingArgError` — the #168 hazard
-`static_call_args()` already documents, reached by a different route. The scan
-in `test-utils.R` that enforces that hazard is extended to follow a list built
-elementwise from a call's arguments, which is what both helpers now read
-through — and it recognizes such a list by the *unwrapper being mapped* as well
-as by the source list, because `grouping_helper_vars()` is handed its arguments
-as a parameter and nothing in its body says where they came from. Matching only
-the source would have left the walk with #181's history outside the gate.
+`unwrap_injected_args()`, `injected_quosure_clause()`, and `call_part_label()`
+sit in `R/utils.R` beside `is_name_part()` and `static_call_args()`, which is
+where the shared readers of a call's parts already are, so the four helpers ask
+one question rather than four. The unwrapping is a recursion and not a `while`
+loop, because the loop form assigns the carried expression to a name and a
+quosure carrying the empty argument then raises base R's untyped
+`missingArgError` — the #168 hazard `static_call_args()` already documents,
+reached by a different route.
+
+`unwrap_injected_args()` is a named reader over a whole argument list rather
+than an `lapply()` spelled out at each call site, and that is what keeps the
+same hazard's gate derived. The scans in `test-utils.R` recognize a list of call
+parts by the reader that produced it; a mapping written at the call sites would
+have to be recognized by the function being mapped instead, and
+`grouping_helper_vars()` is handed its arguments as a parameter, so nothing in
+its body says the list it maps over is a call's arguments at all — the walk with
+#181's own history would have sat outside the gate. Adding a reader to that list
+is how the package says a list of parts came from somewhere new.
+
+`injected_quosure_clause()` reads the arguments as written rather than what the
+unwrapping carried out of them, because whether a part arrived injected is
+precisely the fact the unwrapping discards and precisely the fact the clause
+reports.
 
 **The clause is composed by the message, not by the argument.** A caller can
 make two mistakes at once, and which diagnostic wins is each helper's own

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -142,7 +142,8 @@ collision query.
 
 Owns what a summary expression *says*, and decides nothing about it: the name
 and namespace a call carries, the head and arguments a walk descends into and
-the node rebuilt around them, which arguments a call captures as language
+the node rebuilt around them, the expression an argument carries when it
+arrived as an injected quosure, which arguments a call captures as language
 rather than evaluating, which primitives resolve a name or evaluate language,
 and which language object a call is statically known to build.
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -163,6 +163,17 @@ separate question it answers separately — `static_callee_name()` resolves
 dependency walk has to over-report a lookup it cannot see through rather than
 recognize a helper by it.
 
+Saying what a part is written as belongs here for the same reason as reading
+it. `call_part_label()` writes one back into a diagnostic and
+`injected_quosure_clause()` says which argument of a call arrived by injection
+and what it carries (#169) — both report what the expression says and neither
+decides anything about it, since which message composes the clause, and whether
+to refuse at all, stays with the analysis that asked. Two refusals in different
+modules describe the same written form, so the words for it are one module's
+rather than each caller's; `rlang::as_label()` reading `.data$region` as
+`region` is the kind of thing that would otherwise be got right in one of them
+and not the other.
+
 Four analyses read through it and each decides for itself — the share
 dependency walk, the two rewrites, and the three searches — so the module is
 shallow by design where the ones below it are deep. It is also why the

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -166,8 +166,8 @@ recognize a helper by it.
 
 Saying what a part is written as belongs here for the same reason as reading
 it. `call_part_label()` writes one back into a diagnostic and
-`injected_quosure_clause()` says which argument of a call arrived by injection
-and what it carries (#169) — both report what the expression says and neither
+`injected_quosure_clause()` says that an argument arrived by injection and what
+it carries (#169) — both report what the expression says and neither
 decides anything about it, since which message composes the clause, and whether
 to refuse at all, stays with the analysis that asked. Two refusals in different
 modules describe the same written form, so the words for it are one module's

--- a/man/grouping_bit.Rd
+++ b/man/grouping_bit.Rd
@@ -83,6 +83,14 @@ complete label, factor, and missing-value contract.
 
 The \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} works through these values with
 executable examples.
+
+A function of your own may forward the column its caller wrote by injecting
+it: \code{!!rlang::enquo(col)} is accepted wherever a bare column is, and so is
+\code{!!rlang::ensym(col)}. Only the name is read. It is resolved against the
+Grouping plan, as every bare column here is, so the environment
+\code{\link[rlang:enquo]{rlang::enquo()}} captured is not consulted and an injection carrying
+anything but a name is refused exactly where writing that expression out
+would be.
 }
 
 \examples{

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -451,6 +451,14 @@ zero denominators. Infinite values and backend-specific \code{NaN}
 representations are outside that guarantee because supported SQL dialects
 do not share one portable finite-value predicate. Normalize potentially
 non-finite summaries explicitly with operations supported by the backend.
+
+A function of your own may forward the name its caller wrote by injecting
+it: \code{!!rlang::enquo(name)} is accepted wherever a bare name is, and so is
+\code{!!rlang::ensym(name)}. Only the name is read. It is resolved among the
+preceding summaries, as every bare name here is, so the environment
+\code{\link[rlang:enquo]{rlang::enquo()}} captured is not consulted and an injection carrying
+anything but a name is refused exactly where writing that expression out
+would be.
 }
 
 \examples{

--- a/tests/testthat/helper-contextual-probes.R
+++ b/tests/testthat/helper-contextual-probes.R
@@ -1,0 +1,25 @@
+# The input the Contextual helper probes read, in a helper file because two
+# suites probe those helpers along different axes and had a copy each.
+# `test-contextual-helpers.R` varies how a spelling is *written* -- bare,
+# qualified, parenthesized -- and `test-static-expression-analysis.R` varies
+# what an argument *is*, which is #169's question. Neither varies the input, so
+# a second copy of it recorded nothing except which suite was written first.
+#
+# Two numeric columns so that a selection can select more than one, and two
+# dimensions so that a rollup and a cube of them differ -- which is what the
+# constructor case needs to tell a caller's own function from the package's,
+# and what gives a `rollup()` a parent level for a Parent share to divide by.
+#
+# A column added here reaches both suites, which is safe because no probe
+# selects by predicate over these columns: the widest selection either writes
+# names its columns, and the contextual share's `where()` probe selects among
+# preceding summaries rather than among the input's columns.
+contextual_probe_data <- function() {
+  data.frame(
+    region = c("E", "E", "W", "W"),
+    grade = c("a", "b", "a", "b"),
+    units = c(1, 2, 3, 4),
+    qty = c(4, 5, 6, 7),
+    stringsAsFactors = FALSE
+  )
+}

--- a/tests/testthat/helper-contextual-probes.R
+++ b/tests/testthat/helper-contextual-probes.R
@@ -10,10 +10,14 @@
 # constructor case needs to tell a caller's own function from the package's,
 # and what gives a `rollup()` a parent level for a Parent share to divide by.
 #
-# A column added here reaches both suites, which is safe because no probe
-# selects by predicate over these columns: the widest selection either writes
-# names its columns, and the contextual share's `where()` probe selects among
-# preceding summaries rather than among the input's columns.
+# A column added here reaches both suites, and it is not free in either: this
+# input's column set is pinned. `test-contextual-helpers.R` selects
+# `where(is.numeric)` and `dplyr::everything()` over it and asserts the names
+# and the count that come back, which is what makes a caller binding of those
+# spellings visible at all, and the probes here take a `rollup()` of both
+# dimensions. Adding one means reading those expectations rather than only the
+# suite that wanted it -- which is the cost of one input, paid against a second
+# copy silently disagreeing with the first.
 contextual_probe_data <- function() {
   data.frame(
     region = c("E", "E", "W", "W"),

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -19,19 +19,9 @@
 # below supplies one per Contextual helper and is checked against the registry,
 # so a spelling added without a probe fails here rather than going uncovered.
 
-# A data frame every probe reads. Two numeric columns so that a selection can
-# select more than one, and two dimensions so that a rollup and a cube of them
-# differ -- which is what the constructor case below needs to tell a caller's
-# own function from the package's.
-contextual_probe_data <- function() {
-  data.frame(
-    region = c("E", "E", "W", "W"),
-    grade = c("a", "b", "a", "b"),
-    units = c(1, 2, 3, 4),
-    qty = c(4, 5, 6, 7),
-    stringsAsFactors = FALSE
-  )
-}
+# The input every probe reads is `contextual_probe_data()`, in
+# `helper-contextual-probes.R` because the other suite probing these helpers
+# reads the same one.
 
 # One call per Contextual helper, as an expression rather than as a closure.
 # It has to be an expression because the shadow the assertions install is a

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -432,6 +432,258 @@ test_that("a selection inside a quosure resolves in the quosure's own env", {
   expect_identical(result$rows, c(2L, 1L, 3L))
 })
 
+# The four helpers that read a bare name, derived rather than listed: they are
+# the registered Contextual helpers marginplyr itself owns, and a fifth owned
+# spelling is one someone has to decide this question about rather than one
+# that inherits an answer silently. Both halves of the criterion do work. The
+# dplyr-owned families take selections, which tidyselect resolves and which are
+# not this question at all; and the Grouping specification constructors are
+# marginplyr's too but are not Contextual helpers (ADR 0019), so their
+# arguments are evaluated in the caller's environment rather than read against
+# the Grouping plan -- which is the answer #169 turns on.
+marginplyr_owned_spellings <- function() {
+  rules <- lapply(static_spelling_rules(), function(rule) rule())
+  owned <- Filter(
+    function(rule) {
+      identical(rule$namespaces, "marginplyr") && isTRUE(rule$contextual)
+    },
+    rules
+  )
+  sort(unlist(lapply(owned, `[[`, "names"), use.names = FALSE))
+}
+
+# A data frame every probe below reads: two dimensions so a `rollup()` of them
+# has a parent level for a Parent share to divide by, and a measure for the
+# preceding ordinary summary a share helper takes the name of.
+injection_probe_data <- function() {
+  data.frame(
+    region = c("E", "E", "W", "W"),
+    grade = c("a", "b", "a", "b"),
+    units = c(1, 2, 3, 4),
+    stringsAsFactors = FALSE
+  )
+}
+
+# One summary per helper, written as a function from the *argument* to the whole
+# call, because the argument is the only thing that varies between the written
+# spelling and the injected one. A probe that built its own argument would fix
+# one of the two and assert nothing about the other.
+#
+# `name` is the bare name that helper takes -- a grouping column for one family
+# and a preceding ordinary summary for the other -- and it is what every shape
+# below is derived from, so no shape is written out twice.
+#
+# `.probe_data` is the symbol the input is bound to in the evaluation
+# environment; the grouping columns and the preceding summary sit inside
+# defused expressions, which `codetools` cannot follow into.
+# nolint start: object_usage_linter.
+injection_probes <- function() {
+  summary_probe <- function(helper, name) {
+    list(
+      name = name,
+      call = function(argument) {
+        rlang::expr(summarize_with_margins(
+          .probe_data,
+          t = sum(units),
+          k = !!rlang::call2(helper, argument),
+          .grouping = rollup(region, grade),
+          .sort = "last"
+        ))
+      }
+    )
+  }
+
+  list(
+    grouping_bit = summary_probe("grouping_bit", quote(region)),
+    grouping_id = summary_probe("grouping_id", quote(region)),
+    share_of_parent = summary_probe("share_of_parent", quote(t)),
+    share_of_total = summary_probe("share_of_total", quote(t))
+  )
+}
+# nolint end
+
+run_injection_probe <- function(probe, argument) {
+  rlang::eval_bare(
+    probe$call(argument),
+    rlang::env(rlang::current_env(), .probe_data = injection_probe_data())
+  )
+}
+
+test_that("every helper reading a bare name has an injection probe", {
+  # The derivation is what decides coverage, so a spelling registered without a
+  # probe has to fail here rather than go unexercised -- the same reason
+  # `test-contextual-helpers.R` checks its own probe table against the
+  # registry.
+  expect_identical(
+    sort(names(injection_probes())),
+    marginplyr_owned_spellings()
+  )
+})
+
+test_that("a helper reading a bare name accepts one forwarded by injection", {
+  # `rlang::enquo()` is what the tidy-eval idiom hands the author of a wrapper,
+  # and a quosure is not a symbol, so all four helpers refused `!!enquo(col)`
+  # while telling the caller they had not written a bare name -- which they
+  # had, at their own call. The workaround was to reach for `rlang::ensym()`
+  # instead, and nothing in the diagnostic said so (#169).
+  for (helper in names(injection_probes())) {
+    probe <- injection_probes()[[helper]]
+    written <- run_injection_probe(probe, probe$name)
+
+    # The quosure is built on the empty environment, so the assertion carries
+    # the environment answer as well as the acceptance one: nothing there can
+    # answer a lookup, and the result is the same because the name is resolved
+    # against the Grouping plan rather than anywhere at all (ADR 0019).
+    injected <- run_injection_probe(
+      probe,
+      rlang::new_quosure(probe$name, env = rlang::empty_env())
+    )
+    expect_identical(injected, written, info = helper)
+
+    # A quosure can carry another, so the unwrapping is a loop; one step of it
+    # would hand the test back the shape it exists to see through.
+    nested <- run_injection_probe(
+      probe,
+      rlang::new_quosure(
+        rlang::new_quosure(probe$name, env = rlang::empty_env()),
+        env = rlang::empty_env()
+      )
+    )
+    expect_identical(nested, written, info = helper)
+  }
+})
+
+test_that("an injected quosure's environment does not decide the name", {
+  # The environment is discarded, and that is the decision rather than an
+  # oversight (#169): these helpers resolve a name against the Grouping plan by
+  # spelling, so there is no lookup for an environment to answer. A binding of
+  # the same name in the quosure's own environment is the case that would show
+  # one being consulted, and it is the reading #165 gives one layer out, where
+  # a selection inside an injected quosure really is evaluated there.
+  for (helper in names(injection_probes())) {
+    probe <- injection_probes()[[helper]]
+    shadow <- rlang::env()
+    rlang::env_bind(shadow, !!rlang::as_name(probe$name) := "grade")
+
+    expect_identical(
+      run_injection_probe(probe, rlang::new_quosure(probe$name, env = shadow)),
+      run_injection_probe(probe, probe$name),
+      info = helper
+    )
+  }
+})
+
+test_that("an injected quosure carrying no bare name is refused as written", {
+  # One answer for all four helpers, and the same answer the un-injected
+  # spelling already gives: only a quosure carrying a bare name is one, and a
+  # quosure carrying anything else is refused exactly where that expression is
+  # refused without the injection (#169). The message is what the equality
+  # asserts -- the injected form adds a clause naming the injection and stops
+  # there, rather than reporting a different fault.
+  for (helper in names(injection_probes())) {
+    probe <- injection_probes()[[helper]]
+    # Derived from the bare name the helper takes, so the three shapes are one
+    # rule rather than twelve written-out calls: the pronoun spelling, the
+    # string, and a call around the same name.
+    shapes <- list(
+      rlang::call2("$", quote(.data), probe$name),
+      rlang::as_string(probe$name),
+      rlang::call2("+", probe$name, 1)
+    )
+
+    for (index in seq_along(shapes)) {
+      written <- expect_error(run_injection_probe(probe, shapes[[index]]))
+      expect_s3_class(written, "marginplyr_error")
+      # The written spelling says nothing about an injection, which is what
+      # stops the clause leaking into a refusal that has nothing to do with one.
+      expect_false(grepl("injected", conditionMessage(written), fixed = TRUE))
+
+      injected <- expect_error(run_injection_probe(
+        probe,
+        rlang::new_quosure(shapes[[index]], env = rlang::empty_env())
+      ))
+      expect_s3_class(injected, "marginplyr_error")
+      expect_identical(
+        conditionMessage(injected),
+        paste0(
+          conditionMessage(written),
+          " The injected quosure carries `",
+          deparse1(shapes[[index]]),
+          "`, which is not a bare name."
+        ),
+        info = helper
+      )
+    }
+
+    # `rlang::as_label()` reads `.data$region` as `region`, so a clause written
+    # with it would quote the refused part as the bare name the message says it
+    # is not. Asserted on the shape that shows it rather than left to the
+    # equality above, which `deparse1()` on both sides would satisfy either way.
+    pronoun <- expect_error(run_injection_probe(
+      probe,
+      rlang::new_quosure(shapes[[1L]], env = rlang::empty_env())
+    ))
+    expect_match(
+      conditionMessage(pronoun),
+      paste0("carries `.data$", rlang::as_string(probe$name), "`"),
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("an injected quosure carrying the empty argument is named as one", {
+  # The empty argument deparses to nothing at all, so a clause built from
+  # `deparse1()` alone would refuse it with an empty pair of backticks. It is
+  # reachable only by injection -- `f(, )` is two arguments to the parser, so
+  # the written spelling is caught by arity (#181) -- which is why the label is
+  # asserted here rather than beside the empty-argument cases.
+  probe <- injection_probes()$grouping_id
+  error <- expect_error(run_injection_probe(
+    probe,
+    rlang::new_quosure(rlang::missing_arg(), env = rlang::empty_env())
+  ))
+  expect_s3_class(error, "marginplyr_error")
+  expect_match(
+    conditionMessage(error),
+    "The injected quosure carries `<empty>`",
+    fixed = TRUE
+  )
+})
+
+test_that("injection is transparent to the checks after the name test", {
+  # Unwrapping happens before every question `grouping_helper_vars()` asks, not
+  # only before the symbol test, so a name that arrives injected is the same
+  # name to the duplicate check and to the plan membership check. Reading one
+  # through and the others around it is the shape that would let an injected
+  # duplicate through.
+  data <- injection_probe_data()
+  injected <- rlang::new_quosure(quote(region), env = rlang::empty_env())
+
+  duplicated <- expect_error(rlang::inject(summarize_with_margins(
+    data,
+    k = grouping_id(region, !!injected),
+    .grouping = rollup(region, grade)
+  )))
+  expect_s3_class(duplicated, "marginplyr_error")
+  expect_match(
+    conditionMessage(duplicated),
+    "does not accept duplicate columns",
+    fixed = TRUE
+  )
+
+  unknown <- expect_error(rlang::inject(summarize_with_margins(
+    data,
+    k = grouping_id(!!rlang::new_quosure(quote(nowhere))),
+    .grouping = rollup(region, grade)
+  )))
+  expect_s3_class(unknown, "marginplyr_error")
+  expect_match(
+    conditionMessage(unknown),
+    "Column `nowhere` is not part of `.by` or `.grouping`.",
+    fixed = TRUE
+  )
+})
+
 # Runs `code` with rlang's soft deprecations raised as errors, restoring
 # whatever the checking environment had before. Written with `on.exit()` rather
 # than withr so the tests add no dependency beyond the ones DESCRIPTION

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -444,7 +444,7 @@ test_that("a selection inside a quosure resolves in the quosure's own env", {
 marginplyr_owned_spellings <- function() {
   owned <- Filter(
     function(family) {
-      identical(static_spelling_rule(family)$namespaces, "marginplyr")
+      identical(static_spelling_namespaces(family), "marginplyr")
     },
     contextual_helper_families()
   )

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -534,8 +534,9 @@ test_that("a helper reading a bare name accepts one forwarded by injection", {
     )
     expect_identical(injected, written, info = helper)
 
-    # A quosure can carry another, so the unwrapping is a loop; one step of it
-    # would hand the test back the shape it exists to see through.
+    # A quosure can carry another, so the unwrapping repeats until it reaches
+    # something that is not one; a single step would hand the test back the
+    # shape it exists to see through.
     nested <- run_injection_probe(
       probe,
       rlang::new_quosure(

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -451,23 +451,11 @@ marginplyr_owned_spellings <- function() {
   sort(unlist(lapply(owned, static_spelling_names), use.names = FALSE))
 }
 
-# A data frame every probe below reads: two dimensions so a `rollup()` of them
-# has a parent level for a Parent share to divide by, and a measure for the
-# preceding ordinary summary a share helper takes the name of.
-#
-# Its own fixture rather than the one `test-contextual-helpers.R` builds, which
-# is a near neighbour: that file varies the *head* spelling and needs a column
-# for a selection to pick more than one of, and this one varies the *argument*
-# and needs a parent level instead. Sharing one would make a column added for
-# either suite's next case appear in the other's.
-injection_probe_data <- function() {
-  data.frame(
-    region = c("E", "E", "W", "W"),
-    grade = c("a", "b", "a", "b"),
-    units = c(1, 2, 3, 4),
-    stringsAsFactors = FALSE
-  )
-}
+# The probes below read `contextual_probe_data()`, from
+# `helper-contextual-probes.R`: the other suite probing these helpers reads the
+# same input, and a copy here recorded nothing but which was written first. Its
+# two dimensions are what give a `rollup()` a parent level for a Parent share to
+# divide by, and `units` is the measure the preceding ordinary summary takes.
 
 # One summary per helper, written as a function from the *argument* to the whole
 # call, because the argument is the only thing that varies between the written
@@ -510,7 +498,7 @@ injection_probes <- function() {
 run_injection_probe <- function(probe, argument) {
   rlang::eval_bare(
     probe$call(argument),
-    rlang::env(rlang::current_env(), .probe_data = injection_probe_data())
+    rlang::env(rlang::current_env(), .probe_data = contextual_probe_data())
   )
 }
 
@@ -531,8 +519,9 @@ test_that("a helper reading a bare name accepts one forwarded by injection", {
   # while telling the caller they had not written a bare name -- which they
   # had, at their own call. The workaround was to reach for `rlang::ensym()`
   # instead, and nothing in the diagnostic said so (#169).
-  for (helper in names(injection_probes())) {
-    probe <- injection_probes()[[helper]]
+  probes <- injection_probes()
+  for (helper in names(probes)) {
+    probe <- probes[[helper]]
     written <- run_injection_probe(probe, probe$name)
 
     # The quosure is built on the empty environment, so the assertion carries
@@ -565,8 +554,9 @@ test_that("an injected quosure's environment does not decide the name", {
   # the same name in the quosure's own environment is the case that would show
   # one being consulted, and it is the reading #165 gives one layer out, where
   # a selection inside an injected quosure really is evaluated there.
-  for (helper in names(injection_probes())) {
-    probe <- injection_probes()[[helper]]
+  probes <- injection_probes()
+  for (helper in names(probes)) {
+    probe <- probes[[helper]]
     shadow <- rlang::env()
     rlang::env_bind(shadow, !!rlang::as_name(probe$name) := "grade")
 
@@ -585,8 +575,9 @@ test_that("an injected quosure carrying no bare name is refused as written", {
   # refused without the injection (#169). The message is what the equality
   # asserts -- the injected form adds a clause naming the injection and stops
   # there, rather than reporting a different fault.
-  for (helper in names(injection_probes())) {
-    probe <- injection_probes()[[helper]]
+  probes <- injection_probes()
+  for (helper in names(probes)) {
+    probe <- probes[[helper]]
     # Derived from the bare name the helper takes, so the three shapes are one
     # rule rather than twelve written-out calls: the pronoun spelling, the
     # string, and a call around the same name.
@@ -661,7 +652,7 @@ test_that("a caller's two mistakes at once are reported by one message", {
   # the two decide it differently on purpose, so it is asserted rather than left
   # to the message equality above -- which compares one helper against itself
   # and would not notice either decision changing.
-  data <- injection_probe_data()
+  data <- contextual_probe_data()
   injected <- rlang::new_quosure(quote(1 + 1), env = rlang::empty_env())
 
   # `grouping_bit()` counts columns in a message of its own, reached before the
@@ -704,7 +695,7 @@ test_that("a share helper refuses a named empty argument as a non-name", {
   # symbol whose name is `""`. So the call was admitted and refused one layer on
   # for a preceding summary named ``, which is a summary nobody wrote: #181's
   # defect, in the family that ticket did not reach.
-  data <- injection_probe_data()
+  data <- contextual_probe_data()
 
   error <- expect_error(summarize_with_margins(
     data,
@@ -732,7 +723,7 @@ test_that("injection is transparent to the checks after the name test", {
   # name to the duplicate check and to the plan membership check. Reading one
   # through and the others around it is the shape that would let an injected
   # duplicate through.
-  data <- injection_probe_data()
+  data <- contextual_probe_data()
   injected <- rlang::new_quosure(quote(region), env = rlang::empty_env())
 
   duplicated <- expect_error(rlang::inject(summarize_with_margins(

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -435,12 +435,14 @@ test_that("a selection inside a quosure resolves in the quosure's own env", {
 # The four helpers that read a bare name, derived rather than listed: they are
 # the registered Contextual helpers marginplyr itself owns, and a fifth owned
 # spelling is one someone has to decide this question about rather than one
-# that inherits an answer silently. Both halves of the criterion do work. The
-# dplyr-owned families take selections, which tidyselect resolves and which are
-# not this question at all; and the Grouping specification constructors are
-# marginplyr's too but are not Contextual helpers (ADR 0019), so their
-# arguments are evaluated in the caller's environment rather than read against
-# the Grouping plan -- which is the answer #169 turns on.
+# that inherits an answer silently. Both halves of the criterion do work. None
+# of the dplyr-owned families reads a bare name: `across()` and its siblings
+# take a selection, which tidyselect resolves, `where()` takes a predicate
+# function, and the refused `cur_*()` spellings take nothing at all. And the
+# Grouping specification constructors are marginplyr's too but are not
+# Contextual helpers (ADR 0019), so their arguments are evaluated in the
+# caller's environment rather than read against the Grouping plan -- which is
+# the answer #169 turns on.
 marginplyr_owned_spellings <- function() {
   owned <- Filter(
     function(family) {
@@ -588,6 +590,7 @@ test_that("an injected quosure carrying no bare name is refused as written", {
       rlang::call2("+", probe$name, 1)
     )
 
+    refusals <- list()
     for (index in seq_along(shapes)) {
       written <- expect_error(run_injection_probe(probe, shapes[[index]]))
       expect_s3_class(written, "marginplyr_error")
@@ -610,18 +613,17 @@ test_that("an injected quosure carrying no bare name is refused as written", {
         ),
         info = helper
       )
+      refusals[[index]] <- injected
     }
 
     # `rlang::as_label()` reads `.data$region` as `region`, so a clause written
     # with it would quote the refused part as the bare name the message says it
     # is not. Asserted on the shape that shows it rather than left to the
     # equality above, which `deparse1()` on both sides would satisfy either way.
-    pronoun <- expect_error(run_injection_probe(
-      probe,
-      rlang::new_quosure(shapes[[1L]], env = rlang::empty_env())
-    ))
+    # Read back from the refusal the loop already raised, since running the call
+    # again would assert about a second execution of it.
     expect_match(
-      conditionMessage(pronoun),
+      conditionMessage(refusals[[1L]]),
       paste0("carries `.data$", rlang::as_string(probe$name), "`"),
       fixed = TRUE
     )
@@ -630,10 +632,11 @@ test_that("an injected quosure carrying no bare name is refused as written", {
 
 test_that("an injected quosure carrying the empty argument is named as one", {
   # The empty argument deparses to nothing at all, so a clause built from
-  # `deparse1()` alone would refuse it with an empty pair of backticks. It is
-  # reachable only by injection -- `f(, )` is two arguments to the parser, so
-  # the written spelling is caught by arity (#181) -- which is why the label is
-  # asserted here rather than beside the empty-argument cases.
+  # `deparse1()` alone would refuse it with an empty pair of backticks. Only an
+  # injected one reaches the label at all: the clause is the sole caller of
+  # `call_part_label()` and it labels nothing that is not a quosure, so a
+  # written `grouping_id(, )` is refused without one -- which is why this sits
+  # here rather than beside the empty-argument cases #181 covers.
   probe <- injection_probes()$grouping_id
   error <- expect_error(run_injection_probe(
     probe,
@@ -671,8 +674,8 @@ test_that("a caller's two mistakes at once are reported by one message", {
   )
 
   # The share helpers' headline covers the arity and the name-ness together, so
-  # both halves describe this call and the clause says which argument is the
-  # one it is talking about.
+  # both halves describe this call, and the clause quotes what was injected --
+  # which is what tells the two arguments apart, there being no position in it.
   named <- expect_error(rlang::inject(summarize_with_margins(
     data,
     t = sum(units),

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -442,19 +442,24 @@ test_that("a selection inside a quosure resolves in the quosure's own env", {
 # arguments are evaluated in the caller's environment rather than read against
 # the Grouping plan -- which is the answer #169 turns on.
 marginplyr_owned_spellings <- function() {
-  rules <- lapply(static_spelling_rules(), function(rule) rule())
   owned <- Filter(
-    function(rule) {
-      identical(rule$namespaces, "marginplyr") && isTRUE(rule$contextual)
+    function(family) {
+      identical(static_spelling_rule(family)$namespaces, "marginplyr")
     },
-    rules
+    contextual_helper_families()
   )
-  sort(unlist(lapply(owned, `[[`, "names"), use.names = FALSE))
+  sort(unlist(lapply(owned, static_spelling_names), use.names = FALSE))
 }
 
 # A data frame every probe below reads: two dimensions so a `rollup()` of them
 # has a parent level for a Parent share to divide by, and a measure for the
 # preceding ordinary summary a share helper takes the name of.
+#
+# Its own fixture rather than the one `test-contextual-helpers.R` builds, which
+# is a near neighbour: that file varies the *head* spelling and needs a column
+# for a selection to pick more than one of, and this one varies the *argument*
+# and needs a parent level instead. Sharing one would make a column added for
+# either suite's next case appear in the other's.
 injection_probe_data <- function() {
   data.frame(
     region = c("E", "E", "W", "W"),
@@ -647,6 +652,77 @@ test_that("an injected quosure carrying the empty argument is named as one", {
     conditionMessage(error),
     "The injected quosure carries `<empty>`",
     fixed = TRUE
+  )
+})
+
+test_that("a caller's two mistakes at once are reported by one message", {
+  # An injected non-name in a call that also has the wrong arity. Which
+  # diagnostic wins is each helper's own decision rather than the clause's, and
+  # the two decide it differently on purpose, so it is asserted rather than left
+  # to the message equality above -- which compares one helper against itself
+  # and would not notice either decision changing.
+  data <- injection_probe_data()
+  injected <- rlang::new_quosure(quote(1 + 1), env = rlang::empty_env())
+
+  # `grouping_bit()` counts columns in a message of its own, reached before the
+  # non-column one deliberately (#181): a caller who passed two of anything
+  # needs the count, not a remark about one of them.
+  counted <- expect_error(rlang::inject(summarize_with_margins(
+    data,
+    k = grouping_bit(!!injected, region),
+    .grouping = rollup(region, grade)
+  )))
+  expect_s3_class(counted, "marginplyr_error")
+  expect_identical(
+    conditionMessage(counted),
+    "`grouping_bit()` requires exactly one column."
+  )
+
+  # The share helpers' headline covers the arity and the name-ness together, so
+  # both halves describe this call and the clause says which argument is the
+  # one it is talking about.
+  named <- expect_error(rlang::inject(summarize_with_margins(
+    data,
+    t = sum(units),
+    k = share_of_total(!!injected, t),
+    .grouping = rollup(region, grade)
+  )))
+  expect_s3_class(named, "marginplyr_error")
+  expect_match(
+    conditionMessage(named),
+    "The injected quosure carries `1 + 1`, which is not a bare name.",
+    fixed = TRUE
+  )
+})
+
+test_that("a share helper refuses a named empty argument as a non-name", {
+  # Not an injected spelling, and recorded in ADR 0019 as the one un-injected
+  # change asking the name question once produced. `share_of_total(, )` is two
+  # arguments to the parser and is refused for the count, but
+  # `share_of_total(x = )` is one argument and it is empty, and
+  # `rlang::is_symbol()` answered `TRUE` for it -- the empty argument is a
+  # symbol whose name is `""`. So the call was admitted and refused one layer on
+  # for a preceding summary named ``, which is a summary nobody wrote: #181's
+  # defect, in the family that ticket did not reach.
+  data <- injection_probe_data()
+
+  error <- expect_error(summarize_with_margins(
+    data,
+    t = sum(units),
+    k = share_of_total(x = ),
+    .grouping = rollup(region, grade)
+  ))
+  expect_s3_class(error, "marginplyr_error")
+  expect_match(
+    conditionMessage(error),
+    "requires exactly one bare name of a preceding ordinary summary",
+    fixed = TRUE
+  )
+  # The old diagnostic named the summary it invented, which is what makes the
+  # regression readable: an assertion on the new wording alone would pass on any
+  # refusal at all.
+  expect_false(
+    grepl("unknown preceding", conditionMessage(error), fixed = TRUE)
   )
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -141,8 +141,26 @@ reads_call_arguments <- function(expr) {
        identical(expr[[3L]], "call_args"))
 }
 
+# A list built elementwise from such a list is one too. `lapply()` hands each
+# argument to a function and collects what comes back, so an empty argument that
+# went in is an empty argument that came out, and the hazard travels with it.
+# `grouping_helper_vars()` and `validate_share_direct_syntax()` both read their
+# arguments through one to see through an injected quosure (#169), so without
+# this the scans below would read a loop over what they carry as a loop over
+# something else -- the same under-reach the shared matcher above was written to
+# close, arriving through a second list rather than through a second spelling.
+derives_call_arguments <- function(expr, locals) {
+  is.call(expr) &&
+    identical(expr[[1L]], quote(lapply)) &&
+    length(expr) >= 2L &&
+    is_call_arguments(expr[[2L]], locals)
+}
+
 # The names a body binds to such a list, so that a loop over one, or a
-# subscript of one, is read as reaching the arguments themselves.
+# subscript of one, is read as reaching the arguments themselves. Accumulated in
+# source order, which is what lets a list derived from an earlier local be
+# recognized: the assignment naming it is visited before the one deriving from
+# it.
 call_argument_locals <- function(expr, found = character()) {
   if (!is.call(expr)) {
     return(found)
@@ -151,7 +169,8 @@ call_argument_locals <- function(expr, found = character()) {
     identical(expr[[1L]], quote(`<-`)) &&
       length(expr) == 3L &&
       is.symbol(expr[[2L]]) &&
-      reads_call_arguments(expr[[3L]])
+      (reads_call_arguments(expr[[3L]]) ||
+         derives_call_arguments(expr[[3L]], found))
   ) {
     found <- unique(c(found, as.character(expr[[2L]])))
   }
@@ -247,6 +266,17 @@ test_that("the walk scan detects the shape it is written to forbid", {
       part
     }
   }
+  # And over a list built elementwise from one, which is how both helpers now
+  # read through an injected quosure (#169). The empty argument survives the
+  # `lapply()` that unwraps, so the loop it would be read with is the same
+  # hazard one list further along.
+  through_derived <- function(expr) {
+    args <- static_call_args(expr)
+    carried <- lapply(args, unwrap_injected_quosure)
+    for (part in carried) {
+      part
+    }
+  }
   compliant <- function(expr) {
     parts <- static_call_args(expr)
     for (index in seq_along(parts)) {
@@ -258,6 +288,7 @@ test_that("the walk scan detects the shape it is written to forbid", {
   expect_true(binds_call_parts_with_for(body(nested)))
   expect_true(binds_call_parts_with_for(body(through_local)))
   expect_true(binds_call_parts_with_for(body(through_parsed)))
+  expect_true(binds_call_parts_with_for(body(through_derived)))
   expect_false(binds_call_parts_with_for(body(compliant)))
   # An empty argument in the scanned code must not abort the scan, which is the
   # bug one level up.
@@ -348,6 +379,14 @@ test_that("the assignment scan detects the shape it is written to forbid", {
     part <- static_call_args(expr)[[1L]]
     part
   }
+  # The same subscript, one list along: what `lapply()` collected from a call's
+  # arguments holds an empty one wherever the arguments did (#169).
+  through_derived <- function(expr) {
+    args <- static_call_args(expr)
+    carried <- lapply(args, unwrap_injected_quosure)
+    part <- carried[[1L]]
+    part
+  }
   compliant_local <- function(expr) {
     parts <- static_call_args(expr)
     rlang::is_symbol(parts[[1L]])
@@ -362,6 +401,7 @@ test_that("the assignment scan detects the shape it is written to forbid", {
   expect_true(binds_call_parts_by_assign(body(through_parsed_local)))
   expect_true(binds_call_parts_by_assign(body(through_string_element)))
   expect_true(binds_call_parts_by_assign(body(through_reader)))
+  expect_true(binds_call_parts_by_assign(body(through_derived)))
   expect_false(binds_call_parts_by_assign(body(compliant_local)))
   # An ordinary list read is not the shape, or the scan would name most of the
   # package and mean nothing.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -114,8 +114,9 @@ package_functions <- function() {
 }
 
 # Where a list of a call's arguments comes from: the shared reader, the rlang
-# function it wraps, or the `call_args` element of a parse this package builds
-# out of one, in either spelling of the element read.
+# function it wraps, the reader that unwraps each of them through an injected
+# quosure, or the `call_args` element of a parse this package builds out of one,
+# in either spelling of the element read.
 #
 # One matcher serves both scans below, because the hazard is one hazard: a list
 # reached this way holds elements that may be empty, whichever construct then
@@ -123,6 +124,14 @@ package_functions <- function() {
 # `static_call_args()` call alone, so the same loop over a local -- the shape
 # `removal_retained_bound()` sits one line away from -- passed both gates while
 # the prose above claimed otherwise.
+#
+# `unwrap_injected_args()` is here rather than recognized as an `lapply()` over
+# one of the others, which is what it is (#169): a mapping spelled out at each
+# call site would have to be matched by the function being mapped, and
+# `grouping_helper_vars()` is handed its arguments as a parameter, so nothing in
+# its body says the list it maps over is a call's arguments at all. A reader
+# with a name is what this list is written to hold, and adding one to it is how
+# the package says a list of parts came from somewhere new.
 reads_call_arguments <- function(expr) {
   if (!is.call(expr)) {
     return(FALSE)
@@ -130,7 +139,8 @@ reads_call_arguments <- function(expr) {
   head <- expr[[1L]]
   named_reader <-
     identical(head, quote(static_call_args)) ||
-    identical(head, quote(rlang::call_args))
+    identical(head, quote(rlang::call_args)) ||
+    identical(head, quote(unwrap_injected_args))
   if (named_reader) {
     return(TRUE)
   }
@@ -141,39 +151,8 @@ reads_call_arguments <- function(expr) {
        identical(expr[[3L]], "call_args"))
 }
 
-# A list built elementwise from such a list is one too. `lapply()` hands each
-# argument to a function and collects what comes back, so an empty argument that
-# went in is an empty argument that came out, and the hazard travels with it.
-# `grouping_helper_vars()` and `validate_share_direct_syntax()` both read their
-# arguments through one to see through an injected quosure (#169), so without
-# this the scans below would read a loop over what they carry as a loop over
-# something else -- the same under-reach the shared matcher above was written to
-# close, arriving through a second list rather than through a second spelling.
-#
-# Two ways to recognize one, and the second is what makes the first reach both
-# functions. Mapping over a list this already knows is a list of call arguments
-# covers `validate_share_direct_syntax()`, which reads one from
-# `static_call_args()` a line earlier -- but `grouping_helper_vars()` is handed
-# its arguments as a parameter, so nothing in its body says where they came
-# from and matching on the source would leave the walk with #181's history
-# uncovered. Mapping `unwrap_injected_quosure()` is the other way: it answers
-# for a call part and nothing else, so what a mapping of it collects is call
-# parts whatever it was handed.
-derives_call_arguments <- function(expr, locals) {
-  if (!is.call(expr) || !identical(expr[[1L]], quote(lapply))) {
-    return(FALSE)
-  }
-  mapped_reader <- length(expr) >= 3L &&
-    identical(expr[[3L]], quote(unwrap_injected_quosure))
-  mapped_reader ||
-    (length(expr) >= 2L && is_call_arguments(expr[[2L]], locals))
-}
-
 # The names a body binds to such a list, so that a loop over one, or a
-# subscript of one, is read as reaching the arguments themselves. Accumulated in
-# source order, which is what lets a list derived from an earlier local be
-# recognized: the assignment naming it is visited before the one deriving from
-# it.
+# subscript of one, is read as reaching the arguments themselves.
 call_argument_locals <- function(expr, found = character()) {
   if (!is.call(expr)) {
     return(found)
@@ -182,8 +161,7 @@ call_argument_locals <- function(expr, found = character()) {
     identical(expr[[1L]], quote(`<-`)) &&
       length(expr) == 3L &&
       is.symbol(expr[[2L]]) &&
-      (reads_call_arguments(expr[[3L]]) ||
-         derives_call_arguments(expr[[3L]], found))
+      reads_call_arguments(expr[[3L]])
   ) {
     found <- unique(c(found, as.character(expr[[2L]])))
   }
@@ -279,23 +257,22 @@ test_that("the walk scan detects the shape it is written to forbid", {
       part
     }
   }
-  # And over a list built elementwise from one, which is how both helpers now
-  # read through an injected quosure (#169). The empty argument survives the
-  # `lapply()` that unwraps, so the loop it would be read with is the same
-  # hazard one list further along.
+  # And over the reader that unwraps each argument through an injected quosure,
+  # whose result is a list of parts like any other: the empty argument goes into
+  # the unwrapping and comes out of it (#169). Once through a list the same body
+  # read, and once in a function handed its arguments -- the shape
+  # `grouping_helper_vars()` has, and the one the reader has to be recognized by
+  # its name for, since nothing else in such a body says where the list came
+  # from.
   through_derived <- function(expr) {
     args <- static_call_args(expr)
-    carried <- lapply(args, unwrap_injected_quosure)
+    carried <- unwrap_injected_args(args)
     for (part in carried) {
       part
     }
   }
-  # The same derivation in a function handed its arguments rather than reading
-  # them, which is `grouping_helper_vars()`'s shape: nothing in the body says
-  # where the list came from, so the unwrapper being mapped is the only thing
-  # that says the result holds call parts.
   through_derived_parameter <- function(args) {
-    carried <- lapply(args, unwrap_injected_quosure)
+    carried <- unwrap_injected_args(args)
     for (part in carried) {
       part
     }
@@ -403,18 +380,17 @@ test_that("the assignment scan detects the shape it is written to forbid", {
     part <- static_call_args(expr)[[1L]]
     part
   }
-  # The same subscript, one list along: what `lapply()` collected from a call's
-  # arguments holds an empty one wherever the arguments did (#169). Both ways of
-  # recognizing that list, since the second is what reaches a function handed
-  # its arguments rather than reading them.
+  # The same subscript, one list along: what the unwrapping reader collected
+  # from a call's arguments holds an empty one wherever the arguments did
+  # (#169). Read from a local and from a parameter, as above.
   through_derived <- function(expr) {
     args <- static_call_args(expr)
-    carried <- lapply(args, unwrap_injected_quosure)
+    carried <- unwrap_injected_args(args)
     part <- carried[[1L]]
     part
   }
   through_derived_parameter <- function(args) {
-    carried <- lapply(args, unwrap_injected_quosure)
+    carried <- unwrap_injected_args(args)
     part <- carried[[1L]]
     part
   }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -149,11 +149,24 @@ reads_call_arguments <- function(expr) {
 # this the scans below would read a loop over what they carry as a loop over
 # something else -- the same under-reach the shared matcher above was written to
 # close, arriving through a second list rather than through a second spelling.
+#
+# Two ways to recognize one, and the second is what makes the first reach both
+# functions. Mapping over a list this already knows is a list of call arguments
+# covers `validate_share_direct_syntax()`, which reads one from
+# `static_call_args()` a line earlier -- but `grouping_helper_vars()` is handed
+# its arguments as a parameter, so nothing in its body says where they came
+# from and matching on the source would leave the walk with #181's history
+# uncovered. Mapping `unwrap_injected_quosure()` is the other way: it answers
+# for a call part and nothing else, so what a mapping of it collects is call
+# parts whatever it was handed.
 derives_call_arguments <- function(expr, locals) {
-  is.call(expr) &&
-    identical(expr[[1L]], quote(lapply)) &&
-    length(expr) >= 2L &&
-    is_call_arguments(expr[[2L]], locals)
+  if (!is.call(expr) || !identical(expr[[1L]], quote(lapply))) {
+    return(FALSE)
+  }
+  mapped_reader <- length(expr) >= 3L &&
+    identical(expr[[3L]], quote(unwrap_injected_quosure))
+  mapped_reader ||
+    (length(expr) >= 2L && is_call_arguments(expr[[2L]], locals))
 }
 
 # The names a body binds to such a list, so that a loop over one, or a
@@ -277,6 +290,16 @@ test_that("the walk scan detects the shape it is written to forbid", {
       part
     }
   }
+  # The same derivation in a function handed its arguments rather than reading
+  # them, which is `grouping_helper_vars()`'s shape: nothing in the body says
+  # where the list came from, so the unwrapper being mapped is the only thing
+  # that says the result holds call parts.
+  through_derived_parameter <- function(args) {
+    carried <- lapply(args, unwrap_injected_quosure)
+    for (part in carried) {
+      part
+    }
+  }
   compliant <- function(expr) {
     parts <- static_call_args(expr)
     for (index in seq_along(parts)) {
@@ -289,6 +312,7 @@ test_that("the walk scan detects the shape it is written to forbid", {
   expect_true(binds_call_parts_with_for(body(through_local)))
   expect_true(binds_call_parts_with_for(body(through_parsed)))
   expect_true(binds_call_parts_with_for(body(through_derived)))
+  expect_true(binds_call_parts_with_for(body(through_derived_parameter)))
   expect_false(binds_call_parts_with_for(body(compliant)))
   # An empty argument in the scanned code must not abort the scan, which is the
   # bug one level up.
@@ -380,9 +404,16 @@ test_that("the assignment scan detects the shape it is written to forbid", {
     part
   }
   # The same subscript, one list along: what `lapply()` collected from a call's
-  # arguments holds an empty one wherever the arguments did (#169).
+  # arguments holds an empty one wherever the arguments did (#169). Both ways of
+  # recognizing that list, since the second is what reaches a function handed
+  # its arguments rather than reading them.
   through_derived <- function(expr) {
     args <- static_call_args(expr)
+    carried <- lapply(args, unwrap_injected_quosure)
+    part <- carried[[1L]]
+    part
+  }
+  through_derived_parameter <- function(args) {
     carried <- lapply(args, unwrap_injected_quosure)
     part <- carried[[1L]]
     part
@@ -402,6 +433,7 @@ test_that("the assignment scan detects the shape it is written to forbid", {
   expect_true(binds_call_parts_by_assign(body(through_string_element)))
   expect_true(binds_call_parts_by_assign(body(through_reader)))
   expect_true(binds_call_parts_by_assign(body(through_derived)))
+  expect_true(binds_call_parts_by_assign(body(through_derived_parameter)))
   expect_false(binds_call_parts_by_assign(body(compliant_local)))
   # An ordinary list read is not the shape, or the scan would name most of the
   # package and mean nothing.


### PR DESCRIPTION
Closes #169.

`rlang::enquo()` is what the tidy-eval idiom hands the author of a wrapper, and
a quosure is not a symbol, so all four helpers that take a bare name refused
`!!enquo(col)` while telling the caller they had not written a bare name —
which they had, one call further out.

```r
level_by <- function(data, col) {
  q <- rlang::enquo(col)
  summarize_with_margins(
    data,
    level = grouping_id(!!q),
    .grouping = rollup(region)
  )
}
level_by(d, region)
#> Error: `grouping_id()` only accepts bare grouping columns.
```

## The three contract answers

#169 was filed `ready-for-human` because it deliberately left three questions
open. They were answered before any code was written, and ADR 0019 carries them
as an amendment:

1. **Bare symbol only.** An argument read as a bare name is read through an
   injected quosure, however many deep, and only what it carries decides. A
   quosure carrying a bare name *is* one; a quosure carrying anything else —
   `.data$region`, a string, a call, the empty argument — is refused exactly
   where that expression is refused when written out. One rule for all four
   helpers, mirroring the un-injected spelling rather than adding a second
   grammar for the injected one.

2. **The environment is discarded**, and that follows from ADR 0019 rather than
   sitting beside it: a Contextual helper's argument is resolved *by spelling*
   against the Grouping plan or among the preceding summaries, so there is no
   lookup for a quosure's environment to answer. That is the other side of the
   answer #165 reached one layer out, where a walk keeps the environment because
   a selection inside really is evaluated there — one rule seen from two sides:
   the environment is honoured wherever evaluation happens, and these arguments
   are never evaluated.

3. **The diagnostic names the injection.** The headline is unchanged, because it
   is accurate — what is refused really is not a bare name. What the clause adds
   is the expression the headline is about, which is not on the page the caller
   is reading:

   ```
   `grouping_id()` only accepts bare grouping columns. The injected quosure
   carries `.data$region`, which is not a bare name.
   ```

   `deparse1()` rather than `rlang::as_label()`, which reads `.data$region` as
   `region` and would quote the part as the bare name the message says it is not.

## One recorded behaviour change outside the ticket's fence

Asking the name question once meant `is_name_part()` in the share helpers too,
where it had been `rlang::is_symbol()`. That is not behaviour-neutral:
`share_of_total(x = )` is **one** argument and it is empty, and the empty
argument is a symbol whose name is `""`, so the call was admitted and refused
one layer on as

```
Total share `k` refers to unknown preceding ordinary summary ``.
```

— a summary nobody wrote, which is #181's defect in the family that ticket did
not reach. Reverting to `rlang::is_symbol()` would reinstate it and leave the
four helpers asking two different questions to do so, so it stays, recorded in
ADR 0019's *Recorded behaviour change* with a test. `cran-status` reads
`unpublished`, so no released version carried the old behaviour.

## Test strategy

The four helpers are **derived** from `static_spelling_rules()` as the
registered spellings marginplyr owns *and* declares Contextual, so a fifth owned
Contextual helper fails the coverage assertion rather than inheriting an answer
nobody decided. Each probe is a function from the argument to the whole call,
since the argument is the only thing that varies, and the refused shapes are
derived from the bare name each helper takes.

The acceptance case injects a quosure built on the **empty** environment, so it
asserts the environment answer in the same expectation as the acceptance one.
The refusal case asserts message *equality* with the written spelling plus the
clause, which is what stops the injected form reporting a different fault.

`test-utils.R`'s #168 empty-argument gate is extended to reach the new code:
`unwrap_injected_args()` is a named reader, so a list of call parts it produced
is recognized the way `static_call_args()`'s is.

## Checks

`lintr::lint_package()`, `spelling::spell_check_package()`, `roxygen2::roxygenise()`
(no diff), and the full suite under `NOT_CRAN=true` are all green.