### PR TITLE
Say that an option argument refuses a `NULL`

### DIFF
--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -27,6 +27,7 @@
 #' @inheritParams summarize_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
+#' @inheritSection summarize_with_margins Option arguments
 #' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Margin order

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -17,15 +17,18 @@
 #'   specification can be written here, while a specification nested inside
 #'   another must be a constructor call or a name bound to one; see
 #'   [grouping_set()].
-#' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
-#'   duplicate grouping-set occurrences.
+#' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, and nothing
+#'   else, controlling duplicate grouping-set occurrences; see *Option
+#'   arguments*.
 #' @param .format `"text"` for compact display values or `"list"` for exact
-#'   character and integer vectors. Text values are display-only; use
-#'   `"list"` when column names contain separators or other non-syntactic
-#'   characters.
+#'   character and integer vectors, and nothing else; see *Option arguments*.
+#'   Text values are display-only; use `"list"` when column names contain
+#'   separators or other non-syntactic characters.
 #'
 #' @return A local, ungrouped tibble with columns `set_id`, `fixed`,
 #'   `included`, `omitted`, `grouping_bits`, and `grouping_id`.
+#'
+#' @inheritSection summarize_with_margins Option arguments
 #'
 #' @section Grouping identity:
 #' `set_id` is the one-based Grouping set identifier exposed by `.id` for the

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -115,6 +115,13 @@ margin_sort_choices <- c("none", "last", "first")
 # have redefined what an accepted abbreviation resolves to. The one
 # `match.arg()` behaviour the signatures rely on is kept: an untouched formal
 # default arrives as the whole vocabulary and stands for its first entry.
+#
+# `match.arg(NULL, choices)` returned that first entry too, so a `NULL` written
+# by a caller used to select the default silently. The `identical()` guard below
+# is the whole of what refuses one now, and refusing it is a documented contract
+# rather than a leftover of the rewrite (#144): the *Option arguments* section
+# on `?summarize_with_margins` states it and says why an option vocabulary is
+# the place `NULL` does not mean "use the default".
 match_margin_choice <- function(value, choices, arg_name) {
   call <- rlang::caller_call()
   if (identical(value, choices)) {

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -5,6 +5,7 @@
 #' @inheritParams nest_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
+#' @inheritSection summarize_with_margins Option arguments
 #' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Margin order

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -6,6 +6,7 @@
 #' @inheritParams summarize_with_margins
 #' @inheritSection summarize_with_margins Fixed columns and grouping dimensions
 #' @inheritSection summarize_with_margins Grouped and row-wise inputs
+#' @inheritSection summarize_with_margins Option arguments
 #' @inheritSection summarize_with_margins Result class and attributes
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Margin order
@@ -19,9 +20,9 @@
 #' @param .keep Should fixed `.by` columns and grouping dimensions also be kept
 #'   inside each nested data frame? If `TRUE`, the nested columns contain their
 #'   original, pre-margin values rather than `.margin_label`.
-#' @param .duplicates `"error"` or `"drop"`. Nesting does not support the
-#'   `"keep"` policy available in [summarize_with_margins()] and
-#'   [expand_with_margins()].
+#' @param .duplicates `"error"` or `"drop"`, and nothing else; see *Option
+#'   arguments*. Nesting does not support the `"keep"` policy available in
+#'   [summarize_with_margins()] and [expand_with_margins()].
 #'
 #' @section Relationship to tidyr and dplyr:
 #' These functions are margin-aware counterparts, not drop-in replacements,

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -30,7 +30,8 @@
 #'   dimension exactly once; order is irrelevant, and fixed `.by` columns must
 #'   not be named. `NA_character_` and `NULL` use typed missing values instead
 #'   of a display label. See *Display labels and grouping identity*.
-#' @param .margin_label_position Either `"last"` (the default) or `"first"`.
+#' @param .margin_label_position Either `"last"` (the default) or `"first"`,
+#'   and nothing else; see *Option arguments*.
 #'   This controls the position of a non-missing synthetic label in factor and
 #'   ordered-factor levels. It does not sort result rows and has no effect for
 #'   `NA_character_` or `NULL`.
@@ -57,9 +58,11 @@
 #'   nothing where the rule can be applied — a local data frame, a `dtplyr`
 #'   step, and a database that refuses an ineligible summary itself all apply
 #'   it whatever this argument says. See *Contextual shares*.
-#' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, controlling
-#'   duplicate grouping sets after expansion.
-#' @param .sort One of `"none"` (the default), `"last"`, or `"first"`. `"none"`
+#' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, and nothing
+#'   else, controlling duplicate grouping sets after expansion; see *Option
+#'   arguments*.
+#' @param .sort One of `"none"` (the default), `"last"`, or `"first"`, and
+#'   nothing else; see *Option arguments*. `"none"`
 #'   leaves row order unspecified. The other two order the result by the
 #'   structure of its Grouping plan: within each fixed `.by` key, every grouping
 #'   dimension contributes its Grouping bit and its missingness before its own
@@ -148,6 +151,28 @@
 #' [nest_by_with_margins()] instead returns a row-wise data frame grouped by
 #' all visible fixed keys, grouping dimensions, and `.id` when supplied.
 #' Row-wise input is rejected; call [dplyr::ungroup()] first.
+#'
+#' @section Option arguments:
+#' An argument documented as taking one of a listed set of strings —
+#' `.duplicates`, `.margin_label_position`, and `.sort` on the Margin verbs,
+#' and `.format` on [inspect_grouping()] — takes one of those strings written
+#' out exactly. An abbreviation is not shorthand for the value it begins, and
+#' `NULL` is not shorthand for the default: both are errors naming the values
+#' the argument accepts. An argument left out of the call takes its default,
+#' and a `NULL` is not another way of asking for one.
+#'
+#' Elsewhere in this package `NULL` is a documented value, and what it means is
+#' stated with the argument that takes it: it is `.grouping`'s one empty
+#' grouping set, `.margin_label`'s typed missing value in place of a display
+#' label, `.id`'s absent identifier column, and, in [nest_with_margins()], the
+#' `.key` that [tidyr::nest()] reads as `"data"` — while
+#' [nest_by_with_margins()] refuses a `NULL` `.key`, following
+#' [dplyr::nest_by()]. That each of them answers for itself is the point. Those
+#' arguments name a value, a column, or a plan, and such a name has a natural
+#' absent case to give a `NULL`. A vocabulary of options has none — every option
+#' argument already has a default that does something — so a `NULL` arriving at
+#' one is far more often a variable that did not hold what its caller thought
+#' than a request for anything, and it is reported rather than resolved.
 #'
 #' @section Result class and attributes:
 #' Each Margin verb follows the same class and attribute rules as the dplyr

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -40,7 +40,8 @@ dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
 not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
 of a display label. See \emph{Display labels and grouping identity}.}
 
-\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"}.
+\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
+and nothing else; see \emph{Option arguments}.
 This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
@@ -59,8 +60,9 @@ margin row and a source row that no grouping column tells apart; keeping
 added cost. See \emph{Display labels and grouping identity} for the factor
 missing-value contract.}
 
-\item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
-duplicate grouping sets after expansion.}
+\item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, and nothing
+else, controlling duplicate grouping sets after expansion; see \emph{Option
+arguments}.}
 
 \item{.id}{\code{NULL}, or one non-missing, non-empty character string naming an
 integer output column of one-based Grouping set identifiers. Each value
@@ -68,7 +70,8 @@ identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 
-\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}, and
+nothing else; see \emph{Option arguments}. \code{"none"}
 leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
@@ -160,6 +163,30 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Option arguments}{
+
+An argument documented as taking one of a listed set of strings —
+\code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
+out exactly. An abbreviation is not shorthand for the value it begins, and
+\code{NULL} is not shorthand for the default: both are errors naming the values
+the argument accepts. An argument left out of the call takes its default,
+and a \code{NULL} is not another way of asking for one.
+
+Elsewhere in this package \code{NULL} is a documented value, and what it means is
+stated with the argument that takes it: it is \code{.grouping}'s one empty
+grouping set, \code{.margin_label}'s typed missing value in place of a display
+label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
+\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
+\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
+arguments name a value, a column, or a plan, and such a name has a natural
+absent case to give a \code{NULL}. A vocabulary of options has none — every option
+argument already has a default that does something — so a \code{NULL} arriving at
+one is far more often a variable that did not hold what its caller thought
+than a request for anything, and it is reported rather than resolved.
 }
 
 \section{Result class and attributes}{

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -29,13 +29,14 @@ specification can be written here, while a specification nested inside
 another must be a constructor call or a name bound to one; see
 \code{\link[=grouping_set]{grouping_set()}}.}
 
-\item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
-duplicate grouping-set occurrences.}
+\item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, and nothing
+else, controlling duplicate grouping-set occurrences; see \emph{Option
+arguments}.}
 
 \item{.format}{\code{"text"} for compact display values or \code{"list"} for exact
-character and integer vectors. Text values are display-only; use
-\code{"list"} when column names contain separators or other non-syntactic
-characters.}
+character and integer vectors, and nothing else; see \emph{Option arguments}.
+Text values are display-only; use \code{"list"} when column names contain
+separators or other non-syntactic characters.}
 }
 \value{
 A local, ungrouped tibble with columns \code{set_id}, \code{fixed},
@@ -88,6 +89,30 @@ plan to choose which grouping set to keep, and joins one against \code{.id} to
 name the set behind every row. Because the plan is local, that join needs a
 \code{copy} argument when the Margin result is lazy, and it does not preserve a
 Margin order.
+}
+
+\section{Option arguments}{
+
+An argument documented as taking one of a listed set of strings —
+\code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
+out exactly. An abbreviation is not shorthand for the value it begins, and
+\code{NULL} is not shorthand for the default: both are errors naming the values
+the argument accepts. An argument left out of the call takes its default,
+and a \code{NULL} is not another way of asking for one.
+
+Elsewhere in this package \code{NULL} is a documented value, and what it means is
+stated with the argument that takes it: it is \code{.grouping}'s one empty
+grouping set, \code{.margin_label}'s typed missing value in place of a display
+label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
+\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
+\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
+arguments name a value, a column, or a plan, and such a name has a natural
+absent case to give a \code{NULL}. A vocabulary of options has none — every option
+argument already has a default that does something — so a \code{NULL} arriving at
+one is far more often a variable that did not hold what its caller thought
+than a request for anything, and it is reported rather than resolved.
 }
 
 \examples{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -43,7 +43,8 @@ dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
 not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
 of a display label. See \emph{Display labels and grouping identity}.}
 
-\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"}.
+\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
+and nothing else; see \emph{Option arguments}.
 This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
@@ -62,9 +63,9 @@ margin row and a source row that no grouping column tells apart; keeping
 added cost. See \emph{Display labels and grouping identity} for the factor
 missing-value contract.}
 
-\item{.duplicates}{\code{"error"} or \code{"drop"}. Nesting does not support the
-\code{"keep"} policy available in \code{\link[=summarize_with_margins]{summarize_with_margins()}} and
-\code{\link[=expand_with_margins]{expand_with_margins()}}.}
+\item{.duplicates}{\code{"error"} or \code{"drop"}, and nothing else; see \emph{Option
+arguments}. Nesting does not support the \code{"keep"} policy available in
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} and \code{\link[=expand_with_margins]{expand_with_margins()}}.}
 
 \item{.id}{\code{NULL}, or one non-missing, non-empty character string naming an
 integer output column of one-based Grouping set identifiers. Each value
@@ -72,7 +73,8 @@ identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 
-\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}, and
+nothing else; see \emph{Option arguments}. \code{"none"}
 leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
@@ -160,6 +162,30 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Option arguments}{
+
+An argument documented as taking one of a listed set of strings —
+\code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
+out exactly. An abbreviation is not shorthand for the value it begins, and
+\code{NULL} is not shorthand for the default: both are errors naming the values
+the argument accepts. An argument left out of the call takes its default,
+and a \code{NULL} is not another way of asking for one.
+
+Elsewhere in this package \code{NULL} is a documented value, and what it means is
+stated with the argument that takes it: it is \code{.grouping}'s one empty
+grouping set, \code{.margin_label}'s typed missing value in place of a display
+label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
+\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
+\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
+arguments name a value, a column, or a plan, and such a name has a natural
+absent case to give a \code{NULL}. A vocabulary of options has none — every option
+argument already has a default that does something — so a \code{NULL} arriving at
+one is far more often a variable that did not hold what its caller thought
+than a request for anything, and it is reported rather than resolved.
 }
 
 \section{Result class and attributes}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -43,7 +43,8 @@ dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
 not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
 of a display label. See \emph{Display labels and grouping identity}.}
 
-\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"}.
+\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
+and nothing else; see \emph{Option arguments}.
 This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
@@ -62,9 +63,9 @@ margin row and a source row that no grouping column tells apart; keeping
 added cost. See \emph{Display labels and grouping identity} for the factor
 missing-value contract.}
 
-\item{.duplicates}{\code{"error"} or \code{"drop"}. Nesting does not support the
-\code{"keep"} policy available in \code{\link[=summarize_with_margins]{summarize_with_margins()}} and
-\code{\link[=expand_with_margins]{expand_with_margins()}}.}
+\item{.duplicates}{\code{"error"} or \code{"drop"}, and nothing else; see \emph{Option
+arguments}. Nesting does not support the \code{"keep"} policy available in
+\code{\link[=summarize_with_margins]{summarize_with_margins()}} and \code{\link[=expand_with_margins]{expand_with_margins()}}.}
 
 \item{.id}{\code{NULL}, or one non-missing, non-empty character string naming an
 integer output column of one-based Grouping set identifiers. Each value
@@ -72,7 +73,8 @@ identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 
-\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}, and
+nothing else; see \emph{Option arguments}. \code{"none"}
 leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
@@ -206,6 +208,30 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Option arguments}{
+
+An argument documented as taking one of a listed set of strings —
+\code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
+out exactly. An abbreviation is not shorthand for the value it begins, and
+\code{NULL} is not shorthand for the default: both are errors naming the values
+the argument accepts. An argument left out of the call takes its default,
+and a \code{NULL} is not another way of asking for one.
+
+Elsewhere in this package \code{NULL} is a documented value, and what it means is
+stated with the argument that takes it: it is \code{.grouping}'s one empty
+grouping set, \code{.margin_label}'s typed missing value in place of a display
+label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
+\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
+\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
+arguments name a value, a column, or a plan, and such a name has a natural
+absent case to give a \code{NULL}. A vocabulary of options has none — every option
+argument already has a default that does something — so a \code{NULL} arriving at
+one is far more often a variable that did not hold what its caller thought
+than a request for anything, and it is reported rather than resolved.
 }
 
 \section{Result class and attributes}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -61,7 +61,8 @@ dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
 not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
 of a display label. See \emph{Display labels and grouping identity}.}
 
-\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"}.
+\item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
+and nothing else; see \emph{Option arguments}.
 This controls the position of a non-missing synthetic label in factor and
 ordered-factor levels. It does not sort result rows and has no effect for
 \code{NA_character_} or \code{NULL}.}
@@ -91,8 +92,9 @@ nothing where the rule can be applied — a local data frame, a \code{dtplyr}
 step, and a database that refuses an ineligible summary itself all apply
 it whatever this argument says. See \emph{Contextual shares}.}
 
-\item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, controlling
-duplicate grouping sets after expansion.}
+\item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, and nothing
+else, controlling duplicate grouping sets after expansion; see \emph{Option
+arguments}.}
 
 \item{.id}{\code{NULL}, or one non-missing, non-empty character string naming an
 integer output column of one-based Grouping set identifiers. Each value
@@ -100,7 +102,8 @@ identifies one occurrence in the resolved Grouping plan. The name must not
 collide with source columns, grouping keys, summary outputs, or a nesting
 \code{.key}.}
 
-\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}. \code{"none"}
+\item{.sort}{One of \code{"none"} (the default), \code{"last"}, or \code{"first"}, and
+nothing else; see \emph{Option arguments}. \code{"none"}
 leaves row order unspecified. The other two order the result by the
 structure of its Grouping plan: within each fixed \code{.by} key, every grouping
 dimension contributes its Grouping bit and its missingness before its own
@@ -197,6 +200,30 @@ hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
 Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+}
+
+\section{Option arguments}{
+
+An argument documented as taking one of a listed set of strings —
+\code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
+out exactly. An abbreviation is not shorthand for the value it begins, and
+\code{NULL} is not shorthand for the default: both are errors naming the values
+the argument accepts. An argument left out of the call takes its default,
+and a \code{NULL} is not another way of asking for one.
+
+Elsewhere in this package \code{NULL} is a documented value, and what it means is
+stated with the argument that takes it: it is \code{.grouping}'s one empty
+grouping set, \code{.margin_label}'s typed missing value in place of a display
+label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
+\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
+\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
+arguments name a value, a column, or a plan, and such a name has a natural
+absent case to give a \code{NULL}. A vocabulary of options has none — every option
+argument already has a default that does something — so a \code{NULL} arriving at
+one is far more often a variable that did not hold what its caller thought
+than a request for anything, and it is reported rather than resolved.
 }
 
 \section{Result class and attributes}{

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -284,7 +284,11 @@ call_with_option <- function(verb, option, value) {
   if (verb %in% c("summarize_with_margins", "summarise_with_margins")) {
     args <- c(args, list(s = quote(sum(v))))
   }
-  args[[option]] <- value
+  # Single-bracket assignment from a list, because `args[[option]] <- NULL`
+  # removes the element instead of writing one: the call would then omit the
+  # option and exercise its default, which is the very thing the `NULL` case
+  # below asserts is not what happens.
+  args[option] <- list(value)
   eval(rlang::call2(verb, !!!args))
 }
 
@@ -353,6 +357,23 @@ test_that("an abbreviation of an option value is rejected", {
         info = option_case_label(case, abbreviation)
       )
     }
+  }
+})
+
+test_that("`NULL` is rejected by every option rather than taken as a default", {
+  # `match.arg(NULL, choices)` returns `choices[1]`, so every option argument
+  # used to read a `NULL` as a request for its own default. #110 stopped that
+  # along with the abbreviations above, and #144 settled it as a decision: the
+  # *Option arguments* section on `?summarize_with_margins` says which
+  # arguments do give a `NULL` a meaning and why an option vocabulary is not
+  # among them. The untouched formal is what selects a default, and it arrives
+  # as the whole vocabulary rather than as a `NULL`.
+  for (case in option_vocabulary_cases()) {
+    expect_identical(
+      option_rejection_message(case$verb, case$option, NULL),
+      expected_vocabulary_message(case),
+      info = paste0(case$verb, "(", case$option, " = NULL)")
+    )
   }
 })
 


### PR DESCRIPTION
Closes #144, taking the *Keep rejecting* option the ticket recommends.

## What changed

An `Option arguments` section on `summarize_with_margins()`, inherited by
`expand_with_margins()`, `nest_with_margins()`, `nest_by_with_margins()`, and
`inspect_grouping()`. It is written over the class of arguments rather than as
a list of the four: an argument documented as taking one of a listed set of
strings takes one of them exactly, an abbreviation is not shorthand for the
value it begins, and a `NULL` is not shorthand for the default.

`.duplicates`, `.margin_label_position`, `.sort`, and `inspect_grouping()`'s
`.format` each gain `and nothing else` and a pointer to that section, so the
argument's own entry answers the question and the reason lives in one place.

No behaviour change. `match_margin_choice()` is untouched, as the ticket's
*Out of scope* requires; its comment gains a paragraph saying that its
`identical()` guard is the whole of what refuses a `NULL`, and that refusing
one is now a documented contract rather than a leftover of the rewrite that
removed `match.arg()`.

## Why

`match.arg(NULL, choices)` returns `choices[1]`, so a `NULL` reaching any
fixed-vocabulary option used to select that option's default silently. #110
stopped that along with the abbreviations it was really about, and #143
delivered it, but the ticket never named `NULL` -- so the narrowing arrived as
a side effect, and nothing wrote it down in either direction.

Stating it matters because this package gives `NULL` the opposite meaning three
arguments away: `.grouping = NULL` is one empty grouping set,
`.margin_label = NULL` a typed missing value, `.id = NULL` no identifier
column, and `nest_with_margins(.key = NULL)` the `"data"` that `tidyr::nest()`
reads there. A reader who has met any of those carries the expectation across,
and meets a message listing three values, none of which is what they wrote.
Each of those arguments names a value, a column, or a plan, and such a name has
a natural absent case; a vocabulary of options has none, because every one of
them already has a default that does something.

The section names `nest_by_with_margins()` refusing a `NULL` `.key` alongside
`nest_with_margins()` accepting one, because both topics inherit it and the
reader of either needs the same fact: every argument answers for its own
`NULL`, which is what makes the option arguments a rule and not an exception.

## Test

`NULL` rejection is pinned over `option_vocabulary_cases()`, which pairs every
option with every verb that takes it, so all four are covered on all six topics
without a list of its own -- the same table the abbreviation and invalid-value
assertions already read.

`call_with_option()` had to stop assigning with `[[<-`, which deletes an element
when handed a `NULL`. Left alone it would have called each verb without the
option at all: passing, while asserting the default the test exists to rule out.

Nothing else asserts the reachability of the new section, because
`test-documentation.R` already resolves every italicised section reference
against the topic it promises -- a topic that stops inheriting `Option
arguments` fails there rather than rendering a dangling reference.

## Review

Reviewed on both axes before opening. The Spec pass caught a sentence that was
false on five shipped help pages -- "Leaving the argument out of the call is how
its default is chosen, and is the only way to choose it", which `.sort = "none"`
contradicts -- and the `.key` contrast landing backwards on
`nest_by_with_margins()`'s page. Both are fixed above.

One finding is deferred to #208: whether *option argument* should gain a
`CONTEXT.md` entry now that it is a cross-cutting user-facing term. That is a
glossary decision with a case on both sides, and the documentation here stands
either way.