### PR TITLE
Record what every pluralizing diagnostic says today

### DIFF
--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -19,11 +19,13 @@
 # The pins already beside each site stay where they are. Most match a phrase
 # rather than a whole message, which is enough to assert that a caller reaches
 # the diagnostic -- a different question from what it says -- and which
-# survives the re-wording this file exists to make visible. Three are already
-# exact: the singular arms of the `.by` invariant, the summary-overwrite
-# refusal, and the grouping-helper refusal. Those three are recorded again
-# here, because a baseline with holes in it is one a reader has to reassemble
-# from five files before trusting it.
+# survives the re-wording this file exists to make visible. Two are already
+# identities: the singular arms of the `.by` invariant and of the
+# summary-overwrite refusal. A third, the grouping-helper refusal's singular
+# arm, matches its whole message but as a substring, so a re-wording fails it
+# while an addition to the end would not. All three are recorded again here,
+# because a baseline with holes in it is one a reader has to reassemble from
+# five files before trusting it.
 #
 # Each Package condition is reached through the public verb that raises it, so
 # a message that stops being reachable fails here rather than passing on an
@@ -35,10 +37,10 @@
 # `marginplyr_error` assertions next to the behaviour that raises them, paired
 # with the External-condition half, so that the ADR 0015 boundary stays
 # reviewable; collecting them here would be the single file that section rules
-# out. Nothing is lost, because an exact message identifies a condition more
-# narrowly than its class does. What the invariants assert is the absence of
-# that class, which is the promise their own sites make and which #224 asks for
-# by name.
+# out. Leaving them out loses nothing, because each of those assertions is
+# still at its own site, which is where the boundary is read. The invariants
+# assert the absence of that class rather than its presence; their own sites
+# assert it too, and #224 asks for it here by name.
 #
 # Plain expectations rather than snapshots: snapshots are skipped under CRAN
 # semantics, and these hold there too. Nothing here needs an optional backend,

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -6,17 +6,29 @@
 # dropped arm would read as an ordinary deletion; here the set is visible at
 # once, and a file-by-file re-authoring edits a contiguous block of it (#224).
 #
-# The regex pins already beside each site stay where they are. They assert that
-# a caller reaches the diagnostic, which is a different question from what it
-# says, and a phrase match survives the re-wording this file exists to make
-# visible.
+# The pins already beside each site stay where they are. Most match a phrase
+# rather than a whole message, which is enough to assert that a caller reaches
+# the diagnostic -- a different question from what it says -- and which
+# survives the re-wording this file exists to make visible. Three are already
+# exact: the singular arms of the `.by` invariant, the summary-overwrite
+# refusal, and the grouping-helper refusal. Those three are recorded again
+# here, because a baseline with holes in it is one a reader has to reassemble
+# from five files before trusting it.
 #
 # Each Package condition is reached through the public verb that raises it, so
 # a message that stops being reachable fails here rather than passing on an
 # internal call that production no longer performs. The two internal invariants
 # have no such path by construction -- that is what makes them invariants -- so
-# they are called directly, and the classification is asserted beside the
-# wording because ADR 0015 makes it part of what the site promises.
+# they are called directly.
+#
+# Only those two assert a condition class. `design/architecture.md` keeps the
+# `marginplyr_error` assertions next to the behaviour that raises them, paired
+# with the External-condition half, so that the ADR 0015 boundary stays
+# reviewable; collecting them here would be the single file that section rules
+# out. Nothing is lost, because an exact message identifies a condition more
+# narrowly than its class does. What the invariants assert is the absence of
+# that class, which is the promise their own sites make and which #224 asks for
+# by name.
 #
 # Plain expectations rather than snapshots: snapshots are skipped under CRAN
 # semantics, and these hold there too. Nothing here needs an optional backend,
@@ -76,7 +88,6 @@ test_that("the fixed `.by` label refusal pluralizes its column noun", {
     .grouping = rollup(grade),
     .margin_label = c(region = "A", grade = "A")
   ))
-  expect_s3_class(singular, "marginplyr_error")
   expect_identical(
     conditionMessage(singular),
     "`.margin_label` must not name fixed `.by` column `region`."
@@ -88,7 +99,6 @@ test_that("the fixed `.by` label refusal pluralizes its column noun", {
     .grouping = rollup(n),
     .margin_label = c(region = "A", grade = "A", n = "A")
   ))
-  expect_s3_class(plural, "marginplyr_error")
   expect_identical(
     conditionMessage(plural),
     "`.margin_label` must not name fixed `.by` columns `region`, `grade`."
@@ -102,14 +112,12 @@ test_that("the unknown label dimension refusal pluralizes its name noun", {
   }
 
   singular <- expect_error(operation(c(region = "A", u = "A")))
-  expect_s3_class(singular, "marginplyr_error")
   expect_identical(
     conditionMessage(singular),
     "`.margin_label` has unknown dimension name `u`."
   )
 
   plural <- expect_error(operation(c(region = "A", u = "A", v = "A")))
-  expect_s3_class(plural, "marginplyr_error")
   expect_identical(
     conditionMessage(plural),
     "`.margin_label` has unknown dimension names `u`, `v`."
@@ -135,7 +143,6 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
   }
 
   singular <- expect_error(operation(rollup(g)))
-  expect_s3_class(singular, "marginplyr_error")
   expect_identical(
     conditionMessage(singular),
     paste0(
@@ -146,7 +153,6 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
   )
 
   plural <- expect_error(operation(rollup(g, h)))
-  expect_s3_class(plural, "marginplyr_error")
   expect_identical(
     conditionMessage(plural),
     paste0(
@@ -159,9 +165,12 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
 
 # Both `kind` values are pinned, because the pluralized noun sits between words
 # the kind chooses and a re-authoring reads the whole sentence rather than the
-# branch. The last case is the builder's other label arm: labels that are not
-# all one value replace the quoted label with a plural subject and its own
-# verb, so it is the one place the plural spelling of that subject exists.
+# branch it came from. The mixed cases are the builder's other subject arm:
+# labels that are not all one value replace the quoted label with a plural
+# subject carrying its own verb, and under the declared kind a second noun
+# pluralizes with it. That arm exists under both kinds and is plural-only,
+# since two distinct label values need two columns, so both are recorded and
+# neither stands in for the other.
 test_that("the margin label collision pluralizes its grouping column noun", {
   declared <- data.frame(
     a = factor(c("All", "x")),
@@ -169,79 +178,63 @@ test_that("the margin label collision pluralizes its grouping column noun", {
     n = 1:2
   )
   observed <- data.frame(a = c("All", "x"), b = c("All", "y"), n = 1:2)
+  mixed <- c(a = "All", b = "y")
+  declare <- function(grouping, label) {
+    summarize_with_margins(
+      declared,
+      k = sum(n),
+      .grouping = grouping,
+      .margin_label = label
+    )
+  }
+  observe <- function(grouping, label) {
+    summarize_with_margins(
+      observed,
+      k = sum(n),
+      .grouping = grouping,
+      .margin_label = label,
+      .check_margin_label = TRUE
+    )
+  }
 
-  declared_singular <- expect_error(summarize_with_margins(
-    declared,
-    k = sum(n),
-    .grouping = rollup(a),
-    .margin_label = "All"
-  ))
-  expect_s3_class(declared_singular, "marginplyr_error")
   expect_identical(
-    conditionMessage(declared_singular),
+    conditionMessage(expect_error(declare(rollup(a), "All"))),
     paste0(
       "\"All\" is already a factor level in grouping column `a`. ",
       "Choose another `.margin_label`."
     )
   )
-
-  declared_plural <- expect_error(summarize_with_margins(
-    declared,
-    k = sum(n),
-    .grouping = rollup(a, b),
-    .margin_label = "All"
-  ))
-  expect_s3_class(declared_plural, "marginplyr_error")
   expect_identical(
-    conditionMessage(declared_plural),
+    conditionMessage(expect_error(declare(rollup(a, b), "All"))),
     paste0(
       "\"All\" is already a factor level in grouping columns `a`, `b`. ",
       "Choose another `.margin_label`."
     )
   )
-
-  observed_singular <- expect_error(summarize_with_margins(
-    observed,
-    k = sum(n),
-    .grouping = rollup(a),
-    .margin_label = "All",
-    .check_margin_label = TRUE
-  ))
-  expect_s3_class(observed_singular, "marginplyr_error")
   expect_identical(
-    conditionMessage(observed_singular),
+    conditionMessage(expect_error(declare(rollup(a, b), mixed))),
+    paste0(
+      "Margin labels are already factor levels in grouping columns `a`, ",
+      "`b`. Choose another `.margin_label`."
+    )
+  )
+
+  expect_identical(
+    conditionMessage(expect_error(observe(rollup(a), "All"))),
     paste0(
       "\"All\" is already present in grouping column `a`. ",
       "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
     )
   )
-
-  observed_plural <- expect_error(summarize_with_margins(
-    observed,
-    k = sum(n),
-    .grouping = rollup(a, b),
-    .margin_label = "All",
-    .check_margin_label = TRUE
-  ))
-  expect_s3_class(observed_plural, "marginplyr_error")
   expect_identical(
-    conditionMessage(observed_plural),
+    conditionMessage(expect_error(observe(rollup(a, b), "All"))),
     paste0(
       "\"All\" is already present in grouping columns `a`, `b`. ",
       "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
     )
   )
-
-  mixed_plural <- expect_error(summarize_with_margins(
-    observed,
-    k = sum(n),
-    .grouping = rollup(a, b),
-    .margin_label = c(a = "All", b = "y"),
-    .check_margin_label = TRUE
-  ))
-  expect_s3_class(mixed_plural, "marginplyr_error")
   expect_identical(
-    conditionMessage(mixed_plural),
+    conditionMessage(expect_error(observe(rollup(a, b), mixed))),
     paste0(
       "Margin labels are already present in grouping columns `a`, `b`. ",
       "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
@@ -257,7 +250,6 @@ test_that("the grouping helper refusal pluralizes its noun and its verb", {
     k = grouping_id(nowhere),
     .grouping = rollup(region)
   ))
-  expect_s3_class(singular, "marginplyr_error")
   expect_identical(
     conditionMessage(singular),
     "Column `nowhere` is not part of `.by` or `.grouping`."
@@ -268,7 +260,6 @@ test_that("the grouping helper refusal pluralizes its noun and its verb", {
     k = grouping_id(nowhere, nor),
     .grouping = rollup(region)
   ))
-  expect_s3_class(plural, "marginplyr_error")
   expect_identical(
     conditionMessage(plural),
     "Columns `nowhere`, `nor` are not part of `.by` or `.grouping`."
@@ -283,7 +274,6 @@ test_that("the summary overwrite refusal pluralizes its column noun", {
     region = sum(n),
     .grouping = rollup(region, grade)
   ))
-  expect_s3_class(singular, "marginplyr_error")
   expect_identical(
     conditionMessage(singular),
     "Summary results cannot overwrite grouping column `region`."
@@ -295,7 +285,6 @@ test_that("the summary overwrite refusal pluralizes its column noun", {
     grade = sum(n),
     .grouping = rollup(region, grade)
   ))
-  expect_s3_class(plural, "marginplyr_error")
   expect_identical(
     conditionMessage(plural),
     "Summary results cannot overwrite grouping columns `region`, `grade`."

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -1,10 +1,20 @@
-# The byte-exact record of every diagnostic that pluralizes its own noun, both
-# arms of each. It is one file rather than an addition to each site's own test
-# file because these pins are one artifact with one purpose: #223 re-authors
-# these messages in the cli idiom file by file, and each of those PRs diffs
-# against this baseline. Spread across the five files that raise them, a
-# dropped arm would read as an ordinary deletion; here the set is visible at
-# once, and a file-by-file re-authoring edits a contiguous block of it (#224).
+# The byte-exact record of the eight diagnostics that pluralize a noun by
+# suffixing it, both arms of each. It is one file rather than an addition to
+# each site's own test file because these pins are one artifact with one
+# purpose: #223 re-authors these messages in the cli idiom file by file, and
+# each of those PRs diffs against this baseline. Spread across the five files
+# that raise them, a dropped arm would read as an ordinary deletion; here the
+# set is visible at once, and a file-by-file re-authoring edits a contiguous
+# block of it (#224).
+#
+# Suffixing is what bounds the set, not pluralizing, and two diagnostics
+# pluralize by another construction. `abort_selection_rename()` picks between a
+# singular and a plural noun held in a labels list; all four of its messages
+# are already pinned exactly in `test-grouping-plan.R`, so recording them again
+# would buy nothing. The duplicate-grouping-set refusal switches a whole phrase
+# rather than suffixing one, and only its singular arm is pinned anywhere --
+# that gap is #225, kept separate because its plural arm needs a specification
+# shape none of these eight do.
 #
 # The pins already beside each site stay where they are. Most match a phrase
 # rather than a whole message, which is enough to assert that a caller reaches
@@ -197,44 +207,54 @@ test_that("the margin label collision pluralizes its grouping column noun", {
     )
   }
 
+  declared_singular <- expect_error(declare(rollup(a), "All"))
   expect_identical(
-    conditionMessage(expect_error(declare(rollup(a), "All"))),
+    conditionMessage(declared_singular),
     paste0(
       "\"All\" is already a factor level in grouping column `a`. ",
       "Choose another `.margin_label`."
     )
   )
+
+  declared_plural <- expect_error(declare(rollup(a, b), "All"))
   expect_identical(
-    conditionMessage(expect_error(declare(rollup(a, b), "All"))),
+    conditionMessage(declared_plural),
     paste0(
       "\"All\" is already a factor level in grouping columns `a`, `b`. ",
       "Choose another `.margin_label`."
     )
   )
+
+  declared_mixed <- expect_error(declare(rollup(a, b), mixed))
   expect_identical(
-    conditionMessage(expect_error(declare(rollup(a, b), mixed))),
+    conditionMessage(declared_mixed),
     paste0(
       "Margin labels are already factor levels in grouping columns `a`, ",
       "`b`. Choose another `.margin_label`."
     )
   )
 
+  observed_singular <- expect_error(observe(rollup(a), "All"))
   expect_identical(
-    conditionMessage(expect_error(observe(rollup(a), "All"))),
+    conditionMessage(observed_singular),
     paste0(
       "\"All\" is already present in grouping column `a`. ",
       "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
     )
   )
+
+  observed_plural <- expect_error(observe(rollup(a, b), "All"))
   expect_identical(
-    conditionMessage(expect_error(observe(rollup(a, b), "All"))),
+    conditionMessage(observed_plural),
     paste0(
       "\"All\" is already present in grouping columns `a`, `b`. ",
       "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
     )
   )
+
+  observed_mixed <- expect_error(observe(rollup(a, b), mixed))
   expect_identical(
-    conditionMessage(expect_error(observe(rollup(a, b), mixed))),
+    conditionMessage(observed_mixed),
     paste0(
       "Margin labels are already present in grouping columns `a`, `b`. ",
       "Choose another `.margin_label` or set `.check_margin_label = FALSE`."

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -1,0 +1,303 @@
+# The byte-exact record of every diagnostic that pluralizes its own noun, both
+# arms of each. It is one file rather than an addition to each site's own test
+# file because these pins are one artifact with one purpose: #223 re-authors
+# these messages in the cli idiom file by file, and each of those PRs diffs
+# against this baseline. Spread across the five files that raise them, a
+# dropped arm would read as an ordinary deletion; here the set is visible at
+# once, and a file-by-file re-authoring edits a contiguous block of it (#224).
+#
+# The regex pins already beside each site stay where they are. They assert that
+# a caller reaches the diagnostic, which is a different question from what it
+# says, and a phrase match survives the re-wording this file exists to make
+# visible.
+#
+# Each Package condition is reached through the public verb that raises it, so
+# a message that stops being reachable fails here rather than passing on an
+# internal call that production no longer performs. The two internal invariants
+# have no such path by construction -- that is what makes them invariants -- so
+# they are called directly, and the classification is asserted beside the
+# wording because ADR 0015 makes it part of what the site promises.
+#
+# Plain expectations rather than snapshots: snapshots are skipped under CRAN
+# semantics, and these hold there too. Nothing here needs an optional backend,
+# so every configuration of the release matrix executes all of it.
+
+test_that("the selection proxy invariant pluralizes its column noun", {
+  data <- data.frame(region = "East", units = 1)
+
+  singular <- expect_error(proxy_columns(data, c("region", "absent")))
+  expect_false(inherits(singular, "marginplyr_error"))
+  expect_identical(
+    conditionMessage(singular),
+    "The selection proxy has no column `absent`."
+  )
+
+  plural <- expect_error(
+    proxy_columns(data, c("region", "absent", "missing"))
+  )
+  expect_false(inherits(plural, "marginplyr_error"))
+  expect_identical(
+    conditionMessage(plural),
+    "The selection proxy has no columns `absent`, `missing`."
+  )
+})
+
+test_that("the unknown `.by` invariant pluralizes its column noun", {
+  compile <- function(by) {
+    compile_grouping_spec(
+      rollup(region),
+      "region",
+      .by = by,
+      duplicates_choices = margin_duplicates_choices
+    )
+  }
+
+  singular <- expect_error(compile("nope"))
+  expect_false(inherits(singular, "marginplyr_error"))
+  expect_identical(
+    conditionMessage(singular),
+    "Unknown `.by` column `nope`."
+  )
+
+  plural <- expect_error(compile(c("nope", "nor")))
+  expect_false(inherits(plural, "marginplyr_error"))
+  expect_identical(
+    conditionMessage(plural),
+    "Unknown `.by` columns `nope`, `nor`."
+  )
+})
+
+test_that("the fixed `.by` label refusal pluralizes its column noun", {
+  data <- data.frame(region = "E", grade = "A", n = 1)
+
+  singular <- expect_error(expand_with_margins(
+    data,
+    .by = region,
+    .grouping = rollup(grade),
+    .margin_label = c(region = "A", grade = "A")
+  ))
+  expect_s3_class(singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(singular),
+    "`.margin_label` must not name fixed `.by` column `region`."
+  )
+
+  plural <- expect_error(expand_with_margins(
+    data,
+    .by = c(region, grade),
+    .grouping = rollup(n),
+    .margin_label = c(region = "A", grade = "A", n = "A")
+  ))
+  expect_s3_class(plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(plural),
+    "`.margin_label` must not name fixed `.by` columns `region`, `grade`."
+  )
+})
+
+test_that("the unknown label dimension refusal pluralizes its name noun", {
+  data <- data.frame(region = "E", grade = "A", n = 1)
+  operation <- function(label) {
+    expand_with_margins(data, .grouping = rollup(region), .margin_label = label)
+  }
+
+  singular <- expect_error(operation(c(region = "A", u = "A")))
+  expect_s3_class(singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(singular),
+    "`.margin_label` has unknown dimension name `u`."
+  )
+
+  plural <- expect_error(operation(c(region = "A", u = "A", v = "A")))
+  expect_s3_class(plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(plural),
+    "`.margin_label` has unknown dimension names `u`, `v`."
+  )
+})
+
+test_that("the NA-level refusal pluralizes its grouping column noun", {
+  na_factor <- function(x) {
+    factor(x, levels = c(unique(x[!is.na(x)]), NA), exclude = NULL)
+  }
+  data <- data.frame(
+    g = na_factor(c("a", NA)),
+    h = na_factor(c("p", NA)),
+    n = 1:2
+  )
+  operation <- function(grouping) {
+    summarize_with_margins(
+      data,
+      k = sum(n),
+      .grouping = grouping,
+      .margin_label = NA_character_
+    )
+  }
+
+  singular <- expect_error(operation(rollup(g)))
+  expect_s3_class(singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(singular),
+    paste0(
+      "`NA_character_` is already a factor level in grouping column `g`. ",
+      "Use `NULL` for a typed-missing Margin label while preserving the NA ",
+      "level."
+    )
+  )
+
+  plural <- expect_error(operation(rollup(g, h)))
+  expect_s3_class(plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(plural),
+    paste0(
+      "`NA_character_` is already a factor level in grouping columns `g`, ",
+      "`h`. Use `NULL` for a typed-missing Margin label while preserving ",
+      "the NA level."
+    )
+  )
+})
+
+# Both `kind` values are pinned, because the pluralized noun sits between words
+# the kind chooses and a re-authoring reads the whole sentence rather than the
+# branch. The last case is the builder's other label arm: labels that are not
+# all one value replace the quoted label with a plural subject and its own
+# verb, so it is the one place the plural spelling of that subject exists.
+test_that("the margin label collision pluralizes its grouping column noun", {
+  declared <- data.frame(
+    a = factor(c("All", "x")),
+    b = factor(c("All", "y")),
+    n = 1:2
+  )
+  observed <- data.frame(a = c("All", "x"), b = c("All", "y"), n = 1:2)
+
+  declared_singular <- expect_error(summarize_with_margins(
+    declared,
+    k = sum(n),
+    .grouping = rollup(a),
+    .margin_label = "All"
+  ))
+  expect_s3_class(declared_singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(declared_singular),
+    paste0(
+      "\"All\" is already a factor level in grouping column `a`. ",
+      "Choose another `.margin_label`."
+    )
+  )
+
+  declared_plural <- expect_error(summarize_with_margins(
+    declared,
+    k = sum(n),
+    .grouping = rollup(a, b),
+    .margin_label = "All"
+  ))
+  expect_s3_class(declared_plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(declared_plural),
+    paste0(
+      "\"All\" is already a factor level in grouping columns `a`, `b`. ",
+      "Choose another `.margin_label`."
+    )
+  )
+
+  observed_singular <- expect_error(summarize_with_margins(
+    observed,
+    k = sum(n),
+    .grouping = rollup(a),
+    .margin_label = "All",
+    .check_margin_label = TRUE
+  ))
+  expect_s3_class(observed_singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(observed_singular),
+    paste0(
+      "\"All\" is already present in grouping column `a`. ",
+      "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+    )
+  )
+
+  observed_plural <- expect_error(summarize_with_margins(
+    observed,
+    k = sum(n),
+    .grouping = rollup(a, b),
+    .margin_label = "All",
+    .check_margin_label = TRUE
+  ))
+  expect_s3_class(observed_plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(observed_plural),
+    paste0(
+      "\"All\" is already present in grouping columns `a`, `b`. ",
+      "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+    )
+  )
+
+  mixed_plural <- expect_error(summarize_with_margins(
+    observed,
+    k = sum(n),
+    .grouping = rollup(a, b),
+    .margin_label = c(a = "All", b = "y"),
+    .check_margin_label = TRUE
+  ))
+  expect_s3_class(mixed_plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(mixed_plural),
+    paste0(
+      "Margin labels are already present in grouping columns `a`, `b`. ",
+      "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+    )
+  )
+})
+
+test_that("the grouping helper refusal pluralizes its noun and its verb", {
+  data <- data.frame(region = "E", grade = "A", n = 1)
+
+  singular <- expect_error(summarize_with_margins(
+    data,
+    k = grouping_id(nowhere),
+    .grouping = rollup(region)
+  ))
+  expect_s3_class(singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(singular),
+    "Column `nowhere` is not part of `.by` or `.grouping`."
+  )
+
+  plural <- expect_error(summarize_with_margins(
+    data,
+    k = grouping_id(nowhere, nor),
+    .grouping = rollup(region)
+  ))
+  expect_s3_class(plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(plural),
+    "Columns `nowhere`, `nor` are not part of `.by` or `.grouping`."
+  )
+})
+
+test_that("the summary overwrite refusal pluralizes its column noun", {
+  data <- data.frame(region = "E", grade = "A", n = 1)
+
+  singular <- expect_error(summarize_with_margins(
+    data,
+    region = sum(n),
+    .grouping = rollup(region, grade)
+  ))
+  expect_s3_class(singular, "marginplyr_error")
+  expect_identical(
+    conditionMessage(singular),
+    "Summary results cannot overwrite grouping column `region`."
+  )
+
+  plural <- expect_error(summarize_with_margins(
+    data,
+    region = sum(n),
+    grade = sum(n),
+    .grouping = rollup(region, grade)
+  ))
+  expect_s3_class(plural, "marginplyr_error")
+  expect_identical(
+    conditionMessage(plural),
+    "Summary results cannot overwrite grouping columns `region`, `grade`."
+  )
+})


### PR DESCRIPTION
Closes #224. Phase 1 of #223.

Eight message builders choose a singular or plural spelling from the length of
the vector they report. The singular arm was pinned at most of them and the
plural arm at one, so #223's re-authoring would have diffed against an
assumption for the rest. This records what all sixteen arms say today, before
anything moves.

## What it pins

One new file, `tests/testthat/test-diagnostic-pluralization.R`. No file under
`R/` changes — this ticket only writes down what the messages already say.

Twenty message pins, all `expect_identical(conditionMessage(...), ...)`, over
the eight builders #206 enumerated. The margin-label collision builder gets six
rather than two: it branches on `kind` and on whether the labels are all one
value as well as on the count, and the reachable space is six — labels that
differ need two columns, so the mixed-singular cells cannot occur.

## Two choices worth review

**Package conditions are reached through the public verb that raises them.** A
direct internal call would pin the text just as well, but it would keep passing
after the message stopped being reachable. The two internal invariants have no
public path by construction, so they are called directly, and they are the only
sites here that assert a condition class — ADR 0015 makes the absence of
`marginplyr_error` part of what they promise, and #224 asks for it by name.

**No Package-condition class assertions.** An earlier revision collected
nineteen of them, which `design/architecture.md` § Test seams rules out:
"Package conditions are not tested in one file. Each module's tests assert the
`marginplyr_error` class next to the behavior that raises it … Keeping the two
halves adjacent is what makes the boundary in ADR 0015 reviewable." They are
gone; each one is still at its own site, which is where the boundary is read.

## Gates

| | |
|---|---|
| Full suite | 586 tests, 0 failed, 0 skipped |
| New file under CRAN semantics | 44 expectations, all pass |
| `verify-suite-coverage.R` | every test executes in ≥1 backend configuration |
| `lintr` | clean |

Nothing here needs an optional backend, so every configuration of the release
matrix executes all of it.

## Left out on purpose

The set is bounded by *suffixing*, not by pluralizing. Two other diagnostics
pluralize by a different construction:

- `abort_selection_rename()` picks between a singular and a plural noun held in
  a labels list. All four of its messages are already pinned byte-exactly in
  `test-grouping-plan.R`, so there was nothing to add.
- The duplicate-grouping-set refusal switches a whole phrase rather than
  suffixing one, and only its singular arm is pinned anywhere. That gap is
  **#225**, kept separate because reaching its plural arm needs a specification
  shape none of these eight need.

The file's header says both of these, so the next reader does not have to work
out which exclusion is a gap and which is already covered.
