### PR TITLE
Give the one-test-one-backend policy one home, and say why no gate guards it

### DIFF
--- a/.github/scripts/verify-suite-coverage.R
+++ b/.github/scripts/verify-suite-coverage.R
@@ -14,7 +14,8 @@
 # "regenerate the list and commit it" records a change rather than refusing one.
 # So this script makes naming unnecessary instead of making it better (#93).
 #
-# The policy it enforces is one sentence:
+# The policy it enforces is one sentence, whose home is `AGENTS.md`'s *Release
+# matrix* section:
 #
 #     No test may require more than one member of `optional_backends()`.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,6 +429,21 @@ structural rather than a list of test names (#93). One policy carries it:
 
 > No test may require more than one member of `optional_backends()`.
 
+That sentence has one home, and this is it. `design/architecture.md` names the
+policy without restating it, because what its test chapter needs is the
+architectural property and not the rule's text.
+`.github/scripts/verify-suite-coverage.R` quotes it in full and attributes it
+here, because the argument its header makes cannot be read without the sentence
+in front of it. Nothing asserts that the two spellings stay in step, which is
+deliberate rather than an omission. The rule is restated as a consequence
+wherever the coverage argument is made, and individual tests state it for their
+own sections; those restatements outnumber the verbatim copies. So a scan over
+the copies would itself be the incomplete gate, reporting a clean result for
+every site it did not read — and which sites those are is not something this
+paragraph could be trusted to keep current, which is the objection it would be
+built to answer. What cannot drift from the gate is not prose at all, but the
+remedies `verify-suite-coverage.R` prints when it fires (#220).
+
 While that holds, the `backend` jobs cover the whole suite by construction —
 each installs one backend, plus whatever companions its entry declares, and
 withholds everything else, so between them they execute every test that

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -588,8 +588,8 @@ under CRAN semantics, so they run only in those jobs.
 
 What the seam does not ask is that a test keep its title: no job names the
 tests it executes (#93). Coverage is structural instead, resting on a policy
-about what a test may require — no test may require more than one member of
-`optional_backends()` — rather than on a list of what each job must run.
+about what a test may require, whose one home is `AGENTS.md`'s *Release matrix*
+section, rather than on a list of what each job must run.
 
 `AGENTS.md` is the operational reference for the jobs, the verifier scripts,
 and the sites registering an optional Suggest has to touch.


### PR DESCRIPTION
Closes #220.

The policy sentence stood in three documents with nothing holding them in step.
That is the shape of the defect #204 fixed — a document describing a gate and
free to disagree with it — but the remedy #220 reached for first, a scan
asserting the copies agree, does not survive its own inventory.

## Why not a scan

Besides the three normative statements, the rule is restated as a consequence
wherever the coverage argument is made: in `release-matrix.yaml`'s header, in
`verify-suite-coverage.R`'s header both above and below its own quotation, in
the two remedies that script prints, in `AGENTS.md` immediately after the
blockquote, and in tests that state it for their own sections. Those
restatements outnumber the verbatim copies, so a scan over the copies would
itself be the incomplete gate — the illusion of coverage
`verify-matrix-coverage.R` was deleted for in #93.

It could not live in `tests/` either. `AGENTS.md`, `design/`, and `.github/`
are all `.Rbuildignore`d, so a testthat test reaches none of them under
`R CMD check` and would either skip — which `verify-backend.R` fails a job over
— or stop on the empty set and fail every tarball check.

## What this does instead

The remedy the repository already uses for a fact with one home: name it.

- **`AGENTS.md`** holds the sentence and now says so.
- **`design/architecture.md`** keeps the architectural property — coverage rests
  on a policy about what a test may require — and drops the restatement of the
  rule's text. This is what #221 intended when it asked for the policy "in the
  wording `AGENTS.md` and `verify-suite-coverage.R` already share rather than in
  a third one of its own"; re-casing it inline is what made it a third one.
- **`verify-suite-coverage.R`** keeps its verbatim quotation, because the
  argument its header makes cannot be read without the sentence in front of it,
  and names the home in a clause.

Both forms are already house style, in `test-branch-union.R` and
`test-margin-order.R` respectively. The consequence restatements are untouched:
each states the mechanism from its own file's vantage, which is what those
files are for.

## Review

Two rounds, two axes each. Review caught the new paragraph doing the thing it
forbids, twice — both fixed in the commit.

The first draft justified the absent gate by counting ("four further places",
"six sites it never read") and both numbers were wrong, because two
restatements inside `verify-suite-coverage.R` went uncounted. The defect is not
the arithmetic: `AGENTS.md` holds every gate to deriving rather than listing, on
the ground that a list "records a change rather than refusing one", and a
hand-maintained tally load-bearing for a decision reintroduces that failure one
level up. Replacing the tally with an enumeration of the sites was the same
defect in weaker form, so the paragraph now states only the relation and says
outright that which sites those are is not something it could keep current.
The second was the script header duplicating reasoning `AGENTS.md` already
carries.

The brief's own census is corrected in a comment on #220.

## Verification

- `Rscript .github/scripts/verify-suite-coverage.R` passes: 578 tests over 5
  single-backend configurations, 0 executing in 0 configurations.
- The change to that script is comments-only — no non-comment line differs — so
  its verdict cannot have moved.
- A verbatim grep for the policy sentence returns exactly two hits.
- No change under `tests/`, no new script under `.github/scripts/`.
