### PR TITLE
Name the wrapper shape that does not track this signature

### DIFF
--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -181,6 +181,15 @@
 #' way: any other vector of more than one value is an error, a reordering of
 #' the vocabulary included.
 #'
+#' What such a wrapper does hold is a copy of this vocabulary, read by exact
+#' match, so a change to the vocabulary refuses the wrapper's own default while
+#' leaving a value passed through it alone. A wrapper that
+#' would rather not track this signature resolves the value itself and passes
+#' the one string it chose, which no later widening or reordering of the
+#' vocabulary can invalidate. [rlang::arg_match()] refuses an abbreviation there
+#' as this package does, while [base::match.arg()] resolves one, so a wrapper
+#' built on that accepts spellings this package would not.
+#'
 #' Elsewhere in this package `NULL` is a documented value, and what it means is
 #' stated with the argument that takes it: it is `.grouping`'s one empty
 #' grouping set, `.margin_label`'s typed missing value in place of a display

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -194,6 +194,15 @@ matching call of its own. Only the spelling the signature gives is read this
 way: any other vector of more than one value is an error, a reordering of
 the vocabulary included.
 
+What such a wrapper does hold is a copy of this vocabulary, read by exact
+match, so a change to the vocabulary refuses the wrapper's own default while
+leaving a value passed through it alone. A wrapper that
+would rather not track this signature resolves the value itself and passes
+the one string it chose, which no later widening or reordering of the
+vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
+as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
+built on that accepts spellings this package would not.
+
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty
 grouping set, \code{.margin_label}'s typed missing value in place of a display

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -120,6 +120,15 @@ matching call of its own. Only the spelling the signature gives is read this
 way: any other vector of more than one value is an error, a reordering of
 the vocabulary included.
 
+What such a wrapper does hold is a copy of this vocabulary, read by exact
+match, so a change to the vocabulary refuses the wrapper's own default while
+leaving a value passed through it alone. A wrapper that
+would rather not track this signature resolves the value itself and passes
+the one string it chose, which no later widening or reordering of the
+vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
+as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
+built on that accepts spellings this package would not.
+
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty
 grouping set, \code{.margin_label}'s typed missing value in place of a display

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -193,6 +193,15 @@ matching call of its own. Only the spelling the signature gives is read this
 way: any other vector of more than one value is an error, a reordering of
 the vocabulary included.
 
+What such a wrapper does hold is a copy of this vocabulary, read by exact
+match, so a change to the vocabulary refuses the wrapper's own default while
+leaving a value passed through it alone. A wrapper that
+would rather not track this signature resolves the value itself and passes
+the one string it chose, which no later widening or reordering of the
+vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
+as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
+built on that accepts spellings this package would not.
+
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty
 grouping set, \code{.margin_label}'s typed missing value in place of a display

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -239,6 +239,15 @@ matching call of its own. Only the spelling the signature gives is read this
 way: any other vector of more than one value is an error, a reordering of
 the vocabulary included.
 
+What such a wrapper does hold is a copy of this vocabulary, read by exact
+match, so a change to the vocabulary refuses the wrapper's own default while
+leaving a value passed through it alone. A wrapper that
+would rather not track this signature resolves the value itself and passes
+the one string it chose, which no later widening or reordering of the
+vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
+as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
+built on that accepts spellings this package would not.
+
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty
 grouping set, \code{.margin_label}'s typed missing value in place of a display

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -231,6 +231,15 @@ matching call of its own. Only the spelling the signature gives is read this
 way: any other vector of more than one value is an error, a reordering of
 the vocabulary included.
 
+What such a wrapper does hold is a copy of this vocabulary, read by exact
+match, so a change to the vocabulary refuses the wrapper's own default while
+leaving a value passed through it alone. A wrapper that
+would rather not track this signature resolves the value itself and passes
+the one string it chose, which no later widening or reordering of the
+vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
+as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
+built on that accepts spellings this package would not.
+
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
 stated with the argument that takes it: it is \code{.grouping}'s one empty
 grouping set, \code{.margin_label}'s typed missing value in place of a display


### PR DESCRIPTION
Closes #213, implementing the agent brief on that issue.

## What changed

One paragraph in the `Option arguments` section on `summarize_with_margins()`,
inherited by the other three Margin verbs and by `inspect_grouping()`, plus the
regenerated `man/`. No behaviour change, no test change, and `CONTEXT.md`
untouched.

## Why

#210 documented that an Option argument reads its whole vocabulary as a request
for the default, and gave the reason: it lets a caller repeat the signature in a
wrapper of their own and hand the argument on. The section shows that wrapper
and says it needs no matching call of its own, which is true and was also the
whole of what it said.

What it left out is that the wrapper holds a copy of this package's vocabulary,
read by exact match. A change to the vocabulary refuses the wrapper's own
default -- with a message listing values, saying nothing about the copy having
gone stale. A value passed through the wrapper is unaffected, and the section
now says which half breaks rather than leaving a reader to conclude the wrapper
stops working.

That is not hypothetical. `nest_with_margins()` narrows `.duplicates` to
`c("error", "drop")`, so a wrapper spelling the wider Margin vocabulary in its
own formal is refused by it today, exactly as one written before a widening
would be refused after.

The fix is not a warning. The uncoupled shape is one line away and is the
ordinary R idiom: a wrapper that resolves the value itself passes one string,
which no later widening or reordering of a vocabulary can invalidate. The
section was steering readers away from it by saying only that the matching call
is unnecessary. Both shapes stay supported; #210 is not walked back.

## The two ways a caller would resolve it are not interchangeable

`rlang::arg_match()` refuses an abbreviation, as this package does since #110;
`base::match.arg()` resolves one, so a wrapper built on it accepts
`.sort = "f"` and hands `"first"` on. Offering the pair without saying so would
have recommended, three paragraphs below "an abbreviation is not shorthand for
the value it begins", a wrapper that puts abbreviations back. Both halves were
verified in a session rather than assumed.

That marginplyr's own helper is neither function is a separate decision about
this package's internals, recorded in
`investigation/rlang-arg-match-for-option-arguments.md`, and it constrains
nothing about what a caller reaches for in their own function.

## Test

None, and none should be needed: the brief named a test requiring edits as the
signal that the change had gone out of scope. The full suite passes unchanged,
`lintr::lint_package()` and `spelling::spell_check_package()` are clean, and
`man/` is regenerated in this commit.

## Review

Two rounds on both axes. The first caught the `match.arg()` recommendation
contradicting the section's own opening, and an overstatement -- "whatever else
changes" -- that a narrowing or rename would falsify. The second verified both
fixes and caught a factual imprecision worth one more edit: "so it is refused"
read as the whole wrapper breaking, where only its default path does.

`CONTEXT.md` was deliberately left out, which the brief asked to be decided and
stated: the glossary entry says what an Option argument is, while how to write a
wrapper around one is advice to a caller rather than part of the term.