### PR TITLE
Demote the unknown `.by` guard to the invariant it is

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -402,15 +402,26 @@ compile_grouping_spec_impl <- function(.grouping,
     data_proxy <- grouping_name_proxy(data_vars)
   }
 
+  # A backstop behind the resolutions that produce `.by`, not a Package
+  # condition: each of them binds every value to `data_vars` already, so no
+  # documented call reaches this (ADR 0015, #159). They are
+  # `dplyr::group_vars()` of a grouped input, whose values are columns of that
+  # input; a name-based selection resolved against
+  # `grouping_name_proxy(data_vars)`, this same set; and a selection column
+  # names alone cannot settle, resolved against the typed snapshot, whose
+  # columns are that set on every backend. A `.by` source that could invent a
+  # name is the thing that has to justify itself here — before #134 one did,
+  # and reported a column the caller never wrote. The `.by`/`.grouping` overlap
+  # check below is the opposite case and stays a Package condition: an ordinary
+  # call reaches it.
   unknown_by <- setdiff(.by, data_vars)
   if (length(unknown_by) > 0L) {
-    abort_marginplyr(
-      paste0(
-        "Unknown `.by` column",
-        if (length(unknown_by) == 1L) " " else "s ",
-        paste0("`", unknown_by, "`", collapse = ", "),
-        "."
-      )
+    stop(
+      "Unknown `.by` column",
+      if (length(unknown_by) == 1L) " " else "s ",
+      paste0("`", unknown_by, "`", collapse = ", "),
+      ".",
+      call. = FALSE
     )
   }
 

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -713,6 +713,35 @@ test_that("invalid or ambiguous specifications fail early", {
   )
 })
 
+# The compiler's guard on this is an invariant rather than a Package condition
+# (#159; the reasoning is at its site). That demotion is only correct while the
+# selection is what a caller actually meets, so both halves are pinned here.
+# The public half would hold with the guard promoted back, since the public
+# path never reaches it, and the internal half is what records the demotion --
+# neither says enough alone. The upstream message stays loosely matched: ADR
+# 0015 propagates an external condition unchanged, so its wording is
+# tidyselect's to revise.
+test_that("an unknown `.by` column fails outside the public contract", {
+  data <- data.frame(region = "x", value = 1)
+
+  public <- expect_error(
+    inspect_grouping(data, .by = nope, .grouping = rollup(region))
+  )
+  expect_false(inherits(public, "marginplyr_error"))
+  expect_match(conditionMessage(public), "Column `nope` doesn't exist")
+
+  internal <- expect_error(
+    compile_grouping_spec(
+      rollup(region),
+      "region",
+      .by = "nope",
+      duplicates_choices = margin_duplicates_choices
+    )
+  )
+  expect_false(inherits(internal, "marginplyr_error"))
+  expect_identical(conditionMessage(internal), "Unknown `.by` column `nope`.")
+})
+
 # The plan compiler was reachable without going through
 # `compile_grouping_spec()`, so the preflight and the `.duplicates` matching
 # the wrapper performs were a second source of truth that production supplied


### PR DESCRIPTION
Closes #159, taking option 1 as the decision comment there words it.

## What changed

`compile_grouping_spec_impl()`'s `Unknown `.by` column` guard moves from
`abort_marginplyr()` to `stop(..., call. = FALSE)`. The message text is
unchanged and still names the column, so an internal caller that reaches it
learns which one; only the condition's class changes.

A comment at the site records why the guard is unreachable through the public
interface — the three resolutions that produce every `.by` the compiler sees
(`dplyr::group_vars()` of a grouped input, a name-based selection against
`grouping_name_proxy(data_vars)`, and a selection column names alone cannot
settle, resolved against the typed snapshot) each bind their values to
`data_vars` already — so a future `.by` source that could invent a name is the
thing that has to justify itself.

## Why

ADR 0015 admits a Package condition exactly when the caller can avoid it by
rewriting the call within the documented public interface, and puts guards
unreachable through it on `stop()` or `stopifnot()`. Since #134 this guard is in
the second category: its one live trigger was the invented name #134 fixed
(`.by = c(area = region)` reporting `area`), which the selection now refuses
with a message naming the rename. A plain unknown column never reached it —
`.by = nope` fails in the selection with tidyselect's own condition. So
`marginplyr_error` was promising a condition no documented call could raise.

`expand_grouping_family()`'s unknown-kind `stop()`, twelve lines below, is the
same shape: a backstop behind a gate that already enforced the contract. ADR
0015 names that pair as the split it wrote down.

## Test

Both halves are pinned, because the demotion is only correct while the selection
is what a caller meets: the public path fails there, and the compiler's path
fails without joining the public contract. Neither was pinned before.

The public assertion deliberately keeps matching tidyselect's sentence rather
than the column name alone — the demoted guard's own message also contains the
name and is also not a `marginplyr_error`, so a name-only match would pass on
exactly the regression this half exists to catch.

## Out of scope

- The `.by`/`.grouping` overlap check just below stays a Package condition: an
  ordinary call (`.by = region, .grouping = rollup(region)`) reaches it.
- Nothing about how `.by` selections are resolved. #134 settled that.
- The pluralization idiom in the message, written out at eight sites across
  `R/`, is filed separately as #206.

No `NEWS.md` entry: the condition was never publicly reachable, and `NEWS.md` is
still the initial submission. No roxygen touched, so no regeneration.

## Checks run locally

- `lintr::lint_package()` after `pkgload::load_all()`: no lints.
- Full suite under `NOT_CRAN=true`: passes, no failures, no skips.
- `Rscript .github/scripts/verify-suite-coverage.R`: 560 tests, all executing in
  at least one single-backend configuration.