### PR TITLE
Name the Option argument in the glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -153,6 +153,17 @@ runs when it is. A diagnostic refusing one tells the caller their spelling is
 glossary, and not a second term.
 _Avoid_: Contextual function, masked helper, reserved argument
 
+**Option argument**:
+An argument whose value is one of a fixed set of strings, written out exactly
+as documented. An abbreviation is not shorthand for the value it begins, and a
+`NULL` is not shorthand for the default; both are refused, and an argument left
+out of the call takes its default. Several arguments do give a `NULL` a
+meaning, each stating for itself what it is, and those name a value, a column,
+or a plan — such a name has a natural absent case for a `NULL` to mean.
+An Option argument has none, because it already has a default that does
+something, so a `NULL` reaching one is reported rather than resolved.
+_Avoid_: Choice argument, enum argument, flag argument, mode argument
+
 **Package condition**:
 An error marginplyr itself raises, inheriting the `marginplyr_error` base
 class. It reports something the caller can avoid by rewriting the call within


### PR DESCRIPTION
Closes #208, implementing the agent brief on that issue.

## What changed

One entry in `CONTEXT.md`, between `Contextual helper` and `Package condition`.
Nothing else -- no `R/`, no `man/`, no `tests/`, no `vignettes/`.

#144 gave the four fixed-vocabulary options one rule and one place to read it:
an `Option arguments` section on `summarize_with_margins()`, inherited by the
other three Margin verbs and by `inspect_grouping()`. That made the concept
load-bearing in the shipped help while nothing owned its spelling -- the
comment above `match_margin_choice()` and the verb-argument admission tests
both use the term as settled, and the glossary had never heard of it.

## Why there rather than anywhere else

`Contextual helper`, `Option argument`, and `Package condition` are all about
what a caller writes and how marginplyr reads it, and the third is what
refusing the first two looks like.

`Nested specification position` is the precedent for a glossary entry about an
argument at all, and it is why the objection recorded in #208's body -- that
this is a general R convention rather than this project's vocabulary -- does
not hold. That objection was mine, written before checking; triage found the
glossary already carries rules for reading what is written in an argument, and
the brief tells the reader so rather than leaving a stale argument above a
contradicting entry.

## What the entry does not do

It names no argument and enumerates no permitted value. Those live in the
shared vocabulary constants beside `match_margin_choice()` and in each
`@param`, and a third copy in a file no test reads is a copy that goes stale
silently -- which is the shape of #110. It also does not restate the help
page's argument for the rule, only its conclusion and the reason.

Every `_Avoid_` item is a compound rather than a bare word, because three of
the four bare words are live in this repository in another sense: `choice` is
the implementation's own name for the vocabulary a value is matched against
(`match_margin_choice()`, `margin_sort_choices`), `enum` is what the DuckDB
material calls that backend's factor representation, and `flag` is how the
`Grouping bit` entry ten lines up defines itself. What is avoided is a name for
the *argument*, which none of those three uses is.

## Test

None, and none is possible: `CONTEXT.md` is in `.Rbuildignore` and no test or
CI script reads it. The full suite, `lintr::lint_package()`, and
`spelling::spell_check_package()` were run to establish that nothing else
moved, not to prove the entry.

## Review

Two rounds on both axes before opening. Round 1 caught a reason that had
degraded into a near-tautology diverging from the help page, an `_Avoid_` list
of bare words colliding with live repository vocabulary, and prose imported
wholesale from the Rd. Round 2 caught two residual over-claims: a flat
universal the code contradicts -- `nest_by_with_margins()` names a column in
`.key` and refuses a `NULL` there, which is why the help page hedges with
"natural" -- and an exclusivity in "is what takes its default" that the help
page does not claim. All fixed.

One finding was deferred to #210: `match_margin_choice()` accepts an option's
whole vocabulary written out explicitly, silently meaning the first entry, and
nothing documents it. Closing that would change four public signatures, so it
is a decision rather than a cleanup and does not belong in a glossary edit.