### PR TITLE
Name the table for the Suggests it holds

### DIFF
--- a/.github/scripts/ci-helpers.R
+++ b/.github/scripts/ci-helpers.R
@@ -76,14 +76,14 @@ test_tally <- function(test_log) {
 }
 
 # `optional_suggests()` and `optional_backends()`, the one list of optional
-# backends the release matrix reasons about. It is defined with the guards that
+# packages the release matrix reasons about. It is defined with the guards that
 # consume it rather than here; the helper's own comment records why that
-# direction is forced. This reads the working tree rather than the built
-# tarball, and every job that runs these scripts checks out the repository, so
-# the path resolves.
+# direction is forced, and why those two names describe different sets. This
+# reads the working tree rather than the built tarball, and every job that runs
+# these scripts checks out the repository, so the path resolves.
 #
 # `source()` evaluates top-level expressions only, and the helper's sole
-# testthat call sits inside `skip_if_backend_absent()`'s body, so this works
+# testthat call sits inside `skip_if_suggest_absent()`'s body, so this works
 # from a bare `Rscript` with testthat unattached. Its reading of DESCRIPTION and
 # of `inst/suggests/guard.R` is inside function bodies for the same reason, one
 # step further on: `generate-backend-matrix.R` runs before marginplyr is
@@ -91,7 +91,7 @@ test_tally <- function(test_log) {
 # fail a script that has no version question to ask. `verify-suite-coverage.R`
 # does ask one, and runs from the repository root where both are present.
 #
-# The helper also brings in `backend_available()`, `suggest_status()`, and
+# The helper also brings in `suggest_available()`, `suggest_status()`, and
 # `required_suggests()`; separating the list into its own file would trade that
 # for a file whose only purpose is the separation.
 source("tests/testthat/helper-optional-backends.R")

--- a/.github/scripts/generate-backend-matrix.R
+++ b/.github/scripts/generate-backend-matrix.R
@@ -1,7 +1,7 @@
 # Generates `release-matrix.yaml`'s `backend` matrix from the one table.
 #
 # Those jobs used to be four hand-written entries, each repeating what
-# `optional_backend_spec()` in `tests/testthat/helper-optional-backends.R`
+# `optional_suggest_spec()` in `tests/testthat/helper-optional-backends.R`
 # already says: which package the job installs, which packages its absence must
 # fail on, and a `cache-version` spelled from its name. Repetition is what the
 # `coverage` job existed to police -- it read the workflow file back against the
@@ -40,7 +40,7 @@ if (length(backends) == 0L) {
 }
 
 entries <- lapply(backends, function(package) {
-  packages <- backend_job_packages(package)
+  packages <- suggest_job_packages(package)
   list(
     name = package,
     # What `setup-r-dependencies` installs on top of the hard dependencies.

--- a/.github/scripts/verify-suite-coverage.R
+++ b/.github/scripts/verify-suite-coverage.R
@@ -62,7 +62,7 @@ if (length(backends) == 0L) {
 
 # Half one of the mechanism: this run's library holds every backend, at a
 # version DESCRIPTION accepts. Asked of the library rather than through
-# `backend_available()`, because the guards are the thing under test here --
+# `suggest_available()`, because the guards are the thing under test here --
 # `suggest_status()` reads DESCRIPTION and the installed version and knows
 # nothing of `MARGINPLYR_HIDE_SUGGESTS`, which is what the simulation drives.
 #
@@ -94,7 +94,7 @@ skip_messages <- function(expectations) {
 }
 
 # Skips read `Reason: {arrow} is not installed`, the wording
-# `skip_if_backend_absent()` writes. Parsing it is what lets a violation name
+# `skip_if_suggest_absent()` writes. Parsing it is what lets a violation name
 # the backends it requires rather than only the test.
 skipped_packages <- function(messages) {
   named <- regmatches(messages, regexpr("\\{[^}]+\\}", messages))
@@ -112,12 +112,12 @@ observe <- function(selected) {
   on.exit(Sys.unsetenv("MARGINPLYR_HIDE_SUGGESTS"), add = TRUE)
 
   # Half two of the mechanism, asserted inside the configuration it describes.
-  reported <- vapply(backends, backend_available, logical(1))
+  reported <- vapply(backends, suggest_available, logical(1))
   if (!isTRUE(reported[[selected]]) || any(reported[withheld])) {
     stop(call. = FALSE, sprintf(
       paste0(
         "The absence simulation is not working: with %s selected and %s ",
-        "hidden, `backend_available()` reports %s. Every conclusion below ",
+        "hidden, `suggest_available()` reports %s. Every conclusion below ",
         "would be vacuous."
       ),
       selected,
@@ -167,7 +167,7 @@ observations <- unlist(
   use.names = FALSE
 )
 
-# The wording `skip_if_backend_absent()` writes for a backend this run hid.
+# The wording `skip_if_suggest_absent()` writes for a backend this run hid.
 # Anything else is a skip a `backend` job could not attribute either.
 attributable <- sprintf("Reason: {%s} is not installed", backends)
 
@@ -256,7 +256,7 @@ if (length(unattributable) > 0L) {
     paste0(
       "These skip reasons name no optional backend, so a `backend` job ",
       "meeting one cannot attribute it to a package it withheld and fails: ",
-      "%s. Guard the test with `skip_if_backend_absent()` on the one backend ",
+      "%s. Guard the test with `skip_if_suggest_absent()` on the one backend ",
       "it needs, splitting it first if it selects among several."
     ),
     paste(sprintf("\"%s\"", unattributable), collapse = "; ")

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -31,7 +31,7 @@
 #
 # Which contracts those jobs prove is settled by construction rather than by a
 # list (#93). Every `backend` job installs one optional backend -- plus the
-# companions its entry declares, which may themselves be tracked backends when
+# companions its entry declares, which may themselves be tracked entries when
 # one drags another in -- and withholds everything else, so between them they
 # execute every test that requires at most one backend; a test requiring two is
 # executed by none of them and skips in all of them, unnoticed. Three layers
@@ -161,7 +161,7 @@ jobs:
 
   # The `backend` jobs below are one job body repeated per optional backend, and
   # every field that differed between them was a restatement of
-  # `optional_backend_spec()`. This job derives them from it instead, so a
+  # `optional_suggest_spec()`. This job derives them from it instead, so a
   # backend cannot be tracked by the tests and executed by nothing: the job is
   # the table. That is what retired the `coverage` job, which existed only to
   # read this file back against the same list (#71).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,10 @@ example run interactively, and the site build — whose `Config/Needs/website`
 entries carry no versions, so a site job can legitimately install a version the
 package's own Suggests entry rejects.
 
+*Suggest* and *backend* are used from here on in the senses *Release matrix*
+below separates them into, since the helpers this section names are shared with
+the jobs that section describes.
+
 DESCRIPTION states each constraint and the guard is the only thing that reads
 one, so there is no version written down twice and nothing to keep in step. The
 guard lives under `inst/` for the reason `must-error.R` does: the four
@@ -334,10 +338,6 @@ call on a `system.file()` path, and a copy in `tests/` would be the copy the
 shipped sites drift from. Adding an optional Suggest still means editing the
 two places *Release matrix* names — a version is not a third place, because the
 guard reads it.
-
-*Suggest* and *backend* are used below in the senses *Release matrix*
-separates them into, since the helpers this section names are shared with the
-jobs that section describes.
 
 `suggest_available()` consults the guard, so a too-old package skips rather
 than running, unless the job named it in `MARGINPLYR_REQUIRED_SUGGESTS` — then
@@ -388,12 +388,15 @@ set that arrived empty is a set that passes.
 
 `.github/workflows/release-matrix.yaml` checks one built tarball rather than
 the working tree, because a check that passes on the development tree can be
-passing on a file the tarball does not ship. Its `backend` jobs each install a
-single member of `optional_backends()` and set `MARGINPLYR_REQUIRED_SUGGESTS`,
-which turns that package's absence into a test failure instead of a skip.
+passing on a file the tarball does not ship. Each of its `backend` jobs is for
+one member of `optional_backends()`, and installs that member plus the
+companions its entry declares. `MARGINPLYR_REQUIRED_SUGGESTS` names all of
+them, so any one of them failing to install fails the job instead of skipping
+its tests.
 
-Two words are in use in this section and they name different sets (#185). A
-*Suggest* is any optional package a guard may name — what
+Two words are in use in this section and in *Optional-dependency guards*
+above, and they name different sets (#185). A *Suggest* is any optional
+package a guard may name — what
 `optional_suggest_spec()` holds, and what every helper taking a package name
 speaks of. A *backend* is the narrower thing a generated job exists for: the
 subset `optional_backends()` returns, which is what those jobs iterate over.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,27 +331,27 @@ guard lives under `inst/` for the reason `must-error.R` does: the four
 vignettes, the four examples, and
 `tests/testthat/helper-optional-backends.R` each reach it in one `source()`
 call on a `system.file()` path, and a copy in `tests/` would be the copy the
-shipped sites drift from. Adding a backend still means editing the two places
-*Release matrix* names — a version is not a third place, because the guard
-reads it.
+shipped sites drift from. Adding an optional Suggest still means editing the
+two places *Release matrix* names — a version is not a third place, because the
+guard reads it.
 
-`backend_available()` consults the guard, so a too-old backend skips rather
+`suggest_available()` consults the guard, so a too-old package skips rather
 than running, unless the job named it in `MARGINPLYR_REQUIRED_SUGGESTS` — then
-it errors, exactly as an absent required backend does, and a `backend` job
+it errors, exactly as an absent required package does, and a `backend` job
 holding a stale version reds as a failure rather than passing on a skipped
 suite. The skip says which case it is: `{duckdb} 1.5.4.3 is installed, but
 marginplyr requires >= 1.5.5`, deliberately not the `{pkg} is not installed`
 wording, which would send a reader looking for a package sitting in their
-library. A `backend` job cannot produce that skip — a backend it named errors
+library. A `backend` job cannot produce that skip — a package it named errors
 and one it withheld is not installed — but the wording is still what stops
-`verify-backend.R` attributing a version failure to a withheld backend if one
+`verify-backend.R` attributing a version failure to a withheld package if one
 ever reached that path. A package hidden by `MARGINPLYR_HIDE_SUGGESTS` keeps
 the absent wording, because a simulated absence that announced a version is a
 skip neither `verify-suite-coverage.R` nor `verify-depends-only.R` could
 attribute.
 
 Guarding on a package DESCRIPTION does not suggest is an error, not an answer.
-`backend_available()` already refuses a backend `optional_suggests()` does not
+`suggest_available()` already refuses a package `optional_suggests()` does not
 name, but a vignette and an example have no such registry, and a typo or a
 dependency that moved to `Config/Needs/website` would otherwise guard on
 installation alone while reading as protection.
@@ -385,14 +385,22 @@ set that arrived empty is a set that passes.
 `.github/workflows/release-matrix.yaml` checks one built tarball rather than
 the working tree, because a check that passes on the development tree can be
 passing on a file the tarball does not ship. Its `backend` jobs each install a
-single optional backend and set `MARGINPLYR_REQUIRED_SUGGESTS`, which turns
-that backend's absence into a test failure instead of a skip.
+single member of `optional_backends()` and set `MARGINPLYR_REQUIRED_SUGGESTS`,
+which turns that package's absence into a test failure instead of a skip.
 
-That variable is what makes skipping safe everywhere else. Optional-backend
-tests skip when their package is missing, which is correct for CRAN's minimal
-flavors but means a green job proves nothing about the backend. Every such
-test therefore goes through `skip_if_backend_absent()` or `backend_available()`
-from `tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
+Two words are in use in this section and they name different sets (#185). A
+*Suggest* is any optional package a guard may name — what
+`optional_suggest_spec()` holds, and what every helper taking a package name
+speaks of. A *backend* is the narrower thing a generated job is: the subset
+`optional_backends()` returns, which is what these jobs iterate over. Most
+entries are both; `DBI` is neither a job nor a translation target, and
+`data.table` gets a job for an input class rather than a translation.
+
+That variable is what makes skipping safe everywhere else. A test behind an
+optional package skips when it is missing, which is correct for CRAN's minimal
+flavors but means a green job proves nothing about it. Every such test
+therefore goes through `skip_if_suggest_absent()` or `suggest_available()` from
+`tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
 or `rlang::is_installed()` directly, since those cannot be told to fail — and
 never `requireNamespace()` either, for the separate reason in
 *Optional-dependency guards* above. (`skip_if_not_installed("dbplyr")` is not
@@ -453,10 +461,10 @@ run: it fails the job when an optional backend the job did not declare in
 it rather than the workflow calling it as a step, so the assertion cannot be
 dropped from a job that still checks a tarball.
 
-Adding an optional backend means editing two places. Every partial edit fails
+Adding an optional Suggest means editing two places. Every partial edit fails
 loudly:
 
-1. `optional_backend_spec()` in `tests/testthat/helper-optional-backends.R`,
+1. `optional_suggest_spec()` in `tests/testthat/helper-optional-backends.R`,
    the one table every other consumer derives from — `optional_suggests()` for
    its `asserted` column, `optional_backends()` for the subset a job can be
    asked to withhold, and `verify-depends-only.R`,
@@ -470,14 +478,14 @@ loudly:
    entry claims no absence
    and gets no job, so nothing asserts it — which is the DBI case above, and
    the reason that value exists. `companions` names what the generated job
-   installs alongside the backend, which is how `DBI` reaches the driver jobs
-   without a job of its own. It is also how a backend declares what its own
+   installs alongside the entry, which is how `DBI` reaches the driver jobs
+   without a job of its own. It is also how an entry declares what its own
    dependencies drag in, and there the companion is a tracked entry rather
    than an untracked one: dtplyr declares `Imports: data.table`, so its job
    installs data.table whichever way the entry is written, and leaving it
    undeclared makes `verify-library-isolation.R` fail the job for a leak that
-   is really the requested backend's own closure.
-2. the `skip_if_backend_absent()` or `backend_available()` call in the tests.
+   is really the requested package's own closure.
+2. the `skip_if_suggest_absent()` or `suggest_available()` call in the tests.
    Doing only this errors immediately: those helpers refuse a package
    `optional_suggests()` does not name, since nothing would execute it and
    nothing would assert it absent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,15 +396,15 @@ its tests.
 
 Two words are in use in this section and in *Optional-dependency guards*
 above, and they name different sets (#185). A *Suggest* is an optional package
-the test suite guards on — an entry in `optional_suggest_spec()`, which is what
-every helper taking a package name accepts and refuses anything else. A
-*backend* is the narrower thing a generated job exists for: the subset
+the test suite guards on — an entry in `optional_suggest_spec()`. A *backend*
+is the narrower thing a generated job exists for: the subset
 `optional_backends()` returns, which is what those jobs iterate over. `DBI` is
 a Suggest and not a backend — it has no job of its own — while `data.table` is
 both, and what its job proves is an input class rather than a query
-translation. A Suggest only a vignette or an example guards on is neither, and
-belongs in neither place: `tidyr` reaches `marginplyr_suggest_available()`
-directly, and DESCRIPTION is the whole of its registration.
+translation. A Suggested package only a vignette or an example guards on is
+neither, and belongs in neither place: `tidyr` reaches
+`marginplyr_suggest_available()` directly, and DESCRIPTION is the whole of its
+registration.
 
 `MARGINPLYR_REQUIRED_SUGGESTS` is what makes skipping safe everywhere else. A
 test behind an optional package skips when it is missing, which is correct for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,10 @@ shipped sites drift from. Adding an optional Suggest still means editing the
 two places *Release matrix* names — a version is not a third place, because the
 guard reads it.
 
+*Suggest* and *backend* are used below in the senses *Release matrix*
+separates them into, since the helpers this section names are shared with the
+jobs that section describes.
+
 `suggest_available()` consults the guard, so a too-old package skips rather
 than running, unless the job named it in `MARGINPLYR_REQUIRED_SUGGESTS` — then
 it errors, exactly as an absent required package does, and a `backend` job

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,9 +335,9 @@ guard lives under `inst/` for the reason `must-error.R` does: the four
 vignettes, the four examples, and
 `tests/testthat/helper-optional-backends.R` each reach it in one `source()`
 call on a `system.file()` path, and a copy in `tests/` would be the copy the
-shipped sites drift from. Adding an optional Suggest still means editing the
-two places *Release matrix* names — a version is not a third place, because the
-guard reads it.
+shipped sites drift from. Registering an optional Suggest with the test suite
+still means editing the two places *Release matrix* names — a version is not a
+third place, because the guard reads it.
 
 `suggest_available()` consults the guard, so a too-old package skips rather
 than running, unless the job named it in `MARGINPLYR_REQUIRED_SUGGESTS` — then
@@ -395,14 +395,16 @@ them, so any one of them failing to install fails the job instead of skipping
 its tests.
 
 Two words are in use in this section and in *Optional-dependency guards*
-above, and they name different sets (#185). A *Suggest* is any optional
-package a guard may name — what
-`optional_suggest_spec()` holds, and what every helper taking a package name
-speaks of. A *backend* is the narrower thing a generated job exists for: the
-subset `optional_backends()` returns, which is what those jobs iterate over.
-`DBI` is a Suggest and not a backend — it has no job of its own — while
-`data.table` is both, and what its job proves is an input class rather than a
-query translation.
+above, and they name different sets (#185). A *Suggest* is an optional package
+the test suite guards on — an entry in `optional_suggest_spec()`, which is what
+every helper taking a package name accepts and refuses anything else. A
+*backend* is the narrower thing a generated job exists for: the subset
+`optional_backends()` returns, which is what those jobs iterate over. `DBI` is
+a Suggest and not a backend — it has no job of its own — while `data.table` is
+both, and what its job proves is an input class rather than a query
+translation. A Suggest only a vignette or an example guards on is neither, and
+belongs in neither place: `tidyr` reaches `marginplyr_suggest_available()`
+directly, and DESCRIPTION is the whole of its registration.
 
 `MARGINPLYR_REQUIRED_SUGGESTS` is what makes skipping safe everywhere else. A
 test behind an optional package skips when it is missing, which is correct for
@@ -469,8 +471,8 @@ run: it fails the job when an optional backend the job did not declare in
 it rather than the workflow calling it as a step, so the assertion cannot be
 dropped from a job that still checks a tarball.
 
-Adding an optional Suggest means editing two places. Every partial edit fails
-loudly:
+Registering an optional Suggest with the test suite means editing two places.
+Every partial edit fails loudly:
 
 1. `optional_suggest_spec()` in `tests/testthat/helper-optional-backends.R`,
    the one table every other consumer derives from — `optional_suggests()` for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,15 +391,16 @@ which turns that package's absence into a test failure instead of a skip.
 Two words are in use in this section and they name different sets (#185). A
 *Suggest* is any optional package a guard may name — what
 `optional_suggest_spec()` holds, and what every helper taking a package name
-speaks of. A *backend* is the narrower thing a generated job is: the subset
-`optional_backends()` returns, which is what these jobs iterate over. Most
-entries are both; `DBI` is neither a job nor a translation target, and
-`data.table` gets a job for an input class rather than a translation.
+speaks of. A *backend* is the narrower thing a generated job exists for: the
+subset `optional_backends()` returns, which is what those jobs iterate over.
+`DBI` is a Suggest and not a backend — it has no job of its own — while
+`data.table` is both, and what its job proves is an input class rather than a
+query translation.
 
-That variable is what makes skipping safe everywhere else. A test behind an
-optional package skips when it is missing, which is correct for CRAN's minimal
-flavors but means a green job proves nothing about it. Every such test
-therefore goes through `skip_if_suggest_absent()` or `suggest_available()` from
+`MARGINPLYR_REQUIRED_SUGGESTS` is what makes skipping safe everywhere else. A
+test behind an optional package skips when it is missing, which is correct for
+CRAN's minimal flavors but means a green job proves nothing about it. Every
+such test goes through `skip_if_suggest_absent()` or `suggest_available()` from
 `tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
 or `rlang::is_installed()` directly, since those cannot be told to fail — and
 never `requireNamespace()` either, for the separate reason in

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -586,7 +586,7 @@ under CRAN semantics, so they run only in those jobs.
 A test title is part of that contract, because each job names the titles it
 exists to execute. Renaming a contract test is expected to break its job.
 `AGENTS.md` is the operational reference for the jobs, the verifier scripts,
-and the sites an added backend has to touch.
+and the sites an added optional Suggest has to touch.
 
 ## Extending backend support
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -586,7 +586,7 @@ under CRAN semantics, so they run only in those jobs.
 A test title is part of that contract, because each job names the titles it
 exists to execute. Renaming a contract test is expected to break its job.
 `AGENTS.md` is the operational reference for the jobs, the verifier scripts,
-and the sites an added optional Suggest has to touch.
+and the sites registering an optional Suggest has to touch.
 
 ## Extending backend support
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -574,13 +574,14 @@ green job. A backend contract therefore has a second seam, in
 backend alone and fails if the contract did not execute.
 
 What this asks of a test is that it never decide on its own whether it may
-skip. Optional-backend tests route through `skip_if_backend_absent()` or
-`backend_available()` in `tests/testthat/helper-optional-backends.R` — never
-`skip_if_not_installed()` or `rlang::is_installed()` — because only the helper
-can be told, through `MARGINPLYR_REQUIRED_SUGGESTS`, that this job promised to
-prove the backend and an absence is a failure. `test-optional-backends.R`
-covers the helper itself. Snapshot expectations belong to the same seam:
-testthat skips them under CRAN semantics, so they run only in those jobs.
+skip. A test behind an optional package routes through
+`skip_if_suggest_absent()` or `suggest_available()` in
+`tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
+or `rlang::is_installed()` — because only the helper can be told, through
+`MARGINPLYR_REQUIRED_SUGGESTS`, that this job promised to prove that package
+and an absence is a failure. `test-optional-backends.R` covers the helper
+itself. Snapshot expectations belong to the same seam: testthat skips them
+under CRAN semantics, so they run only in those jobs.
 
 A test title is part of that contract, because each job names the titles it
 exists to execute. Renaming a contract test is expected to break its job.

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -738,7 +738,10 @@ The finding also missed the second reversed site,
 `tests/testthat/test-factor.R:63`. #69 reorders both for consistency, records
 the closure reason where the list now lives, and asserts it in
 `test-optional-backends.R`, so a future dbplyr that drops DBI fails a test
-rather than silently making the exclusion wrong.
+rather than silently making the exclusion wrong. The helper this entry quotes
+is `skip_if_suggest_absent()` since #185, which renamed it and the table behind
+it for the optional Suggests they actually hold; the finding is quoted as it
+was raised.
 
 ### Rejected
 

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -1,8 +1,15 @@
-# Every backend behind these helpers is a Suggested package, so a check run
-# without it must skip rather than fail. That is right for CRAN's minimal
-# flavors, but it makes a skip indistinguishable from a proof: a release job
-# whose whole purpose is to execute DuckDB would pass green with fourteen
-# silently skipped tests if duckdb failed to install.
+# Every package behind these helpers is a Suggested one, so a check run without
+# it must skip rather than fail. That is right for CRAN's minimal flavors, but
+# it makes a skip indistinguishable from a proof: a release job whose whole
+# purpose is to execute DuckDB would pass green with fourteen silently skipped
+# tests if duckdb failed to install.
+#
+# Two words are in use here and they are not synonyms (#185). A *Suggest* is any
+# optional package a guard may name, which is what `optional_suggest_spec()`
+# below holds and what every helper taking a package name speaks of. A *backend*
+# is narrower -- a job the release matrix generates -- which is why
+# `optional_backends()` keeps its name for the subset those jobs iterate over
+# and no helper accepting an entry is named for one.
 #
 # Both variables below arrive as a comma-separated package list, and the CI
 # scripts read the same values through `env_list()` in `.github/scripts/`. That
@@ -15,7 +22,7 @@ suggests_env_list <- function(name) {
   declared[nzchar(declared)]
 }
 
-# `MARGINPLYR_REQUIRED_SUGGESTS` is how a job states which backends it exists
+# `MARGINPLYR_REQUIRED_SUGGESTS` is how a job states which Suggests it exists
 # to prove. A package named there must be installed, and its absence fails the
 # test instead of skipping it. Generic jobs leave the variable unset and keep
 # skipping. `.github/workflows/release-matrix.yaml` sets it per dedicated job.
@@ -31,7 +38,7 @@ required_suggests <- function() {
 #
 # Hiding is a claim about a package this process could otherwise see, so it is
 # deliberately not the same mechanism as `.libPaths()` surgery: a test that
-# reaches its backend through anything but these helpers would keep working and
+# reaches its package through anything but these helpers would keep working and
 # be reported as running, which is the honest answer -- the guards are what
 # decide whether a test skips, and the guards are what this reads.
 hidden_suggests <- function() {
@@ -54,7 +61,7 @@ hidden_suggests <- function() {
 #
 # The lookup is a function rather than a value because `.github/scripts/`
 # sources this file from a bare `Rscript` before marginplyr is installed --
-# `generate-backend-matrix.R` needs only `optional_backend_spec()` -- so
+# `generate-backend-matrix.R` needs only `optional_suggest_spec()` -- so
 # resolving a path at source time would fail a script that never asks a version
 # question. Both candidate paths are relative, and both possible working
 # directories are covered: the repository root under those scripts, and
@@ -85,7 +92,7 @@ declared_suggests <- function() {
   }
   suggests <- unname(read.dcf(path, fields = "Suggests")[1L, 1L])
   # A DESCRIPTION stating no Suggests would make every guard below report every
-  # backend unconstrained, which reads exactly like a package whose constraints
+  # package unconstrained, which reads exactly like a package whose constraints
   # are all satisfied.
   if (is.na(suggests)) {
     stop(sprintf("%s states no Suggests field.", path))
@@ -109,7 +116,7 @@ suggest_guard <- local({
     if (!nzchar(path) || !file.exists(path)) {
       stop(
         "`inst/suggests/guard.R` is not reachable, so no guard here can tell ",
-        "an installed backend from a usable one."
+        "an installed package from a usable one."
       )
     }
     loaded <<- new.env(parent = globalenv())
@@ -132,9 +139,15 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # tarball, and `.Rbuildignore` excludes `^\.github$` from that tarball, so a
 # table kept in `.github/scripts/` would not exist where the tests execute. The
 # CI scripts run from the checkout instead and can read this file, which makes
-# `tests/` the only placement both sides reach. Adding a backend starts here,
-# because `backend_available()` below refuses a name this table does not carry,
+# `tests/` the only placement both sides reach. Adding an entry starts here,
+# because `suggest_available()` below refuses a name this table does not carry,
 # and `release-matrix.yaml` generates its `backend` job from it.
+#
+# What the table holds is every optional Suggest a guard may name, and two of
+# its entries are why that is not the same set as the backends: `DBI` is a
+# companion no job proves on its own, and `data.table` is an input class rather
+# than a translation target. The other four are translation targets, and the
+# table is named for the wider set it holds rather than for them (#185).
 #
 # `asserted` answers whether the release matrix can assert the package absent by
 # name. `DBI` cannot. `dbplyr` is an Import and declares `Imports: DBI`, so DBI
@@ -143,28 +156,22 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # require a `{DBI} is not installed` line that no run can produce, and
 # `verify-library-isolation.R` would find DBI on `.libPaths()` in every job that
 # withheld it. An entry that is not `asserted` gets no job of its own; it
-# reaches CI as another backend's companion.
+# reaches CI as another entry's companion.
 #
-# `companions` names the packages a job proving this backend must install
-# alongside it. They are not the backend, so they are not what the job promises
-# to execute -- but a driver package without DBI installs and then does nothing.
-# It is also how a job declares what its backend drags in: dtplyr declares
-# `Imports: data.table`, so a job installing dtplyr installs data.table whether
-# it asked for it or not, and `verify-library-isolation.R` would read that as a
-# leak from a shared cache. Naming it here is the job saying it expected it.
+# `companions` names the packages a job proving this entry must install
+# alongside it. They are not what the job promises to execute -- but a driver
+# package without DBI installs and then does nothing. It is also how a job
+# declares what its own entry drags in: dtplyr declares `Imports: data.table`,
+# so a job installing dtplyr installs data.table whether it asked for it or not,
+# and `verify-library-isolation.R` would read that as a leak from a shared
+# cache. Naming it here is the job saying it expected it.
 #
 # `data.table` is an entry of its own as well, because it is not only dtplyr's
 # dependency here: raw `data.table` input reaches the local backend as an
 # ordinary data frame subclass (#176), and it is genuinely absent under
-# `_R_CHECK_DEPENDS_ONLY_=true`, which is what `asserted` claims. It is the
-# second entry to stretch the word "backend" -- `DBI` was the first -- since
-# what the table actually holds is every optional Suggest a guard may name, and
-# what a `backend` job proves for this one is an input class rather than a
-# translation target. The name is left alone deliberately and the choice is
-# #185's to make: it is spelled into four CI scripts, the workflow, and every
-# guard, so renaming it is a larger change than any entry it holds, and nothing
-# reads the table wrongly today.
-optional_backend_spec <- function() {
+# `_R_CHECK_DEPENDS_ONLY_=true`, which is what `asserted` claims. What its
+# `backend` job proves is that input class, not a translation.
+optional_suggest_spec <- function() {
   list(
     arrow = list(asserted = TRUE, companions = character()),
     duckdb = list(asserted = TRUE, companions = "DBI"),
@@ -177,47 +184,54 @@ optional_backend_spec <- function() {
 
 # The table's `asserted` column, in the shape every existing caller reads.
 optional_suggests <- function() {
-  vapply(optional_backend_spec(), function(entry) entry$asserted, logical(1))
+  vapply(optional_suggest_spec(), function(entry) entry$asserted, logical(1))
 }
 
 # The subset a job can be asked to withhold, which is what the release matrix's
 # absence assertions iterate over and what its `backend` matrix is generated
 # from. Keeps the name it had while it lived in `ci-helpers.R`, so
 # `verify-depends-only.R` and `verify-library-isolation.R` call it unchanged.
+#
+# #185 renamed the table and the guards around it without touching this, because
+# this is the one place the narrower word is the right one: what it returns is
+# exactly the set `backend` jobs are generated from, and it takes no package
+# name, so it cannot be read as a claim that any particular entry translates
+# queries. `suggest_job_packages()` below does take one, which is why that one
+# moved.
 optional_backends <- function() {
   asserted <- optional_suggests()
   names(asserted)[asserted]
 }
 
 # Every package a job proving `package` must install and name in
-# `MARGINPLYR_REQUIRED_SUGGESTS`. The backend leads, so a reader of the
-# generated matrix sees which entry a job is for before its companions.
-backend_job_packages <- function(package) {
-  spec <- optional_backend_spec()
+# `MARGINPLYR_REQUIRED_SUGGESTS`. The entry leads, so a reader of the
+# generated matrix sees which one a job is for before its companions.
+suggest_job_packages <- function(package) {
+  spec <- optional_suggest_spec()
   if (!package %in% names(spec)) {
     stop(sprintf(
-      "{%s} is not named in `optional_backend_spec()`.",
+      "{%s} is not named in `optional_suggest_spec()`.",
       package
     ))
   }
   unique(c(package, spec[[package]]$companions))
 }
 
-# Reports whether an optional backend can be used, and refuses to report FALSE
-# for a backend the running job promised to exercise. Callers that select among
-# several backends use this directly, because dropping one from a list records
+# Reports whether an optional Suggest can be used, and refuses to report FALSE
+# for one the running job promised to exercise. Callers that select among
+# several packages use this directly, because dropping one from a list records
 # no skip at all and would otherwise be invisible.
 #
 # "Can be used" includes the version DESCRIPTION requires, which is what
 # `requireNamespace()` here could not say (#123). An installed-but-too-old
-# backend now reports FALSE and skips, where it used to report TRUE and let the
+# package now reports FALSE and skips, where it used to report TRUE and let the
 # test call an API the installed version does not have.
 #
 # A package `known` does not name is an error rather than FALSE. Nothing in the
 # release matrix executes such a package and nothing asserts it absent, so a
 # guard on it would do nothing while reading as protection; erroring is what
-# makes this test suite the place a backend gets registered. The check runs
-# before the guard is consulted so that it fires the same way on a fully
+# makes this test suite the place an optional Suggest gets registered. The check
+# runs before the guard is consulted so that it fires the same way on a fully
 # provisioned developer machine, where the package is installed and a check
 # placed after it would never be reached.
 #
@@ -226,7 +240,7 @@ backend_job_packages <- function(package) {
 # package that is always installed, and a constraint no installed version can
 # satisfy; none of the three belongs in `optional_suggests()` or in DESCRIPTION.
 # Every other call site takes the defaults.
-backend_available <- function(package,
+suggest_available <- function(package,
                               known = optional_suggests(),
                               suggests = declared_suggests()) {
   if (!package %in% names(known)) {
@@ -234,7 +248,7 @@ backend_available <- function(package,
       paste0(
         "{%s} is not named in `optional_suggests()`, so no release-matrix job ",
         "executes it and no job asserts it is absent. Add it to ",
-        "`optional_backend_spec()`, which is what generates its job."
+        "`optional_suggest_spec()`, which is what generates its job."
       ),
       package
     ))
@@ -267,49 +281,49 @@ backend_available <- function(package,
     stop(sprintf(
       paste0(
         "%s, and it is named in MARGINPLYR_REQUIRED_SUGGESTS, so this job ",
-        "cannot prove its backend contract."
+        "cannot prove the contract it exists for."
       ),
-      backend_absence_reason(package, suggests = suggests)
+      suggest_absence_reason(package, suggests = suggests)
     ))
   }
   FALSE
 }
 
-# Why a backend is unusable, in the wording a skip carries.
+# Why a package is unusable, in the wording a skip carries.
 #
-# A hidden backend reports the absent wording rather than the guard's, because
+# A hidden package reports the absent wording rather than the guard's, because
 # `MARGINPLYR_HIDE_SUGGESTS` claims a package this process could otherwise see
 # is gone: `verify-suite-coverage.R` and `verify-depends-only.R` both attribute
 # a skip by matching `{pkg} is not installed`, and a simulated absence that
 # announced itself differently would be a skip neither could attribute.
 #
 # The too-old wording is deliberately not that phrase, and not because a
-# `backend` job needs it to be: a backend that job named is required, so
-# `backend_available()` above stops rather than skipping, and a backend it
-# withheld is not installed at all. What the distinction is for is the reader of
-# a skip -- "not installed" would send someone looking for a package sitting in
-# their library -- and for `verify-backend.R`, which fails a job on any skip it
+# `backend` job needs it to be: a package that job named is required, so
+# `suggest_available()` above stops rather than skipping, and one it withheld is
+# not installed at all. What the distinction is for is the reader of a skip --
+# "not installed" would send someone looking for a package sitting in their
+# library -- and for `verify-backend.R`, which fails a job on any skip it
 # cannot attribute. Sharing the absent wording would let a version failure pass
-# there as a withheld backend if one ever reached that path.
-backend_absence_reason <- function(package, suggests = declared_suggests()) {
+# there as a withheld package if one ever reached that path.
+suggest_absence_reason <- function(package, suggests = declared_suggests()) {
   if (package %in% hidden_suggests()) {
     return(sprintf("{%s} is not installed", package))
   }
   suggest_status(package, suggests = suggests)$reason
 }
 
-# Skips unless every named backend is usable, keeping testthat's own wording for
+# Skips unless every named package is usable, keeping testthat's own wording for
 # an absent package so the skip summary reads the same as it did under
 # `skip_if_not_installed()`.
 #
 # `known` and `suggests` sit after `...` and so can only be supplied by full
-# name, which keeps them from ever swallowing a backend argument.
-skip_if_backend_absent <- function(...,
+# name, which keeps them from ever swallowing a package argument.
+skip_if_suggest_absent <- function(...,
                                    known = optional_suggests(),
                                    suggests = declared_suggests()) {
   for (package in c(...)) {
-    if (!backend_available(package, known = known, suggests = suggests)) {
-      skip(backend_absence_reason(package, suggests = suggests))
+    if (!suggest_available(package, known = known, suggests = suggests)) {
+      skip(suggest_absence_reason(package, suggests = suggests))
     }
   }
   invisible(NULL)

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -13,10 +13,10 @@
 # a backend; `data.table` is both, and what its job proves is an input class.
 #
 # This file and `test-optional-backends.R` keep the narrower word in their
-# names, which is the one place it is left standing: a testthat helper file is
-# addressed by path from `ci-helpers.R`, `release-matrix.yaml`, `guard.R`, and
-# three sections of `AGENTS.md`, and no reader reaches those names while writing
-# a guard.
+# names, which is the one place it stands without being accurate: a testthat
+# helper file is reached by path -- from the CI scripts, the workflow,
+# `inst/suggests/guard.R`, and the design documents, `grep` being the way to
+# find them all -- and no reader meets either name while writing a guard.
 #
 # Both variables below arrive as a comma-separated package list, and the CI
 # scripts read the same values through `env_list()` in `.github/scripts/`. That
@@ -160,12 +160,13 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # reaches CI as another entry's companion.
 #
 # `companions` names the packages a job proving this entry must install
-# alongside it. They are not what the job promises to execute -- but a driver
-# package without DBI installs and then does nothing. It is also how a job
-# declares what its own entry drags in: dtplyr declares `Imports: data.table`,
-# so a job installing dtplyr installs data.table whether it asked for it or not,
-# and `verify-library-isolation.R` would read that as a leak from a shared
-# cache. Naming it here is the job saying it expected it.
+# alongside it. They are not the entry the job is for, so they are not what it
+# promises to execute -- but a driver package without DBI installs and then does
+# nothing. It is also how a job declares what its own entry drags in: dtplyr
+# declares `Imports: data.table`, so a job installing dtplyr installs data.table
+# whether it asked for it or not, and `verify-library-isolation.R` would read
+# that as a leak from a shared cache. Naming it here is the job saying it
+# expected it.
 #
 # `data.table` is an entry of its own as well, because it is not only dtplyr's
 # dependency here: raw `data.table` input reaches the local backend as an
@@ -194,11 +195,10 @@ optional_suggests <- function() {
 # `verify-depends-only.R` and `verify-library-isolation.R` call it unchanged.
 #
 # #185 renamed the table and the guards around it without touching this, because
-# this is the one place the narrower word is the right one: what it returns is
-# exactly the set `backend` jobs are generated from, and it takes no package
-# name, so it cannot be read as a claim that any particular entry translates
-# queries. `suggest_job_packages()` below does take one, which is why that one
-# moved.
+# here the narrower word is the accurate one: what it returns is exactly the set
+# `backend` jobs are generated from, and it takes no package name, so it cannot
+# be read as a claim that any particular entry translates queries.
+# `suggest_job_packages()` below does take one, which is why that one moved.
 optional_backends <- function() {
   asserted <- optional_suggests()
   names(asserted)[asserted]

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -4,19 +4,20 @@
 # purpose is to execute DuckDB would pass green with fourteen silently skipped
 # tests if duckdb failed to install.
 #
-# Two words are in use here and they are not synonyms (#185). A *Suggest* is any
-# optional package a guard may name, which is what `optional_suggest_spec()`
-# below holds and what every helper taking a package name speaks of. A *backend*
-# is narrower -- an entry the release matrix generates a job for -- which is why
-# `optional_backends()` keeps its name for the subset those jobs iterate over
-# and no helper accepting an entry is named for one. `DBI` is a Suggest and not
-# a backend; `data.table` is both, and what its job proves is an input class.
+# Two words are in use here and they are not synonyms: a *Suggest* is any
+# optional package a guard may name, and a *backend* is the narrower thing the
+# release matrix generates a job for. `AGENTS.md`'s *Release matrix* section
+# states the distinction once, with the entries that turn on it; what follows
+# from it here is that `optional_suggest_spec()` below is named for what it
+# holds, `optional_backends()` for the subset those jobs iterate over, and no
+# helper accepting a package name is named for a backend (#185).
 #
 # This file and `test-optional-backends.R` keep the narrower word in their
-# names, which is the one place it stands without being accurate: a testthat
-# helper file is reached by path -- from the CI scripts, the workflow,
-# `inst/suggests/guard.R`, and the design documents, `grep` being the way to
-# find them all -- and no reader meets either name while writing a guard.
+# names, which is the one place it stands without being accurate: a file name
+# is reached by path, and a path is not a claim about what the file holds.
+# Renaming one moves a string in the CI scripts, the workflow,
+# `inst/suggests/guard.R`, and the design documents -- `grep` finds them --
+# without changing a word anyone writes when they write a guard.
 #
 # Both variables below arrive as a comma-separated package list, and the CI
 # scripts read the same values through `env_list()` in `.github/scripts/`. That

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -4,20 +4,20 @@
 # purpose is to execute DuckDB would pass green with fourteen silently skipped
 # tests if duckdb failed to install.
 #
-# Two words are in use here and they are not synonyms: a *Suggest* is any
-# optional package a guard may name, and a *backend* is the narrower thing the
-# release matrix generates a job for. `AGENTS.md`'s *Release matrix* section
-# states the distinction once, with the entries that turn on it; what follows
-# from it here is that `optional_suggest_spec()` below is named for what it
-# holds, `optional_backends()` for the subset those jobs iterate over, and no
-# helper accepting a package name is named for a backend (#185).
+# Two words are in use here and they are not synonyms: a *Suggest* is an
+# optional package the test suite guards on, and a *backend* is the narrower
+# thing the release matrix generates a job for. `AGENTS.md`'s *Release matrix*
+# section states the distinction once, with the entries that turn on it; what
+# follows from it here is that `optional_suggest_spec()` below is named for
+# what it holds, `optional_backends()` for the subset those jobs iterate over,
+# and no helper accepting a package name is named for a backend (#185).
 #
 # This file and `test-optional-backends.R` keep the narrower word in their
 # names, which is the one place it stands without being accurate: a file name
 # is reached by path, and a path is not a claim about what the file holds.
-# Renaming one moves a string in the CI scripts, the workflow,
-# `inst/suggests/guard.R`, and the design documents -- `grep` finds them --
-# without changing a word anyone writes when they write a guard.
+# Renaming one moves a string through the CI scripts, the workflow, and the
+# prose that names the path -- `grep` finds them -- without changing a word
+# anyone writes when they write a guard.
 #
 # Both variables below arrive as a comma-separated package list, and the CI
 # scripts read the same values through `env_list()` in `.github/scripts/`. That

--- a/tests/testthat/helper-optional-backends.R
+++ b/tests/testthat/helper-optional-backends.R
@@ -7,9 +7,16 @@
 # Two words are in use here and they are not synonyms (#185). A *Suggest* is any
 # optional package a guard may name, which is what `optional_suggest_spec()`
 # below holds and what every helper taking a package name speaks of. A *backend*
-# is narrower -- a job the release matrix generates -- which is why
+# is narrower -- an entry the release matrix generates a job for -- which is why
 # `optional_backends()` keeps its name for the subset those jobs iterate over
-# and no helper accepting an entry is named for one.
+# and no helper accepting an entry is named for one. `DBI` is a Suggest and not
+# a backend; `data.table` is both, and what its job proves is an input class.
+#
+# This file and `test-optional-backends.R` keep the narrower word in their
+# names, which is the one place it is left standing: a testthat helper file is
+# addressed by path from `ci-helpers.R`, `release-matrix.yaml`, `guard.R`, and
+# three sections of `AGENTS.md`, and no reader reaches those names while writing
+# a guard.
 #
 # Both variables below arrive as a comma-separated package list, and the CI
 # scripts read the same values through `env_list()` in `.github/scripts/`. That
@@ -143,12 +150,6 @@ suggest_status <- function(package, suggests = declared_suggests()) {
 # because `suggest_available()` below refuses a name this table does not carry,
 # and `release-matrix.yaml` generates its `backend` job from it.
 #
-# What the table holds is every optional Suggest a guard may name, and two of
-# its entries are why that is not the same set as the backends: `DBI` is a
-# companion no job proves on its own, and `data.table` is an input class rather
-# than a translation target. The other four are translation targets, and the
-# table is named for the wider set it holds rather than for them (#185).
-#
 # `asserted` answers whether the release matrix can assert the package absent by
 # name. `DBI` cannot. `dbplyr` is an Import and declares `Imports: DBI`, so DBI
 # is inside the hard dependency closure and is installed in every job,
@@ -206,6 +207,12 @@ optional_backends <- function() {
 # Every package a job proving `package` must install and name in
 # `MARGINPLYR_REQUIRED_SUGGESTS`. The entry leads, so a reader of the
 # generated matrix sees which one a job is for before its companions.
+#
+# Defined over the whole table rather than over `optional_backends()`, because
+# an entry with no job of its own still has an answer -- `DBI` installs itself
+# and nothing else -- and refusing a name the table does not carry is the check
+# worth making here. `generate-backend-matrix.R` asks it only about entries a
+# job exists for.
 suggest_job_packages <- function(package) {
   spec <- optional_suggest_spec()
   if (!package %in% names(spec)) {

--- a/tests/testthat/helper-sqlite-simulation.R
+++ b/tests/testthat/helper-sqlite-simulation.R
@@ -3,11 +3,11 @@
 # Simulated SQLite queries therefore need the optional RSQLite package even
 # though nothing is executed.
 sqlite_simulation_available <- function() {
-  backend_available("RSQLite")
+  suggest_available("RSQLite")
 }
 
 skip_if_no_sqlite_simulation <- function() {
-  skip_if_backend_absent("RSQLite")
+  skip_if_suggest_absent("RSQLite")
 }
 
 # Drops the dialects whose SQL cannot be rendered without an optional driver

--- a/tests/testthat/helper-unpredictable-summary-names.R
+++ b/tests/testthat/helper-unpredictable-summary-names.R
@@ -29,7 +29,7 @@
 # `"{.fn}"` names the output for the function alone, and `NULL` leaves
 # `across()`'s own `{.col}_{.fn}`.
 #
-# `predict` is a parameter for the same reason `backend_available()` takes
+# `predict` is a parameter for the same reason `suggest_available()` takes
 # `known`: this helper's own tests need to drive both outcomes, and the shape
 # that reaches the failing one is the shape this helper exists to avoid
 # building. Every other call site takes the default.

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -130,7 +130,7 @@ test_that("an eager expansion over 512 branches keeps one branch per set", {
 })
 
 test_that("lazy branches nest logarithmically rather than linearly", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   # Folding 512 branches from the left builds 512 nested dtplyr steps, and
   # collecting that exhausts the C stack; pairing and halving bounds the depth
@@ -143,7 +143,7 @@ test_that("lazy branches nest logarithmically rather than linearly", {
 })
 
 test_that("a union-path query is one flat `UNION ALL` over every branch", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
 
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -208,7 +208,7 @@ test_that("a union-path query is one flat `UNION ALL` over every branch", {
 # Comparing to local also keeps this to one optional backend, as AGENTS.md
 # requires.
 test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   empty <- data.frame()
   expect_identical(dim(empty), c(0L, 0L))
@@ -290,7 +290,7 @@ test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
 # documented on `summarize_with_margins()` rather than beside #184's
 # column-less input, whose other verbs now agree.
 test_that("a column-less dtplyr summary keeps dtplyr's own empty answer", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   for (input in list(data.frame(), data.frame(a = 1:3, g = c("x", "x", "y")))) {
     upstream <- dplyr::collect(dplyr::summarize(dtplyr::lazy_dt(input)))
@@ -327,7 +327,7 @@ test_that("a column-less dtplyr summary keeps dtplyr's own empty answer", {
 # other lazy backend that can be handed a zero-column table at all, and it
 # already answered the local count.
 test_that("a zero-column arrow input keeps the local row count", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   empty <- data.frame()
   query <- expand_with_margins(

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -520,7 +520,7 @@ test_that("a caller binding never changes a helper on a lazy input", {
   # both re-analyze the call, and dbplyr's `partial_eval()` matches these names
   # without examining the qualifier at all, so a qualified head reaches the
   # translation an unqualified one did.
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- contextual_probe_data()
   probes <- contextual_probes()
   for (entry in contextual_registry_table(contextual_helper_families())) {

--- a/tests/testthat/test-data-frame-subclass.R
+++ b/tests/testthat/test-data-frame-subclass.R
@@ -26,7 +26,7 @@
 # it is absent and the generated `data.table` job in `release-matrix.yaml` is
 # what executes them. dtplyr is not the guard even though it brings data.table:
 # guarding on a package other than the one used is the mistake `AGENTS.md`
-# names, and the two are separate entries in `optional_backend_spec()`.
+# names, and the two are separate entries in `optional_suggest_spec()`.
 
 subclass_data <- function() {
   data.frame(
@@ -60,7 +60,7 @@ expect_margin_agrees <- function(margin_call) {
 }
 
 test_that("summarize_with_margins() accepts a raw data.table", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
 
   expect_margin_agrees(function(input) {
     summarize_with_margins(
@@ -74,7 +74,7 @@ test_that("summarize_with_margins() accepts a raw data.table", {
 })
 
 test_that("expand_with_margins() accepts a raw data.table", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
 
   expect_margin_agrees(function(input) {
     expand_with_margins(
@@ -86,7 +86,7 @@ test_that("expand_with_margins() accepts a raw data.table", {
 })
 
 test_that("the nesting verbs accept a raw data.table", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
 
   expect_margin_agrees(function(input) {
     nest_with_margins(
@@ -103,7 +103,7 @@ test_that("the nesting verbs accept a raw data.table", {
 })
 
 test_that("inspect_grouping() accepts a raw data.table", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
   # Not through `expect_margin_agrees()`: this returns no data frame, and the
   # plan it reports is one object to compare rather than two to flatten.
   data <- subclass_data()
@@ -119,7 +119,7 @@ test_that("inspect_grouping() accepts a raw data.table", {
 })
 
 test_that("a factor dimension of a raw data.table keeps its typed metadata", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
   # The narrower half of the agreement above, stated on its own because it is
   # the metadata the old `[` was reading: a Margin label arrives as a synthetic
   # level rather than coercing the column to character, and the missing value
@@ -137,7 +137,7 @@ test_that("a factor dimension of a raw data.table keeps its typed metadata", {
 })
 
 test_that("a Margin-label collision is found in a raw data.table", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
   # The collision check reads the same columns, so a subclass that reached the
   # verbs without it would accept a label already present and silently merge
   # two meanings into one row.
@@ -162,7 +162,7 @@ test_that("a Margin-label collision is found in a raw data.table", {
 })
 
 test_that("a raw data.table is not modified by reference", {
-  skip_if_backend_absent("data.table")
+  skip_if_suggest_absent("data.table")
   # A data.table can be changed in place, so "the input still works afterwards"
   # is not the same claim as "the input is unchanged". Compared against an
   # independent copy taken before the call, which catches a column rewritten in

--- a/tests/testthat/test-duckdb-storage.R
+++ b/tests/testthat/test-duckdb-storage.R
@@ -35,7 +35,7 @@ duckdb_storage_directories <- function(con) {
 }
 
 test_that("a test DuckDB connection stores its files under tempdir() alone", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
 

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -329,7 +329,7 @@ test_that("a Package condition raised while branches run is untouched", {
 # it -- and CONTEXT.md's *Repeated condition* says so: a verb answers only for
 # the occurrences raised while it runs.
 test_that("a lazy input leaves its execution warnings to the caller", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   query <- summarize_with_margins(
     dtplyr::lazy_dt(coercion_frame()),

--- a/tests/testthat/test-expand-operation.R
+++ b/tests/testthat/test-expand-operation.R
@@ -51,7 +51,7 @@ register_expand_proxy_methods <- function() {
 }
 
 test_that("expand rejects invalid grouping before typed metadata acquisition", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_expand_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_expand_proxy_counter", class(source))
@@ -132,7 +132,7 @@ test_that("expand rejects invalid grouping before typed metadata acquisition", {
 })
 
 test_that("dtplyr expansion acquires typed metadata once and stays lazy", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_expand_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),
@@ -156,7 +156,7 @@ test_that("dtplyr expansion acquires typed metadata once and stays lazy", {
 })
 
 test_that("Arrow expansion uses schema metadata without collecting", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   register_expand_proxy_methods()
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
@@ -180,7 +180,7 @@ test_that("Arrow expansion uses schema metadata without collecting", {
 })
 
 test_that("DuckDB expansion acquires one typed selection proxy", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   register_expand_proxy_methods()
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -269,7 +269,7 @@ test_that("expand preserves duplicate grouping-set policies", {
 })
 
 test_that("expand rejects unsupported sources with a package condition", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   error <- expect_error(
     expand_with_margins(

--- a/tests/testthat/test-factor.R
+++ b/tests/testthat/test-factor.R
@@ -64,7 +64,7 @@ test_that("reconstruct_factor() works with data.frame", {
 })
 
 test_that("reconstruct_factor() works with duckdb", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   x <- c("a", "b", "c", NA_character_)
   data <- data.frame(
@@ -125,7 +125,7 @@ test_that("reconstruct_factor() works with duckdb", {
 })
 
 test_that("reconstruct_factor() works with dtplyr_step", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   x <- c("a", "b", "c", NA_character_)
   data <- data.frame(

--- a/tests/testthat/test-get-col-names.R
+++ b/tests/testthat/test-get-col-names.R
@@ -37,7 +37,7 @@ test_that("get_col_names reads dbplyr query metadata", {
 })
 
 test_that("get_col_names reads dtplyr step metadata", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   data <- data.frame(
     first = 1:2,
@@ -53,7 +53,7 @@ test_that("get_col_names reads dtplyr step metadata", {
 })
 
 test_that("get_col_names reads Arrow metadata", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   data <- data.frame(
     first = 1:2,

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -68,7 +68,7 @@ normalized_contract_data <- function() {
 }
 
 test_that("dtplyr uses the normalized grouping contract", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- normalized_contract_data()
 
   expect_no_message(
@@ -92,7 +92,7 @@ test_that("dtplyr uses the normalized grouping contract", {
 })
 
 test_that("Arrow uses the normalized grouping contract", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   data <- normalized_contract_data()
 
   arrow_result <- summarize_with_margins(
@@ -116,7 +116,7 @@ test_that("Arrow uses the normalized grouping contract", {
 })
 
 test_that("Arrow schema metadata supports predicates and computed queries", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   data <- data.frame(
     group = c("x", "x", "y"),
@@ -166,7 +166,7 @@ test_that("Arrow schema metadata supports predicates and computed queries", {
 })
 
 test_that("Arrow metadata preserves ordered dictionaries without collecting", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   registerS3method(
     "head",
     "margin_selection_proxy_counter",
@@ -208,7 +208,7 @@ test_that("Arrow metadata preserves ordered dictionaries without collecting", {
 })
 
 test_that("dtplyr constructs one typed selection proxy for predicates", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   registerS3method(
     "head",
     "margin_selection_proxy_counter",
@@ -258,7 +258,7 @@ test_that("dtplyr constructs one typed selection proxy for predicates", {
 })
 
 test_that("DuckDB constructs one typed selection proxy for predicates", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   registerS3method(
     "head",
     "margin_selection_proxy_counter",
@@ -316,7 +316,7 @@ test_that("DuckDB constructs one typed selection proxy for predicates", {
 })
 
 test_that("public Arrow table classes are supported", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   data <- data.frame(group = c("x", "y"), value = 1:2)
   table <- arrow::Table$create(data)
@@ -417,7 +417,7 @@ test_that("a lazy .by selection is settled before the table is read", {
 # resolution of its own would look like, and it would still return the right
 # columns (ADR-0002).
 test_that("an Arrow .by predicate resolves against the typed snapshot", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   source <- arrow::Table$create(
     data.frame(region = c("x", "y"), area = c("p", "q"), value = 1:2)
@@ -465,7 +465,7 @@ margin_label_check_data <- function() {
 # out in each rather than wrapped in a shared expectation, because a closure
 # would put `first` and `second` somewhere `codetools` cannot follow them.
 test_that("dtplyr checks margin labels across all dimensions", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   expect_error(
     summarize_with_margins(
       dtplyr::lazy_dt(margin_label_check_data()),
@@ -478,7 +478,7 @@ test_that("dtplyr checks margin labels across all dimensions", {
 })
 
 test_that("Arrow checks margin labels across all dimensions", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   expect_error(
     summarize_with_margins(
       arrow::Table$create(margin_label_check_data()),
@@ -491,7 +491,7 @@ test_that("Arrow checks margin labels across all dimensions", {
 })
 
 test_that("DuckDB checks margin labels across all dimensions", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
@@ -648,7 +648,7 @@ test_that("local summaries reserve user columns that look internal", {
 })
 
 test_that("the dtplyr union adapter reserves user columns that look internal", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   result <- summarize_with_margins(
     dtplyr::lazy_dt(reserved_column_data()),
     total = sum(value),
@@ -660,7 +660,7 @@ test_that("the dtplyr union adapter reserves user columns that look internal", {
 })
 
 test_that("the Arrow union adapter reserves user columns that look internal", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   result <- summarize_with_margins(
     arrow::Table$create(reserved_column_data()),
     total = sum(value),
@@ -705,7 +705,7 @@ test_that("local summaries reserve generated summary names", {
 })
 
 test_that("the dtplyr union adapter reserves generated summary names", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   result <- summarize_with_margins(
     dtplyr::lazy_dt(generated_name_data()),
     dplyr::across(
@@ -721,7 +721,7 @@ test_that("the dtplyr union adapter reserves generated summary names", {
 })
 
 test_that("the Arrow union adapter reserves generated summary names", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   result <- summarize_with_margins(
     arrow::Table$create(generated_name_data()),
     dplyr::across(
@@ -809,7 +809,7 @@ test_that("native adapters reserve generated summary names", {
   expect_match(sql, "\"..marginplyr_grouping_1\"", fixed = TRUE)
   expect_match(sql, "\"..marginplyr_grouping_1__\"", fixed = TRUE)
 
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
@@ -880,7 +880,7 @@ test_that("native adapters reject a summary output shadowing a dimension", {
 })
 
 test_that("DuckDB rejects a summary output shadowing a dimension", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   # The reported failure, kept in the shape it was reported in: two dimensions
   # where the second is named for the first, so `across(all_of("x"), fns)` with
@@ -983,7 +983,7 @@ test_that("native adapters keep unpredictable names that collide with none", {
     fixed = TRUE
   )
 
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
@@ -1013,7 +1013,7 @@ test_that("column-wise summaries share one lazy-backend selection", {
     value = c(1, 2, 3)
   )
 
-  if (backend_available("dtplyr")) {
+  if (suggest_available("dtplyr")) {
     dt_result <- summarize_with_margins(
       dtplyr::lazy_dt(data),
       dplyr::across(
@@ -1028,7 +1028,7 @@ test_that("column-wise summaries share one lazy-backend selection", {
     expect_setequal(dt_result$n_value, c(2L, 1L, 3L))
   }
 
-  if (backend_available("arrow")) {
+  if (suggest_available("arrow")) {
     arrow_result <- summarize_with_margins(
       arrow::Table$create(data),
       dplyr::across(
@@ -1096,7 +1096,7 @@ test_that("local summaries preserve margin values without implicit ordering", {
 })
 
 test_that("dtplyr preserves margin values without implicit ordering", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   result <- summarize_with_margins(
     dtplyr::lazy_dt(unordered_margin_data()),
     total = sum(value),
@@ -1107,7 +1107,7 @@ test_that("dtplyr preserves margin values without implicit ordering", {
 })
 
 test_that("Arrow preserves margin values without implicit ordering", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   result <- summarize_with_margins(
     arrow::Table$create(unordered_margin_data()),
     total = sum(value),
@@ -1118,7 +1118,7 @@ test_that("Arrow preserves margin values without implicit ordering", {
 })
 
 test_that("dtplyr nesting retains original keys and empty rowwise behavior", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("a", "a", "b"),
     item = c("x", "y", "z"),
@@ -1166,7 +1166,7 @@ grouped_lazy_values <- function() {
 }
 
 test_that("grouped dtplyr inputs use their groups as fixed keys", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   grouped_dt <- dtplyr::lazy_dt(grouped_lazy_data()) |>
     dplyr::group_by(year)
 
@@ -1200,7 +1200,7 @@ test_that("grouped dtplyr inputs use their groups as fixed keys", {
 })
 
 test_that("grouped Arrow inputs use their groups as fixed keys", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   grouped_arrow <- arrow::Table$create(grouped_lazy_data()) |>
     dplyr::group_by(year)
 
@@ -1244,7 +1244,7 @@ test_that("grouped SQL inputs use their groups as fixed keys", {
 })
 
 test_that("DuckDB executes grouped lazy input as fixed keys", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1465,7 +1465,7 @@ test_that("PostgreSQL duplicate keep falls back conservatively", {
 })
 
 test_that("DuckDB executes native grouping sets with unambiguous bits", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1495,7 +1495,7 @@ test_that("DuckDB executes native grouping sets with unambiguous bits", {
 })
 
 test_that("DuckDB keeps input types available to summary expressions", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1519,7 +1519,7 @@ test_that("DuckDB keeps input types available to summary expressions", {
 })
 
 test_that("DuckDB native and UNION adapters agree", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1565,7 +1565,7 @@ test_that("DuckDB native and UNION adapters agree", {
 })
 
 test_that("DuckDB duplicate keep and downstream verbs remain lazy", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -1603,7 +1603,7 @@ test_that("DuckDB duplicate keep and downstream verbs remain lazy", {
 })
 
 test_that("DuckDB safely quotes factor identifiers and labels", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -356,7 +356,7 @@ test_that("all Margin verbs eagerly check local margin-label collisions", {
 })
 
 test_that("Margin verbs skip label checks for lazy inputs by default", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(group = c("Total", "x"), value = 1:2)
   source <- dtplyr::lazy_dt(data)
 

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -464,7 +464,7 @@ register_inspect_proxy_methods <- function() {
 }
 
 test_that("lazy inspection reads typed metadata once, executing no margins", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_inspect_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("Total", "x"),
@@ -490,7 +490,7 @@ test_that("a name-only grouping error precedes a .by predicate's read", {
   # puts its rejection before any backend read. Deferred fixed keys stand in as
   # none for that pass, so the read a predicate needs cannot be pulled ahead of
   # an error the names already decide.
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_inspect_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),

--- a/tests/testthat/test-internal-name-shadowing.R
+++ b/tests/testthat/test-internal-name-shadowing.R
@@ -116,7 +116,7 @@ test_that("missing factor values survive a column named `missing_sentinel`", {
 })
 
 test_that("dtplyr factor restoration ignores columns named like its locals", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   for (name in factor_shadow_names) {
     result <- dplyr::collect(summarize_with_margins(
@@ -140,7 +140,7 @@ test_that("dtplyr factor restoration ignores columns named like its locals", {
 })
 
 test_that("duckdb factor restoration ignores a column named `sql_query`", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   data <- factor_shadow_data("sql_query")
   con <- duckdb_test_connection()

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -363,7 +363,7 @@ test_that("non-syntactic .id names work across Margin verbs", {
 })
 
 test_that("DuckDB native and portable summaries agree on .id", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -292,7 +292,7 @@ test_that("a check with no column left to read contacts nothing", {
 })
 
 test_that("dtplyr rejects a declared collision and stays silent on a value", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     declared = factor(c("a", "b"), levels = c("a", "b", "Total")),
     observed = c("Total", "x"),
@@ -341,7 +341,7 @@ test_that("dtplyr rejects a declared collision and stays silent on a value", {
 # zero-row read ADR 0020 exempts rather than as a factor column, which is a
 # different route to the same rejection than the one dtplyr takes above.
 test_that("DuckDB rejects a declared collision without being asked", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -384,7 +384,7 @@ test_that("DuckDB rejects a declared collision without being asked", {
 # is declared in the source data frame reaches the database as text and the
 # check above it has nothing to read the collision off.
 test_that("RSQLite leaves an observed collision silent until it is asked", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
 
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -428,7 +428,7 @@ test_that("RSQLite leaves an observed collision silent until it is asked", {
 })
 
 test_that("dtplyr applies mixed named labels lazily and restores factors", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     first = factor(c("a", "b")),
     second = ordered(c("x", "y")),
@@ -453,7 +453,7 @@ test_that("dtplyr applies mixed named labels lazily and restores factors", {
 })
 
 test_that("Arrow applies mixed named labels lazily with typed missing values", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   data <- data.frame(
     first = c("a", "b"),
     second = c(1L, 2L),
@@ -495,7 +495,7 @@ test_that("portable SQL consumes named per-column labels lazily", {
 })
 
 test_that("DuckDB uses typed missing for a missing factor Margin label", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -669,7 +669,7 @@ expect_computed_margin_order <- function(as_input) {
 }
 
 test_that("DuckDB executes a Margin order on its native plan", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -742,7 +742,7 @@ test_that("DuckDB executes a Margin order on its native plan", {
 })
 
 test_that("DuckDB native and portable Margin orders agree", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -810,7 +810,7 @@ test_that("DuckDB native and portable Margin orders agree", {
 })
 
 test_that("DuckDB materializes a sorted Margin result with `compute()`", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -852,7 +852,7 @@ test_that("DuckDB materializes a sorted Margin result with `compute()`", {
 })
 
 test_that("DuckDB orders a factor dimension by its restored levels", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
 
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -875,7 +875,7 @@ test_that("DuckDB orders a factor dimension by its restored levels", {
 })
 
 test_that("RSQLite executes a portable Margin order end to end", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
 
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -920,7 +920,7 @@ test_that("RSQLite executes a portable Margin order end to end", {
 })
 
 test_that("RSQLite materializes a portable Margin order with `compute()`", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
 
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -930,7 +930,7 @@ test_that("RSQLite materializes a portable Margin order with `compute()`", {
 })
 
 test_that("RSQLite places missing values where its own default would not", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
 
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
@@ -982,7 +982,7 @@ test_that("RSQLite places missing values where its own default would not", {
 })
 
 test_that("dtplyr executes a Margin order end to end", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   expect_margin_order_agrees(function(data, name) dtplyr::lazy_dt(data))
 
@@ -997,7 +997,7 @@ test_that("dtplyr executes a Margin order end to end", {
 })
 
 test_that("dtplyr orders a factor dimension by its restored levels", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   data <- margin_order_factor_data()
   result <- dplyr::collect(summarize_with_margins(
@@ -1024,7 +1024,7 @@ test_that("dtplyr orders a factor dimension by its restored levels", {
 })
 
 test_that("Arrow executes a Margin order end to end", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   expect_margin_order_agrees(function(data, name) arrow::as_arrow_table(data))
 

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -27,7 +27,7 @@ register_nest_proxy_methods <- function() {
 }
 
 test_that("nest rejects grouping before typed metadata acquisition", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_nest_proxy_counter", class(source))
@@ -65,7 +65,7 @@ test_that("nest rejects grouping before typed metadata acquisition", {
 })
 
 test_that("dtplyr nesting reuses one typed snapshot and stays lazy", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),
@@ -128,7 +128,7 @@ test_that("nest verbs preserve their own quosure environments", {
 })
 
 test_that("nest preflight precedes semantic margin-label validation", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("Total", "x"), value = 1:2))
   class(source) <- c("margin_nest_proxy_counter", class(source))
@@ -423,7 +423,7 @@ test_that("nesting keeps cardinality when duplicate sets are dropped", {
 })
 
 test_that("dtplyr nesting agrees with the local result and stays lazy", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   # Both inputs are needed: whether a payload column remains is what selects
   # the cell expression, and a keys-only input alone would pass however that
   # choice was made.

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -1,4 +1,4 @@
-# The release matrix relies on these helpers to tell a proved backend contract
+# The release matrix relies on these helpers to tell a proved contract
 # apart from a silently skipped one, so the helpers themselves need coverage:
 # a regression here would be invisible in every other test file.
 
@@ -38,13 +38,13 @@ with_hidden_suggests <- function(value, code) {
 
 # A name no CRAN package uses, so it is reliably absent from every checking
 # environment.
-absent_package <- "marginplyrNoSuchBackend"
+absent_package <- "marginplyrNoSuchSuggest"
 
 # The `known` tables the tests below inject. Neither name belongs in
 # `optional_suggests()` -- the sentinel is not a package, and `stats` is a base
-# package rather than an optional backend -- but between them they make both
-# sides of `backend_available()` reachable without depending on which optional
-# backends the checking environment happens to have.
+# package rather than an optional Suggest -- but between them they make both
+# sides of `suggest_available()` reachable without depending on which optional
+# Suggests the checking environment happens to have.
 known_absent <- stats::setNames(TRUE, absent_package)
 known_installed <- c(stats = TRUE)
 
@@ -69,9 +69,9 @@ test_that("required suggests are parsed from the environment variable", {
   )
 })
 
-test_that("an absent backend is skippable when no job promised it", {
+test_that("an absent package is skippable when no job promised it", {
   with_required_suggests("", {
-    expect_false(backend_available(
+    expect_false(suggest_available(
       absent_package,
       known = known_absent,
       suggests = suggests_absent
@@ -80,7 +80,7 @@ test_that("an absent backend is skippable when no job promised it", {
     # a skip condition escape an expectation and skip the whole test instead.
     skipped <- tryCatch(
       {
-        skip_if_backend_absent(
+        skip_if_suggest_absent(
           absent_package,
           known = known_absent,
           suggests = suggests_absent
@@ -94,10 +94,10 @@ test_that("an absent backend is skippable when no job promised it", {
   })
 })
 
-test_that("an absent backend fails when the job promised to prove it", {
+test_that("an absent package fails when the job promised to prove it", {
   with_required_suggests(absent_package, {
     expect_error(
-      backend_available(
+      suggest_available(
         absent_package,
         known = known_absent,
         suggests = suggests_absent
@@ -105,7 +105,7 @@ test_that("an absent backend fails when the job promised to prove it", {
       "MARGINPLYR_REQUIRED_SUGGESTS"
     )
     expect_error(
-      skip_if_backend_absent(
+      skip_if_suggest_absent(
         absent_package,
         known = known_absent,
         suggests = suggests_absent
@@ -115,30 +115,30 @@ test_that("an absent backend fails when the job promised to prove it", {
   })
 })
 
-test_that("promising one backend does not make an unrelated one required", {
-  with_required_suggests("duckdb", expect_false(backend_available(
+test_that("promising one package does not make an unrelated one required", {
+  with_required_suggests("duckdb", expect_false(suggest_available(
     absent_package,
     known = known_absent,
     suggests = suggests_absent
   )))
 })
 
-test_that("an installed backend is available whether or not it is required", {
+test_that("an installed package is available whether or not it is required", {
   with_required_suggests(
     "",
-    expect_true(backend_available(
+    expect_true(suggest_available(
       "stats",
       known = known_installed,
       suggests = suggests_installed
     ))
   )
   with_required_suggests("stats", {
-    expect_true(backend_available(
+    expect_true(suggest_available(
       "stats",
       known = known_installed,
       suggests = suggests_installed
     ))
-    expect_no_error(skip_if_backend_absent(
+    expect_no_error(skip_if_suggest_absent(
       "stats",
       known = known_installed,
       suggests = suggests_installed
@@ -148,18 +148,18 @@ test_that("an installed backend is available whether or not it is required", {
 
 test_that("a package outside the tracked list is refused rather than skipped", {
   with_required_suggests("", {
-    expect_error(backend_available(absent_package), "optional_suggests")
-    expect_error(skip_if_backend_absent(absent_package), "optional_suggests")
+    expect_error(suggest_available(absent_package), "optional_suggests")
+    expect_error(skip_if_suggest_absent(absent_package), "optional_suggests")
   })
 })
 
 test_that("an untracked package is refused even when it is installed", {
   # The refusal runs before `requireNamespace()`. Placed after it, this call
-  # would return TRUE, and a guard on an unregistered backend would go
+  # would return TRUE, and a guard on an unregistered package would go
   # unnoticed on every provisioned machine and in `R-CMD-check.yaml`.
   with_required_suggests(
     "",
-    expect_error(backend_available("stats"), "optional_suggests")
+    expect_error(suggest_available("stats"), "optional_suggests")
   )
 })
 
@@ -171,20 +171,20 @@ test_that("hidden suggests are parsed from the environment variable", {
   )
 })
 
-test_that("a hidden backend reports absent even though it is installed", {
+test_that("a hidden package reports absent even though it is installed", {
   # The whole of `verify-suite-coverage.R` rests on this one substitution: an
   # installed package has to answer the guards the way an absent one would, or
   # the simulation reports that every test runs in every configuration.
   with_required_suggests("", {
     with_hidden_suggests("stats", {
-      expect_false(backend_available(
+      expect_false(suggest_available(
         "stats",
         known = known_installed,
         suggests = suggests_installed
       ))
       skipped <- tryCatch(
         {
-          skip_if_backend_absent(
+          skip_if_suggest_absent(
             "stats",
             known = known_installed,
             suggests = suggests_installed
@@ -198,14 +198,14 @@ test_that("a hidden backend reports absent even though it is installed", {
   })
 })
 
-test_that("hiding a backend a job promised to prove is refused", {
+test_that("hiding a package a job promised to prove is refused", {
   # Nothing structural stops the two variables from naming the same package,
   # and if they did the hook would turn a `backend` job's proof into a skip and
   # the job would pass. This is the refusal that makes that impossible.
   with_required_suggests("stats", {
     with_hidden_suggests("stats", {
       expect_error(
-        backend_available(
+        suggest_available(
           "stats",
           known = known_installed,
           suggests = suggests_installed
@@ -213,7 +213,7 @@ test_that("hiding a backend a job promised to prove is refused", {
         "MARGINPLYR_HIDE_SUGGESTS"
       )
       expect_error(
-        skip_if_backend_absent(
+        skip_if_suggest_absent(
           "stats",
           known = known_installed,
           suggests = suggests_installed
@@ -224,19 +224,19 @@ test_that("hiding a backend a job promised to prove is refused", {
   })
 })
 
-test_that("hiding one backend leaves an unrelated promise alone", {
+test_that("hiding one package leaves an unrelated promise alone", {
   # Refusal is per queried package rather than per variable. Refusing whenever
   # the two lists intersected at all would fail every test in this file under
   # `verify-suite-coverage.R`, which hides real backends while these tests
   # promise sentinel ones.
   with_required_suggests("stats", {
     with_hidden_suggests("arrow", {
-      expect_true(backend_available(
+      expect_true(suggest_available(
         "stats",
         known = known_installed,
         suggests = suggests_installed
       ))
-      expect_false(backend_available(
+      expect_false(suggest_available(
         absent_package,
         known = known_absent,
         suggests = suggests_absent
@@ -245,18 +245,18 @@ test_that("hiding one backend leaves an unrelated promise alone", {
   })
 })
 
-test_that("a backend job installs its backend and its companions", {
+test_that("a backend job installs its entry and its companions", {
   # `generate-backend-matrix.R` builds each job's `required` list and its
   # `extra-packages` from this, so a driver backend that arrived without DBI
   # would install, run nothing, and report green.
-  expect_identical(backend_job_packages("duckdb"), c("duckdb", "DBI"))
-  expect_identical(backend_job_packages("RSQLite"), c("RSQLite", "DBI"))
+  expect_identical(suggest_job_packages("duckdb"), c("duckdb", "DBI"))
+  expect_identical(suggest_job_packages("RSQLite"), c("RSQLite", "DBI"))
   # dtplyr declares `Imports: data.table`, so the job installs it regardless;
   # naming it is what keeps `verify-library-isolation.R` from reading a
   # dependency of the requested backend as a cache leak.
-  expect_identical(backend_job_packages("dtplyr"), c("dtplyr", "data.table"))
-  expect_identical(backend_job_packages("data.table"), "data.table")
-  expect_error(backend_job_packages(absent_package), "optional_backend_spec")
+  expect_identical(suggest_job_packages("dtplyr"), c("dtplyr", "data.table"))
+  expect_identical(suggest_job_packages("data.table"), "data.table")
+  expect_error(suggest_job_packages(absent_package), "optional_suggest_spec")
 })
 
 test_that("every companion is itself a tracked Suggest", {
@@ -264,7 +264,7 @@ test_that("every companion is itself a tracked Suggest", {
   # refused by `verify-library-isolation.R`, which reads the same `required`
   # list and knows only what the table names.
   companions <- unlist(lapply(
-    optional_backend_spec(),
+    optional_suggest_spec(),
     function(entry) entry$companions
   ))
   expect_true(all(companions %in% names(optional_suggests())))
@@ -287,8 +287,8 @@ test_that("optional_backends() is the subset a job can be asked to withhold", {
 })
 
 test_that("every tracked Suggest is declared in DESCRIPTION", {
-  # A typo in `optional_suggests()` would make `backend_available()` refuse the
-  # real backend at every guard, which reads as a registration error rather
+  # A typo in `optional_suggests()` would make `suggest_available()` refuse the
+  # real package at every guard, which reads as a registration error rather
   # than as the typo it is.
   #
   # Read through the shipped guard's own reading of the field rather than a
@@ -307,7 +307,7 @@ test_that("DBI is untrackable because dbplyr puts it in the hard closure", {
   expect_false(optional_suggests()[["DBI"]])
 })
 
-# A guard that reports a backend usable now promises the version DESCRIPTION
+# A guard that reports a package usable now promises the version DESCRIPTION
 # requires, not only that the package is installed (#123). The two claims came
 # apart under `duckdb (>= 1.5.5)`, where the older `duckdb()` rejects the
 # `shared_home` argument outright: `requireNamespace()` answered TRUE, the
@@ -370,7 +370,7 @@ test_that("a package DESCRIPTION does not suggest is refused, not answered", {
   # version-blind question at exactly the call sites with no other registry: a
   # vignette or an example naming a typo, or a Suggest that moved to
   # `Config/Needs/website`, would guard on installation alone and read as
-  # protection. `backend_available()` refuses an unregistered backend for the
+  # protection. `suggest_available()` refuses an unregistered package for the
   # same reason, but nothing outside `tests/` reaches that refusal.
   guard <- suggest_guard()
   expect_error(
@@ -385,14 +385,14 @@ test_that("a package DESCRIPTION does not suggest is refused, not answered", {
   ))
 })
 
-test_that("an installed backend below its constraint is not available", {
+test_that("an installed package below its constraint is not available", {
   with_required_suggests("", {
-    expect_true(backend_available(
+    expect_true(suggest_available(
       "stats",
       known = known_installed,
       suggests = suggests_installed
     ))
-    expect_false(backend_available(
+    expect_false(suggest_available(
       "stats",
       known = known_installed,
       suggests = suggests_too_old
@@ -400,14 +400,14 @@ test_that("an installed backend below its constraint is not available", {
   })
 })
 
-test_that("a too-old backend skips with a reason that is not \"absent\"", {
+test_that("a too-old package skips with a reason that is not \"absent\"", {
   # Reported as absent, this skip would send a reader looking for a package
   # sitting in their library. It also has to stay distinguishable to
   # `verify-backend.R`, which attributes a skip by matching the absent wording.
   with_required_suggests("", {
     skipped <- tryCatch(
       {
-        skip_if_backend_absent(
+        skip_if_suggest_absent(
           "stats",
           known = known_installed,
           suggests = suggests_too_old
@@ -423,12 +423,12 @@ test_that("a too-old backend skips with a reason that is not \"absent\"", {
   })
 })
 
-test_that("a too-old backend fails when the job promised to prove it", {
+test_that("a too-old package fails when the job promised to prove it", {
   # A `backend` job installs the version DESCRIPTION asks for, so a job holding
   # an older one has not proved its contract and must not report that it did.
   with_required_suggests("stats", {
     expect_error(
-      backend_available(
+      suggest_available(
         "stats",
         known = known_installed,
         suggests = suggests_too_old
@@ -436,7 +436,7 @@ test_that("a too-old backend fails when the job promised to prove it", {
       "MARGINPLYR_REQUIRED_SUGGESTS"
     )
     expect_error(
-      backend_available(
+      suggest_available(
         "stats",
         known = known_installed,
         suggests = suggests_too_old
@@ -446,7 +446,7 @@ test_that("a too-old backend fails when the job promised to prove it", {
   })
 })
 
-test_that("a hidden backend reports absent whatever its version says", {
+test_that("a hidden package reports absent whatever its version says", {
   # `MARGINPLYR_HIDE_SUGGESTS` claims a package is gone, and both
   # `verify-suite-coverage.R` and `verify-depends-only.R` attribute the skip it
   # produces by matching the absent wording. A simulated absence that announced
@@ -454,7 +454,7 @@ test_that("a hidden backend reports absent whatever its version says", {
   with_required_suggests("", {
     with_hidden_suggests("stats", {
       expect_identical(
-        backend_absence_reason("stats", suggests = suggests_too_old),
+        suggest_absence_reason("stats", suggests = suggests_too_old),
         "{stats} is not installed"
       )
     })
@@ -465,7 +465,7 @@ test_that("the constraints the guard honors are the ones DESCRIPTION states", {
   # The mechanism before the conclusion: every test above supplies its own
   # `suggests`, so all of them would pass against a DESCRIPTION the guard reads
   # nothing out of. This is the one that reads the real field, and it fails if
-  # a tracked backend's constraint stops being found.
+  # a tracked Suggest's constraint stops being found.
   requirement <- suggest_guard()$marginplyr_suggest_requirement
   found <- Filter(
     Negate(is.null),
@@ -476,7 +476,7 @@ test_that("the constraints the guard honors are the ones DESCRIPTION states", {
     requirement("duckdb")$comparisons[[1]]$operator,
     ">="
   )
-  # Every tracked backend present in the checking environment satisfies what
+  # Every tracked Suggest present in the checking environment satisfies what
   # DESCRIPTION asks of it, which is what makes a skip elsewhere in the suite
   # attributable to absence rather than to this run's own library.
   for (package in names(optional_suggests())) {
@@ -490,7 +490,7 @@ test_that("the guard the tests read is the guard the vignettes source", {
   # `tests/`, so they reach `inst/suggests/guard.R` through `system.file()`.
   # These helpers source the same file, which is what makes one reading of
   # DESCRIPTION serve all of them; a second copy here is exactly the drift
-  # `AGENTS.md` keeps `optional_backend_spec()` single to prevent.
+  # `AGENTS.md` keeps `optional_suggest_spec()` single to prevent.
   expect_true(is.function(suggest_guard()$marginplyr_suggest_available))
   installed <- system.file("suggests", "guard.R", package = "marginplyr")
   expect_true(nzchar(installed))

--- a/tests/testthat/test-optional-backends.R
+++ b/tests/testthat/test-optional-backends.R
@@ -245,7 +245,7 @@ test_that("hiding one package leaves an unrelated promise alone", {
   })
 })
 
-test_that("a backend job installs its entry and its companions", {
+test_that("a backend job installs the package it is for and its companions", {
   # `generate-backend-matrix.R` builds each job's `required` list and its
   # `extra-packages` from this, so a driver backend that arrived without DBI
   # would install, run nothing, and report green.

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -45,7 +45,7 @@ test_that("Parent shares preserve columns, grouping, and laziness", {
     expect_no_error(dbplyr::sql_render(sql))
   }
 
-  if (backend_available("dtplyr")) {
+  if (suggest_available("dtplyr")) {
     lazy <- summarize(dtplyr::lazy_dt(data))
     expect_s3_class(lazy, "dtplyr_step")
     expect_identical(as.character(dplyr::tbl_vars(lazy)), expected_names)
@@ -61,7 +61,7 @@ test_that("Parent shares preserve columns, grouping, and laziness", {
 })
 
 test_that("dtplyr validates Parent-share source types during collection", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -90,7 +90,7 @@ test_that("dtplyr validates Parent-share source types during collection", {
 })
 
 test_that("dtplyr rejects every ineligible Parent-share source type", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     value = 1:2,
@@ -132,7 +132,7 @@ test_that("dtplyr rejects every ineligible Parent-share source type", {
 })
 
 test_that("dtplyr rejects non-scalar Parent-share sources on collection", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = 1:3
@@ -173,7 +173,7 @@ test_that("dtplyr rejects non-scalar Parent-share sources on collection", {
 })
 
 test_that("dtplyr integer and double Parent shares match local results", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     integer_value = 1:3,
@@ -205,7 +205,7 @@ test_that("dtplyr integer and double Parent shares match local results", {
 })
 
 test_that("dtplyr validates each referenced source expanded by across", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = 1:3
@@ -234,7 +234,7 @@ test_that("dtplyr validates each referenced source expanded by across", {
 })
 
 test_that("dtplyr validates constant summaries expanded by across", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -268,7 +268,7 @@ test_that("dtplyr validates constant summaries expanded by across", {
 })
 
 test_that("dtplyr Parent validation preserves ordinary across arguments", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = c(1, NA, 3)
@@ -294,7 +294,7 @@ test_that("dtplyr Parent validation preserves ordinary across arguments", {
 })
 
 test_that("dtplyr preserves across arguments for unreferenced functions", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "x", "y"),
     value = c(1, NA, 3)
@@ -324,7 +324,7 @@ test_that("dtplyr preserves across arguments for unreferenced functions", {
 })
 
 test_that("dtplyr preserves an omitted across selection", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   # dtplyr takes the share `across()` apart and rebuilds it a second time, to
   # wrap each function in the validation the lazy backend needs, so an argument
   # the caller omitted has one more rebuild to survive (#174). Compared against
@@ -362,7 +362,7 @@ test_that("dtplyr preserves an omitted across selection", {
 })
 
 test_that("Arrow rejects Parent shares before constructing a query", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -420,7 +420,7 @@ test_that("Arrow rejects Parent shares before constructing a query", {
 })
 
 test_that("Arrow ordinary Margin summaries remain lazy and available", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   query <- summarize_with_margins(
     arrow::Table$create(data.frame(
       group = c("x", "x", "y"),
@@ -439,7 +439,7 @@ test_that("Arrow ordinary Margin summaries remain lazy and available", {
 })
 
 test_that("Arrow Parent-share planning errors precede backend rejection", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
     value = 1:2
@@ -514,7 +514,7 @@ test_that("Arrow Parent-share planning errors precede backend rejection", {
 })
 
 test_that("dtplyr batches Parent shares with missing-safe matching", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     fixed = c(NA_character_, NA_character_, "a", "a"),
     group = c(NA_character_, "x", NA_character_, "x"),
@@ -553,7 +553,7 @@ parent_sql_count <- function(sql, pattern) {
 }
 
 test_that("dtplyr batches validated summaries and parent mapping", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     group = c("x", "y"),
     revenue = c(1, 3),
@@ -830,7 +830,7 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
 })
 
 test_that("RSQLite executes portable Parent shares end to end", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   data <- data.frame(
@@ -913,7 +913,7 @@ test_that("RSQLite executes portable Parent shares end to end", {
 })
 
 test_that("RSQLite Parent shares preserve runtime backend conditions", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   remote <- dplyr::copy_to(
@@ -954,7 +954,7 @@ test_that("RSQLite Parent shares preserve runtime backend conditions", {
 # dialect, and this dialect answers it the same way whatever the call
 # summarizes.
 test_that("RSQLite refuses a share its dialect cannot establish", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   data <- data.frame(
@@ -1030,7 +1030,7 @@ test_that("RSQLite refuses a share its dialect cannot establish", {
 # that identifies its Margin levels must still reach the rule for its measures,
 # and must still calculate them once the caller takes that rule on themselves.
 test_that("RSQLite keeps the share rule beside Margin level helpers", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   data <- data.frame(
@@ -1078,7 +1078,7 @@ test_that("RSQLite keeps the share rule beside Margin level helpers", {
 })
 
 test_that("RSQLite calculates eligible shares a caller has established", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   data <- data.frame(
@@ -1342,7 +1342,7 @@ test_that("the source checker refuses an unrecognized backend kind", {
 # of the summary to rewrite. Nothing here is a marginplyr condition: the
 # diagnostic is the database's own, and the assertion is that it is usable.
 test_that("DuckDB reports an ineligible share source against its summary", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
@@ -1397,7 +1397,7 @@ test_that("DuckDB reports an ineligible share source against its summary", {
 })
 
 test_that("DuckDB Parent shares agree across native, portable, local paths", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
@@ -1516,7 +1516,7 @@ expect_empty_share_identities <- function(root, partitioned) {
 }
 
 test_that("dtplyr shares preserve empty-input grand total and partitions", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   source <- dtplyr::lazy_dt(empty_share_data())
 
   root <- summarize_with_margins(
@@ -1543,7 +1543,7 @@ test_that("dtplyr shares preserve empty-input grand total and partitions", {
 })
 
 test_that("DuckDB shares preserve empty-input grand total and partitions", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   source <- dplyr::copy_to(
@@ -1582,7 +1582,7 @@ duplicate_share_data <- function() {
 }
 
 test_that("dtplyr Parent shares skip duplicate grouping-set occurrences", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- duplicate_share_data()
   summarize <- function(source, include_id) {
     id_name <- if (include_id) "set" else NULL
@@ -1616,7 +1616,7 @@ test_that("dtplyr Parent shares skip duplicate grouping-set occurrences", {
 })
 
 test_that("DuckDB Parent shares skip duplicate grouping-set occurrences", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   data <- duplicate_share_data()
   summarize <- function(source, include_id) {
     id_name <- if (include_id) "set" else NULL
@@ -1711,7 +1711,7 @@ test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
     expect_no_error(dbplyr::sql_render(simulated))
   }
 
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- dplyr::copy_to(
@@ -1728,7 +1728,7 @@ test_that("lazy Parent-share staging avoids adversarial user-name collisions", {
 })
 
 test_that("RSQLite executes portable Total shares end to end", {
-  skip_if_backend_absent("RSQLite", "DBI")
+  skip_if_suggest_absent("RSQLite", "DBI")
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   data <- data.frame(
@@ -1818,7 +1818,7 @@ test_that("RSQLite executes portable Total shares end to end", {
 })
 
 test_that("DuckDB Total shares agree across native, portable, local paths", {
-  skip_if_backend_absent("duckdb", "DBI")
+  skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   data <- data.frame(
@@ -1904,7 +1904,7 @@ test_that("DuckDB Total shares agree across native, portable, local paths", {
 })
 
 test_that("dtplyr Total shares match local results", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   data <- data.frame(
     fixed = c("p", "p", "q", "q"),
     group = c("x", "y", "x", "y"),
@@ -1958,7 +1958,7 @@ test_that("dtplyr Total shares match local results", {
 })
 
 test_that("dtplyr rejects ineligible Total-share sources on collection", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   step <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
 
   query <- summarize_with_margins(
@@ -1999,7 +1999,7 @@ test_that("dtplyr rejects ineligible Total-share sources on collection", {
 })
 
 test_that("Arrow rejects Total shares before constructing a query", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
   source <- arrow::Table$create(data.frame(
     group = c("x", "y"),
     value = 1:2

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -1521,7 +1521,7 @@ parent_preflight_collect <- function(x, ...) {
 }
 
 test_that("Parent syntax and local execution errors precede typed metadata", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   registerS3method(
     "head",
     "parent_preflight_counter",

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -156,7 +156,7 @@ test_that("shared lifecycle options preserve user-expression conditions", {
 })
 
 test_that("summary rejects grouping before typed metadata acquisition", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_summary_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_summary_proxy_counter", class(source))
@@ -177,7 +177,7 @@ test_that("summary rejects grouping before typed metadata acquisition", {
 })
 
 test_that("removed .groups is rejected before typed metadata acquisition", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_summary_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))
   class(source) <- c("margin_summary_proxy_counter", class(source))
@@ -198,7 +198,7 @@ test_that("removed .groups is rejected before typed metadata acquisition", {
 })
 
 test_that("dtplyr summary reuses one typed snapshot across selections", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   register_summary_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(
     group = c("x", "y"),
@@ -230,7 +230,7 @@ test_that("dtplyr summary reuses one typed snapshot across selections", {
 })
 
 test_that("dtplyr unwraps a `.fns` list of one into the function it holds", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   # dtplyr is the only backend whose `across()` output names are normalized
   # before staging: the `.names` template is expanded into the selection, and
   # a `.fns` list holding one function is unwrapped to that function, since a

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -26,7 +26,7 @@ test_that("assert_sring_scalar() works", {
 })
 
 test_that("assert_nest_possible() works", {
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
 
   expect_no_error(assert_nest_possible(data.frame()))
   expect_no_error(assert_nest_possible(dtplyr::lazy_dt(data.frame())))
@@ -40,7 +40,7 @@ test_that("assert_nest_possible() works", {
 })
 
 test_that("assert_lazy_table() works", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   expect_error(
     assert_lazy_table(
@@ -442,7 +442,7 @@ test_that("every shared reader answers an empty call part", {
 })
 
 test_that("lazy-table assertions use the package condition seam", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   error <- expect_error(
     assert_lazy_table(arrow::as_record_batch_reader(data.frame())),

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -470,7 +470,7 @@ test_that("every entry point admits input the same way", {
 })
 
 test_that("admission does not widen what the nesting verbs accept", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   # Admitted by the shared rule, still refused by nesting's own constraint.
   expect_error(
@@ -498,7 +498,7 @@ test_that("supported backends are still admitted", {
     )
   )
 
-  skip_if_backend_absent("dtplyr")
+  skip_if_suggest_absent("dtplyr")
   expect_no_error(
     dplyr::collect(summarize_with_margins(
       dtplyr::lazy_dt(admission_data()),
@@ -509,7 +509,7 @@ test_that("supported backends are still admitted", {
 })
 
 test_that("arrow input is still admitted", {
-  skip_if_backend_absent("arrow")
+  skip_if_suggest_absent("arrow")
 
   expect_no_error(
     dplyr::collect(summarize_with_margins(


### PR DESCRIPTION
Closes #185.

`optional_backend_spec()` was named for backends while holding every optional
Suggest the test suite guards on, two of which are not backends: `DBI` is a
companion no job proves on its own, and `data.table` is an input class that
reaches the local backend as an ordinary data frame subclass (#176). So
`skip_if_backend_absent("data.table")` read as a claim about a backend that
does not exist, and the gap between the word and the contents was recorded
only in a comment beside the table.

Option 1 as triage decided it. The table and every helper taking a package
name now say Suggest — `optional_suggest_spec()`, `suggest_available()`,
`skip_if_suggest_absent()`, `suggest_absence_reason()`,
`suggest_job_packages()` — across every guard call site, the five
`.github/scripts/`, the workflow, `AGENTS.md`, and `design/architecture.md`.

## Where the narrower word survives

`optional_suggests()` and `optional_backends()` keep their names, as the brief
asked. The line is drawn where the acceptance criterion draws it: a helper that
*accepts* a package name says Suggest, because the argument may be an entry that
is not a backend. `optional_backends()` takes no argument and returns exactly
the set `backend` jobs are generated from, so the narrower word is the accurate
one there, and the comment beside it says which of the two it is. That reading —
a backend is an entry a job exists for — is stated once in `AGENTS.md`'s
*Release matrix* section, with the entries that turn on it, and the helper
header defers to it rather than keeping a second copy.

The file names `helper-optional-backends.R` and `test-optional-backends.R` stay.
A file name is reached by path and is not a claim about what the file holds, and
the header records that choice where the old comment recorded the previous one.

## What did not change

No behaviour. The six table entries are byte-identical, with the same `asserted`
and `companions` values; `generate-backend-matrix.R` produces the same five jobs
with the same `cache-version` values; no guard starts or stops firing; the
`Live data.table` job keeps its title, which was Option 2's mechanism and out of
scope here. Both skip wordings the gates match on are untouched — `{pkg} is not
installed`, which `verify-depends-only.R` and `verify-backend.R` read, and the
distinct too-old wording. `inst/` has a zero-line diff.

Every gate still derives from the table rather than gaining a list:
`verify-depends-only.R`, `verify-library-isolation.R`, and `verify-backend.R`
are absent from the diff entirely, because they only ever called the two
accessors that kept their names.

`investigation/` is untouched. `design/review-dispositions.md` quotes a #69
review finding that names the old helper, which stays quoted as it was raised;
the disposition paragraph beneath it gains a pointer to the current name, so a
reader grepping the old one is not left at a dead end.

## Checks

- Full suite green under `NOT_CRAN`, no failures.
- `lintr::lint_package()` clean after `pkgload::load_all(".")`.
- `Rscript .github/scripts/verify-suite-coverage.R` exits 0: 559 tests over the
  same five single-backend configurations, none executing in zero.
- `Rscript .github/scripts/generate-backend-matrix.R` output compared against
  `main`'s, unchanged.

## Review

Five rounds of the two-axis review, both axes each round. Spec was clean from
round 2 on; its round-4 pass walked all seven acceptance criteria and cited the
line meeting each. Standards found something every round, all of it prose the
rename had made inaccurate rather than merely awkward — the two worth naming
are that spelling out `optional_backends()` turned a vague sentence into a
false one (the dtplyr job installs data.table too, so "each install a single
member" was wrong), and that the rename had widened a true claim about backends
into a false claim about Suggests: `tidyr` is guarded by a vignette through
`marginplyr_suggest_available()` and is deliberately not in the table, so
"adding an optional Suggest means editing two places" pointed a reader at an
edit that would red `depends-only`. Both are fixed here; the commits carry the
reasoning.

One finding is left open deliberately and filed as #204:
`design/architecture.md` still says a job names the test titles it exists to
execute, which #93 retired. It is pre-existing and about the release matrix
rather than the vocabulary, so it is not fixed here.