### PR TITLE
Say that a forwarded vocabulary asks for the default

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -154,10 +154,14 @@ glossary, and not a second term.
 _Avoid_: Contextual function, masked helper, reserved argument
 
 **Option argument**:
-An argument whose value is one of a fixed set of strings, written out exactly
-as documented. An abbreviation is not shorthand for the value it begins, and a
-`NULL` is not shorthand for the default; both are refused, and an argument left
-out of the call takes its default. Several arguments do give a `NULL` a
+An argument whose value is one of a fixed set of strings, spelled in full. An
+abbreviation is not shorthand for the value it begins, and a `NULL` is not
+shorthand for the default; both are refused. Its default is asked for by
+leaving the argument out, or by passing the vocabulary as the signature spells
+it — which is what leaving it out already does, and what lets a caller's own
+wrapper repeat the signature and hand the argument on. No other vector of more
+than one value is accepted, a reordering included. Several arguments do give a
+`NULL` a
 meaning, each stating for itself what it is, and those name a value, a column,
 or a plan — such a name has a natural absent case for a `NULL` to mean.
 An Option argument has none, because it already has a default that does

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -155,11 +155,31 @@
 #' @section Option arguments:
 #' An argument documented as taking one of a listed set of strings —
 #' `.duplicates`, `.margin_label_position`, and `.sort` on the Margin verbs,
-#' and `.format` on [inspect_grouping()] — takes one of those strings written
-#' out exactly. An abbreviation is not shorthand for the value it begins, and
+#' and `.format` on [inspect_grouping()] — takes one of those strings, spelled
+#' in full. An abbreviation is not shorthand for the value it begins, and
 #' `NULL` is not shorthand for the default: both are errors naming the values
-#' the argument accepts. An argument left out of the call takes its default,
-#' and a `NULL` is not another way of asking for one.
+#' the argument accepts.
+#'
+#' There are two ways to ask for the default, and a `NULL` is neither of them.
+#' One is to leave the argument out. The other is to pass the whole vocabulary
+#' as the signature spells it, which is what leaving the argument out already
+#' does — the default *is* that vector — and what lets a function of your own
+#' repeat the signature and hand the argument on:
+#'
+#' ```r
+#' my_report <- function(data, .sort = c("none", "last", "first")) {
+#'   summarize_with_margins(
+#'     data, revenue = sum(revenue),
+#'     .grouping = rollup(region), .sort = .sort
+#'   )
+#' }
+#' ```
+#'
+#' Called without `.sort`, that function forwards the vector its own formal
+#' holds and the Margin verb reads it as the default, so the wrapper needs no
+#' matching call of its own. Only the spelling the signature gives is read this
+#' way: any other vector of more than one value is an error, a reordering of
+#' the vocabulary included.
 #'
 #' Elsewhere in this package `NULL` is a documented value, and what it means is
 #' stated with the argument that takes it: it is `.grouping`'s one empty

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -169,11 +169,30 @@ Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} f
 
 An argument documented as taking one of a listed set of strings —
 \code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
-and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
-out exactly. An abbreviation is not shorthand for the value it begins, and
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings, spelled
+in full. An abbreviation is not shorthand for the value it begins, and
 \code{NULL} is not shorthand for the default: both are errors naming the values
-the argument accepts. An argument left out of the call takes its default,
-and a \code{NULL} is not another way of asking for one.
+the argument accepts.
+
+There are two ways to ask for the default, and a \code{NULL} is neither of them.
+One is to leave the argument out. The other is to pass the whole vocabulary
+as the signature spells it, which is what leaving the argument out already
+does — the default \emph{is} that vector — and what lets a function of your own
+repeat the signature and hand the argument on:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_report <- function(data, .sort = c("none", "last", "first")) \{
+  summarize_with_margins(
+    data, revenue = sum(revenue),
+    .grouping = rollup(region), .sort = .sort
+  )
+\}
+}\if{html}{\out{</div>}}
+
+Called without \code{.sort}, that function forwards the vector its own formal
+holds and the Margin verb reads it as the default, so the wrapper needs no
+matching call of its own. Only the spelling the signature gives is read this
+way: any other vector of more than one value is an error, a reordering of
+the vocabulary included.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -95,11 +95,30 @@ Margin order.
 
 An argument documented as taking one of a listed set of strings —
 \code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
-and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
-out exactly. An abbreviation is not shorthand for the value it begins, and
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings, spelled
+in full. An abbreviation is not shorthand for the value it begins, and
 \code{NULL} is not shorthand for the default: both are errors naming the values
-the argument accepts. An argument left out of the call takes its default,
-and a \code{NULL} is not another way of asking for one.
+the argument accepts.
+
+There are two ways to ask for the default, and a \code{NULL} is neither of them.
+One is to leave the argument out. The other is to pass the whole vocabulary
+as the signature spells it, which is what leaving the argument out already
+does — the default \emph{is} that vector — and what lets a function of your own
+repeat the signature and hand the argument on:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_report <- function(data, .sort = c("none", "last", "first")) \{
+  summarize_with_margins(
+    data, revenue = sum(revenue),
+    .grouping = rollup(region), .sort = .sort
+  )
+\}
+}\if{html}{\out{</div>}}
+
+Called without \code{.sort}, that function forwards the vector its own formal
+holds and the Margin verb reads it as the default, so the wrapper needs no
+matching call of its own. Only the spelling the signature gives is read this
+way: any other vector of more than one value is an error, a reordering of
+the vocabulary included.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -168,11 +168,30 @@ Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} f
 
 An argument documented as taking one of a listed set of strings —
 \code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
-and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
-out exactly. An abbreviation is not shorthand for the value it begins, and
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings, spelled
+in full. An abbreviation is not shorthand for the value it begins, and
 \code{NULL} is not shorthand for the default: both are errors naming the values
-the argument accepts. An argument left out of the call takes its default,
-and a \code{NULL} is not another way of asking for one.
+the argument accepts.
+
+There are two ways to ask for the default, and a \code{NULL} is neither of them.
+One is to leave the argument out. The other is to pass the whole vocabulary
+as the signature spells it, which is what leaving the argument out already
+does — the default \emph{is} that vector — and what lets a function of your own
+repeat the signature and hand the argument on:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_report <- function(data, .sort = c("none", "last", "first")) \{
+  summarize_with_margins(
+    data, revenue = sum(revenue),
+    .grouping = rollup(region), .sort = .sort
+  )
+\}
+}\if{html}{\out{</div>}}
+
+Called without \code{.sort}, that function forwards the vector its own formal
+holds and the Margin verb reads it as the default, so the wrapper needs no
+matching call of its own. Only the spelling the signature gives is read this
+way: any other vector of more than one value is an error, a reordering of
+the vocabulary included.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -214,11 +214,30 @@ Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} f
 
 An argument documented as taking one of a listed set of strings —
 \code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
-and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
-out exactly. An abbreviation is not shorthand for the value it begins, and
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings, spelled
+in full. An abbreviation is not shorthand for the value it begins, and
 \code{NULL} is not shorthand for the default: both are errors naming the values
-the argument accepts. An argument left out of the call takes its default,
-and a \code{NULL} is not another way of asking for one.
+the argument accepts.
+
+There are two ways to ask for the default, and a \code{NULL} is neither of them.
+One is to leave the argument out. The other is to pass the whole vocabulary
+as the signature spells it, which is what leaving the argument out already
+does — the default \emph{is} that vector — and what lets a function of your own
+repeat the signature and hand the argument on:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_report <- function(data, .sort = c("none", "last", "first")) \{
+  summarize_with_margins(
+    data, revenue = sum(revenue),
+    .grouping = rollup(region), .sort = .sort
+  )
+\}
+}\if{html}{\out{</div>}}
+
+Called without \code{.sort}, that function forwards the vector its own formal
+holds and the Margin verb reads it as the default, so the wrapper needs no
+matching call of its own. Only the spelling the signature gives is read this
+way: any other vector of more than one value is an error, a reordering of
+the vocabulary included.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -206,11 +206,30 @@ Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} f
 
 An argument documented as taking one of a listed set of strings —
 \code{.duplicates}, \code{.margin_label_position}, and \code{.sort} on the Margin verbs,
-and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings written
-out exactly. An abbreviation is not shorthand for the value it begins, and
+and \code{.format} on \code{\link[=inspect_grouping]{inspect_grouping()}} — takes one of those strings, spelled
+in full. An abbreviation is not shorthand for the value it begins, and
 \code{NULL} is not shorthand for the default: both are errors naming the values
-the argument accepts. An argument left out of the call takes its default,
-and a \code{NULL} is not another way of asking for one.
+the argument accepts.
+
+There are two ways to ask for the default, and a \code{NULL} is neither of them.
+One is to leave the argument out. The other is to pass the whole vocabulary
+as the signature spells it, which is what leaving the argument out already
+does — the default \emph{is} that vector — and what lets a function of your own
+repeat the signature and hand the argument on:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_report <- function(data, .sort = c("none", "last", "first")) \{
+  summarize_with_margins(
+    data, revenue = sum(revenue),
+    .grouping = rollup(region), .sort = .sort
+  )
+\}
+}\if{html}{\out{</div>}}
+
+Called without \code{.sort}, that function forwards the vector its own formal
+holds and the Margin verb reads it as the default, so the wrapper needs no
+matching call of its own. Only the spelling the signature gives is read this
+way: any other vector of more than one value is an error, a reordering of
+the vocabulary included.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -279,11 +279,19 @@ option_vocabulary_cases <- function() {
   ))
 }
 
-call_with_option <- function(verb, option, value) {
-  args <- list(quote(admission_data()), .grouping = quote(rollup(g)))
+# The arguments every case supplies whatever it is testing, so that a verb's
+# own requirements are stated once. A summary is added only where the verb
+# demands one.
+option_call_args <- function(verb, grouping = quote(rollup(g))) {
+  args <- list(quote(admission_data()), .grouping = grouping)
   if (verb %in% c("summarize_with_margins", "summarise_with_margins")) {
     args <- c(args, list(s = quote(sum(v))))
   }
+  args
+}
+
+call_with_option <- function(verb, option, value) {
+  args <- option_call_args(verb)
   # Single-bracket assignment from a list, because `args[[option]] <- NULL`
   # removes the element instead of writing one: the call would then omit the
   # option and exercise its default, which is the very thing the `NULL` case
@@ -292,8 +300,19 @@ call_with_option <- function(verb, option, value) {
   eval(rlang::call2(verb, !!!args))
 }
 
+# The same call with the option never written, which is what a forwarded
+# vocabulary has to agree with.
+call_without_option <- function(verb) {
+  eval(rlang::call2(verb, !!!option_call_args(verb)))
+}
+
 option_case_label <- function(case, value) {
-  paste0(case$verb, "(", case$option, " = \"", value, "\")")
+  written <- if (length(value) == 1L) {
+    paste0("\"", value, "\"")
+  } else {
+    paste0("c(", paste0("\"", value, "\"", collapse = ", "), ")")
+  }
+  paste0(case$verb, "(", case$option, " = ", written, ")")
 }
 
 # The one message a rejected value may produce, built from the vocabulary the
@@ -360,6 +379,94 @@ test_that("an abbreviation of an option value is rejected", {
   }
 })
 
+test_that("the case table reaches every option on every verb that takes it", {
+  # Every test below iterates that table and concludes something from what it
+  # found, so a table that arrived empty -- or one an option quietly dropped
+  # out of -- is a table that passes all of them. What this catches is an axis
+  # being dropped, and not an axis never added: each entry's vocabulary is read
+  # from the shared constants, while the verbs and the options are written out
+  # in `option_vocabulary_cases()` and written out again here.
+  cases <- option_vocabulary_cases()
+
+  expect_gt(length(cases), 0L)
+  expect_setequal(
+    unique(vapply(cases, function(case) case$option, character(1L))),
+    c(".duplicates", ".margin_label_position", ".sort", ".format")
+  )
+  expect_setequal(
+    unique(vapply(cases, function(case) case$verb, character(1L))),
+    c(
+      "summarize_with_margins",
+      "summarise_with_margins",
+      "expand_with_margins",
+      "nest_with_margins",
+      "nest_by_with_margins",
+      "inspect_grouping"
+    )
+  )
+  # A one-value vocabulary would make the reordering case below identical to
+  # the forwarded one, so it would assert acceptance and refusal at once.
+  for (case in cases) {
+    expect_true(
+      length(case$values) > 1L,
+      info = paste(case$verb, case$option)
+    )
+  }
+})
+
+test_that("a forwarded vocabulary resolves to the first value", {
+  # The public formals spell their vocabularies out, so an argument nobody
+  # wrote arrives as the whole vector and has to stand for its first entry.
+  # `match_margin_choice()` cannot tell that from a caller who typed the same
+  # vector, and the two are deliberately not told apart (#210): a function of
+  # the caller's own that repeats the signature forwards exactly this vector,
+  # and refusing it would break that wrapper while breaking nothing else.
+  #
+  # Asserted where the resolution happens, because a Margin result does not
+  # show it. On any one input most values of `.duplicates` and
+  # `.margin_label_position` produce the same result as each other, so a verb
+  # resolving a forwarded vocabulary to the wrong member would return the right
+  # answer anyway; the test below pairs this with what the verbs do.
+  for (case in option_vocabulary_cases()) {
+    expect_identical(
+      match_margin_choice(case$values, case$values, case$option),
+      case$values[[1L]],
+      info = option_case_label(case, case$values)
+    )
+  }
+})
+
+test_that("every verb accepts the vocabulary its own signature spells out", {
+  # The other half: that each verb hands its formal down far enough to be
+  # resolved, and answers as though the argument had never been written.
+  # Equality with the option left out is all this can assert -- see above --
+  # and it is what fails if a verb starts refusing the vector its own default
+  # supplies.
+  for (case in option_vocabulary_cases()) {
+    expect_identical(
+      call_with_option(case$verb, case$option, case$values),
+      call_without_option(case$verb),
+      info = option_case_label(case, case$values)
+    )
+  }
+})
+
+test_that("a reordering of the vocabulary is refused", {
+  # The vocabulary is read as the default because it is the spelling the
+  # signature gives, not because its members are the permitted values in some
+  # order. `rlang::arg_match()` and `rlang::arg_match0()` both accept any
+  # permutation and are looser here, which is recorded in
+  # investigation/rlang-arg-match-for-option-arguments.md.
+  for (case in option_vocabulary_cases()) {
+    reordered <- rev(case$values)
+    expect_identical(
+      option_rejection_message(case$verb, case$option, reordered),
+      expected_vocabulary_message(case),
+      info = option_case_label(case, reordered)
+    )
+  }
+})
+
 test_that("`NULL` is rejected by every option rather than taken as a default", {
   # `match.arg(NULL, choices)` returns `choices[1]`, so every option argument
   # used to read a `NULL` as a request for its own default. #110 stopped that
@@ -396,11 +503,7 @@ test_that("a diagnostic offering a `.duplicates` policy offers a real one", {
   duplicated_sets <- grouping_sets(grouping_set(g), grouping_set(g))
 
   refusal <- function(verb) {
-    fn <- get(verb, envir = asNamespace("marginplyr"))
-    args <- list(admission_data(), .grouping = duplicated_sets)
-    if (verb %in% c("summarize_with_margins", "summarise_with_margins")) {
-      args <- c(args, list(s = quote(sum(v))))
-    }
+    args <- option_call_args(verb, grouping = duplicated_sets)
     conditionMessage(rlang::catch_cnd(
       eval(rlang::call2(verb, !!!args)),
       classes = "marginplyr_error"


### PR DESCRIPTION
Closes #210, implementing the agent brief on that issue.

## What changed

The `Option arguments` section on `summarize_with_margins()`, inherited by the
other three Margin verbs and by `inspect_grouping()`; the `Option argument`
entry in `CONTEXT.md`; and four tests in `test-verb-argument-admission.R`. No
behaviour change -- `match_margin_choice()` is untouched.

## Why

The public formals spell their vocabularies out, so an option argument nobody
wrote arrives as the whole vector and stands for its first entry.
`match_margin_choice()` cannot tell that from a caller who typed the same
vector, and #144 left the documentation saying a value is "written out
exactly", which reads as excluding it. The one input a caller is most likely to
send by accident -- a variable holding the vocabulary -- was accepted, and the
help page said the opposite.

#210 opened asking whether to refuse it. Triage established the opposite: not
telling the two apart is what makes the ordinary caller-written wrapper work,

```r
my_report <- function(data, .sort = c("none", "last", "first")) {
  summarize_with_margins(data, ..., .sort = .sort)
}
```

and every `match.arg()`-based function in R supports that shape. Refusing it
would break the wrapper while breaking nothing else, so the acceptance is part
of the contract and the silence was the defect.

The section now gives two ways to ask for the default and says a `NULL` is
neither, where it gave one. "Written out exactly" becomes "spelled in full",
which says what it was there to say -- no abbreviations -- without denying the
vector.

## Test

Four, all over `option_vocabulary_cases()`, so all four options are covered on
every verb that takes them.

The resolution is asserted at `match_margin_choice()` rather than end-to-end,
because a Margin result does not show it: on one input, every value of
`.duplicates` and both values of `.margin_label_position` produce the same
result as each other, so a verb resolving a forwarded vocabulary to the wrong
member would return the right answer anyway. The verb-level test asserts only
that the vector is not refused, and says so. A third pins the boundary -- a
reordering is refused -- which is worth its own test because `rlang::arg_match()`
and `arg_match0()` both draw that line elsewhere, as
`investigation/rlang-arg-match-for-option-arguments.md` records. The fourth
asserts the case table itself, since every other test in the file iterates it
and a table that arrived empty is a table that passes them all.

Mutation-tested during review: removing the whole-vocabulary branch, accepting
any permutation, and resolving to the last member are each detected, the last
two by exactly one test apiece.

## Review

Two rounds on both axes. The first found the end-to-end test could not detect a
wrong resolution, which is what produced the split above. The second found a
comment of mine claiming "six tests" where eight iterate -- a hand-count in the
file whose argument is that hand-counts go stale -- an overstated claim that
the case table is derived when only its vocabularies are, and a `CONTEXT.md`
sentence that contradicted the one before it. All fixed.

One finding is deferred to #213: this change promotes the wrapper from an
incidental capability to a documented reason, and that wrapper holds a copy of
the vocabulary matched exactly, so growing an option vocabulary would refuse
every wrapper written against the old signature. Nothing is wrong today, and
the right time to decide is before a vocabulary changes rather than during it.