### PR TITLE
Pin the plural arm of the duplicate-grouping-set refusal

### DIFF
--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -12,9 +12,9 @@
 # singular and a plural noun held in a labels list; all four of its messages
 # are already pinned exactly in `test-grouping-plan.R`, so recording them again
 # would buy nothing. The duplicate-grouping-set refusal switches a whole phrase
-# rather than suffixing one, and only its singular arm is pinned anywhere --
-# that gap is #225, kept separate because its plural arm needs a specification
-# shape none of these eight do.
+# rather than suffixing one; both of its arms are pinned in
+# `test-grouping-plan.R`, the plural one separately from this file because it
+# needs a specification shape none of these eight do (#225).
 #
 # The pins already beside each site stay where they are. Most match a phrase
 # rather than a whole message, which is enough to assert that a caller reaches

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -677,6 +677,45 @@ test_that("duplicate grouping sets have explicit policies", {
   expect_identical(kept$set_ids, 1:2)
 })
 
+# This diagnostic does not pluralize by suffixing a noun the way the eight
+# builders enumerated in #206 do: it switches a whole phrase on the number of
+# *groups* of duplicated positions, so the arms share no wording to pin once.
+# The singular arm is pinned by "compile_grouping_spec() reads a narrowed
+# duplicates vocabulary" below, which asserts it for the vocabulary's sake
+# rather than the phrase's; the plural arm has this test, and nothing else in
+# the suite tells the arms apart — every other expectation reaching this
+# diagnostic matches the prefix alone, which both arms satisfy (#225).
+test_that("duplicated grouping sets in more than one group name their groups", {
+  # Two *distinct* duplicated sets rather than one set duplicated twice, which
+  # is what makes `split()` return more than one group and selects the plural
+  # arm.
+  spec <- grouping_sets(
+    grouping_set(a),
+    grouping_set(b),
+    grouping_set(a),
+    grouping_set(b)
+  )
+
+  duplicated <- expect_error(
+    compile_grouping_spec(
+      spec,
+      c("a", "b"),
+      duplicates_choices = margin_duplicates_choices
+    )
+  )
+  expect_s3_class(duplicated, "marginplyr_error")
+  # The groups arrive in `split()`'s order, which is by key and not by first
+  # position, so `2, 4` precedes `1, 3`. This records what the code emits;
+  # whether that ordering is what a reader wants belongs to #223.
+  expect_identical(
+    conditionMessage(duplicated),
+    paste0(
+      "Duplicate grouping sets were produced at position groups 2, 4; 1, 3. ",
+      "Use `.duplicates = \"drop\"` or `\"keep\"`."
+    )
+  )
+})
+
 test_that("invalid or ambiguous specifications fail early", {
   expect_error(
     compile_grouping_spec(


### PR DESCRIPTION
Closes #225. Part of #223, and the arm #224 deliberately left out: #224's scope is the eight suffix-pluralizing builders #206 enumerated, and this one pluralizes by a different construction.

## What this pins

The duplicate-grouping-set refusal switches a whole phrase on the number of *groups* of duplicated positions rather than suffixing a noun, so its two arms share no wording one pin could cover. The singular arm has had a byte-exact pin since #110 recorded the narrowed `.duplicates` vocabulary; the plural arm had none. The seven other expectations reaching this diagnostic match the prefix `"Duplicate grouping sets"` alone, which both arms satisfy, so none of them told the arms apart.

```
Duplicate grouping sets were produced at position groups 2, 4; 1, 3. Use `.duplicates = "drop"` or `"keep"`.
```

Reaching that arm needs two *distinct* duplicated sets rather than one set duplicated twice — the specification shape none of the eight in `test-diagnostic-pluralization.R` have, and the reason this pin lives in `test-grouping-plan.R` instead. The compiler is called directly, as the duplicate-policy test above it is: no data frame, no backend, so the test runs in every `verify-suite-coverage.R` configuration.

The expectation records the order `split()` emits — by key, so `2, 4` precedes `1, 3`. That is what the code emits today; whether the ordering is desirable belongs to #223, as does any wording change.

`test-diagnostic-pluralization.R`'s header recorded this arm as pinned nowhere and named #225 as the open gap, so this closes that too.

## Checks

- `devtools::test()` — `FAIL 0 | WARN 0 | SKIP 0 | PASS 4732`
- `lintr::lint_package()` after `pkgload::load_all()` — no lints
- `Rscript .github/scripts/verify-suite-coverage.R` — `Verified`, same verdict as before; the new test lands in the 5-configuration bucket
- Mutation check: changing `" groups "` to `" group "` in `R/grouping-plan.R` fails this test and only this test, so the pin is load-bearing and the seven prefix expectations do not stand in for it

No file under `R/` changes.

## Noted, not addressed here

- #225's body says "Six other tests match the diagnostic by the prefix"; the count is seven. The ticket text is wrong, not the code.
- `.github/scripts/verify-site.R:280` also pins the singular arm's phrasing, outside the suite. #223's re-authoring reaches it.