### PR TITLE
Quote the caller's own spelling in a Condition context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -189,12 +189,13 @@ _Avoid_: Third-party error, foreign error
 The lines an External condition carries naming where it arose — the argument
 it is attributed to, the grouping values in force when it did, and the call
 blamed for it. It is distinct from the condition's class and diagnostic. A
-Margin verb owes the caller a context written in names the caller can act on,
-so a grouping value is reported under the column the caller named and the
-blamed call is the Margin verb the caller wrote, rather than the columns and
-the calls marginplyr allocated to compute the grouping sets. A context it
-cannot restate in those terms it leaves as it found it, because a context that
-misdirects is still worth more than none.
+Margin verb owes the caller a context written in the names and the expressions
+the caller can act on, so a grouping value is reported under the column the
+caller named, an argument is quoted as the caller spelled it, and the blamed
+call is the Margin verb the caller wrote, rather than the columns, the
+expressions, and the calls marginplyr allocated to compute the grouping sets. A
+context it cannot restate in those terms it leaves as it found it, because a
+context that misdirects is still worth more than none.
 _Avoid_: Error context, provenance, backtrace
 
 **Repeated condition**:
@@ -202,9 +203,11 @@ One External condition raised once per grouping set, because a Margin
 operation evaluates the caller's summary expression once per grouping set
 although the caller wrote it once. Two occurrences are repetitions of one
 condition when they agree on identity — the class, the diagnostic, and the
-argument they are attributed to — and are distinct conditions otherwise. Which
-grouping set produced an occurrence is never part of that identity, since it
-is the part that necessarily differs. A Margin verb reports a Repeated
+argument they are attributed to as the caller wrote it — and are distinct
+conditions otherwise. Which grouping set produced an occurrence is never part of
+that identity, since it is the part that necessarily differs, and neither is a
+rewrite that differs between grouping sets because the occurrences sit in
+different ones. A Margin verb reports a Repeated
 condition once, and says how many further grouping sets raised it. It answers
 only for the occurrences raised while it runs: a lazy input evaluates the
 caller's expression when the caller later collects the result, and that is the

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -77,23 +77,24 @@ new_branch_conditions <- function(keys, call = NULL) {
 # evaluated inside `expr`: a Package condition is raised by the branch builders
 # around it, which is what keeps this from reaching one.
 #
-# `arguments` is this branch's own map from what it handed dplyr to what the
-# caller wrote, and sits here rather than in `conditions` because a branch
-# rewrites a Grouping helper to its own constant, so no two branches
-# necessarily hand dplyr the same expressions.
+# `argument_labels` is this branch's own map from the label of what it handed
+# dplyr to the label of what the caller wrote, and sits here rather than in
+# `conditions` because a branch rewrites `grouping_bit()` and `grouping_id()`
+# to its own constants, so no two branches necessarily hand dplyr the same
+# expressions.
 with_branch_conditions <- function(expr,
                                    conditions,
-                                   arguments = character()) {
+                                   argument_labels = character()) {
   tryCatch(
     withCallingHandlers(
       expr,
       warning = function(cnd) {
-        buffer_branch_warning(cnd, conditions, arguments)
+        buffer_branch_warning(cnd, conditions, argument_labels)
         invokeRestart("muffleWarning")
       }
     ),
     error = function(cnd) {
-      stop(restate_branch_error(cnd, conditions, arguments))
+      stop(restate_branch_error(cnd, conditions, argument_labels))
     }
   )
 }
@@ -106,8 +107,8 @@ with_branch_conditions <- function(expr,
 # Errors are not deduplicated, and there is nothing to deduplicate: branches
 # run in sequence, so the first error aborts the operation and no second
 # occurrence is ever raised.
-restate_branch_error <- function(cnd, conditions, arguments) {
-  cnd <- restate_condition_arguments(cnd, arguments)
+restate_branch_error <- function(cnd, conditions, argument_labels) {
+  cnd <- restate_condition_arguments(cnd, argument_labels)
   cnd <- restate_condition_names(cnd, conditions$keys)
   if (!is.null(conditions$call)) {
     cnd$call <- conditions$call
@@ -135,12 +136,12 @@ restate_condition_names <- function(cnd, keys) {
 # A warning arrives as one condition per branch whose message dplyr has already
 # aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
 # `$body`, so the text is all there is to compare.
-buffer_branch_warning <- function(cnd, conditions, arguments) {
+buffer_branch_warning <- function(cnd, conditions, argument_labels) {
   # The spelling is restored before the identity is read, so the identity is
-  # over the argument the caller wrote: a Grouping helper renders as a different
-  # constant in every branch, which split one written expression into one report
-  # per branch (ADR 0022).
-  cnd <- restate_condition_arguments(cnd, arguments)
+  # over the argument the caller wrote: `grouping_bit()` renders as a different
+  # constant in every branch, which split one written expression into one
+  # report per branch (ADR 0022).
+  cnd <- restate_condition_arguments(cnd, argument_labels)
   cnd <- restate_condition_names(cnd, conditions$keys)
   key <- branch_warning_identity(cnd)
 
@@ -183,11 +184,7 @@ buffer_branch_warning <- function(cnd, conditions, arguments) {
 branch_warning_identity <- function(cnd) {
   lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
   runs <- message_line_runs(lines)
-  written <- vapply(
-    runs,
-    function(run) paste(sub("^ +", "", lines[run]), collapse = " "),
-    character(1)
-  )
+  written <- written_message_lines(lines, runs)
   # `!` opens the caller's own diagnostic, so a message dplyr attributed to no
   # argument still has a bullet where its header ends. Both spellings of the
   # informational one are matched because the symbol is cli's and follows
@@ -236,6 +233,18 @@ message_line_runs <- function(lines) {
   unname(split(seq_along(lines), cumsum(!wrapped)))
 }
 
+# Each run rejoined to the one line it was written as. The identity and the
+# argument restatement both read messages through this, which is what keeps
+# the two readings one: a message the identity reads as three written lines is
+# a message the restatement reads as the same three.
+written_message_lines <- function(lines, runs) {
+  vapply(
+    runs,
+    function(run) paste(sub("^ +", "", lines[run]), collapse = " "),
+    character(1)
+  )
+}
+
 # Replays what the branches withheld: one report per distinct identity, each
 # saying how many further grouping sets raised it. The conditions are replayed
 # in the order the branches raised them, and the reported occurrence is the
@@ -262,13 +271,15 @@ report_branch_warnings <- function(conditions) {
 # The label dplyr quotes an argument by, reproduced so that the expression
 # marginplyr handed it can be recognised in a context it rendered. dplyr writes
 # `paste0(name, " = ", expr_as_label(expr))` for a named argument
-# (`error_label_named()`), and its `expr_as_label()` is `rlang::as_label()` with
-# rlang's infix labelling suppressed through an option neither package
-# documents. Plain `as_label()` is what this uses, so the two disagree exactly
-# where dplyr abbreviates a long infix expression -- `total = +...` -- and there
-# the caller's own label renders that same string. ADR 0022 reproduces the
-# convention and not the option for that reason: what the option covers is a
-# substitution nothing could observe.
+# (`error_label_named()`), and its `expr_as_label()` is `rlang::as_label()`
+# with rlang's infix labelling suppressed through an option neither package
+# documents, and with a `.data` pronoun deparsed rather than labelled. Plain
+# `as_label()` is what this uses, so the two disagree where dplyr abbreviates
+# a long infix expression -- `total = +...` -- and where an argument is itself
+# a bare pronoun. Neither disagreement is observable: a truncated label
+# renders the same whichever expression it came from, and a bare pronoun is
+# never rewritten, so its map entry is dropped as unchanged. ADR 0022
+# reproduces the convention and not the internals for that reason.
 summary_argument_labels <- function(dots) {
   arg_names <- names(dots)
   if (is.null(arg_names)) {
@@ -290,30 +301,33 @@ summary_argument_labels <- function(dots) {
   )
 }
 
-# What one branch hands dplyr, mapped to what the caller wrote. `origins` holds
-# the caller's label for each dot and is carried from
-# `plan_summary_expressions()`, because nothing between there and here preserves
-# position: share planning drops a dot and expands a placeholder into one dot
-# per output. A length that stops agreeing with the dots is an invariant rather
-# than a Package condition (ADR 0015) -- no call can produce it, and a map built
-# from a misaligned pair would quote one argument's expression under another.
+# What one branch hands dplyr, mapped to what the caller wrote. `caller_labels`
+# is the label half of what `new_summary_arguments()` built: the caller's label
+# for each dot, kept beside the dots since planning because nothing later
+# preserves position -- share planning drops a dot and expands a placeholder
+# into one dot per output. The lengths still agree or stop the operation, as an
+# invariant rather than a Package condition (ADR 0015): the constructor checked
+# the pair, so disagreeing here means a rewrite between it and this branch
+# changed the arity, and a map built from a misaligned pair would quote one
+# argument's expression under another. `NULL` is a caller with no spelling to
+# restore, and maps nothing.
 #
 # A label several dots share is kept only where the callers' own labels agree,
 # since the replacement is then the same whichever dot dplyr meant; where they
 # differ the entry is dropped and the quotation stays as dplyr wrote it. An
 # entry no rewrite changed is dropped as well, having nothing to restate.
-branch_argument_map <- function(dots, origins) {
-  if (length(origins) == 0L) {
+branch_argument_map <- function(dots, caller_labels) {
+  if (length(caller_labels) == 0L) {
     return(character())
   }
-  stopifnot(length(dots) == length(origins))
+  stopifnot(length(dots) == length(caller_labels))
 
   labels <- summary_argument_labels(dots)
   written <- unique(labels)
   restored <- vapply(
     written,
     function(label) {
-      candidates <- unique(origins[labels == label])
+      candidates <- unique(caller_labels[labels == label])
       if (length(candidates) == 1L) candidates else NA_character_
     },
     character(1),
@@ -330,15 +344,25 @@ branch_argument_map <- function(dots, origins) {
 # message whose format changed, and the whole of how this degrades (ADR 0022).
 # Only the span moves: the sentence around it is dplyr's, and rewriting a
 # sentence is what ADR 0021 refused for the blamed call.
-restate_condition_arguments <- function(cnd, arguments) {
-  if (length(arguments) == 0L || !is.character(cnd$message)) {
+#
+# Which part of the message *is* dplyr's differs by kind, and the bound is
+# positional, as every reading of dplyr's format here is. A warning's message
+# carries the caller's own diagnostic after a `Caused by` line, and a
+# diagnostic can spell anything -- including dplyr's bullet over a label a
+# branch really handed dplyr -- so only what precedes that line is dplyr's to
+# restate, and a warning without one is not dplyr's aggregation at all and is
+# left whole. An error's `$message` is dplyr's bullet alone, the caller's
+# diagnostic being `$parent`, so nothing bounds it.
+restate_condition_arguments <- function(cnd, argument_labels) {
+  if (length(argument_labels) == 0L || !is.character(cnd$message)) {
     return(cnd)
   }
   restated <- vapply(
     cnd$message,
     restate_argument_lines,
     character(1),
-    arguments = arguments,
+    argument_labels = argument_labels,
+    bounded = inherits(cnd, "warning"),
     USE.NAMES = FALSE
   )
   # The names carry the bullet markers of a structured condition, so they are
@@ -348,32 +372,61 @@ restate_condition_arguments <- function(cnd, arguments) {
   cnd
 }
 
-# An error's `$message` is the argument bullet and nothing else, while a
-# warning's is the whole text dplyr rendered before signalling, so both are read
-# as the lines they were written as -- `message_line_runs()`, the same reading
-# the identity uses, and for the same reason: cli wraps a bullet it cannot fit,
-# and a span read off the line a bullet opens is a prefix of the label at any
-# narrow width. Reading one line at a time restored the spelling at 80 columns
-# and not at 40, which made the console width decide how many conditions a
-# caller receives.
+# The message is read as the lines it was written as --
+# `written_message_lines()`, the same reading the identity uses, and for the
+# same reason: cli wraps a bullet it cannot fit, and a span read off the line
+# a bullet opens is a prefix of the label at any narrow width. Reading one
+# line at a time restored the spelling at 80 columns and not at 40, which made
+# the console width decide how many conditions a caller receives.
 #
-# A run that is restated collapses to the one line it was written as, since what
-# replaces it is a line of a different length and cli is no longer there to wrap
-# it. Every other run is given back exactly as it arrived.
-restate_argument_lines <- function(text, arguments) {
+# A run that is restated collapses to the one line it was written as, since
+# what replaces it is a line of a different length and cli is no longer there
+# to wrap it. A message in which nothing is restated is returned as the object
+# that arrived, not rebuilt from its lines: rebuilding dropped a trailing
+# newline, which is a byte the degradation contract says this may not touch.
+# The same guard restores a restated message's trailing newline, of which
+# splitting keeps all but one.
+restate_argument_lines <- function(text, argument_labels, bounded) {
   lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
   if (length(lines) == 0L) {
     return(text)
   }
-  restated <- lapply(
-    message_line_runs(lines),
-    function(run) {
-      written <- paste(sub("^ +", "", lines[run]), collapse = " ")
-      line <- restate_argument_line(written, arguments)
-      if (identical(line, written)) lines[run] else line
+  runs <- message_line_runs(lines)
+  written <- written_message_lines(lines, runs)
+
+  last <- length(runs)
+  if (bounded) {
+    cause <- match(TRUE, grepl("^Caused by ", written))
+    if (is.na(cause)) {
+      return(text)
     }
-  )
-  paste(unlist(restated, use.names = FALSE), collapse = "\n")
+    last <- cause - 1L
+  }
+
+  changed <- FALSE
+  pieces <- vector("list", length(runs))
+  for (i in seq_along(runs)) {
+    restated <- if (i <= last) {
+      restate_argument_bullet(written[[i]], argument_labels)
+    } else {
+      written[[i]]
+    }
+    if (identical(restated, written[[i]])) {
+      pieces[[i]] <- lines[runs[[i]]]
+    } else {
+      pieces[[i]] <- restated
+      changed <- TRUE
+    }
+  }
+  if (!changed) {
+    return(text)
+  }
+
+  restated <- paste(unlist(pieces, use.names = FALSE), collapse = "\n")
+  if (endsWith(text, "\n")) {
+    restated <- paste0(restated, "\n")
+  }
+  restated
 }
 
 # `In argument:` opens the bullet, carrying cli's informational marker in a
@@ -381,7 +434,7 @@ restate_argument_lines <- function(text, arguments) {
 # the name of the message vector rather than part of its text. The span is read
 # to the last backtick on the line, because a non-syntactic name the caller
 # wrote puts backticks inside it.
-restate_argument_line <- function(line, arguments) {
+restate_argument_bullet <- function(line, argument_labels) {
   found <- regmatches(
     line,
     regexec("^([i\u2139] )?In argument: `(.*)`\\.$", line)
@@ -389,7 +442,7 @@ restate_argument_line <- function(line, arguments) {
   if (length(found) == 0L) {
     return(line)
   }
-  restored <- unname(arguments[found[[3L]]])
+  restored <- unname(argument_labels[found[[3L]]])
   if (is.na(restored)) {
     return(line)
   }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -404,10 +404,9 @@ dplyr_message_runs <- function(written, rendered) {
 # The same guard restores a restated message's trailing newline, of which
 # splitting keeps all but one.
 restate_argument_lines <- function(text, restatements, rendered) {
+  # An empty message needs no guard of its own: it splits into no lines, so
+  # there is no run to restate and the unchanged path below returns it.
   lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
-  if (length(lines) == 0L) {
-    return(text)
-  }
   runs <- message_line_runs(lines)
   written <- written_message_lines(lines, runs)
   restatable <- dplyr_message_runs(written, rendered)

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -273,13 +273,14 @@ report_branch_warnings <- function(conditions) {
 # `paste0(name, " = ", expr_as_label(expr))` for a named argument
 # (`error_label_named()`), and its `expr_as_label()` is `rlang::as_label()`
 # with rlang's infix labelling suppressed through an option neither package
-# documents, and with a `.data` pronoun deparsed rather than labelled. Plain
-# `as_label()` is what this uses, so the two disagree where dplyr abbreviates
-# a long infix expression -- `total = +...` -- and where an argument is itself
-# a bare pronoun. Neither disagreement is observable: a truncated label
-# renders the same whichever expression it came from, and a bare pronoun is
-# never rewritten, so its map entry is dropped as unchanged. ADR 0022
-# reproduces the convention and not the internals for that reason.
+# documents, and with a data pronoun -- `.data$x` -- deparsed rather than
+# labelled, where `as_label()` answers `x`. Plain `as_label()` is what this
+# uses, so the two disagree in those two places. Neither disagreement is
+# observable: a truncated label renders the same whichever expression it came
+# from, and a pronoun argument is spelled alike by the caller and the branch,
+# so the map drops it as unchanged. Both diverge in dplyr's direction only, so
+# neither can make dplyr's label of one argument equal this label of another.
+# ADR 0022 reproduces the convention and not the internals for that reason.
 summary_argument_labels <- function(dots) {
   arg_names <- names(dots)
   if (is.null(arg_names)) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -76,17 +76,25 @@ new_branch_conditions <- function(keys, call = NULL) {
 # of the error that aborts it. Only the caller's own summary expressions are
 # evaluated inside `expr`: a Package condition is raised by the branch builders
 # around it, which is what keeps this from reaching one.
-with_branch_conditions <- function(expr, conditions) {
+#
+# `arguments` is this branch's own map from what it handed dplyr to what the
+# caller wrote, and sits here rather than in `conditions` because a branch
+# rewrites a Grouping helper to its own constant, so no two branches
+# necessarily hand dplyr the same expressions. Nothing reads it yet: what does
+# is the restatement in the commit after this one.
+with_branch_conditions <- function(expr,
+                                   conditions,
+                                   arguments = character()) {
   tryCatch(
     withCallingHandlers(
       expr,
       warning = function(cnd) {
-        buffer_branch_warning(cnd, conditions)
+        buffer_branch_warning(cnd, conditions, arguments)
         invokeRestart("muffleWarning")
       }
     ),
     error = function(cnd) {
-      stop(restate_branch_error(cnd, conditions))
+      stop(restate_branch_error(cnd, conditions, arguments))
     }
   )
 }
@@ -99,7 +107,7 @@ with_branch_conditions <- function(expr, conditions) {
 # Errors are not deduplicated, and there is nothing to deduplicate: branches
 # run in sequence, so the first error aborts the operation and no second
 # occurrence is ever raised.
-restate_branch_error <- function(cnd, conditions) {
+restate_branch_error <- function(cnd, conditions, arguments) {
   cnd <- restate_condition_names(cnd, conditions$keys)
   if (!is.null(conditions$call)) {
     cnd$call <- conditions$call
@@ -127,7 +135,7 @@ restate_condition_names <- function(cnd, keys) {
 # A warning arrives as one condition per branch whose message dplyr has already
 # aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
 # `$body`, so the text is all there is to compare.
-buffer_branch_warning <- function(cnd, conditions) {
+buffer_branch_warning <- function(cnd, conditions, arguments) {
   cnd <- restate_condition_names(cnd, conditions$keys)
   key <- branch_warning_identity(cnd)
 
@@ -244,6 +252,70 @@ report_branch_warnings <- function(conditions) {
     warning(cnd)
   }
   invisible(NULL)
+}
+
+# The label dplyr quotes an argument by, reproduced so that the expression
+# marginplyr handed it can be recognised in a context it rendered. dplyr writes
+# `paste0(name, " = ", expr_as_label(expr))` for a named argument
+# (`error_label_named()`), and its `expr_as_label()` is `rlang::as_label()` with
+# rlang's infix labelling suppressed through an option neither package
+# documents. Plain `as_label()` is what this uses, so the two disagree exactly
+# where dplyr abbreviates a long infix expression -- `total = +...` -- and there
+# the caller's own label renders that same string. ADR 0022 reproduces the
+# convention and not the option for that reason: what the option covers is a
+# substitution nothing could observe.
+summary_argument_labels <- function(dots) {
+  arg_names <- names(dots)
+  if (is.null(arg_names)) {
+    arg_names <- rep("", length(dots))
+  }
+  vapply(
+    seq_along(dots),
+    function(i) {
+      dot <- dots[[i]]
+      expr <- if (rlang::is_quosure(dot)) rlang::quo_get_expr(dot) else dot
+      label <- rlang::as_label(expr)
+      if (nzchar(arg_names[[i]])) {
+        paste0(arg_names[[i]], " = ", label)
+      } else {
+        label
+      }
+    },
+    character(1)
+  )
+}
+
+# What one branch hands dplyr, mapped to what the caller wrote. `origins` holds
+# the caller's label for each dot and is carried from
+# `plan_summary_expressions()`, because nothing between there and here preserves
+# position: share planning drops a dot and expands a placeholder into one dot
+# per output. A length that stops agreeing with the dots is an invariant rather
+# than a Package condition (ADR 0015) -- no call can produce it, and a map built
+# from a misaligned pair would quote one argument's expression under another.
+#
+# A label several dots share is kept only where the callers' own labels agree,
+# since the replacement is then the same whichever dot dplyr meant; where they
+# differ the entry is dropped and the quotation stays as dplyr wrote it. An
+# entry no rewrite changed is dropped as well, having nothing to restate.
+branch_argument_map <- function(dots, origins) {
+  if (length(origins) == 0L) {
+    return(character())
+  }
+  stopifnot(length(dots) == length(origins))
+
+  labels <- summary_argument_labels(dots)
+  written <- unique(labels)
+  restored <- vapply(
+    written,
+    function(label) {
+      candidates <- unique(origins[labels == label])
+      if (length(candidates) == 1L) candidates else NA_character_
+    },
+    character(1),
+    USE.NAMES = FALSE
+  )
+  keep <- !is.na(restored) & restored != written
+  stats::setNames(restored[keep], written[keep])
 }
 
 # Rewrites the internal grouping-column names dplyr built the context from into

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -80,8 +80,7 @@ new_branch_conditions <- function(keys, call = NULL) {
 # `arguments` is this branch's own map from what it handed dplyr to what the
 # caller wrote, and sits here rather than in `conditions` because a branch
 # rewrites a Grouping helper to its own constant, so no two branches
-# necessarily hand dplyr the same expressions. Nothing reads it yet: what does
-# is the restatement in the commit after this one.
+# necessarily hand dplyr the same expressions.
 with_branch_conditions <- function(expr,
                                    conditions,
                                    arguments = character()) {
@@ -108,6 +107,7 @@ with_branch_conditions <- function(expr,
 # run in sequence, so the first error aborts the operation and no second
 # occurrence is ever raised.
 restate_branch_error <- function(cnd, conditions, arguments) {
+  cnd <- restate_condition_arguments(cnd, arguments)
   cnd <- restate_condition_names(cnd, conditions$keys)
   if (!is.null(conditions$call)) {
     cnd$call <- conditions$call
@@ -136,6 +136,11 @@ restate_condition_names <- function(cnd, keys) {
 # aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
 # `$body`, so the text is all there is to compare.
 buffer_branch_warning <- function(cnd, conditions, arguments) {
+  # The spelling is restored before the identity is read, so the identity is
+  # over the argument the caller wrote: a Grouping helper renders as a different
+  # constant in every branch, which split one written expression into one report
+  # per branch (ADR 0022).
+  cnd <- restate_condition_arguments(cnd, arguments)
   cnd <- restate_condition_names(cnd, conditions$keys)
   key <- branch_warning_identity(cnd)
 
@@ -316,6 +321,79 @@ branch_argument_map <- function(dots, origins) {
   )
   keep <- !is.na(restored) & restored != written
   stats::setNames(restored[keep], written[keep])
+}
+
+# The argument bullet, restated to quote the expression the caller wrote. The
+# span inside the backticks is compared with marginplyr's own rendering of what
+# it handed dplyr, so a span equal to one is replaced by the caller's label,
+# and a span equal to none is left where it was -- which is every span in a
+# message whose format changed, and the whole of how this degrades (ADR 0022).
+# Only the span moves: the sentence around it is dplyr's, and rewriting a
+# sentence is what ADR 0021 refused for the blamed call.
+restate_condition_arguments <- function(cnd, arguments) {
+  if (length(arguments) == 0L || !is.character(cnd$message)) {
+    return(cnd)
+  }
+  restated <- vapply(
+    cnd$message,
+    restate_argument_lines,
+    character(1),
+    arguments = arguments,
+    USE.NAMES = FALSE
+  )
+  # The names carry the bullet markers of a structured condition, so they are
+  # put back rather than left to `vapply()`, which would otherwise name each
+  # element after the text it was rendered from.
+  cnd$message <- stats::setNames(restated, names(cnd$message))
+  cnd
+}
+
+# An error's `$message` is the argument bullet and nothing else, while a
+# warning's is the whole text dplyr rendered before signalling, so both are read
+# as the lines they were written as -- `message_line_runs()`, the same reading
+# the identity uses, and for the same reason: cli wraps a bullet it cannot fit,
+# and a span read off the line a bullet opens is a prefix of the label at any
+# narrow width. Reading one line at a time restored the spelling at 80 columns
+# and not at 40, which made the console width decide how many conditions a
+# caller receives.
+#
+# A run that is restated collapses to the one line it was written as, since what
+# replaces it is a line of a different length and cli is no longer there to wrap
+# it. Every other run is given back exactly as it arrived.
+restate_argument_lines <- function(text, arguments) {
+  lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
+  if (length(lines) == 0L) {
+    return(text)
+  }
+  restated <- lapply(
+    message_line_runs(lines),
+    function(run) {
+      written <- paste(sub("^ +", "", lines[run]), collapse = " ")
+      line <- restate_argument_line(written, arguments)
+      if (identical(line, written)) lines[run] else line
+    }
+  )
+  paste(unlist(restated, use.names = FALSE), collapse = "\n")
+}
+
+# `In argument:` opens the bullet, carrying cli's informational marker in a
+# rendered warning and no marker at all in a structured error, where the `i` is
+# the name of the message vector rather than part of its text. The span is read
+# to the last backtick on the line, because a non-syntactic name the caller
+# wrote puts backticks inside it.
+restate_argument_line <- function(line, arguments) {
+  found <- regmatches(
+    line,
+    regexec("^([i\u2139] )?In argument: `(.*)`\\.$", line)
+  )[[1L]]
+  if (length(found) == 0L) {
+    return(line)
+  }
+  restored <- unname(arguments[found[[3L]]])
+  if (is.na(restored)) {
+    return(line)
+  }
+  paste0(found[[2L]], "In argument: `", restored, "`.")
 }
 
 # Rewrites the internal grouping-column names dplyr built the context from into

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -77,24 +77,25 @@ new_branch_conditions <- function(keys, call = NULL) {
 # evaluated inside `expr`: a Package condition is raised by the branch builders
 # around it, which is what keeps this from reaching one.
 #
-# `argument_labels` is this branch's own map from the label of what it handed
-# dplyr to the label of what the caller wrote, and sits here rather than in
-# `conditions` because a branch rewrites `grouping_bit()` and `grouping_id()`
-# to its own constants, so no two branches necessarily hand dplyr the same
-# expressions.
+# `restatements` is this branch's own map from the label of what it handed
+# dplyr to the label of what the caller wrote. It is a map and not the vector
+# of labels `new_summary_arguments()` carries -- the two are one word apart and
+# hold different things -- and it sits here rather than in `conditions` because
+# a branch rewrites `grouping_bit()` and `grouping_id()` to its own constants,
+# so no two branches necessarily hand dplyr the same expressions.
 with_branch_conditions <- function(expr,
                                    conditions,
-                                   argument_labels = character()) {
+                                   restatements = character()) {
   tryCatch(
     withCallingHandlers(
       expr,
       warning = function(cnd) {
-        buffer_branch_warning(cnd, conditions, argument_labels)
+        buffer_branch_warning(cnd, conditions, restatements)
         invokeRestart("muffleWarning")
       }
     ),
     error = function(cnd) {
-      stop(restate_branch_error(cnd, conditions, argument_labels))
+      stop(restate_branch_error(cnd, conditions, restatements))
     }
   )
 }
@@ -107,8 +108,8 @@ with_branch_conditions <- function(expr,
 # Errors are not deduplicated, and there is nothing to deduplicate: branches
 # run in sequence, so the first error aborts the operation and no second
 # occurrence is ever raised.
-restate_branch_error <- function(cnd, conditions, argument_labels) {
-  cnd <- restate_condition_arguments(cnd, argument_labels)
+restate_branch_error <- function(cnd, conditions, restatements) {
+  cnd <- restate_condition_arguments(cnd, restatements)
   cnd <- restate_condition_names(cnd, conditions$keys)
   if (!is.null(conditions$call)) {
     cnd$call <- conditions$call
@@ -136,12 +137,12 @@ restate_condition_names <- function(cnd, keys) {
 # A warning arrives as one condition per branch whose message dplyr has already
 # aggregated, flattened, and rendered: `$parent` is `NULL` and there is no
 # `$body`, so the text is all there is to compare.
-buffer_branch_warning <- function(cnd, conditions, argument_labels) {
+buffer_branch_warning <- function(cnd, conditions, restatements) {
   # The spelling is restored before the identity is read, so the identity is
   # over the argument the caller wrote: `grouping_bit()` renders as a different
   # constant in every branch, which split one written expression into one
   # report per branch (ADR 0022).
-  cnd <- restate_condition_arguments(cnd, argument_labels)
+  cnd <- restate_condition_arguments(cnd, restatements)
   cnd <- restate_condition_names(cnd, conditions$keys)
   key <- branch_warning_identity(cnd)
 
@@ -318,9 +319,6 @@ summary_argument_labels <- function(dots) {
 # differ the entry is dropped and the quotation stays as dplyr wrote it. An
 # entry no rewrite changed is dropped as well, having nothing to restate.
 branch_argument_map <- function(dots, caller_labels) {
-  if (length(caller_labels) == 0L) {
-    return(character())
-  }
   stopifnot(length(dots) == length(caller_labels))
 
   labels <- summary_argument_labels(dots)
@@ -346,24 +344,20 @@ branch_argument_map <- function(dots, caller_labels) {
 # Only the span moves: the sentence around it is dplyr's, and rewriting a
 # sentence is what ADR 0021 refused for the blamed call.
 #
-# Which part of the message *is* dplyr's differs by kind, and the bound is
-# positional, as every reading of dplyr's format here is. A warning's message
-# carries the caller's own diagnostic after a `Caused by` line, and a
-# diagnostic can spell anything -- including dplyr's bullet over a label a
-# branch really handed dplyr -- so only what precedes that line is dplyr's to
-# restate, and a warning without one is not dplyr's aggregation at all and is
-# left whole. An error's `$message` is dplyr's bullet alone, the caller's
-# diagnostic being `$parent`, so nothing bounds it.
-restate_condition_arguments <- function(cnd, argument_labels) {
-  if (length(argument_labels) == 0L || !is.character(cnd$message)) {
+# `rendered` says which shape the message has rather than what to do with it: a
+# warning carries the text dplyr rendered before signalling, and an error's
+# `$message` is the structured bullet alone. What each shape means for the
+# restatement is `dplyr_message_runs()` below, in one piece.
+restate_condition_arguments <- function(cnd, restatements) {
+  if (length(restatements) == 0L || !is.character(cnd$message)) {
     return(cnd)
   }
   restated <- vapply(
     cnd$message,
     restate_argument_lines,
     character(1),
-    argument_labels = argument_labels,
-    bounded = inherits(cnd, "warning"),
+    restatements = restatements,
+    rendered = inherits(cnd, "warning"),
     USE.NAMES = FALSE
   )
   # The names carry the bullet markers of a structured condition, so they are
@@ -371,6 +365,28 @@ restate_condition_arguments <- function(cnd, argument_labels) {
   # element after the text it was rendered from.
   cnd$message <- stats::setNames(restated, names(cnd$message))
   cnd
+}
+
+# Which written lines of a message are dplyr's to restate, which is the whole
+# of the bound and is therefore in one place.
+#
+# A rendered warning carries the caller's own diagnostic after its `Caused by`
+# line, and a diagnostic can spell anything -- including dplyr's bullet over a
+# label a branch really handed dplyr -- so only what precedes that line is
+# dplyr's. A rendered message with no such line is left whole: that is dplyr's
+# aggregation of a caller diagnostic that rendered empty, among everything that
+# is not an aggregation at all, and telling those apart would need the reading
+# of dplyr's format this declines to do. An error's `$message` is dplyr's
+# bullet alone, the caller's diagnostic being `$parent`, so nothing bounds it.
+dplyr_message_runs <- function(written, rendered) {
+  if (!rendered) {
+    return(seq_along(written))
+  }
+  cause <- match(TRUE, grepl("^Caused by ", written))
+  if (is.na(cause)) {
+    return(integer())
+  }
+  seq_len(cause - 1L)
 }
 
 # The message is read as the lines it was written as --
@@ -387,28 +403,20 @@ restate_condition_arguments <- function(cnd, argument_labels) {
 # newline, which is a byte the degradation contract says this may not touch.
 # The same guard restores a restated message's trailing newline, of which
 # splitting keeps all but one.
-restate_argument_lines <- function(text, argument_labels, bounded) {
+restate_argument_lines <- function(text, restatements, rendered) {
   lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
   if (length(lines) == 0L) {
     return(text)
   }
   runs <- message_line_runs(lines)
   written <- written_message_lines(lines, runs)
-
-  last <- length(runs)
-  if (bounded) {
-    cause <- match(TRUE, grepl("^Caused by ", written))
-    if (is.na(cause)) {
-      return(text)
-    }
-    last <- cause - 1L
-  }
+  restatable <- dplyr_message_runs(written, rendered)
 
   changed <- FALSE
   pieces <- vector("list", length(runs))
   for (i in seq_along(runs)) {
-    restated <- if (i <= last) {
-      restate_argument_bullet(written[[i]], argument_labels)
+    restated <- if (i %in% restatable) {
+      restate_argument_bullet(written[[i]], restatements)
     } else {
       written[[i]]
     }
@@ -435,7 +443,7 @@ restate_argument_lines <- function(text, argument_labels, bounded) {
 # the name of the message vector rather than part of its text. The span is read
 # to the last backtick on the line, because a non-syntactic name the caller
 # wrote puts backticks inside it.
-restate_argument_bullet <- function(line, argument_labels) {
+restate_argument_bullet <- function(line, restatements) {
   found <- regmatches(
     line,
     regexec("^([i\u2139] )?In argument: `(.*)`\\.$", line)
@@ -443,7 +451,7 @@ restate_argument_bullet <- function(line, argument_labels) {
   if (length(found) == 0L) {
     return(line)
   }
-  restored <- unname(argument_labels[found[[3L]]])
+  restored <- unname(restatements[found[[3L]]])
   if (is.na(restored)) {
     return(line)
   }

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -145,18 +145,18 @@ add_grouping_set_id <- function(result,
 # dplyr builds every context it attaches out of those. `call` is the Margin
 # verb a Condition context is owed instead of the internal `summarize()` the
 # branch issues; a caller that reaches this directly has none to name and
-# leaves the blamed call alone, as empty `origins` are for the argument
-# spelling.
+# leaves the blamed call alone -- and `new_summary_arguments()` without labels
+# is the same statement about the argument spelling.
 summarize_margin_union <- function(.data,
-                                   dots,
+                                   summaries,
                                    plan,
                                    margin_labels,
                                    column_info,
                                    reserved_names,
                                    set_id_name = NULL,
                                    set_id_is_internal = FALSE,
-                                   call = NULL,
-                                   origins = character()) {
+                                   call = NULL) {
+  dots <- summaries$dots
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
     length(group_vars),
@@ -204,7 +204,7 @@ summarize_margin_union <- function(.data,
           .by = unname(key_names[grouping_set])
         ),
         conditions = conditions,
-        argument_labels = branch_argument_map(branch_dots, origins)
+        argument_labels = branch_argument_map(branch_dots, summaries$labels)
       )
 
       check_summary_output_names(

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -154,7 +154,8 @@ summarize_margin_union <- function(.data,
                                    reserved_names,
                                    set_id_name = NULL,
                                    set_id_is_internal = FALSE,
-                                   call = NULL) {
+                                   call = NULL,
+                                   origins = character()) {
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
     length(group_vars),
@@ -191,13 +192,18 @@ summarize_margin_union <- function(.data,
       # Only the caller's expressions are wrapped. The checks and the branch
       # builders below raise Package conditions, which carry their own context
       # and are never deduplicated.
+      #
+      # The map is built per branch rather than once, because `branch_dots` is
+      # where a Grouping helper has become this branch's own constant, and that
+      # is the expression dplyr will quote.
       result <- with_branch_conditions(
         summarize_margin_branch(
           .data = .data,
           !!!branch_dots,
           .by = unname(key_names[grouping_set])
         ),
-        conditions = conditions
+        conditions = conditions,
+        arguments = branch_argument_map(branch_dots, origins)
       )
 
       check_summary_output_names(

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -204,7 +204,7 @@ summarize_margin_union <- function(.data,
           .by = unname(key_names[grouping_set])
         ),
         conditions = conditions,
-        argument_labels = branch_argument_map(branch_dots, summaries$labels)
+        restatements = branch_argument_map(branch_dots, summaries$labels)
       )
 
       check_summary_output_names(

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -145,7 +145,8 @@ add_grouping_set_id <- function(result,
 # dplyr builds every context it attaches out of those. `call` is the Margin
 # verb a Condition context is owed instead of the internal `summarize()` the
 # branch issues; a caller that reaches this directly has none to name and
-# leaves the blamed call alone.
+# leaves the blamed call alone, as empty `origins` are for the argument
+# spelling.
 summarize_margin_union <- function(.data,
                                    dots,
                                    plan,
@@ -193,9 +194,9 @@ summarize_margin_union <- function(.data,
       # builders below raise Package conditions, which carry their own context
       # and are never deduplicated.
       #
-      # The map is built per branch rather than once, because `branch_dots` is
-      # where a Grouping helper has become this branch's own constant, and that
-      # is the expression dplyr will quote.
+      # The map is built per branch rather than once, because `branch_dots`
+      # is where `grouping_bit()` has become this branch's own constant, and
+      # that is the expression dplyr will quote.
       result <- with_branch_conditions(
         summarize_margin_branch(
           .data = .data,
@@ -203,7 +204,7 @@ summarize_margin_union <- function(.data,
           .by = unname(key_names[grouping_set])
         ),
         conditions = conditions,
-        arguments = branch_argument_map(branch_dots, origins)
+        argument_labels = branch_argument_map(branch_dots, origins)
       )
 
       check_summary_output_names(

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -66,10 +66,14 @@
 #' refusing. What a Margin verb does adjust, for an error and a warning alike,
 #' is the context reported around one, because a margin operation may summarize
 #' your expression once per grouping set. Such a condition reports its grouping
-#' values under the columns you named rather than under internal ones, and an
-#' error blames the Margin verb you wrote rather than the internal summary that
-#' ran it. A warning still names that internal summary, because the name is
-#' part of a sentence dplyr renders before marginplyr sees the warning at all.
+#' values under the columns you named rather than under internal ones, quotes
+#' the argument as you spelled it rather than as marginplyr rewrote it to
+#' compute the grouping sets, and an error blames the Margin verb you wrote
+#' rather than the internal summary that ran it. A warning still names that
+#' internal summary, because the name is part of a sentence dplyr renders
+#' before marginplyr sees the warning at all. Where the expression dplyr quoted
+#' cannot be matched -- a long one dplyr shortens to `+...`, or a diagnostic a
+#' later dplyr lays out differently -- the quotation stays as dplyr wrote it.
 #'
 #' A warning that every grouping set raises is reported once, saying how many
 #' further grouping sets raised it; warnings that differ from each other are

--- a/R/share.R
+++ b/R/share.R
@@ -859,7 +859,12 @@ plan_share_expressions <- function(dots,
   list(
     dots = planned_dots,
     requests = requests,
-    cardinality = cardinality
+    cardinality = cardinality,
+    # Which incoming dot each planned dot came from, for the same reason
+    # `flattened_positions` above exists: a share dot is dropped and a
+    # placeholder expands into one dot per output, so a consumer holding one
+    # value per dot the caller wrote cannot subscript it by position.
+    origin_positions = rep(which(keep), widths)
   )
 }
 

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -858,7 +858,8 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
         set_id_name = operation$set_id_name,
         call = operation$call
       )
-      dots <- summary_plan$dots
+      summaries <- summary_plan$summaries
+      dots <- summaries$dots
       summary_selection_proxy <- dplyr::select(
         operation$data_proxy,
         dplyr::all_of(setdiff(
@@ -897,8 +898,7 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
 
       staged_result <- stage_margin_summaries(
         operation,
-        dots = dots,
-        origins = summary_plan$origins,
+        summaries = summaries,
         reserved_names = reserved_names,
         keep_set_identity = has_shares
       )
@@ -923,13 +923,11 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
   )
 }
 
-# `origins` is the caller's label for each dot, carried only so that the union
-# adapter can restate a Condition context in the caller's own spelling. It is
-# passed beside `dots` and never read here, because what a label describes is
-# one of those dots.
+# `summaries` is what `new_summary_arguments()` built: the caller's summary
+# dots beside the caller's label for each, one value because the pair may not
+# drift apart between the planning that built it and the adapter that reads it.
 stage_margin_summaries <- function(operation,
-                                   dots,
-                                   origins,
+                                   summaries,
                                    reserved_names,
                                    keep_set_identity) {
   plan <- operation$plan
@@ -977,9 +975,12 @@ stage_margin_summaries <- function(operation,
   result <- tryCatch(
     {
       if (use_native) {
+        # The labels stay behind: the native adapter issues one `summarize()`
+        # and repeats nothing, and the backends holding the capability are
+        # lazy, so no condition is raised while the verb runs (ADR 0022).
         summarize_margin_native(
           operation$data,
-          dots = dots,
+          dots = summaries$dots,
           plan = plan,
           margin_labels = operation$margin_labels,
           reserved_names = reserved_names,
@@ -989,15 +990,14 @@ stage_margin_summaries <- function(operation,
       } else {
         summarize_margin_union(
           operation$data,
-          dots = dots,
+          summaries = summaries,
           plan = plan,
           margin_labels = operation$margin_labels,
           column_info = operation$column_info,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
           set_id_is_internal = set_id_is_internal,
-          call = operation$call,
-          origins = origins
+          call = operation$call
         )
       }
     },

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -898,6 +898,7 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
       staged_result <- stage_margin_summaries(
         operation,
         dots = dots,
+        origins = summary_plan$origins,
         reserved_names = reserved_names,
         keep_set_identity = has_shares
       )
@@ -922,8 +923,13 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
   )
 }
 
+# `origins` is the caller's label for each dot, carried only so that the union
+# adapter can restate a Condition context in the caller's own spelling. It is
+# passed beside `dots` and never read here, because what a label describes is
+# one of those dots.
 stage_margin_summaries <- function(operation,
                                    dots,
+                                   origins,
                                    reserved_names,
                                    keep_set_identity) {
   plan <- operation$plan
@@ -990,7 +996,8 @@ stage_margin_summaries <- function(operation,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
           set_id_is_internal = set_id_is_internal,
-          call = operation$call
+          call = operation$call,
+          origins = origins
         )
       }
     },

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -207,6 +207,23 @@ check_internal_summary_names <- function(output_names, internal_names) {
   )
 }
 
+# What execution carries for the caller's summary arguments: the dots to hand
+# dplyr, beside the caller's own label for each. Constructed at the one point
+# both halves are final -- after every rewrite -- so a pair that stops agreeing
+# in length cannot be built at all, which is an invariant rather than a Package
+# condition (ADR 0015): no call produces it, and a map built from a misaligned
+# pair would quote one argument's expression under another. `labels = NULL` is
+# a caller with no spelling to restore, as a direct call to an adapter is, and
+# restates nothing.
+new_summary_arguments <- function(dots, labels = NULL) {
+  stopifnot(
+    is.list(dots),
+    is.null(labels) ||
+      (is.character(labels) && length(labels) == length(dots))
+  )
+  list(dots = dots, labels = labels)
+}
+
 plan_summary_expressions <- function(dots,
                                      data_proxy,
                                      data_vars,
@@ -219,7 +236,7 @@ plan_summary_expressions <- function(dots,
   # Read before anything is rewritten, which is the whole of what makes these
   # the caller's own labels: every rewrite below runs after this line, and ADR
   # 0007 has already captured the dots at the public verb.
-  origins <- summary_argument_labels(dots)
+  caller_labels <- summary_argument_labels(dots)
   selection_proxy <- dplyr::select(
     data_proxy,
     dplyr::all_of(setdiff(
@@ -245,9 +262,7 @@ plan_summary_expressions <- function(dots,
   # Share planning is the one step that moves a dot, so it reports where each
   # dot it produced came from and the labels are subscripted by that. Every
   # other rewrite here answers one dot with one dot in place.
-  origins <- origins[summary_plan$origin_positions]
-  summary_plan$origin_positions <- NULL
-  summary_plan$origins <- origins
+  caller_labels <- caller_labels[summary_plan$origin_positions]
   summary_plan$dots <- resolve_summary_selections(
     summary_plan$dots,
     data_proxy = data_proxy,
@@ -263,8 +278,10 @@ plan_summary_expressions <- function(dots,
       backend_kind = backend_kind
     )
   }
-  summary_plan$cardinality <- NULL
-  summary_plan
+  list(
+    summaries = new_summary_arguments(summary_plan$dots, caller_labels),
+    requests = summary_plan$requests
+  )
 }
 
 find_summary_context_helpers <- function(expr) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -212,14 +212,19 @@ check_internal_summary_names <- function(output_names, internal_names) {
 # both halves are final -- after every rewrite -- so a pair that stops agreeing
 # in length cannot be built at all, which is an invariant rather than a Package
 # condition (ADR 0015): no call produces it, and a map built from a misaligned
-# pair would quote one argument's expression under another. `labels = NULL` is
-# a caller with no spelling to restore, as a direct call to an adapter is, and
-# restates nothing.
-new_summary_arguments <- function(dots, labels = NULL) {
+# pair would quote one argument's expression under another.
+#
+# The labels default to the dots' own, which is the truth for a caller reaching
+# an adapter directly: what it passed is what it wrote. Nothing is restated
+# there, because `branch_argument_map()` drops a label a rewrite left alone --
+# so "no spelling to restore" needs no representation of its own, and a length
+# is checked once rather than only when a second value says to.
+new_summary_arguments <- function(dots,
+                                  labels = summary_argument_labels(dots)) {
   stopifnot(
     is.list(dots),
-    is.null(labels) ||
-      (is.character(labels) && length(labels) == length(dots))
+    is.character(labels),
+    length(labels) == length(dots)
   )
   list(dots = dots, labels = labels)
 }

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -216,6 +216,10 @@ plan_summary_expressions <- function(dots,
                                      call) {
   stopifnot(inherits(plan, "margin_grouping_plan"))
   group_vars <- c(plan$by, plan$dimensions)
+  # Read before anything is rewritten, which is the whole of what makes these
+  # the caller's own labels: every rewrite below runs after this line, and ADR
+  # 0007 has already captured the dots at the public verb.
+  origins <- summary_argument_labels(dots)
   selection_proxy <- dplyr::select(
     data_proxy,
     dplyr::all_of(setdiff(
@@ -238,6 +242,12 @@ plan_summary_expressions <- function(dots,
     set_id_name = set_id_name,
     validate_cardinality = wraps_share_sources_in_summary(backend_kind)
   )
+  # Share planning is the one step that moves a dot, so it reports where each
+  # dot it produced came from and the labels are subscripted by that. Every
+  # other rewrite here answers one dot with one dot in place.
+  origins <- origins[summary_plan$origin_positions]
+  summary_plan$origin_positions <- NULL
+  summary_plan$origins <- origins
   summary_plan$dots <- resolve_summary_selections(
     summary_plan$dots,
     data_proxy = data_proxy,

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -122,6 +122,13 @@ deparse of the rewritten ones, which is the fragile-parse problem again, for the
 part of the context least likely to mislead. The caller wrote the expression;
 seeing it requoted is confusing rather than wrong.
 
+ADR 0022 decides it, on a mechanism this paragraph does not describe: what
+dplyr quoted is compared with marginplyr's own rendering of the expression it
+handed dplyr, rather than with the caller's spelling. It also measures a cost
+this paragraph missed — a rewrite that differs between branches splits one
+written expression into one report per branch, so the deduplication key above
+is affected and not only the spelling.
+
 ## Consequences
 
 Deduplication is observable, not silent: the surviving occurrence says how many

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -1,0 +1,159 @@
+# Quote the caller's own spelling in a Condition context
+
+A Margin verb's Condition context quotes the expression the caller wrote rather
+than marginplyr's rewrite of it, whenever it can identify which of the caller's
+summary arguments dplyr attributed the condition to. Where it cannot, the
+quotation is left as it was found, which is what ADR 0021 already requires of
+every part of a context a verb cannot restate in the caller's terms. This
+completes the third part of #141's context leak, which ADR 0021 deferred.
+
+The rewriting is not one rewrite. Four layers separate what dplyr quotes from
+what the caller typed: `resolve_summary_selections()` turns a selection into
+`dplyr::all_of()` over resolved source names, `across()`'s `.names` is evaluated
+and its arguments normalised for dtplyr, `wrap_share_sources()` wraps the
+expressions a share reads, and `rewrite_grouping_dots()` replaces a Grouping
+helper with the branch's own constant. The contract is therefore written over
+expressions rather than over any one of those layers, and one mechanism covers
+all four.
+
+## The identification is a test against marginplyr's own rendering
+
+ADR 0021 rejected this fix as "deparsing the caller's dots and text-matching
+them against dplyr's own deparse of the rewritten ones". That is the wrong end
+of the comparison, and rejecting it was right. What the fix actually compares is
+dplyr's quotation against *marginplyr's own rendering of the expression it
+handed dplyr*: each branch dot is labelled the way dplyr labels it, the labels
+are compared for equality with the backticked span dplyr quoted, and a span that
+equals exactly one branch dot's label is replaced by the label of the dot the
+caller wrote. Both sides of that equality are expressions marginplyr generated,
+so nothing is parsed out of dplyr's formatting except the span itself, and a
+span that matches nothing changes nothing.
+
+Where several branch dots share a label, the substitution runs only if the
+callers' own labels agree as well. A label is `name = expr` for a named
+argument, so the collision needs two unnamed arguments rendering alike; there
+the replacement is unique whichever one dplyr meant, and where it is not the
+quotation stays as dplyr wrote it.
+
+An error needs no span at all. Its `$message` is the argument bullet and
+nothing else — measured, one named character vector whose name is `i` — so the
+bullet is rebuilt rather than edited. A warning's is one bullet inside the
+rendered text dplyr flattened before signalling. Only the span inside the
+backticks is replaced: the sentence around it is dplyr's, and editing a
+sentence is what ADR 0021 refused for the blamed call, because a wording change
+would leave it silently naming the wrong thing rather than falling back.
+
+The bullet is read as the line it was *written* as rather than as the lines it
+was rendered onto, through the same `message_line_runs()` the deduplication key
+uses, and for the same reason. cli wraps a bullet it cannot fit, so a span read
+off the line a bullet opens is a prefix of the label at any narrow width: the
+Grouping-helper collapse below held at 80 columns and not at 40, which is the
+console width deciding how many conditions a caller receives. A run that is
+restated is emitted as the one line it was written as, since what replaces it
+is a line of another length and cli is no longer there to wrap it; every other
+run is given back exactly as it arrived. A wrap cli had to make inside a token
+rather than at a space does not rejoin to a label, and is left alone by the
+same rule as any other span that matches nothing.
+
+## The restoration runs before the deduplication key is computed
+
+This is not only a matter of spelling. `total = sum(as.numeric(grade)) +
+grouping_bit(region)` under `rollup(region)` renders `+ 0L` in one branch and
+`+ 1L` in the other, so `branch_warning_identity()` sees two identities and the
+caller receives two reports of a warning they provoked with one expression.
+Restoring the spelling first collapses them, for the same reason ADR 0021 gives
+for excluding the grouping values from an identity: what necessarily differs
+between branches is marginplyr's, not the caller's. CONTEXT.md's *Repeated
+condition* entry therefore reads "the argument they are attributed to" as the
+argument the caller wrote.
+
+## Scope, and why it is the same scope as ADR 0021 for a different reason
+
+The scope is `summarize_margin_union()`, as ADR 0021's is, and the reason that
+ADR gives does not carry: the selection rewrite is not the union adapter's.
+`summary_all_of_expr()` runs inside `plan_summary_expressions()`, before either
+adapter, so the native grouping-sets adapter hands dplyr the same rewritten
+expressions.
+
+What confines this instead is which backends hold `native_grouping_sets`:
+duckdb and postgres, both lazy. A branch `summarize()` there builds a query
+without evaluating the caller's expression, so there is no condition raised
+while the verb runs and nothing to restate — the same reason ADR 0021 gives for
+covering eager inputs only. The exception is an error raised while dbplyr
+translates the rewritten expression, which does arrive while the verb runs and
+is left quoting the rewrite.
+
+## dplyr's rendering is reproduced only as far as it is observable
+
+dplyr labels an argument with `error_label_named()`, which is
+`paste0(name, " = ", expr_as_label(expr))` for a named argument, and
+`expr_as_label()` calls `rlang::as_label()` with rlang's infix labelling
+suppressed through an undocumented option. marginplyr labels with plain
+`rlang::as_label()` and the same `name = ` convention, so the two disagree
+exactly where dplyr abbreviates a long infix expression — `total = +...` where
+`as_label()` answers `sum(as.numeric(grade)) + ...` — and there the span matches
+nothing and the quotation stands.
+
+That costs nothing a caller can see. A label dplyr truncated renders the same
+whichever expression it came from, so substituting the caller's own would print
+the same `+...`; and because the truncation removes what the branches differ in,
+the deduplication key already agrees across branches without any restoration.
+Reproducing the option would buy an unobservable substitution in exchange for
+depending on an internal name in two packages.
+
+## Considered Options
+
+**Carry the caller's label as an attribute on each quosure.** Rejected on how
+it fails. Four rewriters build fresh quosures, so each has to copy the
+attribute, and one that forgets restores nothing while reading as protection;
+whether an attribute survives `!!!` and dplyr's own `enquos()` is undocumented
+besides. The labels are carried as a parallel vector instead, remapped where
+`plan_share_expressions()` already remaps the cardinality positions, and a
+length that stops agreeing with the dots is an invariant that stops the
+operation (ADR 0015).
+
+**Align the caller's dots with the rewritten ones by position.** Rejected on
+measurement: share planning drops a dot to `NULL` and expands a placeholder
+into one dot per output before flattening, so position is not preserved.
+
+**Reproduce `expr_as_label()` faithfully, undocumented option included.**
+Rejected above: what it covers is unobservable.
+
+**Extend the restatement to the native grouping-sets adapter.** Rejected as
+covering nothing today, since both backends holding the capability are lazy.
+It becomes worth revisiting if an eager backend ever gains
+`native_grouping_sets`.
+
+**Leave it and document it.** ADR 0021's position, and correct while the fix
+looked like the fragile parse that ADR describes. It is not that parse.
+
+## Consequences
+
+A caller reading a restated context sees the expression they wrote, so the
+context no longer names `dplyr::all_of()` over resolved column names, a share
+wrapper, or a branch-local Grouping-helper constant.
+
+A warning that differs between branches only in a Grouping helper's constant is
+now one report saying how many further grouping sets raised it, where it was
+one report per branch. That collapse holds at any console width, which is what
+reading the bullet as a written line rather than a rendered one buys; a test
+asserts it across the same widths as the one ADR 0021 added.
+
+A restated bullet is one line where dplyr may have wrapped it over several. The
+alternative was re-wrapping text cli had already laid out, which would rewrite
+lines the caller's own diagnostic wrote.
+
+`dplyr::last_dplyr_warnings()` keeps the rewritten expressions, for the reason
+ADR 0021 gives for the key names: that store is dplyr's and is written before
+marginplyr sees anything.
+
+A warning still names `dplyr::summarize()` as the call it arose in. Nothing here
+changes that asymmetry, which ADR 0021 records.
+
+Tests assert on rendered messages rather than on structure, as ADR 0021's do,
+and two of them assert the degradations rather than the restorations: a long
+infix expression exercises the non-matching span through a real call, and a
+synthetic condition standing in for a dplyr wording change asserts that a span
+matching nothing is left alone. A restoration that quietly stopped happening
+would otherwise read exactly like a package whose contexts were all still
+faithful.

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -178,7 +178,8 @@ both features no-op: measured on `main`, the `cube(region, grade)`
 reproduction reports four times with `cli.num_colors` above one and once
 without. This decision rests on the same reading and therefore inherits the
 same bound; stripping the styling before either reading is what would lift it,
-for both, and belongs with ADR 0021's identity rather than here.
+for both, and belongs with ADR 0021's identity rather than here. Filed as
+#217.
 
 A restated bullet is one line where dplyr may have wrapped it over several. The
 alternative was re-wrapping text cli had already laid out, which would rewrite

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -44,16 +44,33 @@ sentence is what ADR 0021 refused for the blamed call, because a wording change
 would leave it silently naming the wrong thing rather than falling back.
 
 The bullet is read as the line it was *written* as rather than as the lines it
-was rendered onto, through the same `message_line_runs()` the deduplication key
-uses, and for the same reason. cli wraps a bullet it cannot fit, so a span read
-off the line a bullet opens is a prefix of the label at any narrow width: the
-Grouping-helper collapse below held at 80 columns and not at 40, which is the
-console width deciding how many conditions a caller receives. A run that is
-restated is emitted as the one line it was written as, since what replaces it
-is a line of another length and cli is no longer there to wrap it; every other
-run is given back exactly as it arrived. A wrap cli had to make inside a token
-rather than at a space does not rejoin to a label, and is left alone by the
-same rule as any other span that matches nothing.
+was rendered onto, through the same written-line reading the deduplication key
+uses -- one shared helper, so the two readings cannot drift. cli wraps a bullet
+it cannot fit, so a span read off the line a bullet opens is a prefix of the
+label at any narrow width: the constant-rewrite collapse below held at 80
+columns and not at 40, which is the console width deciding how many conditions
+a caller receives. A run that is restated is emitted as the one line it was
+written as, since what replaces it is a line of another length and cli is no
+longer there to wrap it; every other run is given back exactly as it arrived.
+A wrap cli had to make inside a token rather than at a space does not rejoin
+to a label, and is left alone by the same rule as any other span that matches
+nothing.
+
+Which part of a message may be restated at all is bounded positionally, as
+every reading of dplyr's format here is. A warning's rendered text carries the
+caller's own diagnostic after its `Caused by` line, and a diagnostic can spell
+anything -- including dplyr's bullet over a label a branch really handed dplyr
+-- so only the runs before that line are dplyr's to restate, and a warning
+carrying no such line is not dplyr's aggregation and is left whole. An error
+needs no bound: its `$message` is dplyr's bullet alone, and the caller's
+diagnostic is `$parent`, which is never touched. Rewriting a caller's own text
+would be replacing an External condition's diagnostic, which ADR 0015 rules
+out.
+
+A message in which nothing is restated is returned as the object that arrived,
+byte for byte, rather than rebuilt from its lines -- rebuilding dropped a
+trailing newline, and the degradation the constraint on #199 asks for is the
+absence of any edit, not an edit that happens to read the same.
 
 ## The restoration runs before the deduplication key is computed
 
@@ -87,19 +104,22 @@ is left quoting the rewrite.
 
 dplyr labels an argument with `error_label_named()`, which is
 `paste0(name, " = ", expr_as_label(expr))` for a named argument, and
-`expr_as_label()` calls `rlang::as_label()` with rlang's infix labelling
-suppressed through an undocumented option. marginplyr labels with plain
+`expr_as_label()` has two branches of its own: `rlang::as_label()` with
+rlang's infix labelling suppressed through an undocumented option, and a
+`.data` pronoun deparsed instead of labelled. marginplyr labels with plain
 `rlang::as_label()` and the same `name = ` convention, so the two disagree
-exactly where dplyr abbreviates a long infix expression — `total = +...` where
-`as_label()` answers `sum(as.numeric(grade)) + ...` — and there the span matches
-nothing and the quotation stands.
+where dplyr abbreviates a long infix expression — `total = +...` where
+`as_label()` answers `sum(as.numeric(grade)) + ...` — and where an argument is
+itself a bare pronoun; in both places the span matches nothing and the
+quotation stands.
 
 That costs nothing a caller can see. A label dplyr truncated renders the same
 whichever expression it came from, so substituting the caller's own would print
-the same `+...`; and because the truncation removes what the branches differ in,
-the deduplication key already agrees across branches without any restoration.
-Reproducing the option would buy an unobservable substitution in exchange for
-depending on an internal name in two packages.
+the same `+...`; because the truncation removes what the branches differ in,
+the deduplication key already agrees across branches without any restoration;
+and a bare pronoun is an expression no rewrite touches, so it has no entry in
+the map to miss. Reproducing the internals would buy an unobservable
+substitution in exchange for depending on an internal name in two packages.
 
 ## Considered Options
 
@@ -133,11 +153,11 @@ A caller reading a restated context sees the expression they wrote, so the
 context no longer names `dplyr::all_of()` over resolved column names, a share
 wrapper, or a branch-local Grouping-helper constant.
 
-A warning that differs between branches only in a Grouping helper's constant is
-now one report saying how many further grouping sets raised it, where it was
-one report per branch. That collapse holds at any console width, which is what
-reading the bullet as a written line rather than a rendered one buys; a test
-asserts it across the same widths as the one ADR 0021 added.
+A warning that differs between branches only in `grouping_bit()`'s branch
+constant is now one report saying how many further grouping sets raised it,
+where it was one report per branch. That collapse holds at any console width,
+which is what reading the bullet as a written line rather than a rendered one
+buys; a test asserts it across the same widths as the one ADR 0021 added.
 
 A restated bullet is one line where dplyr may have wrapped it over several. The
 alternative was re-wrapping text cli had already laid out, which would rewrite

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -11,8 +11,8 @@ The rewriting is not one rewrite. Four layers separate what dplyr quotes from
 what the caller typed: `resolve_summary_selections()` turns a selection into
 `dplyr::all_of()` over resolved source names, `across()`'s `.names` is evaluated
 and its arguments normalised for dtplyr, `wrap_share_sources()` wraps the
-expressions a share reads, and `rewrite_grouping_dots()` replaces a Grouping
-helper with the branch's own constant. The contract is therefore written over
+expressions a share reads, and `rewrite_grouping_dots()` replaces
+`grouping_bit()` and `grouping_id()` with the branch's own constant. The contract is therefore written over
 expressions rather than over any one of those layers, and one mechanism covers
 all four.
 
@@ -60,12 +60,19 @@ Which part of a message may be restated at all is bounded positionally, as
 every reading of dplyr's format here is. A warning's rendered text carries the
 caller's own diagnostic after its `Caused by` line, and a diagnostic can spell
 anything -- including dplyr's bullet over a label a branch really handed dplyr
--- so only the runs before that line are dplyr's to restate, and a warning
-carrying no such line is not dplyr's aggregation and is left whole. An error
-needs no bound: its `$message` is dplyr's bullet alone, and the caller's
-diagnostic is `$parent`, which is never touched. Rewriting a caller's own text
-would be replacing an External condition's diagnostic, which ADR 0015 rules
-out.
+-- so only the runs before that line are dplyr's to restate, and a message
+carrying no such line is left whole. An error needs no bound: its `$message`
+is dplyr's bullet alone, and the caller's diagnostic is `$parent`, which is
+never touched. Rewriting a caller's own text would be replacing an External
+condition's diagnostic, which ADR 0015 rules out.
+
+*Left whole* covers one aggregation as well as every non-aggregation, and is
+stated as the bound rather than as a test for dplyr's involvement for that
+reason: a caller whose own diagnostic renders empty is aggregated into
+`There were 2 warnings in ...` with an argument bullet and no `Caused by`
+line at all. Such a message is not restated, which is this decision's ordinary
+degradation, and ADR 0021's identity does not collapse it either -- measured
+on `main`, that plan reports twice, so nothing here made it worse.
 
 A message in which nothing is restated is returned as the object that arrived,
 byte for byte, rather than rebuilt from its lines -- rebuilding dropped a
@@ -105,21 +112,25 @@ is left quoting the rewrite.
 dplyr labels an argument with `error_label_named()`, which is
 `paste0(name, " = ", expr_as_label(expr))` for a named argument, and
 `expr_as_label()` has two branches of its own: `rlang::as_label()` with
-rlang's infix labelling suppressed through an undocumented option, and a
-`.data` pronoun deparsed instead of labelled. marginplyr labels with plain
-`rlang::as_label()` and the same `name = ` convention, so the two disagree
-where dplyr abbreviates a long infix expression — `total = +...` where
-`as_label()` answers `sum(as.numeric(grade)) + ...` — and where an argument is
-itself a bare pronoun; in both places the span matches nothing and the
-quotation stands.
+rlang's infix labelling suppressed through an undocumented option, and a data
+pronoun — `.data$x`, `.data[["x"]]` — deparsed instead of labelled, where
+`as_label()` answers `x`. marginplyr labels with plain `rlang::as_label()` and
+the same `name = ` convention, so the two disagree in those two places, and in
+both the span matches nothing and the quotation stands.
 
 That costs nothing a caller can see. A label dplyr truncated renders the same
 whichever expression it came from, so substituting the caller's own would print
 the same `+...`; because the truncation removes what the branches differ in,
 the deduplication key already agrees across branches without any restoration;
-and a bare pronoun is an expression no rewrite touches, so it has no entry in
-the map to miss. Reproducing the internals would buy an unobservable
-substitution in exchange for depending on an internal name in two packages.
+and an argument written as a pronoun is one the caller and the branch spell
+alike, so the map drops it as unchanged and there is nothing to restore.
+Reproducing the internals would buy an unobservable substitution in exchange
+for depending on an internal name in two packages.
+
+Neither divergence can quote the *wrong* expression, which is the failure
+#199 rules out, and the reason is that they are divergences in dplyr's
+direction only: `as_label()` emits neither `+...` nor `.data$x`, so dplyr's
+label of one argument can never equal marginplyr's label of another.
 
 ## Considered Options
 
@@ -152,13 +163,22 @@ looked like the fragile parse that ADR describes. It is not that parse.
 
 A caller reading a restated context sees the expression they wrote, so the
 context no longer names `dplyr::all_of()` over resolved column names, a share
-wrapper, or a branch-local Grouping-helper constant.
+wrapper, or `grouping_bit()`'s branch-local constant.
 
 A warning that differs between branches only in `grouping_bit()`'s branch
 constant is now one report saying how many further grouping sets raised it,
 where it was one report per branch. That collapse holds at any console width,
 which is what reading the bullet as a written line rather than a rendered one
 buys; a test asserts it across the same widths as the one ADR 0021 added.
+
+Width is not the only thing a rendered message varies with, and the other one
+is inherited rather than introduced. In a session with colour, cli styles the
+markers, so every pattern read here and in ADR 0021's identity misses and
+both features no-op: measured on `main`, the `cube(region, grade)`
+reproduction reports four times with `cli.num_colors` above one and once
+without. This decision rests on the same reading and therefore inherits the
+same bound; stripping the styling before either reading is what would lift it,
+for both, and belongs with ADR 0021's identity rather than here.
 
 A restated bullet is one line where dplyr may have wrapped it over several. The
 alternative was re-wrapping text cli had already laid out, which would rewrite

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -127,10 +127,11 @@ substitution in exchange for depending on an internal name in two packages.
 it fails. Four rewriters build fresh quosures, so each has to copy the
 attribute, and one that forgets restores nothing while reading as protection;
 whether an attribute survives `!!!` and dplyr's own `enquos()` is undocumented
-besides. The labels are carried as a parallel vector instead, remapped where
-`plan_share_expressions()` already remaps the cardinality positions, and a
-length that stops agreeing with the dots is an invariant that stops the
-operation (ADR 0015).
+besides. The labels travel beside the dots in one value instead, constructed
+at the single point both halves are final — after every rewrite, remapped
+where `plan_share_expressions()` already remaps the cardinality positions — so
+a pair whose lengths disagree cannot be built, and one that stops agreeing
+later is an invariant that stops the operation (ADR 0015).
 
 **Align the caller's dots with the rewritten ones by position.** Rejected on
 measurement: share planning drops a dot to `NULL` and expands a placeholder

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -122,7 +122,9 @@ Measured on `main` with the ticket's own `cube(region, grade)` reproduction:
 The contract ADR 0021 states — one report, however many grouping sets raised it
 — therefore did not hold in a colour session at all. Nothing in #199's change
 introduced this and nothing in it fixes it; the ADR 0022 work inherits the same
-bound, since it reads the same rendered text.
+bound, since it reads the same rendered text. Filed as #217, which is
+authoritative for what to do about it; this note is authoritative only for the
+measurement above.
 
 **An aggregation without a cause line.** dplyr's aggregated warning normally
 introduces the caller's diagnostic with `Caused by`, and both the identity and

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -1,0 +1,153 @@
+# How dplyr renders the context of a condition from a summary expression
+
+Investigated: 2026-08-18
+
+Measured while implementing #199, which asked for a Condition context quoting
+the caller's own spelling of a summary argument. ADR 0022 records the decision
+that came out of this; what follows is the evidence it rests on, including the
+parts that ruled options out and the two measurements that belong to ADR 0021's
+subject rather than to #199's.
+
+Everything below was run against dplyr 1.2.1 and rlang 1.3.0 on R 4.6.1.
+
+## What a condition carries, by kind
+
+An error from a caller's summary expression arrives with its context in
+separately addressable fields. Measured on
+`summarize_with_margins(data, total = sum(nonexistent_fn(units)), .grouping = rollup(region))`:
+
+```
+class    : "rlang_error" "error" "condition"
+names    : message, trace, parent, body, rlang, call, use_cli_format
+$message : c(i = "In argument: `total = sum(nonexistent_fn(units))`.")
+$body    : c(i = "In group 1: `region = \"East\"`.")
+$call    : the Margin verb, once ADR 0021's restatement has assigned it
+```
+
+`$message` is the argument bullet and nothing else, and the `i` is the *name*
+of the vector element rather than part of its text. The caller's own condition
+is `$parent`.
+
+A warning arrives as one condition per branch whose `$message` is a single
+pre-rendered string, with `$parent` `NULL` and no `$body` — the shape ADR 0021
+already records. The argument bullet is one line inside that string, carrying
+cli's `i` glyph.
+
+**No field names the argument.** Neither kind carries the index or the name of
+the dot the condition was attributed to; the only statement of it is the
+backticked span inside the rendered bullet. That is what forced the
+identification in ADR 0022 to be a text comparison at all, and it was checked by
+listing the fields above rather than inferred.
+
+## How dplyr renders the label
+
+`dplyr:::error_label_named()` and `dplyr:::expr_as_label()`, both unexported:
+
+```r
+error_label_named(name, expr):
+  if (is_null(name) || !nzchar(name)) expr_as_label(expr)
+  else paste0(name, " = ", expr_as_label(expr))
+
+expr_as_label(expr):
+  if (is_data_pronoun(expr)) deparse(expr)[[1]]
+  else with_options(`rlang:::use_as_label_infix` = FALSE, as_label(expr))
+```
+
+So the `name = expr` convention is dplyr's, and reproducible without reading
+anything undocumented. The two divergences from a plain `rlang::as_label()` are:
+
+- **Long infix expressions.** dplyr suppresses rlang's infix labelling through
+  an option named with an internal `:::` spelling. Measured on
+  `total = sum(as.numeric(grade)) + 0 * (sum(units) + sum(units) + sum(units) + sum(units) + sum(units))`,
+  dplyr rendered `` `total = +...` `` where `rlang::as_label()` answered
+  `sum(as.numeric(grade)) + ...`. Plain dplyr, outside marginplyr, rendered the
+  same `+...`, so the abbreviation is dplyr's and not a marginplyr artefact.
+- **Data pronouns.** `is_data_pronoun()` is `FALSE` for `.data` alone and `TRUE`
+  for `.data$x` and `.data[["x"]]`, where `as_label()` answers `x`, `x`, and
+  `<unknown>`.
+
+Both divergences run in dplyr's direction only: `as_label()` emits neither
+`+...` nor `.data$x`. That asymmetry is what establishes that dplyr's label of
+one argument can never equal marginplyr's label of another, which is the
+property #199's hard constraint needed.
+
+## What separates the caller's spelling from what dplyr quotes
+
+Four rewrites, none of them the one #199's body named:
+
+| Rewrite | Where |
+|---|---|
+| a selection becomes `dplyr::all_of()` over resolved source names | `summary_all_of_expr()`, via `resolve_summary_selections()` |
+| `across()`'s `.names` is evaluated, and its arguments normalised for dtplyr | `rewrite_across_selection()` |
+| a share's source expressions are wrapped | `wrap_share_sources()` |
+| `grouping_bit()` / `grouping_id()` become the branch's own constant | `rewrite_grouping_dots()` |
+
+#199's body attributed the `all_of()` rewrite to `rewrite_grouping_dots()`. It
+is `plan_summary_expressions()`, which runs before either adapter — so the
+rewrite is not the `UNION ALL` adapter's, and ADR 0021's reason for confining
+itself to that adapter does not transfer. A correction was posted to the ticket
+on this date.
+
+The first three rewrites are shared by every branch; the fourth is not, and that
+is what made the argument bullet differ *between* grouping sets.
+
+## Positions do not survive planning
+
+`plan_share_expressions()` drops a share dot to `NULL` and expands a placeholder
+into one dot per output before flattening, so the dots handed to an adapter are
+neither the same length as the caller's nor in correspondence with them by
+index. Any per-dot value carried alongside has to be remapped where that
+function already remaps its cardinality positions.
+
+## Two measurements about ADR 0021's identity
+
+Both were taken on `main` — that is, they describe the deduplication ADR 0021
+shipped, before any of #199's work — and both are properties of reading a
+*rendered* message.
+
+**Console width.** ADR 0021's identity reads a message as the lines it was
+*written* as, and holds at any width. A reading of the lines cli *rendered* it
+onto does not: implementing #199 against rendered lines reported the
+`grouping_bit()` reproduction once at 80 columns and twice at 40.
+
+**Colour.** With `cli.num_colors` above 1 — an ordinary interactive session —
+cli styles the markers, so every pattern matched against a message misses.
+Measured on `main` with the ticket's own `cube(region, grade)` reproduction:
+
+| session | reports |
+|---|---|
+| `cli.num_colors = 1` | 1 |
+| `cli.num_colors = 256` | 4 |
+
+The contract ADR 0021 states — one report, however many grouping sets raised it
+— therefore did not hold in a colour session at all. Nothing in #199's change
+introduced this and nothing in it fixes it; the ADR 0022 work inherits the same
+bound, since it reads the same rendered text.
+
+**An aggregation without a cause line.** dplyr's aggregated warning normally
+introduces the caller's diagnostic with `Caused by`, and both the identity and
+#199's restatement use that line as the boundary of dplyr's own region. A
+caller whose diagnostic renders empty is aggregated without one:
+
+```
+There were 2 warnings in `dplyr::summarize()`.
+The first warning was:
+i In argument: `z = { ... }`.
+i In group 1: `region = "East"`.
+i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
+```
+
+Measured on `main`, that plan reported twice. So a message with no `Caused by`
+line is not evidence that dplyr did not aggregate it — only that the boundary
+cannot be found in it.
+
+## Searched for and not found
+
+- No exported dplyr function renders the argument label; `dplyr::as_label` is
+  a re-export of rlang's.
+- No field, attribute, or condition class carries the failing dot's index or
+  name (see the field listing above).
+- `dplyr::last_dplyr_warnings()` holds the structured per-branch conditions the
+  flat message lacks, but it is documented as a debugging aid and is reset per
+  `summarize()` call, so by the end of a branch loop it holds only the last
+  branch's warnings. ADR 0021 records the same finding.

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -5,7 +5,7 @@ Investigated: 2026-08-18
 Measured while implementing #199, which asked for a Condition context quoting
 the caller's own spelling of a summary argument. ADR 0022 records the decision
 that came out of this; what follows is the evidence it rests on, including the
-parts that ruled options out and the two measurements that belong to ADR 0021's
+parts that ruled options out and the measurements that belong to ADR 0021's
 subject rather than to #199's.
 
 Everything below was run against dplyr 1.2.1 and rlang 1.3.0 on R 4.6.1.
@@ -99,10 +99,10 @@ neither the same length as the caller's nor in correspondence with them by
 index. Any per-dot value carried alongside has to be remapped where that
 function already remaps its cardinality positions.
 
-## Two measurements about ADR 0021's identity
+## Three measurements about ADR 0021's identity
 
-Both were taken on `main` — that is, they describe the deduplication ADR 0021
-shipped, before any of #199's work — and both are properties of reading a
+All were taken on `main` — that is, they describe the deduplication ADR 0021
+shipped, before any of #199's work — and all are properties of reading a
 *rendered* message.
 
 **Console width.** ADR 0021's identity reads a message as the lines it was

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -77,10 +77,14 @@ marginplyr itself raises no warning: it states what it will not do by
 refusing. What a Margin verb does adjust, for an error and a warning alike,
 is the context reported around one, because a margin operation may summarize
 your expression once per grouping set. Such a condition reports its grouping
-values under the columns you named rather than under internal ones, and an
-error blames the Margin verb you wrote rather than the internal summary that
-ran it. A warning still names that internal summary, because the name is
-part of a sentence dplyr renders before marginplyr sees the warning at all.
+values under the columns you named rather than under internal ones, quotes
+the argument as you spelled it rather than as marginplyr rewrote it to
+compute the grouping sets, and an error blames the Margin verb you wrote
+rather than the internal summary that ran it. A warning still names that
+internal summary, because the name is part of a sentence dplyr renders
+before marginplyr sees the warning at all. Where the expression dplyr quoted
+cannot be matched -- a long one dplyr shortens to \code{+...}, or a diagnostic a
+later dplyr lays out differently -- the quotation stays as dplyr wrote it.
 
 A warning that every grouping set raises is reported once, saying how many
 further grouping sets raised it; warnings that differ from each other are

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -622,6 +622,7 @@ test_that("a bullet this cannot read leaves the condition alone", {
 # which ADR 0015 rules out.
 test_that("a caller's own text is never restated", {
   arguments <- c(`dplyr::all_of("x")` = "c(x)")
+  cause <- "\nCaused by warning:\n! boom"
   restated <- function(text) {
     conditionMessage(restate_condition_arguments(
       rlang::warning_cnd("test_warning", message = text),
@@ -657,6 +658,16 @@ test_that("a caller's own text is never restated", {
   # newlines included: rebuilding it from its lines silently dropped one.
   expect_identical(restated("no match here\n"), "no match here\n")
   expect_identical(restated("a\n\nb\n\n"), "a\n\nb\n\n")
+  # A message this does restate keeps its trailing newline for the same
+  # reason, and needs saying separately: splitting drops it, so the restated
+  # path puts it back rather than inheriting the one the unchanged path never
+  # removed.
+  expect_identical(
+    restated(paste0("i In argument: `dplyr::all_of(\"x\")`.", cause, "\n")),
+    paste0("i In argument: `c(x)`.", cause, "\n")
+  )
+  # An empty message is neither restated nor rebuilt.
+  expect_identical(restated(""), "")
 })
 
 # Two dots can hand dplyr one expression, and the span then says which

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -27,6 +27,66 @@ summarize_coercion_cube <- function() {
   # nolint end
 }
 
+# The rewrite #199 is about. `resolve_summary_selections()` turns the caller's
+# `c(grade)` into `dplyr::all_of("grade")` before either adapter runs, so dplyr
+# quotes a call the caller never typed. `grade` is summarized here rather than
+# made a dimension, because the selection a Margin summary resolves is over the
+# columns no grouping set holds.
+summarize_across_coercion <- function() {
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    coercion_frame(),
+    dplyr::across(c(grade), ~ sum(as.numeric(.x))),
+    .grouping = rollup(region)
+  )
+  # nolint end
+}
+
+# A share is where the labels slide. `plan_share_expressions()` replaces the
+# across-share dot with one dot per output, so the warning raised by the dot
+# after it sits at a position the caller's dots do not have -- and a label read
+# by position there describes another argument, or none.
+summarize_share_coercion <- function() {
+  data <- coercion_frame()
+  data$revenue <- c(2, 4, 8)
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    data,
+    dplyr::across(c(units, revenue), sum),
+    dplyr::across(c(units, revenue), share_of_parent, .names = "{.col}_share"),
+    dplyr::across(c(grade), ~ sum(as.numeric(.x))),
+    .grouping = rollup(region)
+  )
+  # nolint end
+}
+
+# The rewrite that differs between branches rather than being shared by them:
+# `grouping_bit(region)` is `0L` in the detail set and `1L` in the Grand total
+# set, so dplyr quoted a different argument in each and the deduplication key
+# saw two conditions where the caller wrote one expression.
+summarize_helper_coercion <- function() {
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    coercion_frame(),
+    total = sum(as.numeric(grade)) + grouping_bit(region),
+    .grouping = rollup(region)
+  )
+  # nolint end
+}
+
+# The same rewrite reaching the caller as an error rather than a warning. What
+# the two paths share is the map; what they do not is where the bullet sits --
+# `$message` is the whole of it here, and one line of a rendered text there.
+summarize_across_failure <- function() {
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    coercion_frame(),
+    dplyr::across(c(grade), ~ sum(nope(.x))),
+    .grouping = rollup(region)
+  )
+  # nolint end
+}
+
 # #108's reproduction: an error from the caller's own expression, which aborts
 # the first branch that raises it.
 summarize_failing_rollup <- function() {
@@ -104,12 +164,113 @@ test_that("a reported warning names the caller's own grouping columns", {
   expect_false(grepl("marginplyr_key", message, fixed = TRUE))
 })
 
+# The third part of #141's context leak (ADR 0022). What is quoted is
+# `rlang::as_label()`'s rendering of the expression the caller wrote rather than
+# their source text, because that is the rendering dplyr would have quoted had
+# nothing been rewritten -- the spelling restored is the caller's, not their
+# whitespace.
+test_that("a reported warning quotes the caller's own spelling", {
+  warnings <- collect_warnings(summarize_across_coercion())
+
+  message <- conditionMessage(warnings[[1L]])
+  expect_match(
+    message,
+    "`dplyr::across(c(grade), ~sum(as.numeric(.x)))`",
+    fixed = TRUE
+  )
+  expect_false(grepl("all_of", message, fixed = TRUE))
+})
+
+test_that("a share does not shift which argument is restored", {
+  warnings <- collect_warnings(summarize_share_coercion())
+
+  expect_length(warnings, 1L)
+  message <- conditionMessage(warnings[[1L]])
+  expect_match(
+    message,
+    "`dplyr::across(c(grade), ~sum(as.numeric(.x)))`",
+    fixed = TRUE
+  )
+  expect_false(grepl("all_of", message, fixed = TRUE))
+})
+
+# Restoring the spelling is what makes this one report, so the identity is read
+# after the restatement and not before (ADR 0022). Which grouping set produced
+# an occurrence is not part of an identity, and a Grouping helper's constant is
+# that same fact reaching the argument bullet.
+test_that("a warning is one report where only a Grouping helper differed", {
+  warnings <- collect_warnings(summarize_helper_coercion())
+
+  expect_length(warnings, 1L)
+  message <- conditionMessage(warnings[[1L]])
+  expect_match(
+    message,
+    "`total = sum(as.numeric(grade)) + grouping_bit(region)`",
+    fixed = TRUE
+  )
+  expect_match(message, "1 further grouping set", fixed = TRUE)
+})
+
 # cli wraps a bullet it cannot fit, so how a warning message is laid out is a
 # function of the console width and of how long the grouping values are. Which
 # grouping set raised a warning is no more part of its identity when the bullet
 # naming it wrapped: this reproduction gave three reports of one condition at
 # 60 columns, four at 40, and two anywhere in 15 to 24, where dplyr's opening
 # sentence wraps and cli does not indent what it wraps it onto.
+# The restatement has to read the bullet as the line it was written as, for the
+# same reason the identity does: cli wraps a bullet it cannot fit, and a span
+# read off the line the bullet opens is a prefix of the label at any narrow
+# width. Reading it that way reported the Grouping-helper case once at 80
+# columns and twice at 40, which is the console width deciding how many
+# conditions a caller receives.
+test_that("a Grouping helper's collapse holds at any console width", {
+  for (width in c(80L, 60L, 40L, 24L, 16L)) {
+    warnings <- collect_warnings_at_width(width, summarize_helper_coercion())
+
+    expect_length(warnings, 1L)
+    expect_match(
+      conditionMessage(warnings[[1L]]),
+      "grouping_bit(region)",
+      fixed = TRUE,
+      info = paste("width", width)
+    )
+  }
+})
+
+# The degradation the contract requires, exercised through a real call rather
+# than described: dplyr abbreviates a long infix expression to `+...`, which
+# equals no label marginplyr rendered, so the quotation stays as dplyr wrote it.
+# What goes away is the restoration, never the report.
+#
+# The second case is why reproducing dplyr's abbreviation would buy nothing
+# (ADR 0022): the same truncation removes the Grouping helper's constant, so the
+# branches agree on an identity without any restoration.
+test_that("an abbreviated argument keeps the quotation dplyr wrote", {
+  data <- coercion_frame()
+
+  plain <- collect_warnings(summarize_with_margins(
+    data,
+    total = sum(as.numeric(grade)) +
+      0 * (sum(units) + sum(units) + sum(units) + sum(units) + sum(units)),
+    .grouping = rollup(region)
+  ))
+  with_helper <- collect_warnings(summarize_with_margins(
+    data,
+    total = sum(as.numeric(grade)) + grouping_bit(region) +
+      0 * (sum(units) + sum(units) + sum(units) + sum(units) + sum(units)),
+    .grouping = rollup(region)
+  ))
+
+  expect_length(plain, 1L)
+  expect_match(conditionMessage(plain[[1L]]), "`total = +...`", fixed = TRUE)
+  expect_length(with_helper, 1L)
+  expect_match(
+    conditionMessage(with_helper[[1L]]),
+    "1 further grouping set",
+    fixed = TRUE
+  )
+})
+
 test_that("a repeated warning is one report at any console width", {
   for (width in c(80L, 60L, 40L, 20L, 16L)) {
     warnings <- collect_warnings_at_width(width, summarize_coercion_cube())
@@ -259,6 +420,20 @@ test_that("a branch error reports the caller's column, group, and verb", {
   )
 })
 
+test_that("a branch error quotes the caller's own spelling", {
+  error <- expect_error(summarize_across_failure())
+
+  message <- conditionMessage(error)
+  expect_match(
+    message,
+    "`dplyr::across(c(grade), ~sum(nope(.x)))`",
+    fixed = TRUE
+  )
+  expect_false(grepl("all_of", message, fixed = TRUE))
+  # The condition itself is still the caller's, restated context and all.
+  expect_s3_class(error$parent, "condition")
+})
+
 test_that("a propagated error keeps its class, diagnostic, and cause", {
   error <- expect_error(summarize_failing_rollup())
 
@@ -356,6 +531,85 @@ test_that("the reported conditions read as they are written", {
   # deliberately improved.
   expect_snapshot(cat(conditionMessage(warnings[[1L]])))
   expect_snapshot(cat(conditionMessage(error)))
+})
+
+# Asserted on the seam rather than through a verb, because what these stand in
+# for is a dplyr release: a bullet whose wording this cannot read leaves the
+# condition as it arrived. The matching case is asserted beside them, since a
+# test of non-matches alone would pass just as well if nothing ever matched.
+test_that("a bullet this cannot read leaves the condition alone", {
+  arguments <- c(`dplyr::all_of("x")` = "c(x)")
+  restated <- function(text) {
+    conditionMessage(restate_condition_arguments(
+      rlang::warning_cnd("test_warning", message = text),
+      arguments
+    ))
+  }
+
+  expect_identical(
+    restated("i In argument: `dplyr::all_of(\"x\")`."),
+    "i In argument: `c(x)`."
+  )
+  # A wording dplyr could move to.
+  expect_identical(
+    restated("i In summary: `dplyr::all_of(\"x\")`."),
+    "i In summary: `dplyr::all_of(\"x\")`."
+  )
+  # A span that is no label this branch handed dplyr.
+  expect_identical(
+    restated("i In argument: `dplyr::all_of(\"y\")`."),
+    "i In argument: `dplyr::all_of(\"y\")`."
+  )
+  # A bullet cli wrapped is read as the line it was written as, so one that
+  # rejoins to a label is restated -- as one line, which is what it was written
+  # as. cli breaks at a space, so this is the ordinary case at a narrow width.
+  wrapped <- conditionMessage(restate_condition_arguments(
+    rlang::warning_cnd(
+      "test_warning",
+      message = "i In argument: `dplyr::all_of(c(\"x\",\n  \"y\"))`."
+    ),
+    c(`dplyr::all_of(c("x", "y"))` = "c(x, y)")
+  ))
+  expect_identical(wrapped, "i In argument: `c(x, y)`.")
+  # A wrap that does not rejoin to a label is left alone, which is what happens
+  # wherever cli had to break inside a token rather than at a space.
+  expect_identical(
+    restated("i In argument: `dplyr::all_of(\n  \"x\")`."),
+    "i In argument: `dplyr::all_of(\n  \"x\")`."
+  )
+  # The structured shape, where the marker is the name of the message vector
+  # rather than part of its text, and has to survive the restatement.
+  restated_error <- restate_condition_arguments(
+    rlang::error_cnd("test_error", message = c(i = "In argument: `x`.")),
+    c(x = "c(x)")
+  )
+  expect_identical(restated_error$message, c(i = "In argument: `c(x)`."))
+})
+
+# Two dots can hand dplyr one expression, and the span then says which
+# expression raised the condition but not which argument did. The substitution
+# is made only where it does not depend on that answer.
+test_that("an ambiguous label is restored only where it is unique", {
+  dots <- list(
+    rlang::quo(dplyr::all_of("x")),
+    rlang::quo(dplyr::all_of("x"))
+  )
+
+  expect_identical(
+    branch_argument_map(dots, c("c(x)", "c(x)")),
+    c(`dplyr::all_of("x")` = "c(x)")
+  )
+  expect_length(branch_argument_map(dots, c("c(x)", "any_of(\"x\")")), 0L)
+  # A dot no rewrite touched has nothing to restate, and an empty `origins` is
+  # what a caller reaching the adapter directly hands it.
+  expect_length(
+    branch_argument_map(
+      dots,
+      c("dplyr::all_of(\"x\")", "dplyr::all_of(\"x\")")
+    ),
+    0L
+  )
+  expect_length(branch_argument_map(dots, character()), 0L)
 })
 
 # The shared reading of a condition another package raised, asserted here

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -667,7 +667,8 @@ test_that("an ambiguous label is restored only where it is unique", {
   )
   expect_length(branch_argument_map(dots, c("c(x)", "any_of(\"x\")")), 0L)
   # A dot no rewrite touched has nothing to restate, and `NULL` labels are
-  # what a caller reaching the adapter directly leaves behind.
+  # what `new_summary_arguments()` records for a caller reaching the adapter
+  # directly.
   expect_length(
     branch_argument_map(
       dots,

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -33,6 +33,9 @@ summarize_coercion_cube <- function() {
 # made a dimension, because the selection a Margin summary resolves is over the
 # columns no grouping set holds.
 summarize_across_coercion <- function() {
+  # `grade` and `region` are columns of the frame, which codetools reads as
+  # undefined globals wherever a verb's arguments are written inside a
+  # function.
   # nolint start: object_usage_linter.
   summarize_with_margins(
     coercion_frame(),
@@ -49,6 +52,8 @@ summarize_across_coercion <- function() {
 summarize_share_coercion <- function() {
   data <- coercion_frame()
   data$revenue <- c(2, 4, 8)
+  # `units`, `revenue`, `grade`, and `region` are columns of the frame, which
+  # codetools reads as undefined globals inside a function.
   # nolint start: object_usage_linter.
   summarize_with_margins(
     data,
@@ -63,8 +68,12 @@ summarize_share_coercion <- function() {
 # The rewrite that differs between branches rather than being shared by them:
 # `grouping_bit(region)` is `0L` in the detail set and `1L` in the Grand total
 # set, so dplyr quoted a different argument in each and the deduplication key
-# saw two conditions where the caller wrote one expression.
+# saw two conditions where the caller wrote one expression. `grouping_bit()`
+# is a Contextual helper, and the constant is the branch-local rewrite
+# `rewrite_grouping_dots()` gives it.
 summarize_helper_coercion <- function() {
+  # `grade` and `region` are columns of the frame, which codetools reads as
+  # undefined globals inside a function.
   # nolint start: object_usage_linter.
   summarize_with_margins(
     coercion_frame(),
@@ -78,6 +87,8 @@ summarize_helper_coercion <- function() {
 # the two paths share is the map; what they do not is where the bullet sits --
 # `$message` is the whole of it here, and one line of a rendered text there.
 summarize_across_failure <- function() {
+  # `grade` and `region` are columns of the frame, which codetools reads as
+  # undefined globals inside a function.
   # nolint start: object_usage_linter.
   summarize_with_margins(
     coercion_frame(),
@@ -196,9 +207,9 @@ test_that("a share does not shift which argument is restored", {
 
 # Restoring the spelling is what makes this one report, so the identity is read
 # after the restatement and not before (ADR 0022). Which grouping set produced
-# an occurrence is not part of an identity, and a Grouping helper's constant is
-# that same fact reaching the argument bullet.
-test_that("a warning is one report where only a Grouping helper differed", {
+# an occurrence is not part of an identity, and `grouping_bit()`'s branch
+# constant is that same fact reaching the argument bullet.
+test_that("a warning is one report where only a branch constant differed", {
   warnings <- collect_warnings(summarize_helper_coercion())
 
   expect_length(warnings, 1L)
@@ -220,11 +231,11 @@ test_that("a warning is one report where only a Grouping helper differed", {
 # The restatement has to read the bullet as the line it was written as, for the
 # same reason the identity does: cli wraps a bullet it cannot fit, and a span
 # read off the line the bullet opens is a prefix of the label at any narrow
-# width. Reading it that way reported the Grouping-helper case once at 80
+# width. Reading it that way reported the branch-constant case once at 80
 # columns and twice at 40, which is the console width deciding how many
 # conditions a caller receives.
-test_that("a Grouping helper's collapse holds at any console width", {
-  for (width in c(80L, 60L, 40L, 24L, 16L)) {
+test_that("the constant-rewrite collapse holds at any console width", {
+  for (width in c(80L, 60L, 40L, 20L, 16L)) {
     warnings <- collect_warnings_at_width(width, summarize_helper_coercion())
 
     expect_length(warnings, 1L)
@@ -243,8 +254,8 @@ test_that("a Grouping helper's collapse holds at any console width", {
 # What goes away is the restoration, never the report.
 #
 # The second case is why reproducing dplyr's abbreviation would buy nothing
-# (ADR 0022): the same truncation removes the Grouping helper's constant, so the
-# branches agree on an identity without any restoration.
+# (ADR 0022): the same truncation removes `grouping_bit()`'s branch constant,
+# so the branches agree on an identity without any restoration.
 test_that("an abbreviated argument keeps the quotation dplyr wrote", {
   data <- coercion_frame()
 
@@ -539,6 +550,11 @@ test_that("the reported conditions read as they are written", {
 # test of non-matches alone would pass just as well if nothing ever matched.
 test_that("a bullet this cannot read leaves the condition alone", {
   arguments <- c(`dplyr::all_of("x")` = "c(x)")
+  # A rendered warning always introduces the caller's own diagnostic with a
+  # `Caused by` line, so the fixtures carry one: it is what separates dplyr's
+  # region of the message from the caller's, and a warning without one is a
+  # case of its own below.
+  cause <- "\nCaused by warning:\n! boom"
   restated <- function(text) {
     conditionMessage(restate_condition_arguments(
       rlang::warning_cnd("test_warning", message = text),
@@ -547,18 +563,18 @@ test_that("a bullet this cannot read leaves the condition alone", {
   }
 
   expect_identical(
-    restated("i In argument: `dplyr::all_of(\"x\")`."),
-    "i In argument: `c(x)`."
+    restated(paste0("i In argument: `dplyr::all_of(\"x\")`.", cause)),
+    paste0("i In argument: `c(x)`.", cause)
   )
   # A wording dplyr could move to.
   expect_identical(
-    restated("i In summary: `dplyr::all_of(\"x\")`."),
-    "i In summary: `dplyr::all_of(\"x\")`."
+    restated(paste0("i In summary: `dplyr::all_of(\"x\")`.", cause)),
+    paste0("i In summary: `dplyr::all_of(\"x\")`.", cause)
   )
   # A span that is no label this branch handed dplyr.
   expect_identical(
-    restated("i In argument: `dplyr::all_of(\"y\")`."),
-    "i In argument: `dplyr::all_of(\"y\")`."
+    restated(paste0("i In argument: `dplyr::all_of(\"y\")`.", cause)),
+    paste0("i In argument: `dplyr::all_of(\"y\")`.", cause)
   )
   # A bullet cli wrapped is read as the line it was written as, so one that
   # rejoins to a label is restated -- as one line, which is what it was written
@@ -566,24 +582,74 @@ test_that("a bullet this cannot read leaves the condition alone", {
   wrapped <- conditionMessage(restate_condition_arguments(
     rlang::warning_cnd(
       "test_warning",
-      message = "i In argument: `dplyr::all_of(c(\"x\",\n  \"y\"))`."
+      message = paste0(
+        "i In argument: `dplyr::all_of(c(\"x\",\n  \"y\"))`.",
+        cause
+      )
     ),
     c(`dplyr::all_of(c("x", "y"))` = "c(x, y)")
   ))
-  expect_identical(wrapped, "i In argument: `c(x, y)`.")
+  expect_identical(wrapped, paste0("i In argument: `c(x, y)`.", cause))
   # A wrap that does not rejoin to a label is left alone, which is what happens
   # wherever cli had to break inside a token rather than at a space.
   expect_identical(
-    restated("i In argument: `dplyr::all_of(\n  \"x\")`."),
-    "i In argument: `dplyr::all_of(\n  \"x\")`."
+    restated(paste0("i In argument: `dplyr::all_of(\n  \"x\")`.", cause)),
+    paste0("i In argument: `dplyr::all_of(\n  \"x\")`.", cause)
   )
   # The structured shape, where the marker is the name of the message vector
-  # rather than part of its text, and has to survive the restatement.
+  # rather than part of its text, and has to survive the restatement. An
+  # error's `$message` is dplyr's bullet alone -- the caller's diagnostic
+  # lives in `$parent` -- so no `Caused by` line bounds it.
   restated_error <- restate_condition_arguments(
     rlang::error_cnd("test_error", message = c(i = "In argument: `x`.")),
     c(x = "c(x)")
   )
   expect_identical(restated_error$message, c(i = "In argument: `c(x)`."))
+})
+
+# The two halves of the degradation the issue's constraint rests on: what this
+# cannot attribute to dplyr's own region of the message it may not touch at
+# all, byte for byte. A caller's diagnostic can spell anything -- including a
+# line reading exactly like dplyr's bullet over a label a branch really handed
+# dplyr -- and rewriting one is replacing an External condition's diagnostic,
+# which ADR 0015 rules out.
+test_that("a caller's own text is never restated", {
+  arguments <- c(`dplyr::all_of("x")` = "c(x)")
+  restated <- function(text) {
+    conditionMessage(restate_condition_arguments(
+      rlang::warning_cnd("test_warning", message = text),
+      arguments
+    ))
+  }
+
+  # The caller's diagnostic sits after `Caused by`, and stays as written even
+  # where it spells dplyr's bullet over a matching label; the bullet before it
+  # is dplyr's and is restated.
+  bulletlike <- paste0(
+    "i In argument: `dplyr::all_of(\"x\")`.\n",
+    "Caused by warning:\n",
+    "! boom\n",
+    "In argument: `dplyr::all_of(\"x\")`."
+  )
+  expect_identical(
+    restated(bulletlike),
+    paste0(
+      "i In argument: `c(x)`.\n",
+      "Caused by warning:\n",
+      "! boom\n",
+      "In argument: `dplyr::all_of(\"x\")`."
+    )
+  )
+  # A warning without a `Caused by` line is not one dplyr aggregated, so all
+  # of it is the caller's and none of it is restated.
+  expect_identical(
+    restated("i In argument: `dplyr::all_of(\"x\")`."),
+    "i In argument: `dplyr::all_of(\"x\")`."
+  )
+  # A message this restates nothing in comes back byte-identical, trailing
+  # newlines included: rebuilding it from its lines silently dropped one.
+  expect_identical(restated("no match here\n"), "no match here\n")
+  expect_identical(restated("a\n\nb\n\n"), "a\n\nb\n\n")
 })
 
 # Two dots can hand dplyr one expression, and the span then says which
@@ -600,8 +666,8 @@ test_that("an ambiguous label is restored only where it is unique", {
     c(`dplyr::all_of("x")` = "c(x)")
   )
   expect_length(branch_argument_map(dots, c("c(x)", "any_of(\"x\")")), 0L)
-  # A dot no rewrite touched has nothing to restate, and an empty `origins` is
-  # what a caller reaching the adapter directly hands it.
+  # A dot no rewrite touched has nothing to restate, and `NULL` labels are
+  # what a caller reaching the adapter directly leaves behind.
   expect_length(
     branch_argument_map(
       dots,
@@ -609,7 +675,7 @@ test_that("an ambiguous label is restored only where it is unique", {
     ),
     0L
   )
-  expect_length(branch_argument_map(dots, character()), 0L)
+  expect_length(branch_argument_map(dots, NULL), 0L)
 })
 
 # The shared reading of a condition another package raised, asserted here

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -253,6 +253,13 @@ test_that("the constant-rewrite collapse holds at any console width", {
 # equals no label marginplyr rendered, so the quotation stays as dplyr wrote it.
 # What goes away is the restoration, never the report.
 #
+# Asserting `+...` couples this to an abbreviation ADR 0022 declines to
+# reproduce, and does so deliberately: it is the fixture's premise rather than
+# a promise about dplyr. A dplyr that stopped abbreviating would restore the
+# spelling here and fail this loudly, which is the report that the case no
+# longer reproduces; a test asserting only the degradation would pass by then
+# while exercising nothing.
+#
 # The second case is why reproducing dplyr's abbreviation would buy nothing
 # (ADR 0022): the same truncation removes `grouping_bit()`'s branch constant,
 # so the branches agree on an identity without any restoration.
@@ -666,9 +673,9 @@ test_that("an ambiguous label is restored only where it is unique", {
     c(`dplyr::all_of("x")` = "c(x)")
   )
   expect_length(branch_argument_map(dots, c("c(x)", "any_of(\"x\")")), 0L)
-  # A dot no rewrite touched has nothing to restate, and `NULL` labels are
-  # what `new_summary_arguments()` records for a caller reaching the adapter
-  # directly.
+  # A dot no rewrite touched has nothing to restate, which is also what a
+  # caller reaching an adapter directly hands over: `new_summary_arguments()`
+  # defaults the labels to the dots' own, so absence needs no second value.
   expect_length(
     branch_argument_map(
       dots,
@@ -676,7 +683,10 @@ test_that("an ambiguous label is restored only where it is unique", {
     ),
     0L
   )
-  expect_length(branch_argument_map(dots, NULL), 0L)
+  expect_length(
+    branch_argument_map(dots, new_summary_arguments(dots)$labels),
+    0L
+  )
 })
 
 # The shared reading of a condition another package raised, asserted here

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -1545,7 +1545,7 @@ test_that("DuckDB native and UNION adapters agree", {
   dots <- rlang::quos(total = sum(value), gid = grouping_id(a, b))
   fallback <- summarize_margin_union(
     remote,
-    dots = dots,
+    summaries = new_summary_arguments(dots),
     plan = plan,
     margin_labels = resolve_margin_labels(
       "Total",

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -399,7 +399,7 @@ test_that("DuckDB native and portable summaries agree on .id", {
   )
   portable <- summarize_margin_union(
     remote,
-    dots = rlang::quos(total = sum(value)),
+    summaries = new_summary_arguments(rlang::quos(total = sum(value))),
     plan = plan,
     margin_labels = resolve_margin_labels(
       "Total",


### PR DESCRIPTION
Closes #199.

dplyr's argument bullet quoted marginplyr's rewrite of the caller's expression:
`dplyr::across(dplyr::all_of("grade"), ...)` where the caller wrote
`across(c(grade), ...)`. It now quotes what the caller wrote, and where it
cannot establish which argument dplyr meant, it leaves the quotation exactly as
dplyr wrote it.

## It was not only a spelling

`grouping_bit(region)` becomes a different constant in every branch, so dplyr
quoted a different argument in each and `branch_warning_identity()` saw two
conditions where one expression was written. The caller received one report per
branch. Restoring the spelling before the identity is read collapses them, which
is why the ticket's "Severity: the diagnostic is accurate, it is the spelling
that is not the caller's" understated it by one report per differing branch.

## The mechanism, and why ADR 0021 had rejected it

ADR 0021 rejected this fix as "deparsing the caller's dots and text-matching
them against dplyr's own deparse of the rewritten ones". That is the wrong end
of the comparison. What this compares is dplyr's quoted span against
*marginplyr's own rendering of the expression it handed dplyr* — an equality
test between two renderings of one generated expression — and then replaces the
span with the label of the dot the caller wrote. A span equal to no rendering
changes nothing, which is the degradation #199 requires.

The two places marginplyr's rendering differs from dplyr's (a long infix
expression dplyr shortens to `+...`, and a data pronoun it deparses) both
diverge in dplyr's direction only, so dplyr's label of one argument can never
equal marginplyr's label of another. That is what rules out the failure the
ticket names as worse than the bug: quoting the wrong expression.

ADR 0022 records the decision. ADR 0021's rejected-option paragraph now points
at it.

## Scope

`summarize_margin_union()`, but not for ADR 0021's reason — the `all_of()`
rewrite runs in `plan_summary_expressions()`, before either adapter, so it is
not the union adapter's. What confines it is that duckdb and postgres are the
backends holding `native_grouping_sets` and both are lazy, so no condition is
raised while the verb runs. A dbplyr translation error is the one uncovered
case, and the ADR says so.

## Commits

Reviewed twice on two axes; the last four commits answer those reviews.

| | |
| --- | --- |
| `22f1115` | the plumbing, asserted to change no behaviour by running the suite at that commit |
| `cbf10f1` | the mechanism and its tests |
| `50a65ad` | `?marginplyr`'s condition contract |
| `4d745e2` | ADR 0022, ADR 0021's pointer, CONTEXT.md's two entries |
| `938b4f1` | bound the restatement to dplyr's region; degrade byte-identically |
| `9ee7c08` | carry the dots and the caller's labels as one constructed value |
| `a0215b8` | correct three ADR claims that were wider than the code |
| `3f9b073` | the bound in one function; the evidence in an investigation note |
| `7415307`, `dc3f99e` | cross-references and a count |

## Tests

Nine assertions in `test-execution-conditions.R`, three of them verified by
mutation to fail without the code they cover. Two assert the degradations rather
than the restorations — a long infix expression through a real call, and a
synthetic condition standing in for a dplyr wording change — because a
restoration that quietly stopped happening reads exactly like a package whose
contexts are all still faithful.

The collapse is asserted across the console widths ADR 0021's own test uses:
reading the bullet as a rendered line rather than a written one restored the
spelling at 80 columns and not at 40, which made the console width decide how
many conditions a caller receives.

## Found on the way, not fixed here

**#217** — the same deduplication does not hold in a colour session at all. cli
styles the markers, so every pattern misses: measured on `main`, the `cube()`
reproduction reports four times with `cli.num_colors = 256` and once with 1.
Inherited rather than introduced, and the fix belongs to ADR 0021's identity,
so it is filed rather than folded in. ADR 0022 records the measurement.

`investigation/dplyr-condition-context-rendering.md` holds the evidence behind
all of this: the condition field shapes, dplyr's label internals, the four
rewrites, the positions share planning does not preserve, and the three
measurements taken on `main`.

## Checks

`R CMD check`-adjacent gates run locally: full suite with `NOT_CRAN=true`
(snapshots included), `lintr::lint_package()`, `spelling::spell_check_package()`,
`roxygen2::roxygenise()` with no diff, and
`.github/scripts/verify-suite-coverage.R`.
