### PR TITLE
Record the cli idiom diagnostics are authored in, and what rendering costs

### DIFF
--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -1,0 +1,255 @@
+# Author diagnostics in the cli idiom
+
+Every Package condition marginplyr raises is written as a short refusal plus
+`i` bullets, with cli's inline markup naming what each part of the sentence is,
+and signalled through `cli::cli_abort()`. `abort_marginplyr()` remains the only
+constructor and still owns the class and the blamed call, exactly as ADR 0015
+says; what changes is how the message is built, not what carries it. The
+adoption is a formatting decision and nothing else.
+
+The boundary of the change is that sentence. `abort_marginplyr()` becomes the
+interpolating entry point — it wraps `cli::cli_abort()` with
+`.envir = rlang::caller_env()` — so a call site passes an unexpanded template
+rather than a string it assembled itself. Three paths keep the flat form they
+had: SQL glue templates, which are a different engine that happens to share
+`{}`; bare `stop()` invariants, which ADR 0015 separates from Package
+conditions and which gain nothing from markup they will never render; and any
+sentence built by concatenating a caller's own text, for the reason in *Caller
+text is a value* below.
+
+`Config/marginplyr/cran-status` read `unpublished` when this was decided, which
+is what made it affordable. A diagnostic's exact text is part of what this
+package ships, so after publication these texts harden into something closer to
+a contract.
+
+The measurements this rests on are in
+`investigation/diagnostic-wrapping-under-rlang-and-cli.md`. They are cited
+rather than restated because each is a fact about rlang, cli, or testthat, and
+ages when one of those moves rather than when `R/` does.
+
+## The migration introduces wrapping, so a line is authored to survive it
+
+`rlang::abort()` wraps nothing. `cli_abort()` wraps at retrieval time, at
+whatever width the reader's session has. The diagnostics this package shipped
+were therefore unwrapped everywhere they appeared — including in the rendered
+vignettes, where `.github/scripts/verify-site.R` matches seven of them as
+`fixed = TRUE` substrings of the built HTML.
+
+So this is not a re-formatting whose cost is churn in pinned texts. It puts
+line breaks into shipped pages and into byte-exact pins where none existed.
+Three conditions are what an author writes against:
+
+1. The authored prose of a line, with interpolation excluded, fits in 80
+   columns.
+2. A part whose length the caller decides — a vector of column names, a list of
+   offered values — does not go in the main line. It goes alone in an `i`
+   bullet.
+3. No pin and no marker spans a wrap point. A marker is chosen from a run of
+   uninterpolated prose.
+
+Condition 2 is what makes the first one hold rather than merely being asked
+for. The fixed-`.by` label refusal —
+
+```text
+`.margin_label` must not name fixed `.by` columns `region`, `grade`.
+```
+
+— cannot be kept short by choosing shorter words, because its length is a
+function of how many columns the caller passed. Split into a refusal and a
+bullet carrying the columns, the refusal never wraps whatever arrives.
+
+Condition 3 is what keeps `verify-site.R`'s markers meaningful once condition 1
+stops being enough — which it does the moment a long interpolated vector pushes
+an otherwise short line past the margin.
+
+This is the whole of why the ticket that produced this ADR insisted the
+migration succeeds only as re-authoring. Transporting the existing long flat
+sentences into `cli_abort()` unchanged would satisfy the type system and break
+the site gate.
+
+## Every subject has one inline style
+
+| subject | style | renders as |
+| --- | --- | --- |
+| column or grouping-dimension name | `{.var}` | `` `region` `` |
+| argument name | `{.arg}` | `` `.margin_label` `` |
+| code fragment, assignment included | `{.code}` | `` `.duplicates = "error"` `` |
+| constructor or function | `{.fun}` | `` `rollup()` `` |
+| value the data holds | `{.val}` | `"All"` |
+
+`{.var}`, `{.arg}`, and `{.code}` were measured to render identical bytes for a
+character vector. Separating them is still the decision, because the
+alternative is not three styles collapsing into one — it is every site reaching
+for `{.code}`, which is the one that fits anything, and the table ceasing to
+say anything about what a sentence is made of.
+
+The `{.val}`/`{.code}` boundary is the one `R/margin-label.R`'s collision
+refusal already drew before there was a table: a spelling the caller types is
+`{.code}` — `NA_character_` is an R literal, not a value — while a value the
+data holds is `{.val}` — `"All"` is a factor level. Both renderings preserve
+the bytes that refusal shipped, which is the evidence the boundary was already
+being drawn correctly by hand.
+
+## Caller text is a value, never part of the template
+
+> Caller-derived text is always an interpolated value. It is never concatenated
+> into the template, and the template is always a literal in the source: no
+> computed template strings.
+
+cli interprets the template and not the values it interpolates, so a caller's
+braces are inert wherever this holds. A column named `` `a{b}` `` is legal and
+reaches most of the diagnostics in `R/`, so the hazard is not confined to any
+one module.
+
+That is why this is written as a rule about a practice rather than as an
+exclusion for the restatement machinery of ADR 0021 and ADR 0022. The
+restatement path splices an arbitrary caller string, so it is refused by the
+rule; stating it as "that module is excluded" would have carved out the one
+place the hazard had been noticed and left it live everywhere else.
+
+The same reading puts one line *into* scope that a module-shaped exclusion
+would have kept out. `report_branch_warnings()` writes marginplyr's own
+sentence — `N further grouping set{?s} raised this warning.` — and the only
+value it interpolates is an integer marginplyr counted. It moves to
+`cli::pluralize()` inside `rlang::format_error_bullets()`, which was measured
+byte-identical to the `sprintf()` and `if` it replaces. It gains no markup and
+no width dependence: `pluralize()` does not consult the width. ADR 0021's
+identity is computed when a warning is buffered, before this line is appended,
+so nothing about that contract moves.
+
+## Every singular/plural choice goes through cli's `{?}`
+
+No R branch spells a noun. `{?s}` covers the nine sites that suffix one,
+`{?is/are}` the one that also inflects a verb, and `{?a/b}` the two that switch
+a whole phrase or pick between two different nouns.
+
+The rule is stated over the construction rather than over a list of sites,
+because the complaint that started this work was that one idiom had been
+written out at eight of them. A rule permitting an `if` where `{?}` is
+awkward relocates that idiom rather than dissolving it, and leaves every
+phase-3 pull request deciding for itself whether its own branch is the
+permitted kind.
+
+## cli's vector defaults are adopted unchanged
+
+Serial `and`, `{.or}` where the vector is a list of alternatives, and the
+default 20-element truncation. So `` `a` and `b` ``, `` `a`, `b`, and `c` ``,
+and `` `a`, `b`, or `c` ``.
+
+Three conventions for joining a vector into a sentence were in use at once — a
+bare comma at more than twenty sites, a serial `", or "` in
+`format_grouping_constructors()`, and a bare `" or "` in the `.duplicates`
+offer beside it — so there was no existing spelling to preserve. Adopting the
+defaults converges them, and it is the choice that needs no override written at
+every site.
+
+Truncation is the half that loses information, and it is accepted because the
+subjects here are grouping dimensions, `.by` columns, and named arguments. A
+call reaching twenty of them has a systematic mistake rather than a list to
+work through, and the reader still sees the last two and the count. Writing
+`vec-trunc = Inf` would put a value in every message for a case no measurement
+suggests these diagnostics reach.
+
+## cli becomes an Import, with its own floor
+
+`cli (>= 3.4.0)` moves from Suggests to Imports. After this change every error
+path crosses it, which is direct use and not a promotion made to satisfy a
+check.
+
+The floor is a deliberate departure from #217, which decided that cli carried
+none, and the mechanism is what differs. That floor would have sat in a
+Suggests entry, where `marginplyr_suggest_available()` is the only reader and
+it is never asked about a package that cannot be absent — so the constraint
+really could never bind. An Imports floor is read by the installer. 3.4.0 is
+where cli's current `vec_sep`/`vec_last`/`vec_trunc` spellings arrived, and it
+is the highest version anything above needs.
+
+dplyr declares `cli (>= 3.6.2)`, so nothing extra installs while that holds.
+That is exactly the reason to write our own: `AGENTS.md`'s dependency-metadata
+rule is that another package's closure is a property of that package's
+metadata and can change without a commit here. The availability paragraph above
+`written_message_lines()` stops being true when this lands — cli is no longer
+the `DBI = FALSE` case — and is rewritten in the same commit. `DBI` itself
+still is that case, so the example in `AGENTS.md` stands.
+
+glue stays where it is and is not a diagnostics dependency. Its three
+load-bearing paths are the `across(.names =)` template expansion, rlang's
+`"{name}" :=` injection, and `cli::pluralize()` itself, which calls `glue()` at
+run time because cli only Suggests it. So "cli replaced glue, drop it" is
+answered before it is asked.
+
+## Two rules are gated; the third rests on a gate that already exists
+
+*Caller text is a value* and *every singular/plural choice goes through `{?}`*
+are both caught by one structural test, in the shape of `test-query-policy.R`:
+walk every `abort_marginplyr()` call in the loaded namespace and fail any whose
+message argument is not a literal in the source. A `paste0()`-assembled
+template and an `if`-spelled noun are the same violation seen from two sides,
+because neither can be written without computing the argument.
+
+The line-length conditions get no gate of their own, and that is a decision
+rather than an omission. Their failure mode is a marker that vanished across a
+wrap point, and `verify-site.R` already fails a build for a missing marker. A
+gate measuring the width of the literal alone would return clean for the case
+that actually breaks — a short authored line that a long interpolated vector
+pushed past the margin — which is the objection this repository makes to any
+assertion that cannot fire where the fault is.
+
+## Considered Options
+
+**Adopt cli's pluralization helper without re-authoring the messages** — the
+option #206 weighed, and the one this supersedes. Rejected because it dissolves
+the singular/plural idiom while leaving eighty-three long flat sentences that
+`cli_abort()` then wraps at retrieval time, putting breaks into rendered
+vignettes and pins for no gain the reader can see. The wrapping is not a side
+effect to absorb; it is the reason the sentences have to change shape.
+
+**Keep `abort_marginplyr()` taking an assembled string, and call
+`cli::format_inline()` at each site** — Rejected. It adds the same boilerplate
+at eighty-three sites and leaves each one responsible for pluralizing its own
+bullets, which is the shape *every singular/plural choice goes through `{?}`*
+exists to remove. It also removes the single point where the injection rule can
+be gated.
+
+**Override `vec-last` and `vec-trunc` to preserve the shipped spelling** —
+Rejected. There was no single shipped spelling to preserve, and an override
+written at every vector-bearing site is a second idiom written out repeatedly,
+which is the thing #206 objected to.
+
+**Exclude `R/conditions.R` as a module** — the form the originating ticket gave
+exclusion 1. Rejected because the hazard it names is splicing caller text, not
+the module's identity, and stating it that way both leaves the hazard
+unaddressed in the files that also splice and keeps `report_branch_warnings()`
+— which splices nothing — outside a rule it can satisfy exactly.
+
+## Consequences
+
+The byte-exact pins stay byte-exact and stay out of snapshots. Inside
+`test_that()`, `local_reproducible_output()` fixes the width at 80 and turns
+colours off, so `conditionMessage()` of a `cli_abort()` condition is
+deterministic across runs; retrieval-time formatting varies with a reader's
+session, not between two runs of the suite. Snapshots would be skipped under
+CRAN semantics, which is where `test-diagnostic-pluralization.R` says its
+sixteen arms hold, so moving them there would silently retire the baseline the
+re-authoring is measured against. What changes is that a re-authored text
+carries newlines the flat sentence did not.
+
+The phrase-level pins — the several hundred `expect_error()` and
+`expect_match()` patterns — need a whitespace-normalizing comparison, since a
+phrase can now be split by a wrap. `verify-site.R`'s marker matching needs the
+same, on top of condition 3 above.
+
+`marginplyr_error` survives, so the `must_error` hook and its twenty vignette
+chunks are untouched: `cli_abort()`'s `class` argument carries it through, and
+the hook reads the class chain rather than the text.
+
+`CONTEXT.md` is unchanged. Package condition, External condition, Condition
+context, and Repeated condition already say everything this decision needed to
+be written in, and an inline style table is an implementation decision rather
+than a term.
+
+The rules are enforced where *Two rules are gated* says and reviewed
+everywhere else. In particular, nothing checks that a re-authored diagnostic
+chose the right style from the table — `{.var}` and `{.code}` render alike, so
+a wrong choice is invisible until cli styles them differently, which is the
+respect in which this table is a convention held up by review.

--- a/investigation/diagnostic-wrapping-under-rlang-and-cli.md
+++ b/investigation/diagnostic-wrapping-under-rlang-and-cli.md
@@ -1,0 +1,210 @@
+# How marginplyr's diagnostics render under rlang and cli
+
+Investigated: 2026-08-19
+
+#223 decided to re-author every shipped diagnostic in the cli idiom and asked
+ADR 0023 to settle three things it left open: cli's vector-formatting defaults,
+the inline style each subject gets, and where the short-main-plus-bullets rule
+applies. Those are decisions, and the ADR owns them. This note records the
+measurements they were taken against, because every one of them is a fact about
+rlang, cli, testthat, or the rendered site rather than about marginplyr, and a
+fact of that kind ages when the outside world moves rather than when `R/` does.
+
+The measurement that reshaped the ticket is the first one below. #223 describes
+the migration as a re-formatting whose cost is retrieval-time wrapping. It is
+more than that: the diagnostics marginplyr shipped as of f724ea0 were not
+wrapped at all, so the migration introduces wrapping where none existed, into
+rendered vignettes and into byte-exact test pins alike.
+
+Environment: R 4.6.1 (2026-06-24), cli 3.6.6, rlang 1.3.0, testthat 3.3.2, on
+macOS. Every figure below was produced in that session, against the working
+tree at f724ea0.
+
+## rlang does not wrap a plain message; cli does
+
+The subject is the duplicate-grouping-set refusal exactly as
+`R/grouping-plan.R` built it, 96 characters:
+
+```text
+Duplicate grouping sets were produced at positions 3, 6. Use `.duplicates = "drop"` or `"keep"`.
+```
+
+At `width = 80`:
+
+| call | newlines in `conditionMessage()` |
+| --- | --- |
+| `rlang::abort(msg)` | 0 |
+| `cli::cli_abort(msg)` | 1 |
+
+cli breaks it after `Use`:
+
+```text
+Duplicate grouping sets were produced at positions 3, 6. Use
+`.duplicates = "drop"` or `"keep"`.
+```
+
+`abort_marginplyr()` reached `rlang::abort()` at f724ea0, so the left-hand
+column is what every one of the 83 sites produced.
+
+Bullets behave the same way, so the difference is not specific to a message
+vector's unnamed first element. At `width = 80`, a main line of 30 words and an
+`i` bullet of 30 words came back from `cli_abort()` as four rendered lines — the
+main line broken once, the bullet broken once with its continuation indented by
+two spaces. The same message vector through `rlang::abort()` came back as two
+lines: the main line and the bullet, each whole, the only newline being the one
+between them. rlang wraps nothing.
+
+## What the rendered site held
+
+`docs/vignettes/get_started.html`, as built before f724ea0, carried that same
+96-character message on one line:
+
+```text
+Duplicate grouping sets were produced at positions 3, 6. Use `.duplicates = "drop"` or `"keep"`.
+```
+
+No ANSI escapes, and no HTML elements inside the sentence. That is what lets
+`.github/scripts/verify-site.R` match
+`"Duplicate grouping sets were produced at positions"` as a `fixed = TRUE`
+substring.
+
+Its marker table was read for how many such markers there are. Seven of
+`get_started.html`'s quote a sentence this package authors. Two more quote the
+`Error in ...:` header, which rlang builds from the condition's `call` rather
+than from its message. `recipes.html`'s three quote errors raised by dplyr,
+purrr, and a join, which are External conditions and not this package's text at
+all.
+
+Two things were looked for and not found: any `<span>` inside a rendered
+diagnostic, and any escape sequence. So at that date the marker matching was
+insensitive to cli's styling because there was no styling to be insensitive to,
+not because the matching accounts for it.
+
+## testthat fixes the width and the colours
+
+Inside `test_that()`, `local_reproducible_output()` sets `getOption("width")` to
+80 and `cli::num_ansi_colors()` to 1. `getOption("cli.width")` was `NULL`, so
+cli falls back to `width`.
+
+The consequence is the one #223's re-pinning strategy turns on:
+`conditionMessage()` of a `cli_abort()` condition is deterministic inside the
+test suite. Retrieval-time formatting varies with the session, but not between
+two runs of the same test.
+
+## cli's inline vector defaults
+
+`cli::format_inline()`, cli 3.6.6, no options set:
+
+| template | result |
+| --- | --- |
+| `{.code {v}}`, 2 elements | `` `a` and `b` `` |
+| `{.code {v}}`, 3 elements | `` `a`, `b`, and `c` `` |
+| `{.val {v}}`, 3 elements | `"a", "b", and "c"` |
+| `{.var {v}}`, 3 elements | `` `a`, `b`, and `c` `` |
+| `{.arg {v}}`, 3 elements | `` `a`, `b`, and `c` `` |
+| `{.fun {v}}`, 3 elements | `` `a()`, `b()`, and `c()` `` |
+| `{.or {.code {v}}}`, 3 elements | `` `a`, `b`, or `c` `` |
+| `{.code {v}}`, 25 elements | 18 elements, `…`, then the last two |
+
+`{.var}`, `{.arg}`, and `{.code}` produced identical bytes for a character
+vector. They differ in what they mean to a reader of the source and in what a
+future cli could style differently, not in what a caller saw on 2026-08-19.
+
+The 25-element row is `vec_trunc`, whose default is 20: cli shows twenty of the
+twenty-five, as eighteen from the front and two from the back.
+
+Pluralization was measured on the same call:
+`"column{?s} {.code {v}} {?is/are} gone"` gave
+``column `a` is gone`` for one element and ``columns `a` and `b` are gone`` for
+two.
+
+## Neither `format_inline()` nor `pluralize()` wraps
+
+At `width = 40` and `cli.width = 40`, `cli::format_inline()` returned a
+30-word string with 0 newlines. `cli::pluralize()` behaved the same way. Only
+the block-level entry points — `cli_abort()` among them — consult the width.
+
+## `pluralize()` reproduces the shipped branch byte for byte
+
+`report_branch_warnings()` (`R/conditions.R`) built its count line at f724ea0
+with `sprintf()` and an `if`:
+
+```r
+sprintf(
+  "%d further grouping %s raised this warning.",
+  entry$count - 1L,
+  if (entry$count == 2L) "set" else "sets"
+)
+```
+
+`cli::pluralize("{n} further grouping set{?s} raised this warning.")` was
+measured against both arms:
+
+```text
+n = 3  ->  3 further grouping sets raised this warning.
+n = 1  ->  1 further grouping set raised this warning.
+```
+
+Identical to what the `sprintf()` form produces for the same counts. The two
+were measured to agree at `n = 0` as well — both give `sets` — although the
+shipped branch reaches that only through `entry$count == 1L`, which
+`report_branch_warnings()` never emits.
+
+## cli feature versions, and the floors already in the closure
+
+From cli's own `NEWS.md`, as installed at 3.6.6:
+
+- `format_inline()` and `cli_abort()` — cli 3.0.0.
+- the `vec_sep` / `vec_last` / `vec_trunc` spellings — cli 3.4.0. The entry
+  records that the older names still work.
+- `{.var}` — present by cli 2.5.0, which is where `NEWS.md` first shows it in
+  an example.
+
+Declared floors read from the installed packages' own `DESCRIPTION` on
+2026-08-19:
+
+| package | its cli floor |
+| --- | --- |
+| dplyr | `cli (>= 3.6.2)` |
+| dbplyr | `cli (>= 3.6.1)` |
+| tidyselect | `cli (>= 3.3.0)` |
+
+dplyr and tidyselect are marginplyr Imports, so the highest of these was
+already in the hard dependency closure. The highest version any feature above
+needs is 3.4.0.
+
+## The corpus these apply to
+
+Counted over `R/` at f724ea0: 83 `abort_marginplyr()` call sites, in eight
+files, led by `share.R` (33), `grouping-plan.R` (14), and `margin-label.R` (10).
+That matches #223's own inventory.
+
+Three different conventions for joining a vector into a sentence were in use at
+once:
+
+- a `paste0()` wrapping each element in backticks with `collapse = ", "` — a
+  bare comma, at more than twenty sites;
+- `format_grouping_constructors()` in `R/grouping-plan.R` — a serial `", or "`;
+- the `.duplicates` alternatives in the same file — `" or "` with no comma.
+
+`R/conditions.R`'s `report_branch_warnings()` is a ninth diagnostic that
+pluralizes a noun by suffixing it, beyond the eight
+`tests/testthat/test-diagnostic-pluralization.R` records under #224. Its two
+arms were pinned only as `expect_match(..., fixed = TRUE)` phrases in
+`test-execution-conditions.R` and as one line of
+`_snaps/execution-conditions.md`.
+
+`cli` was absent from `optional_suggest_spec()` in
+`tests/testthat/helper-optional-backends.R`, whose six entries were arrow,
+duckdb, dtplyr, data.table, RSQLite, and DBI. Nothing in the test suite's
+optional-package registry named it.
+
+## What was not established
+
+Whether a `cli_abort()` diagnostic rendered into a vignette acquires HTML
+markup inside the sentence, and at what width quarto renders it. The site
+measurement above establishes only what an *rlang* diagnostic produced, since
+that is what f724ea0 shipped. The first phase-3 pull request that re-authors a
+diagnostic quoted by a `verify-site.R` marker is where this gets answered; ADR
+0023's rule that a marker is chosen from a run of uninterpolated prose is
+written to survive either answer.


### PR DESCRIPTION
Phase 2 of #223, the half that is a decision rather than an edit: ADR 0023 and
the measurements it rests on. No `R/`, `tests/`, or `DESCRIPTION` change is in
here — the cli → Imports move, the `pluralize()` change, the normalization
helper, and the structural gate are the implementation half, and they belong in
a pull request that can be reviewed against a landed ADR.

`design/architecture.md` is deliberately untouched for the same reason. Its
Conditions chapter states what `R/conditions.R` does, and it gains a pointer to
ADR 0023 in the commit that makes the code match.

## What the ADR settles

The three questions #223 handed it — cli's `cli_vec` defaults, the inline style
table, and the boundary of the short-main-plus-bullets rule — and four more the
design session found underneath them.

- **Vector defaults are adopted unchanged**, `{.or}` included. `R/` held three
  different join conventions at once, so there was no shipped spelling to
  preserve.
- **The style table gains `{.var}`.** The ticket's list named
  `{.arg}`/`{.fun}`/`{.code}`/`{.val}`, but a column name is the most common
  subject in the corpus and cli has a style for exactly that. The three that
  render identical bytes are still separated, because the alternative is every
  site reaching for `{.code}`.
- **The line rules are stated as three checkable conditions**, and the reason
  they are load-bearing is the measurement below.
- **Caller text is a value, never part of the template.** Exclusion 1 becomes a
  consequence of that rule instead of a carve-out beside it.
- **`abort_marginplyr()` becomes the interpolating entry point.** ADR 0015's
  boundary does not move: it still owns class and call.
- **cli moves to Imports with `(>= 3.4.0)`**, a deliberate departure from #217.
- **Two rules get one structural gate; the line rules deliberately get none.**

## The measurement that reshaped the ticket

`rlang::abort()` does not wrap a plain string. `cli::cli_abort()` does. Against
the shipped duplicate-grouping-set refusal, 96 characters, at width 80:

```
rlang::abort(msg)     ->  0 newlines
cli::cli_abort(msg)   ->  1 newline
```

So the migration does not move line breaks around — it introduces them, into
rendered vignettes and byte-exact pins where none existed. That is why "short
main line wraps nowhere" is not style advice, and why seven of
`verify-site.R`'s markers are exposed to it.

## Corrections to #223 carried in here

Three, posted to the ticket in full at
https://github.com/sayuks/marginplyr/issues/223#issuecomment-5334971882:

1. The re-pinning strategy's "full texts move to snapshots" is retracted.
   #224's own file already refused it, and its reason holds — snapshots skip
   under CRAN semantics, where those sixteen arms are meant to hold.
2. Exclusion 1 is a rule about splicing, not about a module.
3. There is a ninth suffix-pluralizing diagnostic,
   `report_branch_warnings()`'s count line, and it is in scope rather than out
   of it.

## Checks

Nothing executable changed, so there is no local check to run beyond reading:
no roxygen source moved, so `document.yaml` has nothing to regenerate, and no
R code moved, so `lint_package()` sees the same package.
