### PR TITLE
Stop claiming a job names the test titles it executes

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -586,8 +586,11 @@ and an absence is a failure. `test-optional-backends.R` covers the helper
 itself. Snapshot expectations belong to the same seam: testthat skips them
 under CRAN semantics, so they run only in those jobs.
 
-A test title is part of that contract, because each job names the titles it
-exists to execute. Renaming a contract test is expected to break its job.
+What the seam does not ask is that a test keep its title: no job names the
+tests it executes (#93). Coverage is structural instead, resting on a policy
+about what a test may require — no test may require more than one member of
+`optional_backends()` — rather than on a list of what each job must run.
+
 `AGENTS.md` is the operational reference for the jobs, the verifier scripts,
 and the sites registering an optional Suggest has to touch.
 


### PR DESCRIPTION
Closes #204.

`design/architecture.md`'s *Release gates* section closed by making a test
title part of a backend contract, "because each job names the titles it exists
to execute", and told a reader that renaming a contract test is expected to
break its job.

Neither has held since #93 removed the `proves` lists and the `coverage` job
that read the workflow back against them. `verify-backend.R` reads its own
testthat log for a tally and a set of skip reasons; `verify-suite-coverage.R`
makes naming unnecessary rather than better. Both say so in their own headers,
so the document disagreed with the scripts it was describing.

The cost was a contributor's. The paragraph read as a reason not to make an
otherwise free rename, which is what #185 surfaced by making eleven.

## What replaces it

The architectural property, with the mechanism left to `AGENTS.md` — which the
next sentence already points at, and which describes the current jobs
correctly. Deferring is the cheaper option and the one that cannot go stale a
second time: `design/architecture.md` says coverage is structural and names the
policy it rests on, and `AGENTS.md` carries how the jobs enforce it.

The policy is quoted in the wording `AGENTS.md` and `verify-suite-coverage.R`
already share, rather than in a third one of its own.

## What bounds the change

**Documentation only.** No workflow, verifier script, or test is touched. The
gate works; the description of it did not.

**`design/review-dispositions.md` keeps its present-tense evidence line.** Its
entry for the same gate reads "each `backend` matrix entry names the tests it
proves", but it is a dated record carrying a *Superseded by #93* clause that
states the lists are gone and describes the stronger gate that replaced them.
It is a ledger of past dispositions, not a description of the present.

**The past-tense `proves` references in `verify-backend.R`,
`release-matrix.yaml`, and `verify-suite-coverage.R` stay.** They explain why
the current design is what it is, and are accurate as written.

## Review

Two claims of the same kind reached the first draft of the replacement and were
removed in round 1.

| claim | why it is false |
| --- | --- |
| "every job stays green" for a test requiring two backends | the `structure` job is the *Structure* layer for exactly that case, and `verify-suite-coverage.R` stops on it |
| "the jobs, each installing one, execute the whole suite between them" | rests coverage on a package count `AGENTS.md` says it must not — `dtplyr` declares `data.table` as a companion, and `data.table` is an entry of its own, so that job holds two |

Also removed: a restatement of the split remedy and the compare-against-local
idiom, which `AGENTS.md` and `verify-suite-coverage.R` already carry; a
weakened quotation of the policy that dropped the `optional_backends()`
identifier; and an unqualified "renaming a test breaks nothing", which reaches
past what was verified — snapshot files are keyed by test title.

Round 2 was clean on both axes.

One finding was out of scope here and is filed as #220: after this change the
policy sentence is stated in three files with nothing holding them in step,
which is the same shape as the defect this PR fixes.

## Tests

`testthat::test_local()` under `NOT_CRAN=true` and `lintr::lint_package()`
after `pkgload::load_all()`, both clean. Neither reaches `design/`, which is
`.Rbuildignore`d — the verification that matters here is the fact check against
`verify-backend.R`, `verify-suite-coverage.R`, `release-matrix.yaml`, and
`optional_suggest_spec()`, recorded above.
