### PR TITLE
Ask again when a dialect leaves the question unanswered

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,10 +124,12 @@ decides whether the eligible-type rule for a share source can be left to the
 database: a refusing dialect applies it and reports an ineligible source in
 its own diagnostic, while a converting dialect applies nothing and returns a
 number whatever the source held, so a share over one is refused unless the
-caller establishes the source themselves. It is a property of the dialect and
-not of one connection, so it is established once and reused for every later
-connection carrying that dialect. A dialect that could not be asked is neither,
-and is refused as a converting one is.
+caller establishes the source themselves. Which of the two a dialect is, is a
+property of the dialect and not of one connection, so it is established once and
+reused for every later connection carrying that dialect. A dialect that could
+not be asked is neither, and is refused as a converting one is — but that is a
+fact about one attempt rather than about the dialect, so nothing is recorded and
+the next share request asks again.
 _Avoid_: Coercing backend, lenient database, permissive SQL
 
 **Contextual helper**:

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,11 +19,15 @@
   dtplyr are supported, and lazy inputs stay lazy; Arrow rejects Parent shares
   before a query is built. A share source must be a plain integer or double on
   every backend: where the type is not readable without asking, marginplyr
-  asks each SQL dialect once, with at most two queries that read none of your
-  data, whether it converts a non-numeric value to a number instead of
-  refusing it, and refuses the share rather than calculate one from a source
-  nothing has checked. `.check_share_source = FALSE` opts out for a source you
-  have established yourself (#195, #196).
+  asks each SQL dialect, with at most two queries that read none of your data,
+  whether it converts a non-numeric value to a number instead of refusing it,
+  and refuses the share rather than calculate one from a source nothing has
+  checked. An answer is a property of the dialect, so a dialect that answers is
+  asked once; a question a dropped connection or a resuming warehouse left
+  unanswered is asked again on the next share request rather than refusing
+  every later share on that dialect for the rest of the session.
+  `.check_share_source = FALSE` opts out for a source you have established
+  yourself (#195, #196, #198).
 * Added the contextual `share_of_total()` summary helper, which divides the
   same kind of source summary by the Grand total set within each fixed `.by`
   partition. It shares every rule of `share_of_parent()` except the

--- a/R/share.R
+++ b/R/share.R
@@ -2026,16 +2026,16 @@ check_dialect_share_sources <- function(operation,
   )
 }
 
-# One question per dialect: does it convert a value of another type to a number
-# rather than refusing it? It is asked with at most two queries, neither
+# One question about a dialect: does it convert a value of another type to a
+# number rather than refusing it? It is asked with at most two queries, neither
 # referencing a table of the caller's -- `SELECT SUM('x') FROM (SELECT 1 AS z)`
 # and, only where that is rejected, the control below -- so asking it reads
 # none of their data, which is what ADR 0020's second exemption rests on. What
 # an answered question establishes is a property of the dialect and not of one
 # connection, so the answer is reused for every later connection carrying the
-# same dialect and no dialect is asked twice. A question that went unanswered
-# established nothing, so it is asked again rather than reused -- see the cache
-# write below.
+# same dialect, and a dialect that answers is never asked again. A question that
+# went unanswered established nothing, so it is asked again rather than reused
+# -- see the cache write below.
 share_dialect_verdict <- function(data, backend) {
   con <- share_dialect_connection(data)
   if (!share_dialect_can_be_asked(con)) {

--- a/R/share.R
+++ b/R/share.R
@@ -422,11 +422,12 @@
 #' established yourself. A backend that cannot be asked, such as a
 #' `dbplyr::simulate_*()` connection, is refused the same way.
 #'
-#' A question left unanswered — the control did not come back, which a dropped
-#' connection, a permissions failure, or a dialect whose scaffolding is invalid
-#' all produce — refuses the share the same way, but nothing about it is
-#' remembered. It established nothing about the dialect, so the next share
-#' request there asks again rather than inheriting one attempt's failure, and a
+#' A question left unanswered refuses the share the same way, but nothing about
+#' it is remembered. Neither outcome was read there — a dropped connection, a
+#' permissions failure, a dialect whose SQL scaffolding this question lacks, and
+#' a query that could not be built against the connection at all all end that
+#' way — so nothing was established about the dialect, and the next share
+#' request there asks again rather than inheriting one attempt's failure. A
 #' connection that has recovered gets the verdict its dialect earns.
 #'
 #' Cardinality is not established this way at all: a SQL aggregate returns one

--- a/R/share.R
+++ b/R/share.R
@@ -423,12 +423,12 @@
 #' `dbplyr::simulate_*()` connection, is refused the same way.
 #'
 #' A question left unanswered refuses the share the same way, but nothing about
-#' it is remembered. Neither outcome was read there — a dropped connection, a
-#' permissions failure, a dialect whose SQL scaffolding this question lacks, and
-#' a query that could not be built against the connection at all all end that
-#' way — so nothing was established about the dialect, and the next share
-#' request there asks again rather than inheriting one attempt's failure. A
-#' connection that has recovered gets the verdict its dialect earns.
+#' it is remembered. Neither outcome was read there, which is where a dropped
+#' connection, a permissions failure, a dialect whose SQL scaffolding this
+#' question lacks, and a query that could not be built against the connection
+#' all end up — so nothing was established about the dialect, and the next
+#' share request there asks again rather than inheriting one attempt's failure.
+#' A connection that has recovered gets the verdict its dialect earns.
 #'
 #' Cardinality is not established this way at all: a SQL aggregate returns one
 #' value per grouping row by construction, so there is nothing for a dialect
@@ -2047,13 +2047,15 @@ share_dialect_verdict <- function(data, backend) {
     return(cached)
   }
   verdict <- probe_share_dialect(con)
-  # An invariant, not a Package condition (ADR 0015). Four sites branch on
-  # this string and none of them has a default, so one this frame does not
-  # recognise would reach the caller as `"unknown"`'s diagnostic -- that their
-  # backend could not be asked -- for a dialect that was asked and answered.
-  # The cache write below records only the names it recognises, so such a
-  # verdict would also be re-asked on every later request while continuing to
-  # misreport; this assertion is what stops both.
+  # An invariant, not a Package condition (ADR 0015). Four sites act on this
+  # string -- refusing the share, or describing why -- and none of them has a
+  # default, so one this frame does not recognise would reach the caller as
+  # `"unknown"`'s diagnostic, that their backend could not be asked, for a
+  # dialect that was asked and answered. The cache write just below is the one
+  # site that does have a default, and it fails closed: a verdict it does not
+  # recognise is not recorded, so such a dialect would also be asked again on
+  # every later request while continuing to misreport. This assertion is what
+  # stops both.
   stopifnot(verdict %in% share_dialect_verdict_names())
   # Only a measured outcome is recorded, which is the whole of what makes
   # reuse sound: `"refuses"` and `"converts"` are facts about the dialect,
@@ -2082,7 +2084,7 @@ share_dialect_verdict <- function(data, backend) {
 # The two answers that are properties of the dialect, because
 # `investigation/share-source-eligibility-on-coercing-dialects.md` measured
 # both: the dialect rejected summing a string, or it converted it to a number.
-# These are the two the cache above holds.
+# These are the two the cache write above records.
 share_dialect_measured_names <- function() {
   c("refuses", "converts")
 }

--- a/R/share.R
+++ b/R/share.R
@@ -404,11 +404,13 @@
 #' [dplyr::show_query()] remains non-executing, and no query is run over your
 #' data to improve an error.
 #'
-#' Which of two things a dialect does is what decides the case, and it is
-#' settled once per dialect, with at most two queries referencing none of your
-#' tables: a probe, and — only when the probe is rejected — a control, which is
-#' what tells a dialect that genuinely refuses apart from one whose connection
-#' or SQL scaffolding failed and could not answer at all. Where it refuses an
+#' Which of two things a dialect does is what decides the case, and asking
+#' takes at most two queries referencing none of your tables: a probe, and —
+#' only when the probe is rejected — a control, which is what tells a dialect
+#' that genuinely refuses apart from one whose connection or SQL scaffolding
+#' failed and could not answer at all. An answer is a property of the dialect,
+#' so it settles the case once and is reused for every later connection
+#' carrying that dialect. Where it refuses an
 #' ineligible summary, that refusal is the answer
 #' and reaches you as the database's own diagnostic when [dplyr::collect()]
 #' executes the staged query; the internal denominator column is named after
@@ -419,6 +421,13 @@
 #' `.check_share_source = FALSE` calculates it from sources you have
 #' established yourself. A backend that cannot be asked, such as a
 #' `dbplyr::simulate_*()` connection, is refused the same way.
+#'
+#' A question left unanswered — the control did not come back, which a dropped
+#' connection, a permissions failure, or a dialect whose scaffolding is invalid
+#' all produce — refuses the share the same way, but nothing about it is
+#' remembered. It established nothing about the dialect, so the next share
+#' request there asks again rather than inheriting one attempt's failure, and a
+#' connection that has recovered gets the verdict its dialect earns.
 #'
 #' Cardinality is not established this way at all: a SQL aggregate returns one
 #' value per grouping row by construction, so there is nothing for a dialect
@@ -2021,9 +2030,11 @@ check_dialect_share_sources <- function(operation,
 # referencing a table of the caller's -- `SELECT SUM('x') FROM (SELECT 1 AS z)`
 # and, only where that is rejected, the control below -- so asking it reads
 # none of their data, which is what ADR 0020's second exemption rests on. What
-# it establishes is a property of the dialect and not of one connection, so it
-# is asked once and the answer is reused for every later connection carrying
-# the same dialect.
+# an answered question establishes is a property of the dialect and not of one
+# connection, so the answer is reused for every later connection carrying the
+# same dialect and no dialect is asked twice. A question that went unanswered
+# established nothing, so it is asked again rather than reused -- see the cache
+# write below.
 share_dialect_verdict <- function(data, backend) {
   con <- share_dialect_connection(data)
   if (!share_dialect_can_be_asked(con)) {
@@ -2039,22 +2050,55 @@ share_dialect_verdict <- function(data, backend) {
   # this string and none of them has a default, so one this frame does not
   # recognise would reach the caller as `"unknown"`'s diagnostic -- that their
   # backend could not be asked -- for a dialect that was asked and answered.
-  # Caching it would then repeat that for every later connection.
+  # The cache write below records only the names it recognises, so such a
+  # verdict would also be re-asked on every later request while continuing to
+  # misreport; this assertion is what stops both.
   stopifnot(verdict %in% share_dialect_verdict_names())
-  share_dialect_verdicts[[key]] <- verdict
+  # Only a measured outcome is recorded, which is the whole of what makes
+  # reuse sound: `"refuses"` and `"converts"` are facts about the dialect,
+  # while `"unknown"` is a fact about one attempt. A dropped socket, a
+  # permissions blip, or a warehouse that was resuming produces it on a
+  # connection whose dialect would answer perfectly well, and recording it
+  # would refuse shares on that dialect for the rest of the session -- on
+  # every later connection carrying it, with `.check_share_source = FALSE`,
+  # which opts out of the rule entirely, the only way back.
+  #
+  # Leaving it unrecorded asks again on the next request, which is why ADR
+  # 0020's second exemption bounds the question per share request until the
+  # dialect answers rather than once per dialect. What pays that is a request
+  # that is refused anyway: a dialect that genuinely cannot answer -- Oracle
+  # and SAP HANA reject the probe's `FROM`-less scaffolding, needing
+  # `FROM DUAL` and `FROM DUMMY` -- is asked twice per refused request and
+  # never on a succeeding one. Whether an unanswered attempt was transient is
+  # not asked, because it cannot be read from a raised query; that is what the
+  # control query in `probe_share_dialect()` exists to work around.
+  if (verdict %in% share_dialect_measured_names()) {
+    share_dialect_verdicts[[key]] <- verdict
+  }
   verdict
 }
 
-# The three answers the dialect question can have. `"refuses"` and
-# `"converts"` are the two outcomes
-# `investigation/share-source-eligibility-on-coercing-dialects.md` measured;
-# `"unknown"` is every case that read neither, and refuses the share.
-share_dialect_verdict_names <- function() {
-  c("refuses", "converts", "unknown")
+# The two answers that are properties of the dialect, because
+# `investigation/share-source-eligibility-on-coercing-dialects.md` measured
+# both: the dialect rejected summing a string, or it converted it to a number.
+# These are the two the cache above holds.
+share_dialect_measured_names <- function() {
+  c("refuses", "converts")
 }
 
-# One entry per dialect class, written the first time a share is requested on a
-# connection carrying that dialect.
+# The three answers the dialect question can have: the two measured outcomes,
+# and `"unknown"` for every case that read neither, which refuses the share.
+# Written as the measured pair plus that one so the split the cache turns on is
+# structural -- a verdict added to this vocabulary alone is not recorded, and a
+# question asked again costs a query where a wrong fact cached against a
+# dialect costs every later connection carrying it.
+share_dialect_verdict_names <- function() {
+  c(share_dialect_measured_names(), "unknown")
+}
+
+# One entry per dialect class whose question was answered, written the first
+# time a share is requested on a connection carrying that dialect and the
+# dialect answers.
 share_dialect_verdicts <- new.env(parent = emptyenv())
 
 share_dialect_connection <- function(data) {

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -411,8 +411,9 @@
 #' calculated. `dtplyr` steps stay lazy and report the same conditions during
 #' explicit execution, before an invalid grouping row is emitted. General
 #' dbplyr backends read none of your data to apply the rule: the dialect is
-#' asked once whether it converts a value of another type to a number rather
-#' than refusing it, and where it converts, the share is refused unless
+#' asked whether it converts a value of another type to a number rather than
+#' refusing it, once for as long as it answers, and where it converts, the
+#' share is refused unless
 #' `.check_share_source = FALSE` asks for it anyway. Cardinality remains a
 #' local-and-`dtplyr` rule, because a SQL aggregate returns one value per
 #' grouping row by construction.
@@ -514,14 +515,20 @@
 #'   decomposition loses. It references your table but reads none of it, and
 #'   it is not a shape marginplyr introduced: [dplyr::tbl()] already sends an
 #'   equivalent zero-row read for any table reference, on any dbplyr backend.
-#' - **At most two queries per SQL dialect**, sent once per dialect, the first
-#'   time a share is requested there with `.check_share_source` at its default
-#'   of `TRUE`, asking whether the dialect converts a non-numeric value to a
-#'   number rather than refusing it. Neither references any of your tables, so
-#'   reading them touches none of your data, and the answer is a property of
-#'   the dialect, reused for every later connection that shares it. The second
+#' - **At most two queries per share request until the SQL dialect answers**,
+#'   sent the first time a share is requested there with `.check_share_source`
+#'   at its default of `TRUE`, asking whether the dialect converts a
+#'   non-numeric value to a number rather than refusing it. Neither references
+#'   any of your tables, so reading them touches none of your data. The second
 #'   is a control, sent only when the first is rejected, and it distinguishes
-#'   a dialect that refuses from one that could not be asked at all. A
+#'   a dialect that refuses from one that could not be asked at all. An
+#'   answer is a property of the dialect, reused for every later connection
+#'   that shares it, so a dialect that answers is asked once and never again.
+#'   A question that could not be answered established nothing about the
+#'   dialect, so nothing is remembered and the next share request there asks
+#'   again: one dropped connection does not refuse your shares for the rest of
+#'   the session. What pays for asking again is a request that is refused
+#'   anyway, since an unanswered question refuses the share. A
 #'   connection that cannot be asked -- one built with a
 #'   `dbplyr::simulate_*()` constructor, which executes nothing -- is treated
 #'   as unable to answer, which refuses the share by default the same way a

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -517,8 +517,8 @@
 #'   it is not a shape marginplyr introduced: [dplyr::tbl()] already sends an
 #'   equivalent zero-row read for any table reference, on any dbplyr backend.
 #' - **At most two queries per share request until the SQL dialect answers**,
-#'   sent the first time a share is requested there with `.check_share_source`
-#'   at its default of `TRUE`, asking whether the dialect converts a
+#'   sent when a share is requested there with `.check_share_source` at its
+#'   default of `TRUE`, asking whether the dialect converts a
 #'   non-numeric value to a number rather than refusing it. Neither references
 #'   any of your tables, so reading them touches none of your data. The second
 #'   is a control, sent only when the first is rejected, and it distinguishes

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -412,7 +412,8 @@
 #' explicit execution, before an invalid grouping row is emitted. General
 #' dbplyr backends read none of your data to apply the rule: the dialect is
 #' asked whether it converts a value of another type to a number rather than
-#' refusing it, once for as long as it answers, and where it converts, the
+#' refusing it — once, where it answers, and again on the next share request
+#' where the question could not be answered — and where it converts, the
 #' share is refused unless
 #' `.check_share_source = FALSE` asks for it anyway. Cardinality remains a
 #' local-and-`dtplyr` rule, because a SQL aggregate returns one value per

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -505,10 +505,12 @@ that refusal is the answer and reaches the caller as the database's diagnostic
 at collection. Where the dialect converts instead of refusing, no answer is
 available and the share is refused rather than calculated —
 `.check_share_source = FALSE` calculates it anyway. Which case a dialect is in
-is measured once per dialect by at most two queries that reference none of the
-caller's tables — a probe, and a control sent only when the probe is rejected,
-so that a dialect which refuses is told apart from one whose scaffolding or
-connection failed — and the internal denominator column is named after the
+is measured by at most two queries that reference none of the caller's tables —
+a probe, and a control sent only when the probe is rejected, so that a dialect
+which refuses is told apart from one whose scaffolding or connection failed —
+asked once per dialect that answers and asked again where the question could
+not be answered, for the reasons ADR 0020 states; and the internal denominator
+column is named after the
 summary to rewrite, so that a database's own diagnostic names something the
 caller wrote rather than an internal identifier alone, which
 was #106's DuckDB half.

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -30,7 +30,9 @@ justification covering both would be false of one of them:
    values to numbers rather than refusing them. Neither references a table of
    the caller's — `SELECT SUM('x') FROM (SELECT 1 AS z)` — so no reading of
    either touches their data, and the answer is a property of the dialect and
-   is reused for every later connection sharing it.
+   is reused for every later connection sharing it. The bound stated here is
+   amended below: only an answer is remembered, so it is per share request
+   until the dialect answers.
 
    The second is a control, and it is sent only when the first raises. A
    raised query is how a refusing dialect is recognized, but it is also what a

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -63,6 +63,41 @@ so that collision is rejected on every backend whatever `.check_margin_label`
 says. A label equal to an *observed* value is found only by reading, so that
 collision is what `.check_margin_label` controls.
 
+## Amendment: only an answer is remembered, so the bound is per request
+
+Exemption 2's queries are unchanged, and so is which verdict refuses a share.
+What changed is its bound: **at most two queries per share request until the
+dialect answers**, not two per dialect.
+
+"The answer is a property of the dialect and is reused for every later
+connection sharing it" is true of the two outcomes
+`investigation/share-source-eligibility-on-coercing-dialects.md` measured —
+the dialect refused summing a string, or it converted it to a number — and each
+of those is still recorded and still asked only once per dialect. It is not
+true of a question that went unanswered, which is a fact about one attempt: a
+dropped socket, a permissions blip, or a warehouse that was resuming produces
+it on a connection whose dialect would answer perfectly well. Recording it
+refused shares on that dialect for the rest of the session, on every later
+connection carrying it, and left the caller only
+`.check_share_source = FALSE` — which opts out of the rule rather than retrying
+the question (#198). Nothing of that kind is recorded now, so the next share
+request asks again.
+
+Whether an unanswered attempt was transient is not asked, because it cannot be
+read from a raised query. That is the same fact the control query above exists
+because of, and it is why asking again is the whole of the remedy.
+
+The cost falls only where a request is refused anyway. A dialect that genuinely
+cannot answer — Oracle and SAP HANA, whose scaffolding this exemption's probe
+lacks a `FROM` for — is asked twice per refused request and never on one that
+succeeds, so no calculated share pays for it.
+
+This is the line the design already drew one step earlier, for the same reason.
+A connection that *cannot be asked* — a `dbplyr::simulate_*()` one, which
+executes nothing — records nothing, precisely so that a live connection
+carrying the same dialect does not inherit it. A transient failure on a live
+connection belongs on that side of the line.
+
 ## Considered options
 
 **A capability for backends whose queries are cheap.** Rejected: it cannot be

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -307,10 +307,13 @@ The responsibilities divide as follows:
   rule itself and reports an ineligible summary at collection, unless its
   dialect converts a value of another type to a number instead of refusing it,
   in which case nothing applies the rule and the share is refused;
-  `share_dialect_verdict()` decides which, once per dialect, with at most two
-  queries referencing none of the caller's tables — a probe, and a control
+  `share_dialect_verdict()` decides which, with at most two queries
+  referencing none of the caller's tables — a probe, and a control
   sent only when the probe is rejected, so that a dialect which refuses is
-  told apart from one whose scaffolding or connection failed — and
+  told apart from one whose scaffolding or connection failed. It caches only
+  the two measured answers, so a dialect that answers is asked once and a
+  question that could not be answered is asked again rather than refusing
+  every later share on that dialect (ADR 0020); and
   `.check_share_source = FALSE` calculates the share anyway. Arrow is rejected
   before any of this.
 - **Mapping** is the one responsibility a kind supplies for itself, through

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -413,8 +413,8 @@ decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
 \item \strong{At most two queries per share request until the SQL dialect answers},
-sent the first time a share is requested there with \code{.check_share_source}
-at its default of \code{TRUE}, asking whether the dialect converts a
+sent when a share is requested there with \code{.check_share_source} at its
+default of \code{TRUE}, asking whether the dialect converts a
 non-numeric value to a number rather than refusing it. Neither references
 any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -412,14 +412,20 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
-time a share is requested there with \code{.check_share_source} at its default
-of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. Neither references any of your tables, so
-reading them touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. The second
+\item \strong{At most two queries per share request until the SQL dialect answers},
+sent the first time a share is requested there with \code{.check_share_source}
+at its default of \code{TRUE}, asking whether the dialect converts a
+non-numeric value to a number rather than refusing it. Neither references
+any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes
-a dialect that refuses from one that could not be asked at all. A
+a dialect that refuses from one that could not be asked at all. An
+answer is a property of the dialect, reused for every later connection
+that shares it, so a dialect that answers is asked once and never again.
+A question that could not be answered established nothing about the
+dialect, so nothing is remembered and the next share request there asks
+again: one dropped connection does not refuse your shares for the rest of
+the session. What pays for asking again is a request that is refused
+anyway, since an unanswered question refuses the share. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -395,8 +395,8 @@ decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
 \item \strong{At most two queries per share request until the SQL dialect answers},
-sent the first time a share is requested there with \code{.check_share_source}
-at its default of \code{TRUE}, asking whether the dialect converts a
+sent when a share is requested there with \code{.check_share_source} at its
+default of \code{TRUE}, asking whether the dialect converts a
 non-numeric value to a number rather than refusing it. Neither references
 any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -394,14 +394,20 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
-time a share is requested there with \code{.check_share_source} at its default
-of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. Neither references any of your tables, so
-reading them touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. The second
+\item \strong{At most two queries per share request until the SQL dialect answers},
+sent the first time a share is requested there with \code{.check_share_source}
+at its default of \code{TRUE}, asking whether the dialect converts a
+non-numeric value to a number rather than refusing it. Neither references
+any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes
-a dialect that refuses from one that could not be asked at all. A
+a dialect that refuses from one that could not be asked at all. An
+answer is a property of the dialect, reused for every later connection
+that shares it, so a dialect that answers is asked once and never again.
+A question that could not be answered established nothing about the
+dialect, so nothing is remembered and the next share request there asks
+again: one dropped connection does not refuse your shares for the rest of
+the session. What pays for asking again is a request that is refused
+anyway, since an unanswered question refuses the share. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -441,8 +441,8 @@ decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
 \item \strong{At most two queries per share request until the SQL dialect answers},
-sent the first time a share is requested there with \code{.check_share_source}
-at its default of \code{TRUE}, asking whether the dialect converts a
+sent when a share is requested there with \code{.check_share_source} at its
+default of \code{TRUE}, asking whether the dialect converts a
 non-numeric value to a number rather than refusing it. Neither references
 any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -440,14 +440,20 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
-time a share is requested there with \code{.check_share_source} at its default
-of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. Neither references any of your tables, so
-reading them touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. The second
+\item \strong{At most two queries per share request until the SQL dialect answers},
+sent the first time a share is requested there with \code{.check_share_source}
+at its default of \code{TRUE}, asking whether the dialect converts a
+non-numeric value to a number rather than refusing it. Neither references
+any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes
-a dialect that refuses from one that could not be asked at all. A
+a dialect that refuses from one that could not be asked at all. An
+answer is a property of the dialect, reused for every later connection
+that shares it, so a dialect that answers is asked once and never again.
+A question that could not be answered established nothing about the
+dialect, so nothing is remembered and the next share request there asks
+again: one dropped connection does not refuse your shares for the rest of
+the session. What pays for asking again is a request that is refused
+anyway, since an unanswered question refuses the share. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -442,11 +442,12 @@ than calculated from values nothing has checked —
 established yourself. A backend that cannot be asked, such as a
 \verb{dbplyr::simulate_*()} connection, is refused the same way.
 
-A question left unanswered — the control did not come back, which a dropped
-connection, a permissions failure, or a dialect whose scaffolding is invalid
-all produce — refuses the share the same way, but nothing about it is
-remembered. It established nothing about the dialect, so the next share
-request there asks again rather than inheriting one attempt's failure, and a
+A question left unanswered refuses the share the same way, but nothing about
+it is remembered. Neither outcome was read there — a dropped connection, a
+permissions failure, a dialect whose SQL scaffolding this question lacks, and
+a query that could not be built against the connection at all all end that
+way — so nothing was established about the dialect, and the next share
+request there asks again rather than inheriting one attempt's failure. A
 connection that has recovered gets the verdict its dialect earns.
 
 Cardinality is not established this way at all: a SQL aggregate returns one

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -443,12 +443,12 @@ established yourself. A backend that cannot be asked, such as a
 \verb{dbplyr::simulate_*()} connection, is refused the same way.
 
 A question left unanswered refuses the share the same way, but nothing about
-it is remembered. Neither outcome was read there — a dropped connection, a
-permissions failure, a dialect whose SQL scaffolding this question lacks, and
-a query that could not be built against the connection at all all end that
-way — so nothing was established about the dialect, and the next share
-request there asks again rather than inheriting one attempt's failure. A
-connection that has recovered gets the verdict its dialect earns.
+it is remembered. Neither outcome was read there, which is where a dropped
+connection, a permissions failure, a dialect whose SQL scaffolding this
+question lacks, and a query that could not be built against the connection
+all end up — so nothing was established about the dialect, and the next
+share request there asks again rather than inheriting one attempt's failure.
+A connection that has recovered gets the verdict its dialect earns.
 
 Cardinality is not established this way at all: a SQL aggregate returns one
 value per grouping row by construction, so there is nothing for a dialect

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -424,11 +424,13 @@ yours is read to establish it: the staged query stays lazy,
 \code{\link[dplyr:show_query]{dplyr::show_query()}} remains non-executing, and no query is run over your
 data to improve an error.
 
-Which of two things a dialect does is what decides the case, and it is
-settled once per dialect, with at most two queries referencing none of your
-tables: a probe, and — only when the probe is rejected — a control, which is
-what tells a dialect that genuinely refuses apart from one whose connection
-or SQL scaffolding failed and could not answer at all. Where it refuses an
+Which of two things a dialect does is what decides the case, and asking
+takes at most two queries referencing none of your tables: a probe, and —
+only when the probe is rejected — a control, which is what tells a dialect
+that genuinely refuses apart from one whose connection or SQL scaffolding
+failed and could not answer at all. An answer is a property of the dialect,
+so it settles the case once and is reused for every later connection
+carrying that dialect. Where it refuses an
 ineligible summary, that refusal is the answer
 and reaches you as the database's own diagnostic when \code{\link[dplyr:collect]{dplyr::collect()}}
 executes the staged query; the internal denominator column is named after
@@ -439,6 +441,13 @@ than calculated from values nothing has checked —
 \code{.check_share_source = FALSE} calculates it from sources you have
 established yourself. A backend that cannot be asked, such as a
 \verb{dbplyr::simulate_*()} connection, is refused the same way.
+
+A question left unanswered — the control did not come back, which a dropped
+connection, a permissions failure, or a dialect whose scaffolding is invalid
+all produce — refuses the share the same way, but nothing about it is
+remembered. It established nothing about the dialect, so the next share
+request there asks again rather than inheriting one attempt's failure, and a
+connection that has recovered gets the verdict its dialect earns.
 
 Cardinality is not established this way at all: a SQL aggregate returns one
 value per grouping row by construction, so there is nothing for a dialect

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -582,8 +582,8 @@ decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
 \item \strong{At most two queries per share request until the SQL dialect answers},
-sent the first time a share is requested there with \code{.check_share_source}
-at its default of \code{TRUE}, asking whether the dialect converts a
+sent when a share is requested there with \code{.check_share_source} at its
+default of \code{TRUE}, asking whether the dialect converts a
 non-numeric value to a number rather than refusing it. Neither references
 any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -469,7 +469,8 @@ calculated. \code{dtplyr} steps stay lazy and report the same conditions during
 explicit execution, before an invalid grouping row is emitted. General
 dbplyr backends read none of your data to apply the rule: the dialect is
 asked whether it converts a value of another type to a number rather than
-refusing it, once for as long as it answers, and where it converts, the
+refusing it — once, where it answers, and again on the next share request
+where the question could not be answered — and where it converts, the
 share is refused unless
 \code{.check_share_source = FALSE} asks for it anyway. Cardinality remains a
 local-and-\code{dtplyr} rule, because a SQL aggregate returns one value per

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -468,8 +468,9 @@ Local data frames reject an ineligible source before any share is
 calculated. \code{dtplyr} steps stay lazy and report the same conditions during
 explicit execution, before an invalid grouping row is emitted. General
 dbplyr backends read none of your data to apply the rule: the dialect is
-asked once whether it converts a value of another type to a number rather
-than refusing it, and where it converts, the share is refused unless
+asked whether it converts a value of another type to a number rather than
+refusing it, once for as long as it answers, and where it converts, the
+share is refused unless
 \code{.check_share_source = FALSE} asks for it anyway. Cardinality remains a
 local-and-\code{dtplyr} rule, because a SQL aggregate returns one value per
 grouping row by construction.
@@ -579,14 +580,20 @@ columns marginplyr must decompose and later restore -- currently
 decomposition loses. It references your table but reads none of it, and
 it is not a shape marginplyr introduced: \code{\link[dplyr:tbl]{dplyr::tbl()}} already sends an
 equivalent zero-row read for any table reference, on any dbplyr backend.
-\item \strong{At most two queries per SQL dialect}, sent once per dialect, the first
-time a share is requested there with \code{.check_share_source} at its default
-of \code{TRUE}, asking whether the dialect converts a non-numeric value to a
-number rather than refusing it. Neither references any of your tables, so
-reading them touches none of your data, and the answer is a property of
-the dialect, reused for every later connection that shares it. The second
+\item \strong{At most two queries per share request until the SQL dialect answers},
+sent the first time a share is requested there with \code{.check_share_source}
+at its default of \code{TRUE}, asking whether the dialect converts a
+non-numeric value to a number rather than refusing it. Neither references
+any of your tables, so reading them touches none of your data. The second
 is a control, sent only when the first is rejected, and it distinguishes
-a dialect that refuses from one that could not be asked at all. A
+a dialect that refuses from one that could not be asked at all. An
+answer is a property of the dialect, reused for every later connection
+that shares it, so a dialect that answers is asked once and never again.
+A question that could not be answered established nothing about the
+dialect, so nothing is remembered and the next share request there asks
+again: one dropped connection does not refuse your shares for the rest of
+the session. What pays for asking again is a request that is refused
+anyway, since an unanswered question refuses the share. A
 connection that cannot be asked -- one built with a
 \verb{dbplyr::simulate_*()} constructor, which executes nothing -- is treated
 as unable to answer, which refuses the share by default the same way a

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1151,6 +1151,23 @@ test_that("a lazy backend that answers nothing refuses to establish a share", {
   expect_match(dbplyr::sql_render(query), "UNION ALL", fixed = TRUE)
 })
 
+# The per-dialect verdict cache is package state, so every test below starts
+# from an empty one -- what it records is only observable from there -- and puts
+# back whatever the rest of the suite had recorded. Restoring empties first, so
+# that an entry the test itself wrote is not left beside the saved ones.
+empty_share_dialect_verdicts <- function() {
+  rm(
+    list = ls(share_dialect_verdicts, all.names = TRUE),
+    envir = share_dialect_verdicts
+  )
+}
+
+restore_share_dialect_verdicts <- function(saved) {
+  empty_share_dialect_verdicts()
+  list2env(saved, envir = share_dialect_verdicts)
+  invisible(NULL)
+}
+
 # What the dialect does with an ineligible summary is a property of the
 # dialect, so it is asked once and reused — which is only observable across
 # calls, and only from an empty cache. The second half is why the question is
@@ -1164,19 +1181,7 @@ test_that("a dialect is asked whether it converts at most once", {
   )
   backend <- grouping_backend(remote)
   saved <- as.list(share_dialect_verdicts, all.names = TRUE)
-  empty_verdicts <- function() {
-    rm(
-      list = ls(share_dialect_verdicts, all.names = TRUE),
-      envir = share_dialect_verdicts
-    )
-  }
-  on.exit(
-    {
-      empty_verdicts()
-      list2env(saved, envir = share_dialect_verdicts)
-    },
-    add = TRUE
-  )
+  on.exit(restore_share_dialect_verdicts(saved), add = TRUE)
   probes <- 0L
   local_mocked_bindings(
     probe_share_dialect = function(con) {
@@ -1185,7 +1190,7 @@ test_that("a dialect is asked whether it converts at most once", {
     }
   )
 
-  empty_verdicts()
+  empty_share_dialect_verdicts()
   local_mocked_bindings(share_dialect_can_be_asked = function(con) TRUE)
   expect_identical(share_dialect_verdict(remote, backend = backend), "refuses")
   expect_identical(share_dialect_verdict(remote, backend = backend), "refuses")
@@ -1203,11 +1208,8 @@ test_that("a connection that answers nothing records nothing for its dialect", {
   )
   backend <- grouping_backend(remote)
   saved <- as.list(share_dialect_verdicts, all.names = TRUE)
-  on.exit(list2env(saved, envir = share_dialect_verdicts), add = TRUE)
-  rm(
-    list = ls(share_dialect_verdicts, all.names = TRUE),
-    envir = share_dialect_verdicts
-  )
+  on.exit(restore_share_dialect_verdicts(saved), add = TRUE)
+  empty_share_dialect_verdicts()
 
   expect_identical(share_dialect_verdict(remote, backend = backend), "unknown")
   expect_identical(ls(share_dialect_verdicts, all.names = TRUE), character())
@@ -1233,19 +1235,7 @@ test_that("a question that went unanswered is asked again", {
   backend <- grouping_backend(remote)
   key <- paste(class(backend$dialect), collapse = "\n")
   saved <- as.list(share_dialect_verdicts, all.names = TRUE)
-  empty_verdicts <- function() {
-    rm(
-      list = ls(share_dialect_verdicts, all.names = TRUE),
-      envir = share_dialect_verdicts
-    )
-  }
-  on.exit(
-    {
-      empty_verdicts()
-      list2env(saved, envir = share_dialect_verdicts)
-    },
-    add = TRUE
-  )
+  on.exit(restore_share_dialect_verdicts(saved), add = TRUE)
   answers <- c("unknown", "refuses")
   probes <- 0L
   local_mocked_bindings(
@@ -1256,7 +1246,7 @@ test_that("a question that went unanswered is asked again", {
     }
   )
 
-  empty_verdicts()
+  empty_share_dialect_verdicts()
   expect_identical(share_dialect_verdict(remote, backend = backend), "unknown")
   expect_identical(ls(share_dialect_verdicts, all.names = TRUE), character())
 

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1213,6 +1213,61 @@ test_that("a connection that answers nothing records nothing for its dialect", {
   expect_identical(ls(share_dialect_verdicts, all.names = TRUE), character())
 })
 
+# `"refuses"` and `"converts"` are facts about the dialect, which is what makes
+# reusing them sound. `"unknown"` is a fact about one attempt: a dropped
+# socket, a permissions blip, or a warehouse that was resuming produces it on a
+# connection whose dialect would answer perfectly well. Recording it would
+# refuse shares on that dialect for the rest of the session, on every later
+# connection carrying it, with `.check_share_source = FALSE` -- opting out of
+# the rule entirely -- the only way back. So the question is asked again, and
+# the answer it then gives is the one that is recorded and reused.
+#
+# The third request is what keeps this from being satisfied by not caching at
+# all: the mock has no third answer, so a verdict that is asked again after
+# answering fails here rather than passing.
+test_that("a question that went unanswered is asked again", {
+  remote <- dbplyr::tbl_lazy(
+    data.frame(group = c("x", "y"), value = c(1, 3)),
+    con = dbplyr::simulate_postgres()
+  )
+  backend <- grouping_backend(remote)
+  key <- paste(class(backend$dialect), collapse = "\n")
+  saved <- as.list(share_dialect_verdicts, all.names = TRUE)
+  empty_verdicts <- function() {
+    rm(
+      list = ls(share_dialect_verdicts, all.names = TRUE),
+      envir = share_dialect_verdicts
+    )
+  }
+  on.exit(
+    {
+      empty_verdicts()
+      list2env(saved, envir = share_dialect_verdicts)
+    },
+    add = TRUE
+  )
+  answers <- c("unknown", "refuses")
+  probes <- 0L
+  local_mocked_bindings(
+    share_dialect_can_be_asked = function(con) TRUE,
+    probe_share_dialect = function(con) {
+      probes <<- probes + 1L
+      answers[[probes]]
+    }
+  )
+
+  empty_verdicts()
+  expect_identical(share_dialect_verdict(remote, backend = backend), "unknown")
+  expect_identical(ls(share_dialect_verdicts, all.names = TRUE), character())
+
+  expect_identical(share_dialect_verdict(remote, backend = backend), "refuses")
+  expect_identical(probes, 2L)
+  expect_identical(share_dialect_verdicts[[key]], "refuses")
+
+  expect_identical(share_dialect_verdict(remote, backend = backend), "refuses")
+  expect_identical(probes, 2L)
+})
+
 # `share_source_checker()` routes the `other` backend kind to the dialect
 # checker as well, and an input of that kind carries no connection to put the
 # question to. Answering "unknown" is what refuses the share there; failing

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1151,10 +1151,12 @@ test_that("a lazy backend that answers nothing refuses to establish a share", {
   expect_match(dbplyr::sql_render(query), "UNION ALL", fixed = TRUE)
 })
 
-# The per-dialect verdict cache is package state, so every test below starts
-# from an empty one -- what it records is only observable from there -- and puts
-# back whatever the rest of the suite had recorded. Restoring empties first, so
-# that an entry the test itself wrote is not left beside the saved ones.
+# The per-dialect verdict cache is package state, so the three tests that read
+# what it records start from an empty one -- what a call records is only
+# observable from there -- and put back whatever the rest of the suite had
+# recorded. Restoring empties first, so that an entry the test itself wrote is
+# not left beside the saved ones. The tests after those three assert against
+# the cache as they found it, or do not touch it, and use neither helper.
 empty_share_dialect_verdicts <- function() {
   rm(
     list = ls(share_dialect_verdicts, all.names = TRUE),

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1155,8 +1155,10 @@ test_that("a lazy backend that answers nothing refuses to establish a share", {
 # what it records start from an empty one -- what a call records is only
 # observable from there -- and put back whatever the rest of the suite had
 # recorded. Restoring empties first, so that an entry the test itself wrote is
-# not left beside the saved ones. The tests after those three assert against
-# the cache as they found it, or do not touch it, and use neither helper.
+# not left beside the saved ones. Only those three need either helper: the
+# verdict tests after them call `probe_share_dialect()` directly or assert the
+# cache as they found it, and the live-backend tests further down write to it
+# through the verb without reading what it holds.
 empty_share_dialect_verdicts <- function() {
   rm(
     list = ls(share_dialect_verdicts, all.names = TRUE),

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -373,13 +373,17 @@ Where the dialect converts a value of another type to a number instead of
 refusing it — SQLite answers `sum()` of a text column with `0` rather than an
 error — nothing applies the rule at all, and marginplyr refuses the share
 rather than calculating one from values nothing has checked. Which of the two
-a dialect does is asked once per dialect, with at most two queries referencing
-none of your tables: a probe, and — only when the probe is rejected — a
-control, which is what tells a dialect that genuinely refuses apart from one
-that could not answer at all. A connection that executes nothing, such as the
-simulators used above, cannot be asked and is refused for the same reason;
-`.check_share_source = FALSE` calculates the share from sources you have
-established yourself.
+a dialect does is asked with at most two queries referencing none of your
+tables: a probe, and — only when the probe is rejected — a control, which is
+what tells a dialect that genuinely refuses apart from one that could not
+answer at all. An answer is a property of the dialect, so a dialect that
+answers is asked once and every later connection carrying it reuses that
+answer. Where the question could not be answered, nothing is remembered and
+the next share request asks again, so a dropped connection or a warehouse that
+was resuming does not refuse your shares for the rest of the session. A
+connection that executes nothing, such as the simulators used above, cannot be
+asked and is refused for the same reason; `.check_share_source = FALSE`
+calculates the share from sources you have established yourself.
 
 A refusing dialect is therefore shown against a live DuckDB table rather than
 the simulator used above. The diagnostic is DuckDB's own, and the column it


### PR DESCRIPTION
Closes #198.

`share_dialect_verdict()` cached whatever the probe returned under the
dialect's class, `"unknown"` included. Since `"unknown"` is the verdict that
refuses a share, one probe defeated by a dropped socket, a permissions blip, or
a warehouse that was resuming refused shares on that dialect for the rest of
the session — on every later connection carrying it, however healthy — and
`.check_share_source = FALSE`, which opts out of the rule entirely, was the
only way back.

`"refuses"` and `"converts"` are facts about the dialect, which is what makes
reusing them sound. `"unknown"` is a fact about one attempt, so it is no longer
recorded and the next share request asks again. Whether an attempt was
transient is still not asked, because it cannot be read from a raised query;
that is what the control query already exists to work around.

This changes the bound ADR 0020's second exemption states, from two queries
per dialect to two per share request until the dialect answers, and the ADR
carries an amendment saying so (original decision text left intact, per the
repo's existing amendment convention). What pays for the looser bound is a
request that is refused anyway: a dialect that genuinely cannot answer is
asked twice per refused request and never on one that succeeds.

**Docs updated to state the new bound:** ADR 0020 (amendment) and ADR 0010,
`design/architecture.md`, `CONTEXT.md`'s Converting dialect entry,
`share_of_parent()`'s and the Margin verbs' roxygen (regenerated `man/`),
`vignettes/database_backends.qmd`, and `NEWS.md`.

**Tests:** new case proves an unanswered question is asked again and that the
answer it then gives is the one cached and reused — including a third request
with no third mocked answer, which closes the not-caching-at-all shortcut.
Requires no member of `optional_backends()`.

**Verified:** reproduced the reported defect against a live DuckDB connection
with a transient failure injected into the probe window, confirmed the fix
resolves it, `R CMD check` on the built tarball is `Status: OK`, full suite
green, `lintr::lint_package()` clean, `man/` in sync with roxygen sources.
