### PR TITLE
Read a condition's message blind to how cli rendered it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     utils
 Suggests:
     arrow (>= 13.0.0),
+    cli,
     data.table,
     DBI,
     dtplyr (>= 1.3.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     utils
 Suggests:
     arrow (>= 13.0.0),
-    cli,
+    cli (>= 3.3.0),
     data.table,
     DBI,
     dtplyr (>= 1.3.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     utils
 Suggests:
     arrow (>= 13.0.0),
-    cli (>= 3.3.0),
+    cli,
     data.table,
     DBI,
     dtplyr (>= 1.3.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -139,7 +139,7 @@
   differ from each other are still reported one by one. Only that context
   changes: the class, the diagnostic, and the cause you receive are the ones
   raised. A lazy input is unaffected, because its summary expressions run when
-  you collect the result rather than while the verb runs (#141, #108, #217).
+  you collect the result rather than while the verb runs (#141, #108).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/NEWS.md
+++ b/NEWS.md
@@ -139,7 +139,7 @@
   differ from each other are still reported one by one. Only that context
   changes: the class, the diagnostic, and the cause you receive are the ones
   raised. A lazy input is unaffected, because its summary expressions run when
-  you collect the result rather than while the verb runs (#141, #108).
+  you collect the result rather than while the verb runs (#141, #108, #217).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -251,6 +251,8 @@ message_line_runs <- function(lines) {
 # styles, and links; the wrapping is what the runs above already undid, and the
 # other two each split an identity on their own (#217). ADR 0021's *No rendering
 # decision takes part in the identity* is authoritative for which and why.
+# `link` is spelled although it is the default, because stripping the hyperlink
+# is half of what this call is here for rather than incidental to it.
 #
 # This is a *reading*. `branch_warning_identity()` assembles its key from the
 # lines as they arrived, so nothing here can make two diagnostics that differ
@@ -264,7 +266,7 @@ message_line_runs <- function(lines) {
 # the `DBI = FALSE` case in `AGENTS.md`'s dependency metadata, as
 # `share_dialect_can_be_asked()` is.
 written_message_lines <- function(lines, runs) {
-  lines <- cli::ansi_strip(lines)
+  lines <- cli::ansi_strip(lines, link = TRUE)
   vapply(
     runs,
     function(run) paste(sub("^ +", "", lines[run]), collapse = " "),

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -208,9 +208,14 @@ branch_warning_identity <- function(cnd) {
       (grepl("^[i\u2139] In group ", written) & seq_along(written) < cause)
   }
   # The pointer runs to the end of the message, so everything after it goes
-  # with it.
+  # with it. Its backticks are optional because cli writes the call as an
+  # `x-r-run` hyperlink where the terminal takes one, and the backticks are what
+  # the link replaces -- so removing the escapes is necessary for this line and
+  # not sufficient (#217). That widens what a caller's own diagnostic can be
+  # mistaken for by exactly one spelling, which is the direction this reading is
+  # already chosen to fail in.
   pointer <- which(
-    grepl("^[i\u2139] Run `dplyr::last_dplyr_warnings\\(\\)`", written)
+    grepl("^[i\u2139] Run `?dplyr::last_dplyr_warnings\\(\\)`?", written)
   )
   if (aggregated && length(pointer) > 0L) {
     removed[seq(max(pointer), length(runs))] <- TRUE
@@ -234,11 +239,36 @@ message_line_runs <- function(lines) {
   unname(split(seq_along(lines), cumsum(!wrapped)))
 }
 
-# Each run rejoined to the one line it was written as. The identity and the
-# argument restatement both read messages through this, which is what keeps
-# the two readings one: a message the identity reads as three written lines is
-# a message the restatement reads as the same three.
+# Each run rejoined to the one line it was written as, with cli's rendering
+# taken back off it. The identity and the argument restatement both read
+# messages through this, which is what keeps the two readings one: a message the
+# identity reads as three written lines is a message the restatement reads as
+# the same three.
+#
+# Every pattern either reader matches is matched here, so this is the one place
+# a rendering decision has to be undone, and undoing it here is what makes the
+# contract hold in a session that has one. cli styles the markers it writes and
+# links the calls it names, and either defeats a pattern anchored at the start
+# of a line: at `cli.num_colors` above 1 nothing was removed from an identity
+# and every branch's key differed by its own grouping values, and
+# `cli.hyperlink_run` -- which cli sets for itself in an OSC-8 terminal -- did
+# the same at `cli.num_colors = 1`, so this is not the styling in another
+# spelling (#217). ADR 0021 records the decision; the wrapping this already
+# undid is the same property in the variable that was noticed first.
+#
+# This is a *reading*. `branch_warning_identity()` assembles its key from the
+# lines as they arrived, so nothing here can make two diagnostics that differ
+# only by an escape sequence into one identity. The restatement is the one
+# reader that puts a line it read back into a message, and a restated line is
+# therefore rendered plain -- accepted rather than worked around, and recorded
+# in ADR 0022 beside the wrapping such a line already loses.
+#
+# cli needs no availability guard. It is an Import of both dplyr and
+# tidyselect, so it is in the hard dependency closure and can never be absent:
+# the `DBI = FALSE` case in `AGENTS.md`'s dependency metadata, as
+# `share_dialect_can_be_asked()` is.
 written_message_lines <- function(lines, runs) {
+  lines <- cli::ansi_strip(lines)
   vapply(
     runs,
     function(run) paste(sub("^ +", "", lines[run]), collapse = " "),

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -245,16 +245,12 @@ message_line_runs <- function(lines) {
 # identity reads as three written lines is a message the restatement reads as
 # the same three.
 #
-# Every pattern either reader matches is matched here, so this is the one place
-# a rendering decision has to be undone, and undoing it here is what makes the
-# contract hold in a session that has one. cli styles the markers it writes and
-# links the calls it names, and either defeats a pattern anchored at the start
-# of a line: at `cli.num_colors` above 1 nothing was removed from an identity
-# and every branch's key differed by its own grouping values, and
-# `cli.hyperlink_run` -- which cli sets for itself in an OSC-8 terminal -- did
-# the same at `cli.num_colors = 1`, so this is not the styling in another
-# spelling (#217). ADR 0021 records the decision; the wrapping this already
-# undid is the same property in the variable that was noticed first.
+# Every pattern either reader matches is anchored at the start of a line, so
+# this is the one place cli's rendering has to be undone, and undoing it here is
+# what makes ADR 0021's contract hold in a session that renders one. cli wraps,
+# styles, and links; the wrapping is what the runs above already undid, and the
+# other two each split an identity on their own (#217). ADR 0021's *No rendering
+# decision takes part in the identity* is authoritative for which and why.
 #
 # This is a *reading*. `branch_warning_identity()` assembles its key from the
 # lines as they arrived, so nothing here can make two diagnostics that differ

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -261,10 +261,14 @@ message_line_runs <- function(lines) {
 # therefore rendered plain -- accepted rather than worked around, and recorded
 # in ADR 0022 beside the wrapping such a line already loses.
 #
-# cli needs no availability guard. It is an Import of both dplyr and
-# tidyselect, so it is in the hard dependency closure and can never be absent:
-# the `DBI = FALSE` case in `AGENTS.md`'s dependency metadata, as
-# `share_dialect_can_be_asked()` is.
+# cli needs no availability guard and its Suggests entry carries no version.
+# It is an Import of both dplyr and tidyselect, so it is in the hard dependency
+# closure and can never be absent: the `DBI = FALSE` case in `AGENTS.md`'s
+# dependency metadata, as `share_dialect_can_be_asked()` is. `ansi_strip()`
+# learned `link` in cli 3.3.0, which is tidyselect's own floor and below
+# dplyr's, so a constraint written here could never bind -- and
+# `marginplyr_suggest_available()`, the only thing that reads one, is never
+# asked about a package that cannot be absent.
 written_message_lines <- function(lines, runs) {
   lines <- cli::ansi_strip(lines, link = TRUE)
   vapply(

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -70,6 +70,45 @@ varies with repetition within a branch, which is the one thing an identity may
 not depend on. The reported occurrence keeps the pointer, so a caller reading
 a report that hides something is told so in the same terms dplyr tells them.
 
+## No rendering decision takes part in the identity
+
+*Rendered* bounds what can be read; it does not license the reading to depend
+on how it was rendered. Which grouping set produced an occurrence is excluded
+from the identity because it necessarily differs between branches, and the
+session a caller happens to be sitting in is excluded for the stronger reason
+that it does not differ between branches at all: it is not a property of the
+condition. So the identity is computed from the message as it was *written*,
+and cli's decisions about how to lay that message out are undone before any
+pattern is matched against it.
+
+cli makes three such decisions, and each defeated a pattern on its own. It
+**wraps** a line it cannot fit, onto continuations it indents by two spaces, so
+a part read off a rendered line is a prefix of it at any narrow width. It
+**styles** the markers it writes, so above `cli.num_colors = 1` every pattern
+anchored at the start of a line missed, nothing was removed, and every branch's
+key differed by its own grouping values. And it **links** the calls it names,
+so `cli.hyperlink_run` — which cli sets for itself in a terminal advertising
+OSC-8 — replaced the backticks around the `last_dplyr_warnings()` pointer with
+an escape sequence carrying a per-branch count, splitting the identity at
+`cli.num_colors = 1`.
+
+Only the first was undone when this was written, which is why the property is
+now stated as the rule rather than as three repairs (#217). The contract this
+ADR states did not hold in a session with colour, and most interactive sessions
+have colour; a fix for the styling alone would have left the hyperlink case,
+and both were found only because the second was looked for after the first.
+Undoing the styling is also not sufficient by itself for the pointer: the
+stripped link renders the call without the backticks dplyr writes around it
+otherwise, so that pattern admits both spellings.
+
+Two properties bound this. The removal is a *reading* — the key is still
+assembled from the lines as they arrived, so two caller diagnostics differing
+only by an escape sequence remain two identities, and a caller's own text can
+no more be collapsed by the removal than by the reading it feeds. And a green
+suite under one rendering says nothing about another, so the fixtures cross the
+variables rather than sampling them, and each asserts that the markers it
+exists to exercise are actually present before it asserts the collapse.
+
 ## Rewriting the names is safe for a reason that does not depend on dplyr
 
 The `..marginplyr_key_N` token is a string marginplyr chose, so finding it in a

--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -101,6 +101,12 @@ Undoing the styling is also not sufficient by itself for the pointer: the
 stripped link renders the call without the backticks dplyr writes around it
 otherwise, so that pattern admits both spellings.
 
+Evidence: `investigation/dplyr-condition-context-rendering.md`, whose revisions
+section holds the measured report counts, the rendered pointer line, and the
+two things measured beside them and found not to need changing — the wrap
+indent that survives styling, and the error path that carries no styling at
+all.
+
 Two properties bound this. The removal is a *reading* — the key is still
 assembled from the lines as they arrived, so two caller diagnostics differing
 only by an escape sequence remain two identities, and a caller's own text can

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -79,6 +79,19 @@ byte for byte, rather than rebuilt from its lines -- rebuilding dropped a
 trailing newline, and the degradation the constraint on #199 asks for is the
 absence of any edit, not an edit that happens to read the same.
 
+A restated line is rendered plain, and that is the contract rather than a
+defect. The reading this shares with ADR 0021's identity undoes cli's rendering
+before matching anything, so the text a restatement puts back carries neither
+the styling nor the hyperlinks the line arrived with. The alternative was to
+match against the reading and splice the replacement into the raw line, and it
+was rejected: locating the span there rests on dplyr and cli not styling the
+backticks around it, an undocumented property of exactly the kind that produced
+#217 in the first place. Nothing is lost that a restated line was keeping
+anyway -- such a line already collapses to the one line it was written as,
+because what replaces it is a length cli is no longer there to wrap -- and
+every line the restatement does not touch reaches the caller as it arrived, so
+a caller in a colour session still receives a coloured warning.
+
 ## The restoration runs before the deduplication key is computed
 
 This is not only a matter of spelling. `total = sum(as.numeric(grade)) +

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -1,7 +1,7 @@
 # How dplyr renders the context of a condition from a summary expression
 
 Investigated: 2026-08-18
-Revised: 2026-08-18 — design/adr/0021-report-a-repeated-execution-condition-once.md
+Revised: 2026-08-18 — ADR 0021
 
 Measured while implementing #199, which asked for a Condition context quoting
 the caller's own spelling of a summary argument. ADR 0022 records the decision

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -179,21 +179,22 @@ line reads `ℹ Run dplyr::last_dplyr_warnings() to see the 2 remaining
 warnings.` — so a pattern requiring them still misses. Stripping is necessary
 for that line and not sufficient.
 
-**The closure claim above the measurement was wrong about which package
-supplies cli.** #217's body, written from this note, said cli reaches the
-dependency closure through rlang. It does not: `packageDescription("rlang")
-$Imports` is `utils` alone. cli arrives through **dplyr** (`Imports: cli
-(>= 3.6.2)`) and **tidyselect** (`Imports: cli (>= 3.3.0)`), both hard Imports
-of marginplyr. The conclusion the claim was made in support of — that cli needs
-no availability guard — holds and is stronger for it, since neither route is
-conditional.
+**The closure claim above the measurement named the wrong package.** #217's
+body, written from this note, said cli reaches the dependency closure through
+rlang. On this date `packageDescription("rlang")$Imports` read `utils` alone,
+while `packageDescription("dplyr")$Imports` read `cli (>= 3.6.2)` and
+`packageDescription("tidyselect")$Imports` read `cli (>= 3.3.0)`. Which of
+marginplyr's own dependencies those are is `DESCRIPTION`'s to say, and what
+follows for the guard is `R/conditions.R`'s and ADR 0021's; the readings above
+are what this note establishes.
 
 Two things measured at the same time and found **not** to need changing.
-Continuation lines still begin with two literal spaces ahead of any escape at
+Continuation lines began with two literal spaces ahead of any escape at
 `cli.width = 40` with `cli.num_colors = 256`, so the run splitting that reads
-`^  ` is unaffected by styling. And a structured error carries no styling at
+`^  ` was unaffected by styling. And a structured error carried no styling at
 all in `$message` or `$body` — rlang holds the bare bullets and cli formats
-them at print — so a reading that removes styling is a no-op on the error path.
+them at print — so a reading that removes styling was a no-op on the error
+path.
 
 ## Searched for and not found
 

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -1,6 +1,7 @@
 # How dplyr renders the context of a condition from a summary expression
 
 Investigated: 2026-08-18
+Revised: 2026-08-18 — design/adr/0021-report-a-repeated-execution-condition-once.md
 
 Measured while implementing #199, which asked for a Condition context quoting
 the caller's own spelling of a summary argument. ADR 0022 records the decision
@@ -142,6 +143,57 @@ i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
 Measured on `main`, that plan reported twice. So a message with no `Caused by`
 line is not evidence that dplyr did not aggregate it — only that the boundary
 cannot be found in it.
+
+## Revisions (2026-08-18)
+
+Two corrections, both established while #217 was implemented. ADR 0021's *No
+rendering decision takes part in the identity* section is the artifact that
+records the decision they led to; what follows is the evidence.
+
+**A fourth rendering variable, missed above.** *Three measurements about ADR
+0021's identity* names console width, colour, and the aggregation without a
+cause line, and says of the second that stripping the styling would fix it. It
+would not, on its own. cli also renders a call it names as an OSC-8 hyperlink
+when the terminal advertises support — `cli.hyperlink_run`, which cli sets for
+itself in RStudio and in iTerm2 — and dplyr's pointer at
+`last_dplyr_warnings()` is such a call. Measured on `main` with the same
+`cube(region, grade)` reproduction:
+
+| session | reports |
+|---|---|
+| `cli.num_colors = 1`, `cli.hyperlink_run = TRUE` | 3 |
+
+So the contract failed at `cli.num_colors = 1` as well, and colour was not the
+whole of it. The pointer line renders as
+
+```
+ℹ Run \033]8;;x-r-run:dplyr::last_dplyr_warnings()\adplyr::last_dplyr_warnings()\033]8;;\a to see the 2 remaining warnings.
+```
+
+and the count inside it varies with how many warnings a branch raised, which is
+why the surviving line splits the identity.
+
+`cli::ansi_strip(link = TRUE)` removes the escape but does **not** restore the
+backticks dplyr writes around the call when it does not link it — the stripped
+line reads `ℹ Run dplyr::last_dplyr_warnings() to see the 2 remaining
+warnings.` — so a pattern requiring them still misses. Stripping is necessary
+for that line and not sufficient.
+
+**The closure claim above the measurement was wrong about which package
+supplies cli.** #217's body, written from this note, said cli reaches the
+dependency closure through rlang. It does not: `packageDescription("rlang")
+$Imports` is `utils` alone. cli arrives through **dplyr** (`Imports: cli
+(>= 3.6.2)`) and **tidyselect** (`Imports: cli (>= 3.3.0)`), both hard Imports
+of marginplyr. The conclusion the claim was made in support of — that cli needs
+no availability guard — holds and is stronger for it, since neither route is
+conditional.
+
+Two things measured at the same time and found **not** to need changing.
+Continuation lines still begin with two literal spaces ahead of any escape at
+`cli.width = 40` with `cli.num_colors = 256`, so the run splitting that reads
+`^  ` is unaffected by styling. And a structured error carries no styling at
+all in `$message` or `$body` — rlang holds the bare bullets and cli formats
+them at print — so a reading that removes styling is a no-op on the error path.
 
 ## Searched for and not found
 

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -161,8 +161,18 @@ rendering_configurations <- function() {
     KEEP.OUT.ATTRS = FALSE,
     stringsAsFactors = FALSE
   )
-  configs <- split(grid, seq_len(nrow(grid)))
+  configs <- lapply(
+    split(grid, seq_len(nrow(grid))),
+    function(row) rendering_config(row$width, row$num_colors, row$hyperlink)
+  )
   stats::setNames(configs, vapply(configs, rendering_label, character(1)))
+}
+
+# The one shape a configuration has, so that a test naming a rendering the grid
+# does not cover -- a width wide enough that nothing wraps -- builds the same
+# thing the grid does rather than a second shape the helpers must also accept.
+rendering_config <- function(width, num_colors, hyperlink) {
+  list(width = width, num_colors = num_colors, hyperlink = hyperlink)
 }
 
 rendering_label <- function(config) {
@@ -514,7 +524,7 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
 # The width is set wide enough that nothing wraps, so a line here is a line as
 # dplyr wrote it.
 test_that("only the line a restatement rewrote is rendered plain", {
-  config <- list(width = 200L, num_colors = 256L, hyperlink = FALSE)
+  config <- rendering_config(200L, 256L, FALSE)
   warnings <- collect_warnings_rendered(config, summarize_helper_coercion())
   lines <- strsplit(conditionMessage(warnings[[1L]]), "\n", fixed = TRUE)[[1L]]
   styled <- grepl("\033[", lines, fixed = TRUE)

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -218,16 +218,24 @@ warnings_under_every_rendering <- function(expr) {
   )
 }
 
-# The reported message under each configuration, or `""` where a configuration
-# reported nothing -- the count is asserted separately, and reading past the end
-# of an empty result would replace that assertion's failure with an error.
-first_reported_messages <- function(collected) {
+# Whether each configuration's reported message carries a literal, keyed by the
+# configuration, so that what a failure names is the rendering and not the
+# expectation's position in a loop. A configuration that reported nothing reads
+# as `""` rather than raising: the count is asserted separately, and reading
+# past the end of an empty result would replace that assertion's failure with an
+# error.
+reported_contains <- function(collected, text) {
   vapply(
     collected,
     function(warnings) {
-      if (length(warnings) == 0L) "" else conditionMessage(warnings[[1L]])
+      message <- if (length(warnings) == 0L) {
+        ""
+      } else {
+        conditionMessage(warnings[[1L]])
+      }
+      grepl(text, message, fixed = TRUE)
     },
-    character(1)
+    logical(1)
   )
 }
 
@@ -263,17 +271,6 @@ for_every_rendering <- function(value) {
   stats::setNames(rep(value, length(configs)), names(configs))
 }
 
-# Whether each configuration's reported message carries a literal, keyed by the
-# configuration, so that what a failure names is the rendering and not the
-# expectation's position in a loop.
-reported_contains <- function(collected, text) {
-  vapply(
-    first_reported_messages(collected),
-    function(message) grepl(text, message, fixed = TRUE),
-    logical(1)
-  )
-}
-
 test_that("a warning repeated across grouping sets is reported once", {
   warnings <- collect_warnings(summarize_coercion_cube())
 
@@ -293,23 +290,6 @@ test_that("a reported warning names the caller's own grouping columns", {
   expect_match(message, "`region = \"East\"`", fixed = TRUE)
   expect_match(message, "`grade = \"a\"`", fixed = TRUE)
   expect_false(grepl("marginplyr_key", message, fixed = TRUE))
-})
-
-# The third part of #141's context leak (ADR 0022). What is quoted is
-# `rlang::as_label()`'s rendering of the expression the caller wrote rather than
-# their source text, because that is the rendering dplyr would have quoted had
-# nothing been rewritten -- the spelling restored is the caller's, not their
-# whitespace.
-test_that("a reported warning quotes the caller's own spelling", {
-  warnings <- collect_warnings(summarize_across_coercion())
-
-  message <- conditionMessage(warnings[[1L]])
-  expect_match(
-    message,
-    "`dplyr::across(c(grade), ~sum(as.numeric(.x)))`",
-    fixed = TRUE
-  )
-  expect_false(grepl("all_of", message, fixed = TRUE))
 })
 
 test_that("a share does not shift which argument is restored", {
@@ -342,23 +322,12 @@ test_that("a warning is one report where only a branch constant differed", {
   expect_match(message, "1 further grouping set", fixed = TRUE)
 })
 
-# Three rendering variables, one property. cli wraps a bullet it cannot fit,
-# styles the markers it writes, and turns dplyr's pointer into a hyperlink, and
-# each of the three defeated a reading of the rendered text on its own:
-#
-# - Width. This reproduction gave three reports of one condition at 60 columns,
-#   four at 40, and two anywhere in 15 to 24, where dplyr's opening sentence
-#   wraps and cli does not indent what it wraps it onto. Reading the bullet off
-#   the line it opens rather than the line it was written as restored the
-#   spelling at 80 columns and not at 40.
-# - Colour. Every marker carries an SGR escape above `cli.num_colors = 1`, so
-#   every pattern missed and this reproduction reported twice while quoting the
-#   branch constant `0L` the caller never wrote (#217).
-# - Hyperlinks. `cli.hyperlink_run` turns the pointer at
-#   `last_dplyr_warnings()` into an OSC-8 link carrying a per-branch remaining
-#   count, which split the identity at `cli.num_colors = 1` -- so this is not
-#   the colour case in another spelling, and stripping the escapes is not on its
-#   own enough: the link renders without the backticks dplyr writes otherwise.
+# Three rendering variables, one property, which ADR 0021's *No rendering
+# decision takes part in the identity* is authoritative for. What this fixture
+# contributes is the counts each variable produced on it: three reports of one
+# condition at 60 columns, four at 40, and two anywhere in 15 to 24; two above
+# `cli.num_colors = 1`, quoting the branch constant `0L` the caller never
+# wrote; and two again under `cli.hyperlink_run` at `cli.num_colors = 1`.
 #
 # Asserting the restoration here as well as the collapse is what says #199's
 # restatement is covered rather than leaving it inferred from the count: the two
@@ -385,6 +354,14 @@ test_that("the constant-rewrite collapse holds under every rendering", {
 # split an identity -- which is why it needs its own assertion. A colour session
 # quoted the rewrite here while reporting the expected single condition, and a
 # test reading the count alone would have called that green.
+#
+# The third part of #141's context leak (ADR 0022). What is quoted is
+# `rlang::as_label()`'s rendering of the expression the caller wrote rather than
+# their source text, because that is the rendering dplyr would have quoted had
+# nothing been rewritten -- the spelling restored is the caller's, not their
+# whitespace. This subsumes the single-rendering assertion that stood here
+# before, which read the same fixture for the same two facts under one
+# rendering.
 test_that("the selection rewrite is restored under every rendering", {
   spelled <- "`dplyr::across(c(grade), ~sum(as.numeric(.x)))`"
   collected <- warnings_under_every_rendering(summarize_across_coercion())
@@ -528,6 +505,28 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
     )),
     2L
   )
+})
+
+# ADR 0022's contract for a restated line, asserted line by line rather than in
+# aggregate. `expect_rendering_markers()` above says only that some marker
+# survived somewhere, which a message that had lost the styling on one other
+# line would still satisfy; what the contract promises is which line is plain.
+# The width is set wide enough that nothing wraps, so a line here is a line as
+# dplyr wrote it.
+test_that("only the line a restatement rewrote is rendered plain", {
+  config <- list(width = 200L, num_colors = 256L, hyperlink = FALSE)
+  warnings <- collect_warnings_rendered(config, summarize_helper_coercion())
+  lines <- strsplit(conditionMessage(warnings[[1L]]), "\n", fixed = TRUE)[[1L]]
+  styled <- grepl("\033[", lines, fixed = TRUE)
+
+  restated <- grepl("In argument:", lines, fixed = TRUE)
+  expect_identical(sum(restated), 1L)
+  expect_false(any(styled[restated]))
+  # Every other bullet dplyr wrote keeps the styling it arrived with, including
+  # the two the identity removed from its key -- what a key drops is not what a
+  # caller stops being shown.
+  expect_true(all(styled[grepl("In group ", lines, fixed = TRUE)]))
+  expect_true(all(styled[grepl("last_dplyr_warnings", lines, fixed = TRUE)]))
 })
 
 # Removing the styling is a change to a *reading*, and only to a reading: the

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -195,6 +195,15 @@ collect_warnings_rendered <- function(config, expr) {
   collect_warnings(expr)
 }
 
+# The styling on its own, for the two properties below that are about the
+# reading rather than about a rendering: neither varies with the width or the
+# hyperlinks, so crossing them would assert one thing twenty times.
+at_num_colors <- function(num_colors, expr) {
+  original <- options(cli.num_colors = num_colors)
+  on.exit(options(original), add = TRUE)
+  expr
+}
+
 # One call's warnings under each configuration, keyed by the configuration.
 # `expr` is quoted rather than taken as a promise, because a promise forces
 # once and every configuration has to render the call again.
@@ -236,18 +245,13 @@ first_reported_messages <- function(collected) {
 # unstyled would mean the whole message had been rewritten.
 expect_rendering_markers <- function(collected) {
   configs <- rendering_configurations()
-  messages <- first_reported_messages(collected)
-
-  carries <- function(marker) {
-    vapply(messages, function(m) grepl(marker, m, fixed = TRUE), logical(1))
-  }
 
   expect_identical(
-    carries("\033["),
+    reported_contains(collected, "\033["),
     vapply(configs, function(config) config$num_colors > 1L, logical(1))
   )
   expect_identical(
-    carries("\033]8;;"),
+    reported_contains(collected, "\033]8;;"),
     vapply(configs, function(config) config$hyperlink, logical(1))
   )
 }
@@ -363,8 +367,8 @@ test_that("a warning is one report where only a branch constant differed", {
 test_that("the constant-rewrite collapse holds under every rendering", {
   collected <- warnings_under_every_rendering(summarize_helper_coercion())
 
-  expect_identical(lengths(collected), for_every_rendering(1L))
   expect_rendering_markers(collected)
+  expect_identical(lengths(collected), for_every_rendering(1L))
   expect_identical(
     reported_contains(collected, "grouping_bit(region)"),
     for_every_rendering(TRUE)
@@ -385,8 +389,8 @@ test_that("the selection rewrite is restored under every rendering", {
   spelled <- "`dplyr::across(c(grade), ~sum(as.numeric(.x)))`"
   collected <- warnings_under_every_rendering(summarize_across_coercion())
 
-  expect_identical(lengths(collected), for_every_rendering(1L))
   expect_rendering_markers(collected)
+  expect_identical(lengths(collected), for_every_rendering(1L))
   expect_identical(
     reported_contains(collected, spelled),
     for_every_rendering(TRUE)
@@ -441,8 +445,8 @@ test_that("an abbreviated argument keeps the quotation dplyr wrote", {
 test_that("a repeated warning is one report under every rendering", {
   collected <- warnings_under_every_rendering(summarize_coercion_cube())
 
-  expect_identical(lengths(collected), for_every_rendering(1L))
   expect_rendering_markers(collected)
+  expect_identical(lengths(collected), for_every_rendering(1L))
   expect_identical(
     reported_contains(collected, "3 further grouping sets"),
     for_every_rendering(TRUE)
@@ -536,11 +540,8 @@ test_that("a diagnostic differing only by an escape sequence stays distinct", {
   reports <- vapply(
     c("1" = 1L, "256" = 256L),
     function(num_colors) {
-      original <- options(cli.num_colors = num_colors)
-      on.exit(options(original), add = TRUE)
-      length(collect_warnings(summarize_branch_diagnostics(
-        "bad \033[36mvalue\033[39m",
-        "bad value"
+      at_num_colors(num_colors, length(collect_warnings(
+        summarize_branch_diagnostics("bad \033[36mvalue\033[39m", "bad value")
       )))
     },
     integer(1)
@@ -560,9 +561,10 @@ test_that("a branch error's restatement carries no styling and does not vary", {
   restated <- vapply(
     c("1" = 1L, "256" = 256L),
     function(num_colors) {
-      original <- options(cli.num_colors = num_colors)
-      on.exit(options(original), add = TRUE)
-      error <- tryCatch(summarize_across_failure(), error = function(cnd) cnd)
+      error <- at_num_colors(
+        num_colors,
+        tryCatch(summarize_across_failure(), error = function(cnd) cnd)
+      )
       unname(error$message)
     },
     character(1)

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -142,16 +142,132 @@ collect_warnings <- function(expr) {
   warnings
 }
 
-# `expr` is forced inside `collect_warnings()`, so it is rendered at the width
-# set here. `cli.condition_width` is the one that has to be set: testthat's own
-# `local_reproducible_output()` sets it to `Inf` so that a snapshot does not
-# depend on the pane it was recorded in, and rlang consults it ahead of
-# `cli.width` -- so a test that set `cli.width` alone would render every case
-# unwrapped and pass whatever the code did.
-collect_warnings_at_width <- function(width, expr) {
-  original <- options(cli.width = width, cli.condition_width = width)
+# Every rendering decision cli makes for itself, as the configurations they
+# combine into. The identity is over the message as written, so none of them may
+# change how many conditions a caller receives -- and a suite green under one of
+# them says nothing about the others, which is the whole of #217: the width was
+# the only one asserted, and the contract held under neither of the other two.
+#
+# Generated rather than listed, so a fourth variable is one column here and
+# every assertion below picks it up rather than being extended to meet it.
+# Each configuration is named for itself, because these are asserted as one
+# named vector per property: a failure then says which renderings broke and
+# which held, where twenty separate expectations would say only that one did.
+rendering_configurations <- function() {
+  grid <- expand.grid(
+    width = c(80L, 60L, 40L, 20L, 16L),
+    num_colors = c(1L, 256L),
+    hyperlink = c(FALSE, TRUE),
+    KEEP.OUT.ATTRS = FALSE,
+    stringsAsFactors = FALSE
+  )
+  configs <- split(grid, seq_len(nrow(grid)))
+  stats::setNames(configs, vapply(configs, rendering_label, character(1)))
+}
+
+rendering_label <- function(config) {
+  sprintf(
+    "width %d, num_colors %d, hyperlink %s",
+    config$width,
+    config$num_colors,
+    config$hyperlink
+  )
+}
+
+# `expr` is forced inside `collect_warnings()`, so it is rendered under the
+# options set here. `cli.condition_width` is the one that has to be set for the
+# width: testthat's own `local_reproducible_output()` sets it to `Inf` so that a
+# snapshot does not depend on the pane it was recorded in, and rlang consults it
+# ahead of `cli.width` -- so a test setting `cli.width` alone would render every
+# case unwrapped and pass whatever the code did. `cli.hyperlink_run` is the one
+# dplyr's pointer at `last_dplyr_warnings()` follows; `cli.hyperlink` is set
+# beside it because a terminal advertising one advertises the other, so a
+# configuration separating them would name a session nobody runs.
+collect_warnings_rendered <- function(config, expr) {
+  original <- options(
+    cli.width = config$width,
+    cli.condition_width = config$width,
+    cli.num_colors = config$num_colors,
+    cli.hyperlink = config$hyperlink,
+    cli.hyperlink_run = config$hyperlink
+  )
   on.exit(options(original), add = TRUE)
   collect_warnings(expr)
+}
+
+# One call's warnings under each configuration, keyed by the configuration.
+# `expr` is quoted rather than taken as a promise, because a promise forces
+# once and every configuration has to render the call again.
+warnings_under_every_rendering <- function(expr) {
+  quoted <- substitute(expr)
+  env <- parent.frame()
+  lapply(
+    rendering_configurations(),
+    function(config) {
+      collect_warnings_rendered(config, eval(quoted, env))
+    }
+  )
+}
+
+# The reported message under each configuration, or `""` where a configuration
+# reported nothing -- the count is asserted separately, and reading past the end
+# of an empty result would replace that assertion's failure with an error.
+first_reported_messages <- function(collected) {
+  vapply(
+    collected,
+    function(warnings) {
+      if (length(warnings) == 0L) "" else conditionMessage(warnings[[1L]])
+    },
+    character(1)
+  )
+}
+
+# What stops a configuration passing by not being the configuration it claims.
+# cli decides for itself whether to style and whether to link, so an environment
+# that refused would turn every colour row into a second unstyled one: a suite
+# still green while asserting nothing about the case those rows exist for. This
+# is asserted beside the collapse rather than inferred from it, for the reason
+# `verify-suite-coverage.R` asserts its own mechanism before concluding
+# anything.
+#
+# It is also what pins the other half of ADR 0022's contract: only a restated
+# line is rendered plain, so a reported message still carries the styling of
+# every line the restatement did not touch, and a colour row that arrived
+# unstyled would mean the whole message had been rewritten.
+expect_rendering_markers <- function(collected) {
+  configs <- rendering_configurations()
+  messages <- first_reported_messages(collected)
+
+  carries <- function(marker) {
+    vapply(messages, function(m) grepl(marker, m, fixed = TRUE), logical(1))
+  }
+
+  expect_identical(
+    carries("\033["),
+    vapply(configs, function(config) config$num_colors > 1L, logical(1))
+  )
+  expect_identical(
+    carries("\033]8;;"),
+    vapply(configs, function(config) config$hyperlink, logical(1))
+  )
+}
+
+# The value every configuration has to agree on, shaped like the vectors the
+# assertions compare against it.
+for_every_rendering <- function(value) {
+  configs <- rendering_configurations()
+  stats::setNames(rep(value, length(configs)), names(configs))
+}
+
+# Whether each configuration's reported message carries a literal, keyed by the
+# configuration, so that what a failure names is the rendering and not the
+# expectation's position in a loop.
+reported_contains <- function(collected, text) {
+  vapply(
+    first_reported_messages(collected),
+    function(message) grepl(text, message, fixed = TRUE),
+    logical(1)
+  )
 }
 
 test_that("a warning repeated across grouping sets is reported once", {
@@ -222,30 +338,63 @@ test_that("a warning is one report where only a branch constant differed", {
   expect_match(message, "1 further grouping set", fixed = TRUE)
 })
 
-# cli wraps a bullet it cannot fit, so how a warning message is laid out is a
-# function of the console width and of how long the grouping values are. Which
-# grouping set raised a warning is no more part of its identity when the bullet
-# naming it wrapped: this reproduction gave three reports of one condition at
-# 60 columns, four at 40, and two anywhere in 15 to 24, where dplyr's opening
-# sentence wraps and cli does not indent what it wraps it onto.
-# The restatement has to read the bullet as the line it was written as, for the
-# same reason the identity does: cli wraps a bullet it cannot fit, and a span
-# read off the line the bullet opens is a prefix of the label at any narrow
-# width. Reading it that way reported the branch-constant case once at 80
-# columns and twice at 40, which is the console width deciding how many
-# conditions a caller receives.
-test_that("the constant-rewrite collapse holds at any console width", {
-  for (width in c(80L, 60L, 40L, 20L, 16L)) {
-    warnings <- collect_warnings_at_width(width, summarize_helper_coercion())
+# Three rendering variables, one property. cli wraps a bullet it cannot fit,
+# styles the markers it writes, and turns dplyr's pointer into a hyperlink, and
+# each of the three defeated a reading of the rendered text on its own:
+#
+# - Width. This reproduction gave three reports of one condition at 60 columns,
+#   four at 40, and two anywhere in 15 to 24, where dplyr's opening sentence
+#   wraps and cli does not indent what it wraps it onto. Reading the bullet off
+#   the line it opens rather than the line it was written as restored the
+#   spelling at 80 columns and not at 40.
+# - Colour. Every marker carries an SGR escape above `cli.num_colors = 1`, so
+#   every pattern missed and this reproduction reported twice while quoting the
+#   branch constant `0L` the caller never wrote (#217).
+# - Hyperlinks. `cli.hyperlink_run` turns the pointer at
+#   `last_dplyr_warnings()` into an OSC-8 link carrying a per-branch remaining
+#   count, which split the identity at `cli.num_colors = 1` -- so this is not
+#   the colour case in another spelling, and stripping the escapes is not on its
+#   own enough: the link renders without the backticks dplyr writes otherwise.
+#
+# Asserting the restoration here as well as the collapse is what says #199's
+# restatement is covered rather than leaving it inferred from the count: the two
+# read the same message through the same helper, and in a colour session both
+# no-opped.
+test_that("the constant-rewrite collapse holds under every rendering", {
+  collected <- warnings_under_every_rendering(summarize_helper_coercion())
 
-    expect_length(warnings, 1L)
-    expect_match(
-      conditionMessage(warnings[[1L]]),
-      "grouping_bit(region)",
-      fixed = TRUE,
-      info = paste("width", width)
-    )
-  }
+  expect_identical(lengths(collected), for_every_rendering(1L))
+  expect_rendering_markers(collected)
+  expect_identical(
+    reported_contains(collected, "grouping_bit(region)"),
+    for_every_rendering(TRUE)
+  )
+  expect_identical(
+    reported_contains(collected, "+ 0L"),
+    for_every_rendering(FALSE)
+  )
+})
+
+# The other rewrite #199 restores, under the same configurations: a selection
+# the caller wrote as `c(grade)` reaches dplyr as `dplyr::all_of("grade")`.
+# Unlike the branch constant, this one is shared by every branch, so it never
+# split an identity -- which is why it needs its own assertion. A colour session
+# quoted the rewrite here while reporting the expected single condition, and a
+# test reading the count alone would have called that green.
+test_that("the selection rewrite is restored under every rendering", {
+  spelled <- "`dplyr::across(c(grade), ~sum(as.numeric(.x)))`"
+  collected <- warnings_under_every_rendering(summarize_across_coercion())
+
+  expect_identical(lengths(collected), for_every_rendering(1L))
+  expect_rendering_markers(collected)
+  expect_identical(
+    reported_contains(collected, spelled),
+    for_every_rendering(TRUE)
+  )
+  expect_identical(
+    reported_contains(collected, "all_of"),
+    for_every_rendering(FALSE)
+  )
 })
 
 # The degradation the contract requires, exercised through a real call rather
@@ -289,18 +438,15 @@ test_that("an abbreviated argument keeps the quotation dplyr wrote", {
   )
 })
 
-test_that("a repeated warning is one report at any console width", {
-  for (width in c(80L, 60L, 40L, 20L, 16L)) {
-    warnings <- collect_warnings_at_width(width, summarize_coercion_cube())
+test_that("a repeated warning is one report under every rendering", {
+  collected <- warnings_under_every_rendering(summarize_coercion_cube())
 
-    expect_length(warnings, 1L)
-    expect_match(
-      conditionMessage(warnings[[1L]]),
-      "3 further grouping sets",
-      fixed = TRUE,
-      info = paste("width", width)
-    )
-  }
+  expect_identical(lengths(collected), for_every_rendering(1L))
+  expect_rendering_markers(collected)
+  expect_identical(
+    reported_contains(collected, "3 further grouping sets"),
+    for_every_rendering(TRUE)
+  )
 })
 
 # A test that only asserted collapsing would pass if everything collapsed, so
@@ -377,6 +523,58 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
       "bad value in data"
     )),
     2L
+  )
+})
+
+# Removing the styling is a change to a *reading*, and only to a reading: the
+# identity is still assembled from the lines as they arrived. Two diagnostics
+# differing only by an escape sequence read alike once the styling is off, so an
+# identity computed over the stripped text would collapse them -- a caller's own
+# diagnostic losing the difference between two conditions, which is the one
+# outcome the removal may not produce.
+test_that("a diagnostic differing only by an escape sequence stays distinct", {
+  reports <- vapply(
+    c("1" = 1L, "256" = 256L),
+    function(num_colors) {
+      original <- options(cli.num_colors = num_colors)
+      on.exit(options(original), add = TRUE)
+      length(collect_warnings(summarize_branch_diagnostics(
+        "bad \033[36mvalue\033[39m",
+        "bad value"
+      )))
+    },
+    integer(1)
+  )
+
+  expect_identical(reports, c("1" = 2L, "256" = 2L))
+})
+
+# The reading is shared between the two condition kinds, so changing it for the
+# warning path changes the error path too. An error's context is separately
+# addressable and carries no styling at all -- rlang holds the bare bullets and
+# cli formats them at print -- so the removal is a no-op here. That is asserted
+# rather than left to the warning tests, for the reason those tests now cross
+# the rendering variables at all: a green result under one styling says nothing
+# about the other.
+test_that("a branch error's restatement carries no styling and does not vary", {
+  restated <- vapply(
+    c("1" = 1L, "256" = 256L),
+    function(num_colors) {
+      original <- options(cli.num_colors = num_colors)
+      on.exit(options(original), add = TRUE)
+      error <- tryCatch(summarize_across_failure(), error = function(cnd) cnd)
+      unname(error$message)
+    },
+    character(1)
+  )
+
+  expect_identical(restated[["1"]], restated[["256"]])
+  expect_false(any(grepl("\033", restated, fixed = TRUE)))
+  expect_match(
+    restated,
+    "`dplyr::across(c(grade), ~sum(nope(.x)))`",
+    fixed = TRUE,
+    all = TRUE
   )
 })
 


### PR DESCRIPTION
Closes #217.

ADR 0021 states that a warning every grouping set raises is reported once. It
was not, in any session where cli renders — which is most of them.

Both readings of a rendered message go through `written_message_lines()`, and
every pattern either matches is anchored at the start of a line. cli styles the
markers it writes, so above `cli.num_colors = 1` nothing was removed from an
identity and each branch's key differed by its own grouping values. The
argument restatement #199 added reads the same text through the same helper, so
it no-opped too, quoting the branch constant `0L` the caller never wrote.

Triage turned up a second variable the ticket did not cover. `cli.hyperlink_run`
— which cli sets for itself in RStudio and in OSC-8 terminals — turns dplyr's
pointer at `last_dplyr_warnings()` into a link carrying a per-branch remaining
count, and that split the identity **at `cli.num_colors = 1`**. Stripping the
escapes is not sufficient for that line: the link renders without the backticks
dplyr writes around the call otherwise, so the pattern admits both spellings.

| reproduction | before | after |
| --- | --- | --- |
| `cube(region, grade)`, `cli.num_colors = 1` | 1 | 1 |
| `cube(region, grade)`, `cli.num_colors = 256` | 4 | **1** |
| `cube(region, grade)`, `cli.hyperlink_run = TRUE`, `cli.num_colors = 1` | 3 | **1** |
| `grouping_bit(region)` quoted at `cli.num_colors = 256` | `0 * 0L` | **`0 * grouping_bit(region)`** |

## What bounds the change

**It is a reading, and only a reading.** `branch_warning_identity()` still
assembles its key from the lines as they arrived, so two caller diagnostics
differing only by an escape sequence remain two identities.

**A restated line is rendered plain, and that is the contract.** The
restatement is the one reader that puts a line it read back into a message.
Splicing into the raw line to keep the styling was rejected: locating the span
there rests on dplyr and cli not styling the backticks around it, an
undocumented property of exactly the kind that produced #217. Nothing is lost
that such a line was keeping anyway — it already collapses to the one line it
was written as — and every line the restatement does not touch reaches the
caller as it arrived. ADR 0022 records this.

**cli needs no guard and no version.** It is an Import of both dplyr and
tidyselect, so it is the `DBI = FALSE` case in `AGENTS.md`'s dependency
metadata, as `share_dialect_can_be_asked()` is. `ansi_strip()` learned `link`
in cli 3.3.0, below both floors the closure already imposes, so a constraint
could never bind.

## Tests

The two width loops become one table of rendering configurations — 5 widths ×
2 colour settings × 2 hyperlink settings — generated with `expand.grid()`
rather than listed, so a fourth variable is one column and every assertion
picks it up. Each configuration asserts that the markers it exists to exercise
are actually present *before* it asserts the collapse: cli decides for itself
whether to style, and a row that silently stopped being styled would otherwise
pass as a second unstyled row while asserting nothing about the case it exists
for. That is the failure this whole ticket is an instance of.

Three tests are added — which line loses its styling, asserted line by line;
two diagnostics differing only by an escape sequence staying distinct; an
error's restatement not varying with `cli.num_colors`, since the reading is
shared between the two condition kinds. One is removed, subsumed by the
configuration test that reads the same fixture for the same two facts across
twenty renderings instead of one.

`CONTEXT.md` is unchanged. Its *Repeated condition* entry already defines
identity as the class, the diagnostic, and the argument as the caller wrote it,
which is rendering-independent and correct as written; what failed was the
implementation computing it.

## Checks

- `lintr::lint_package()` — 0 lints
- `roxygen2::roxygenise()` — no diff
- full suite under `NOT_CRAN` — 578 tests, green
- `.github/scripts/verify-suite-coverage.R` — every test executes in at least
  one single-backend configuration
