### PR TITLE
Signal every Package condition through cli_abort()

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -19,6 +19,8 @@
 # succeeds while executing nothing. A page absent from `markers` still gets
 # everything above. A `markers` key naming no derived page is an error, so
 # renaming a vignette cannot quietly drop its markers instead of moving them.
+# A marker is matched with whitespace normalized on both sides, for the reason
+# `normalize_whitespace()` below records.
 
 source(".github/scripts/ci-helpers.R")
 
@@ -222,9 +224,45 @@ forbidden <- c(
   "union_all_with_margins"
 )
 
+# Runs of whitespace collapsed to one space, which is what makes a marker
+# insensitive to where a line broke.
+#
+# marginplyr signals through `cli::cli_abort()`, which wraps a diagnostic at
+# retrieval time to whatever width the renderer had (ADR 0023) -- so a sentence
+# this package authors reaches the page broken across lines, with a bullet's
+# continuation indented by two spaces, where the source holds one line. Markers
+# are also chosen from a run of uninterpolated prose, per that ADR's third line
+# condition, and the two are not the same protection: the choice keeps a marker
+# short enough that it is unlikely to span a break, and this keeps it matching
+# when it does anyway.
+#
+# Applied to both sides, so a marker written with a break in it matches too, and
+# so that nothing this accepts depends on how the marker was typed. It can only
+# widen what matches: a marker that matched the raw page still matches the
+# normalized one.
+#
+# `assert_no_match()`'s two scans below deliberately keep reading the raw page.
+# A wrap cannot split what either of them looks for: cli breaks a line at
+# whitespace and not inside a token -- measured at width 30 against a
+# 68-character path, which stayed whole on a line of its own -- and every
+# pattern written out here is whitespace-free, the home-directory one excluding
+# whitespace explicitly.
+#
+# The one pattern that is not written out here is the `\Q<home>\E` built below
+# from the checking machine's own home directory, and it carries a space when
+# that directory does. A wrap at that space would evade this scan, and
+# normalizing would close it. It is left raw because that gap is neither this
+# commit's nor cli's -- a rendered page has wrapped in a dozen other ways since
+# #99, and the pattern only carries a space on a machine whose home does --
+# while a leak scan reporting the text it matched is worth keeping exact.
+normalize_whitespace <- function(text) {
+  gsub("[[:space:]]+", " ", text)
+}
+
 assert_markers <- function(text, markers, page) {
+  text <- normalize_whitespace(text)
   absent <- markers[!vapply(
-    markers,
+    normalize_whitespace(markers),
     grepl,
     logical(1),
     x = text,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ BugReports: https://github.com/sayuks/marginplyr/issues
 Depends:
     R (>= 4.1.0)
 Imports:
+    cli (>= 3.4.0),
     dbplyr (>= 2.6.0),
     dplyr (>= 1.1.1),
     glue,
@@ -24,7 +25,6 @@ Imports:
     utils
 Suggests:
     arrow (>= 13.0.0),
-    cli,
     data.table,
     DBI,
     dtplyr (>= 1.3.2),

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -8,16 +8,65 @@
 # `class` adds a narrower subclass for handlers marginplyr itself needs. Those
 # subclasses stay implementation details; `marginplyr_error` is the promised
 # public class.
+#
+# It is also the interpolating entry point: `message` is a cli template a call
+# site passes unexpanded, and `.envir` is what lets cli evaluate the template's
+# `{}` expressions in that site's own frame. ADR 0023 is authoritative for the
+# idiom every template is authored in -- the short refusal plus `i` bullets, the
+# inline style each subject takes, `{?}` for every plural, and the rule that
+# caller-derived text is interpolated as a value and never concatenated into the
+# template. ADR 0015's boundary is untouched by that: this still owns the class
+# and the blamed call, and `cli_abort()` carries `marginplyr_error` through.
 abort_marginplyr <- function(message,
                              ...,
                              class = NULL,
                              call = rlang::caller_call()) {
-  rlang::abort(
+  cli::cli_abort(
     message = message,
     ...,
     class = c(class, "marginplyr_error"),
-    call = call
+    call = call,
+    .envir = rlang::caller_env()
   )
+}
+
+# Transitional. A site that has not been re-authored yet still assembles its own
+# string, and handing that string to `abort_marginplyr()` as a template is an
+# injection surface rather than a formatting choice: the braces cli would
+# interpret do not come from the source literals -- an AST walk over `R/` found
+# none -- they come from caller data, and a column named `a{b}` is legal.
+# Against an assembled string `cli_abort()` answers `Could not evaluate cli {}
+# expression` instead of the refusal, so every not-yet-re-authored site passes
+# through here, where the string is interpolated as a *value*, which is what
+# makes a caller's braces inert. Inert is not untouched: cli's formatter
+# collapses a run of whitespace inside a value as it does inside the template,
+# which is a property of signalling through `cli_abort()` at all rather than of
+# this sibling, and is recorded in ADR 0023's consequences.
+#
+# This exists to be deleted. #223's phase 3 re-authors `R/` file by file, and
+# each of those pull requests drops this for its own sites; the last one removes
+# the function. Until then the snapshot in `test-diagnostic-authoring.R` is the
+# visible measure of how much is left, and it is also what stops a new flat site
+# appearing -- the structural gate beside it cannot see one, because what it
+# reads is `abort_marginplyr()`'s own argument, which here is a literal.
+abort_marginplyr_flat <- function(message,
+                                  ...,
+                                  class = NULL,
+                                  call = rlang::caller_call()) {
+  # An invariant rather than a Package condition (ADR 0015), and the one thing
+  # interpolating a whole message as a value cannot express: cli joins a longer
+  # vector with a serial `and`, and it drops the names a message vector carries
+  # its bullet markers in, so either would be silently rewritten rather than
+  # refused. Both are checked, because they fail independently -- a one-element
+  # `c(i = "...")` keeps its length and loses its `i`. Every site here assembles
+  # one unnamed string; the structural gate cannot see this, because what it
+  # reads is the template above.
+  stopifnot(
+    is.character(message),
+    length(message) == 1L,
+    is.null(names(message))
+  )
+  abort_marginplyr("{message}", ..., class = class, call = call)
 }
 
 # The conditions a chain holds, outermost first: the condition given, then each
@@ -261,14 +310,17 @@ message_line_runs <- function(lines) {
 # therefore rendered plain -- accepted rather than worked around, and recorded
 # in ADR 0022 beside the wrapping such a line already loses.
 #
-# cli needs no availability guard and its Suggests entry carries no version.
-# It is an Import of both dplyr and tidyselect, so it is in the hard dependency
-# closure and can never be absent: the `DBI = FALSE` case in `AGENTS.md`'s
-# dependency metadata, as `share_dialect_can_be_asked()` is. `ansi_strip()`
-# learned `link` in cli 3.3.0, which is tidyselect's own floor and below
-# dplyr's, so a constraint written here could never bind -- and
-# `marginplyr_suggest_available()`, the only thing that reads one, is never
-# asked about a package that cannot be absent.
+# cli needs no availability guard: it is an Import of this package, and every
+# error path crosses it since `abort_marginplyr()` above signals through
+# `cli_abort()`. That is a change of mechanism rather than of fact -- it was
+# already unable to be absent as an Import of both dplyr and tidyselect, the
+# `DBI = FALSE` case in `AGENTS.md`'s dependency metadata that
+# `share_dialect_can_be_asked()` still is -- and the difference is that the
+# floor now binds. DESCRIPTION states `cli (>= 3.4.0)`, which the installer
+# reads, where a Suggests floor would have been read only by
+# `marginplyr_suggest_available()`, which is never asked about a package that
+# cannot be absent (ADR 0023). `ansi_strip()` learned `link` in cli 3.3.0, so
+# this reader is satisfied by anything the floor admits.
 written_message_lines <- function(lines, runs) {
   lines <- cli::ansi_strip(lines, link = TRUE)
   vapply(
@@ -282,6 +334,18 @@ written_message_lines <- function(lines, runs) {
 # saying how many further grouping sets raised it. The conditions are replayed
 # in the order the branches raised them, and the reported occurrence is the
 # first, so a plan that raises nothing new reads as one branch's report.
+#
+# The count line is marginplyr's own sentence and is inside ADR 0023's rule,
+# even though everything else this module writes is outside it: the only value
+# interpolated is an integer marginplyr counted, so there is no caller text to
+# splice and `{?s}` is what spells the plural. It gains no markup and no width
+# dependence -- `pluralize()` does not consult the width -- and it is measured
+# byte-identical to the `sprintf()` and the `if` it replaces, which is why no
+# pin moves with it. `format_error_bullets()` stays around it: this is appended
+# to a rendered message rather than raised, so the `i` has to be rendered here.
+#
+# ADR 0021's contract is untouched. The warning's identity is computed when a
+# branch buffers it, before this line exists.
 report_branch_warnings <- function(conditions) {
   for (entry in conditions$warnings) {
     cnd <- entry$condition
@@ -289,10 +353,8 @@ report_branch_warnings <- function(conditions) {
       cnd$message <- paste0(
         cnd$message,
         "\n",
-        rlang::format_error_bullets(c(i = sprintf(
-          "%d further grouping %s raised this warning.",
-          entry$count - 1L,
-          if (entry$count == 2L) "set" else "sets"
+        rlang::format_error_bullets(c(i = cli::pluralize(
+          "{entry$count - 1L} further grouping set{?s} raised this warning."
         )))
       )
     }

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -106,7 +106,7 @@
 #'   .margin_label = NULL
 #' )
 grouping_bit <- function(x) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     "`grouping_bit()` can only be used inside `summarize_with_margins()`."
   )
 }
@@ -114,7 +114,7 @@ grouping_bit <- function(x) {
 #' @rdname grouping_bit
 #' @export
 grouping_id <- function(...) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     "`grouping_id()` can only be used inside `summarize_with_margins()`."
   )
 }
@@ -234,16 +234,16 @@ grouping_helper_vars <- function(args, helper, plan) {
   # -- still reaches the arity diagnostic first, which is the one a caller
   # passing two of anything needs.
   if (any(vapply(carried, rlang::is_missing, logical(1)))) {
-    abort_marginplyr(not_a_column_message)
+    abort_marginplyr_flat(not_a_column_message)
   }
 
   if (identical(helper, "grouping_bit") && length(carried) != 1L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`grouping_bit()` requires exactly one column."
     )
   }
   if (identical(helper, "grouping_id") && length(carried) == 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`grouping_id()` requires at least one column."
     )
   }
@@ -255,24 +255,24 @@ grouping_helper_vars <- function(args, helper, plan) {
   # make the reordering above load-bearing for correctness rather than for which
   # diagnostic a caller reads.
   if (!all(vapply(carried, is_name_part, logical(1)))) {
-    abort_marginplyr(not_a_column_message)
+    abort_marginplyr_flat(not_a_column_message)
   }
 
   vars <- vapply(carried, as.character, character(1))
   if (anyDuplicated(vars)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf("`%s()` does not accept duplicate columns.", helper)
     )
   }
   if (identical(helper, "grouping_id") && length(vars) > 31L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`grouping_id()` supports at most 31 columns."
     )
   }
   allowed <- unique(c(plan$by, plan$dimensions))
   unknown <- setdiff(vars, allowed)
   if (length(unknown) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf(
         "Column%s %s %s not part of `.by` or `.grouping`.",
         if (length(unknown) == 1L) "" else "s",

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -3,7 +3,7 @@ validate_grouping_spec_early <- function(grouping_spec) {
     return(invisible(NULL))
   }
   if (!inherits(grouping_spec, "margin_grouping_spec")) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`.grouping` must be created with ",
         format_grouping_constructors(),
@@ -32,7 +32,7 @@ validate_grouping_spec_early <- function(grouping_spec) {
 }
 
 abort_invalid_grouping_spec <- function() {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     "Invalid grouping specification."
   )
 }
@@ -41,13 +41,13 @@ normalize_grouping_input <- function(.data, by_quo) {
   stopifnot(rlang::is_quosure(by_quo))
 
   if (inherits(.data, "rowwise_df")) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`rowwise()` input is not supported. Call `dplyr::ungroup()` first."
     )
   }
 
   if (!dplyr::group_by_drop_default(.data)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "Grouped input created with `.drop = FALSE` is not supported. ",
         "Call `dplyr::ungroup()` first."
@@ -57,7 +57,7 @@ normalize_grouping_input <- function(.data, by_quo) {
 
   input_groups <- dplyr::group_vars(.data)
   if (length(input_groups) > 0L && !rlang::quo_is_null(by_quo)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "Can't supply `.by` when `.data` is grouped. ",
         "Call `dplyr::ungroup()` first."
@@ -194,13 +194,13 @@ prepare_grouping_plan <- function(.data,
 }
 
 abort_empty_grouping_units <- function(kind) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     sprintf("`%s()` requires at least one dimension.", kind)
   )
 }
 
 abort_empty_composite <- function() {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     "An empty `grouping_set()` cannot be a composite dimension."
   )
 }
@@ -211,7 +211,7 @@ allow_empty_grouping <- function(spec) {
 
 validate_empty_grouping_sets <- function(spec) {
   if (length(spec$args) == 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`grouping_sets()` requires at least one set. Use `grouping_set()` ",
         "for the empty grouping set."
@@ -229,7 +229,7 @@ validate_empty_grouping_units <- function(spec) {
 }
 
 reject_nested_in_set <- function(parent, nested) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "A `grouping_set()` can contain columns, not another ",
       "grouping family."
@@ -243,7 +243,7 @@ allow_nested_grouping <- function(parent, nested) {
 
 validate_nested_grouping_units <- function(parent, nested) {
   if (!identical(nested$type, "set")) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf(
         paste0(
           "`%s()` only accepts columns or `grouping_set()` ",
@@ -436,7 +436,7 @@ compile_grouping_spec_impl <- function(.grouping,
 
   overlap <- intersect(.by, dimensions)
   if (length(overlap) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "Columns cannot appear in both `.by` and `.grouping`: ",
         paste0("`", overlap, "`", collapse = ", "),
@@ -466,7 +466,7 @@ compile_grouping_spec_impl <- function(.grouping,
     alternatives <- setdiff(duplicates_choices, .duplicates)
     offered <- paste0("`\"", alternatives, "\"`")
     offered[[1L]] <- paste0("`.duplicates = \"", alternatives[[1L]], "\"`")
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "Duplicate grouping sets were produced at position",
         if (length(groups) == 1L) "s " else " groups ",
@@ -801,7 +801,7 @@ is_grouping_spec_subscript <- function(cnd, label) {
 }
 
 abort_nested_grouping_spec <- function(label) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`", label, "` is a grouping specification, but a nested position ",
       "recognizes one only when it is a call to ",
@@ -863,7 +863,7 @@ by_rename_labels <- function() {
 }
 
 abort_selection_rename <- function(selected_names, source_names, labels) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "Can't rename ",
       if (length(selected_names) == 1L) labels$singular else labels$plural,

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -3,7 +3,7 @@ normalize_margin_label <- function(.margin_label) {
     return(NULL)
   }
   if (!is.character(.margin_label) || length(.margin_label) == 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`.margin_label` must be `NULL`, an unnamed character scalar, or a ",
         "named character vector."
@@ -13,24 +13,24 @@ normalize_margin_label <- function(.margin_label) {
   label_names <- names(.margin_label)
   if (is.null(label_names)) {
     if (length(.margin_label) != 1L) {
-      abort_marginplyr(
+      abort_marginplyr_flat(
         "An unnamed `.margin_label` must be a character vector of length 1."
       )
     }
     return(.margin_label)
   }
   if (anyNA(label_names)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`.margin_label` names must not be missing."
     )
   }
   if (any(!nzchar(label_names))) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`.margin_label` names must not be empty."
     )
   }
   if (anyDuplicated(label_names)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`.margin_label` names must not be duplicated."
     )
   }
@@ -62,7 +62,7 @@ validate_margin_label_names <- function(.margin_label, dimensions, by) {
   label_names <- names(.margin_label)
   fixed_names <- intersect(label_names, by)
   if (length(fixed_names) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`.margin_label` must not name fixed `.by` column",
         if (length(fixed_names) == 1L) " " else "s ",
@@ -73,7 +73,7 @@ validate_margin_label_names <- function(.margin_label, dimensions, by) {
   }
   unknown_names <- setdiff(label_names, dimensions)
   if (length(unknown_names) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`.margin_label` has unknown dimension name",
         if (length(unknown_names) == 1L) " " else "s ",
@@ -84,7 +84,7 @@ validate_margin_label_names <- function(.margin_label, dimensions, by) {
   }
   missing_names <- setdiff(dimensions, label_names)
   if (length(missing_names) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`.margin_label` must name every Margin dimension; missing ",
         paste0("`", missing_names, "`", collapse = ", "),
@@ -130,7 +130,7 @@ validate_margin_label <- function(.data,
     )
     na_level_cols <- vapply(na_level_cols, function(x) x$col, character(1))
     if (length(na_level_cols) > 0L) {
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(
           "`NA_character_` is already a factor level in grouping column",
           if (length(na_level_cols) == 1L) " " else "s ",
@@ -275,7 +275,7 @@ abort_margin_label_collision <- function(margin_labels, found, kind) {
   } else {
     "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
   }
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       label,
       verb,

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -140,7 +140,7 @@ match_margin_choice <- function(value, choices, arg_name) {
   if (rlang::is_string(value) && value %in% choices) {
     return(value)
   }
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`", arg_name, "` must be one of ",
       paste0("\"", choices, "\"", collapse = ", "),
@@ -196,7 +196,7 @@ normalize_margin_id <- function(.id) {
       is.na(.id) ||
       !nzchar(.id)
   ) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       "`.id` must be `NULL` or one non-missing, non-empty character string."
     )
   }
@@ -205,7 +205,7 @@ normalize_margin_id <- function(.id) {
 
 check_margin_id_collision <- function(.id, names, where) {
   if (!is.null(.id) && .id %in% names) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf("`.id` (`%s`) conflicts with %s.", .id, where)
     )
   }

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -218,12 +218,12 @@ nest_margin_pipeline <- function(.data,
       assert_logical_scalar(.keep)
       assert_string_scalar(.key)
       if (is.na(.key)) {
-        abort_marginplyr(
+        abort_marginplyr_flat(
           "`.key` must not be missing."
         )
       }
       if (!nzchar(.key)) {
-        abort_marginplyr(
+        abort_marginplyr_flat(
           "`.key` must not be empty."
         )
       }
@@ -275,7 +275,7 @@ execute_margin_nest <- function(operation, .key, .keep) {
       plan <- operation$plan
       group_cols <- c(plan$by, plan$dimensions)
       if (.key %in% group_cols) {
-        abort_marginplyr(
+        abort_marginplyr_flat(
           sprintf("`.key` (`%s`) must not be a grouping column.", .key)
         )
       }

--- a/R/share.R
+++ b/R/share.R
@@ -584,7 +584,7 @@
 #'   .grouping = grouping_sets(grouping_set(region), grouping_set(store))
 #' ))
 share_of_parent <- function(x) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`share_of_parent()` can only be used inside ",
       "`summarize_with_margins()` with a `rollup()`. To derive a value from ",
@@ -596,7 +596,7 @@ share_of_parent <- function(x) {
 #' @rdname share_of_parent
 #' @export
 share_of_total <- function(x) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`share_of_total()` can only be used inside ",
       "`summarize_with_margins()` with a Grouping plan that contains the ",
@@ -640,7 +640,7 @@ preflight_shares <- function(dots) {
 }
 
 abort_share_helper_position <- function(kind, complete) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       share_kind_call(kind), " must be the complete right-hand side of a ",
       "named summary, or the direct `.fns` argument of `across()`.",
@@ -661,7 +661,7 @@ abort_share_helper_position <- function(kind, complete) {
 # vocabulary lives here; the executor decides when to raise it.
 abort_arrow_shares <- function(kinds) {
   kinds <- intersect(share_kind_names(), kinds)
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "Arrow backends do not support ",
       share_kind_labels_phrase(kinds),
@@ -689,7 +689,7 @@ share_grouping_spec_validator <- function(kinds) {
 check_parent_grouping_spec <- function(grouping_spec) {
   kind <- if (is.null(grouping_spec)) NULL else grouping_spec$type
   if (!identical(kind, "rollup")) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`share_of_parent()` requires `.grouping` to be one pure `rollup()`. ",
         "`grouping_sets()`, `cube()`, `grouping_spec()`, and other grouping ",
@@ -792,7 +792,7 @@ plan_share_expressions <- function(dots,
       preceding_shares$names
     )
     if (length(share_dependency) > 0L) {
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(
           "Ordinary summaries cannot use an earlier ",
           share_kind_label(share_name_kind(
@@ -1242,7 +1242,7 @@ check_share_scalar <- function(value,
                                call) {
   label <- share_kind_label(share_kind)
   if (length(value) != 1L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         label, " `", share_output, "` requires source summary `",
         source_summary, "` to return exactly one value per grouping row. ",
@@ -1282,7 +1282,7 @@ abort_share_source_type <- function(value,
                                     share_kind,
                                     call) {
   detected_type <- if (is.object(value)) class(value) else typeof(value)
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       share_kind_label(share_kind), " `", share_output,
       "` requires source summary `",
@@ -1463,7 +1463,7 @@ plan_direct_share <- function(expr,
 validate_share_direct_syntax <- function(expr, output_name) {
   helper <- share_helper_name(share_helper_call_kind(expr))
   if (!nzchar(output_name)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "A direct `", helper, "()` summary must have an explicit output ",
         "name. Rewrite it as `name = ", helper, "(source)`."
@@ -1487,7 +1487,7 @@ validate_share_direct_syntax <- function(expr, output_name) {
   # change to an un-injected spelling and is recorded as one in ADR 0019.
   carried <- unwrap_injected_args(args)
   if (length(carried) != 1L || !is_name_part(carried[[1L]])) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`", output_name, " = ", helper, "(...)` requires exactly one ",
         "bare name of a preceding ordinary summary. Define the scalar ",
@@ -1571,7 +1571,7 @@ validate_share_across_syntax <- function(expr, env, output_name) {
       length(names_template) != 1L ||
       is.na(names_template)
   ) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         share_kind_modifier(kind),
         " `across()` `.names` must be one non-missing character ",
@@ -1585,7 +1585,7 @@ validate_share_across_syntax <- function(expr, env, output_name) {
 preflight_share_across_syntax <- function(expr, output_name) {
   kind <- share_across_kind(expr)
   if (nzchar(output_name)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "An `across()` ", share_kind_modifier(kind), " expression must be ",
         "unnamed; use its required `.names` argument to name the output ",
@@ -1596,7 +1596,7 @@ preflight_share_across_syntax <- function(expr, output_name) {
   args <- parse_across_arguments(expr)
   if (!is_share_helper_function(args$fns)) {
     helper <- share_helper_name(kind)
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "For ", share_kind_label(kind), "s, `across()` `.fns` must be `",
         helper, "` or `marginplyr::", helper, "` directly. Use two ordered ",
@@ -1606,7 +1606,7 @@ preflight_share_across_syntax <- function(expr, output_name) {
     )
   }
   if (length(args$additional) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         share_kind_modifier(kind),
         " `across()` does not accept additional function arguments: ",
@@ -1616,7 +1616,7 @@ preflight_share_across_syntax <- function(expr, output_name) {
     )
   }
   if (is.null(args$names)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         share_kind_modifier(kind),
         " `across()` requires an explicit `.names` argument, ",
@@ -1636,7 +1636,7 @@ preflight_share_across_syntax <- function(expr, output_name) {
 }
 
 abort_share_across_unpack <- function(kind) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       share_kind_modifier(kind),
       " `across()` requires `.unpack = FALSE` or an ",
@@ -1655,12 +1655,12 @@ validate_share_request <- function(outputs,
     return(invisible(NULL))
   }
   if (any(!nzchar(outputs))) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(share_kind_modifier(kind), " output names must not be empty.")
     )
   }
   if (anyDuplicated(outputs)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         share_kind_modifier(kind),
         " output names must be unique; duplicate name `",
@@ -1682,7 +1682,7 @@ validate_share_request <- function(outputs,
     source <- sources[[i]]
     output <- outputs[[i]]
     if (source %in% shares$names) {
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(
           label, " `", output, "` cannot use ",
           share_kind_label(share_name_kind(shares, source)), " `", source,
@@ -1692,14 +1692,14 @@ validate_share_request <- function(outputs,
     }
     if (!source %in% preceding_names) {
       if (source %in% all_names) {
-        abort_marginplyr(
+        abort_marginplyr_flat(
           paste0(
             label, " `", output, "` must refer to an ordinary summary ",
             "defined before it; `", source, "` is a forward reference."
           )
         )
       }
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(
           label, " `", output, "` refers to unknown preceding ordinary ",
           "summary `", source, "`."
@@ -1710,7 +1710,7 @@ validate_share_request <- function(outputs,
       !is.na(context$ordinary_counts[[source]]) &&
         context$ordinary_counts[[source]] != 1L
     ) {
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(
           label, " `", output, "` requires source summary `", source,
           "` to be defined exactly once. Use one uniquely named ordinary ",
@@ -1728,7 +1728,7 @@ validate_share_request <- function(outputs,
       )
     }
     if (length(record$dependencies) > 0L) {
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(
           label, " `", output, "` cannot use source summary `", source,
           "` because it depends on earlier summary alias `",
@@ -1748,7 +1748,7 @@ validate_share_request <- function(outputs,
     ))
   )
   if (length(conflicts) > 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         share_kind_modifier(kind), " output name `", conflicts[[1L]],
         "` conflicts with a grouping key, `.id`, ordinary summary, source ",
@@ -1779,7 +1779,7 @@ abort_ineligible_share_source <- function(label, output, source, eligibility) {
       "top-level named summary or a preceding `across()` output."
     )
   }
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(label, " `", output, "` cannot use `", source, "` because ", advice)
   )
 }
@@ -1796,7 +1796,7 @@ check_share_grouping_kinds <- function(plan, kinds) {
 
 check_parent_grouping_kind <- function(plan) {
   if (!identical(plan$kind, "rollup")) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`share_of_parent()` requires `.grouping` to be one pure `rollup()`. ",
         "`grouping_sets()`, `cube()`, `grouping_spec()`, and other grouping ",
@@ -1812,7 +1812,7 @@ check_total_grouping_kind <- function(plan) {
   if (length(grand_total_occurrence_ids(plan)) > 0L) {
     return(invisible(NULL))
   }
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`share_of_total()` requires `.grouping` to produce the Grand total ",
       "set, in which every grouping dimension is omitted. `rollup()` and ",
@@ -2241,7 +2241,7 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
   # unrecognised verdict would otherwise be described to the caller as a
   # backend that could not be asked, which is a different fact.
   stopifnot(identical(verdict, "converts") || identical(verdict, "unknown"))
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "marginplyr cannot establish that the source summaries of ",
       share_kind_labels_phrase(kinds),
@@ -2962,7 +2962,7 @@ resolve_share_selection <- function(expr,
 abort_share_selection_error <- function(cnd, preceding, context, kind) {
   missing <- share_selection_missing_names(cnd)
   if (length(missing) == 0L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "Invalid ", share_kind_modifier(kind), " `across()` selection. ",
         "Select only eligible preceding ordinary summaries by name."
@@ -2984,7 +2984,7 @@ abort_share_source_name <- function(source, preceding, context, kind) {
   )
   occurrences <- sum(all_names == source)
   if (occurrences > 1L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`across()` can't select source summary `", source,
         "` for ", helper, " because summary `", source,
@@ -2997,7 +2997,7 @@ abort_share_source_name <- function(source, preceding, context, kind) {
     )
   }
   if (occurrences == 1L) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`across()` can't select source summary `", source,
         "` for ", helper, " because summary `", source,
@@ -3017,7 +3017,7 @@ abort_share_source_name <- function(source, preceding, context, kind) {
     character(1),
     "name"
   ))
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`across()` refers to unknown summary `", source,
       "` for ", helper, ". Select only eligible preceding ordinary ",
@@ -3083,7 +3083,7 @@ contains_selection_predicate <- function(expr) {
 }
 
 abort_share_predicate <- function(kind) {
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       share_kind_modifier(kind),
       " `across()` only supports name-based tidyselect. Replace ",

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -97,11 +97,11 @@ check_option_named_summaries <- function(dots) {
           "and neither is the `", matched, "` it resembles"
         )
       }
-      abort_marginplyr(
+      abort_marginplyr_flat(
         paste0(opening, "; ", removed_summary_options[[matched]])
       )
     }
-    abort_marginplyr(
+    abort_marginplyr_flat(
       paste0(
         "`", name, "` is not an argument of `summarize_with_margins()`, so ",
         "it was captured as a summary named `", name, "`. Did you mean `",
@@ -132,7 +132,7 @@ check_summary_context_helpers <- function(dots) {
   # because a caller who had bound one of these names themselves was told only
   # that the verb refused the helper and had no way to learn that their own
   # function was never going to run (ADR 0019).
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "`summarize_with_margins()` does not support ",
       paste0("`", unsupported, "()`", collapse = ", "),
@@ -156,7 +156,7 @@ check_summary_group_overwrite <- function(output_names, group_vars) {
     return(invisible(NULL))
   }
 
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "Summary results cannot overwrite grouping column",
       if (length(overwritten_groups) == 1L) " " else "s ",
@@ -197,7 +197,7 @@ check_internal_summary_names <- function(output_names, internal_names) {
     return(invisible(NULL))
   }
 
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "Dynamically generated summary output names conflict with ",
       "internal grouping columns: ",
@@ -697,7 +697,7 @@ check_across_name_count <- function(expanded, template, column) {
     return(expanded)
   }
 
-  abort_marginplyr(
+  abort_marginplyr_flat(
     paste0(
       "The `across()` `.names` template `", template, "` must produce one ",
       "name per column, but it produced ", length(expanded),

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,7 +16,7 @@ margin_column_pronoun <- function(name) {
 assert_logical_scalar <- function(x) {
   nm <- deparse(substitute(x))
   if (!(isTRUE(x) || isFALSE(x))) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf("`%s` must be a logical scalar (`TRUE` or `FALSE`).", nm)
     )
   }
@@ -26,7 +26,7 @@ assert_logical_scalar <- function(x) {
 assert_string_scalar <- function(x) {
   nm <- deparse(substitute(x))
   if (!(is.character(x) && length(x) == 1)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf("`%s` must be a character vector of length 1.", nm)
     )
   }
@@ -36,7 +36,7 @@ assert_nest_possible <- function(x) {
   nm <- deparse(substitute(x))
   valid_classes <- c("data.frame", "dtplyr_step")
   if (!inherits(x, valid_classes)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf(
         "`%s` must be one of the following classes, which can be nested: %s",
         nm,
@@ -80,7 +80,7 @@ assert_margin_input <- function(x) {
     return(invisible(NULL))
   }
 
-  abort_marginplyr(
+  abort_marginplyr_flat(
     sprintf(
       paste0(
         "`%s` must be a data frame or a lazy table that supports dplyr ",
@@ -97,7 +97,7 @@ assert_lazy_table <- function(x) {
   nm <- deparse(substitute(x))
   invalid_lazy_table_names <- "RecordBatchReader"
   if (inherits(x, invalid_lazy_table_names)) {
-    abort_marginplyr(
+    abort_marginplyr_flat(
       sprintf(
         "`%s` must not be an object of the following classes: %s",
         nm,

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -23,7 +23,9 @@ package ships, so after publication these texts harden into something closer to
 a contract.
 
 The measurements this rests on are in
-`investigation/diagnostic-wrapping-under-rlang-and-cli.md`. They are cited
+`investigation/diagnostic-wrapping-under-rlang-and-cli.md` and, for what was
+measured once every site had moved,
+`investigation/retrieval-time-formatting-of-a-cli-diagnostic.md`. They are cited
 rather than restated because each is a fact about rlang, cli, or testthat, and
 ages when one of those moves rather than when `R/` does.
 
@@ -36,8 +38,9 @@ vignettes, where `.github/scripts/verify-site.R` matches seven of them as
 `fixed = TRUE` substrings of the built HTML.
 
 So this is not a re-formatting whose cost is churn in pinned texts. It puts
-line breaks into shipped pages and into byte-exact pins where none existed.
-Three conditions are what an author writes against:
+line breaks into shipped pages where none existed. Not into the byte-exact
+pins: *Consequences* below records the option that keeps the test suite from
+seeing a wrap at all. Three conditions are what an author writes against:
 
 1. The authored prose of a line, with interpolation excluded, fits in 80
    columns.
@@ -225,19 +228,59 @@ unaddressed in the files that also splice and keeps `report_branch_warnings()`
 ## Consequences
 
 The byte-exact pins stay byte-exact and stay out of snapshots. Inside
-`test_that()`, `local_reproducible_output()` fixes the width at 80 and turns
-colours off, so `conditionMessage()` of a `cli_abort()` condition is
-deterministic across runs; retrieval-time formatting varies with a reader's
-session, not between two runs of the suite. Snapshots would be skipped under
-CRAN semantics, which is where `test-diagnostic-pluralization.R` says its
-sixteen arms hold, so moving them there would silently retire the baseline the
-re-authoring is measured against. What changes is that a re-authored text
-carries newlines the flat sentence did not.
+`test_that()`, `local_reproducible_output()` sets `cli.condition_width` to
+`Inf` and rlang consults that ahead of `cli.width` and `width`, so
+`conditionMessage()` of a `cli_abort()` condition is not wrapped at all in the
+test suite, and is therefore deterministic across runs; retrieval-time
+formatting varies with a reader's session, not between two runs of the suite.
+Snapshots would be skipped under CRAN semantics, which is where
+`test-diagnostic-pluralization.R` says its sixteen arms hold, so moving them
+there would silently retire the baseline the re-authoring is measured against.
 
-The phrase-level pins — the several hundred `expect_error()` and
-`expect_match()` patterns — need a whitespace-normalizing comparison, since a
-phrase can now be split by a wrap. `verify-site.R`'s marker matching needs the
-same, on top of condition 3 above.
+That same option is why the phrase-level pins — the several hundred
+`expect_error()` and `expect_match()` patterns — need no normalizing
+comparison: a phrase cannot be split by a wrap that does not happen. The one
+newline such a pin can still meet is the structural break between a re-authored
+message's main line and each of its `i` bullets, and normalization would not
+rescue a phrase spanning that either, because the bullet marker sits in the gap.
+A pin spanning that boundary is a pin whose sentence the re-authoring has split,
+which is what the phase rewriting that file re-pins anyway. `verify-site.R`'s
+marker matching is where the normalization is needed, because a vignette is
+rendered outside `test_that()` and does wrap; it is needed on top of condition 3
+above rather than instead of it.
+
+The first version of this section read `width` rather than
+`cli.condition_width` and asked for a test-side normalizing helper on that
+basis. The measurements correcting it, and the two site markers that only match
+once normalized, are in
+`investigation/retrieval-time-formatting-of-a-cli-diagnostic.md`.
+
+Wrapping is not the whole of what retrieval-time formatting costs. The
+formatter collapses every run of whitespace in the stored message, including
+inside a value the template interpolated, so a subject whose spelling a caller
+chose is shown re-spelled: a `.margin_label` dimension named `` `bad  name` ``
+is stored with its two spaces and shown with one, where `rlang::abort()` showed
+the caller's bytes. Column names, label values, `.id`, and `.key` can all
+legally carry such a run, so this reaches the sixty-six sites that splice caller
+data — and reaches them identically after re-authoring, since it follows from
+signalling through `cli_abort()` rather than from any shim. `format_inline()`
+has `keep_whitespace`; `cli_abort()` exposes no equivalent, so preserving the
+spelling would mean not signalling through it, which is the whole of this
+decision. Whether that trade is right is left open in #230 rather than settled
+here, and nothing pins such a name, which is why this is recorded and not
+caught.
+
+Until the re-authoring is finished, a fourth path holds the flat form, and it is
+not one of the three the opening section names. Every site not yet re-authored
+passes through a transitional `abort_marginplyr_flat()`, which hands its
+already-assembled string to `abort_marginplyr()` as an interpolated value; cli
+interprets the template and not the values, so *Caller text is a value* holds
+across the whole corpus from the day the switch lands rather than file by file.
+That is also what bounds the gate's reach: it reads `abort_marginplyr()`'s own
+argument, so a site still calling the sibling is outside its view, and the
+snapshot beside it in `test-diagnostic-authoring.R` is what stops a new one
+appearing. The sibling is deleted with the last of those sites, and the gate
+then covers every diagnostic this package raises.
 
 `marginplyr_error` survives, so the `must_error` hook and its twenty vignette
 chunks are untouched: `cli_abort()`'s `class` argument carries it through, and

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -384,6 +384,21 @@ review surface: a Package condition demoted to `stop()` silently leaves the
 public contract, and an invariant promoted to `abort_marginplyr()` silently
 enters it.
 
+It is also the interpolating entry point. A call site passes an unexpanded cli
+template and `cli::cli_abort()` expands it in the site's own frame, so the
+constructor owns the message's shape as well as its class: a short refusal plus
+`i` bullets, one inline style per subject, `{?}` for every plural, and
+caller-derived text interpolated as a value rather than concatenated into the
+template. See
+[ADR 0023](adr/0023-author-diagnostics-in-the-cli-idiom.md).
+`test-diagnostic-authoring.R` gates the last two of those together, by failing
+any `abort_marginplyr()` call whose message argument is not a literal in the
+source: an assembled template and an `if`-spelled noun are one violation seen
+from two sides.
+Sites that still assemble their own string pass through
+`abort_marginplyr_flat()`, which interpolates it as a value; that function is
+transitional, and the snapshot beside the gate is what is left of #223.
+
 It also owns the one reading of a condition another package raised.
 `condition_chain()` answers the conditions a `parent` chain holds, outermost
 first, and decides nothing about them. tidyselect wraps a failure raised inside

--- a/investigation/diagnostic-wrapping-under-rlang-and-cli.md
+++ b/investigation/diagnostic-wrapping-under-rlang-and-cli.md
@@ -1,6 +1,7 @@
 # How marginplyr's diagnostics render under rlang and cli
 
 Investigated: 2026-08-19
+Revised: 2026-08-19 — investigation/retrieval-time-formatting-of-a-cli-diagnostic.md
 
 #223 decided to re-author every shipped diagnostic in the cli idiom and asked
 ADR 0023 to settle three things it left open: cli's vector-formatting defaults,
@@ -90,6 +91,28 @@ The consequence is the one #223's re-pinning strategy turns on:
 `conditionMessage()` of a `cli_abort()` condition is deterministic inside the
 test suite. Retrieval-time formatting varies with the session, but not between
 two runs of the same test.
+
+## Revisions (2026-08-19)
+
+`investigation/retrieval-time-formatting-of-a-cli-diagnostic.md` corrects the
+section above and answers *What was not established* at the end of this note.
+It was taken later the same day, while #223's phase 2b moved all 83
+`abort_marginplyr()` sites onto `cli_abort()` at once, which is what made both
+measurable against real diagnostics.
+
+What it corrects: `width` and `cli.width` are not what governs a condition
+inside `test_that()`. `local_reproducible_output()` sets `cli.condition_width`
+to `Inf` and rlang consults that first, so the test suite sees no wrap at all —
+not the narrower deterministic one this note concluded. The conclusion drawn
+from it, that `conditionMessage()` is deterministic inside the suite, survives
+and is stronger. `tests/testthat/test-execution-conditions.R` already held the
+correction before it was measured.
+
+What it adds: retrieval-time formatting also collapses a run of whitespace
+inside an interpolated value, so a caller's own spelling of a column name is not
+preserved the way `rlang::abort()` preserved it; cli breaks a line at
+whitespace and not inside a token; and the rendered vignettes carry the
+diagnostics wrapped, with no markup and no escapes inside the sentence.
 
 ## cli's inline vector defaults
 

--- a/investigation/retrieval-time-formatting-of-a-cli-diagnostic.md
+++ b/investigation/retrieval-time-formatting-of-a-cli-diagnostic.md
@@ -1,0 +1,113 @@
+# What happens to a cli diagnostic between raising it and reading it
+
+Investigated: 2026-08-19
+
+`investigation/diagnostic-wrapping-under-rlang-and-cli.md` established, earlier
+the same day, that `rlang::abort()` wraps nothing and `cli::cli_abort()` wraps
+at retrieval. It read `width` and `cli.width` for the width a condition is
+rendered at, and left one question open: what a `cli_abort()` diagnostic looks
+like once it reaches a rendered vignette.
+
+This note was taken while #223's phase 2b moved all 83 `abort_marginplyr()`
+sites onto `cli_abort()` at once, which is what made both answerable against
+real diagnostics rather than against a constructed message. It corrects the
+first reading and answers the second, and it records a third thing neither note
+looked for: wrapping is not all that retrieval-time formatting does.
+
+Environment: R 4.6.1 (2026-06-24), cli 3.6.6, rlang 1.3.0, testthat 3.3.2,
+quarto 1.9.38, altdoc 0.7.3, on macOS.
+
+## `cli.condition_width` is what governs a condition, not `width`
+
+`testthat::local_reproducible_output()` sets `cli.condition_width` to `Inf`, and
+rlang consults it ahead of `cli.width` and `width`. So inside `test_that()` a
+condition is not wrapped at all, whatever `width` says.
+
+The correction was already written down in this repository before it was
+measured: `collect_warnings_rendered()` in
+`tests/testthat/test-execution-conditions.R` states it, and sets both options
+together for exactly that reason.
+
+Measured through a two-frame helper matching `abort_marginplyr()`'s
+`.envir = rlang::caller_env()`, against the 140-character NA-level refusal that
+`tests/testthat/test-diagnostic-pluralization.R` pins:
+
+| context | newlines in `conditionMessage()` |
+| --- | --- |
+| top level, `width = 80` | 1 |
+| inside `test_that()` | 0 |
+
+A message vector was measured beside it — a main line plus one `i` bullet
+carrying twelve column names — and behaved the same way: 3 newlines at the top
+level, 1 inside `test_that()`. That one is the break between the main line and
+the bullet rather than a wrap.
+
+So the earlier note's conclusion — that `conditionMessage()` is deterministic
+inside the suite — survives, and is stronger than it was stated. The suite does
+not see a narrower deterministic wrap. It sees no wrap.
+
+Two consequences were observed rather than argued. All 83 sites moved to
+`cli_abort()` in one commit and the suite stayed green with no pin edited,
+including the 26 byte-exact ones. And a phrase-level `expect_error()` or
+`expect_match()` pin cannot be split by a wrap that does not happen — the one
+newline such a pin can still meet is the structural main-line/bullet break,
+which normalizing would not rescue either, since the bullet marker sits in the
+gap: `"A refusal.\ni A bullet."` normalizes to `"A refusal. i A bullet."`, and a
+pin reading `"A refusal. A bullet."` misses whichever way it is matched.
+
+## Retrieval also collapses whitespace inside an interpolated value
+
+| stage | `"a\tb\nc  d"` interpolated as a value |
+| --- | --- |
+| `cli::format_inline("{x}")` | double space preserved |
+| the condition's stored `$message` | `a\tb c  d` |
+| `conditionMessage()` | `a b c d` |
+
+A tab and a newline go at glue time; a run of spaces goes at retrieval. Against
+the shipped unknown-dimension refusal, a `.margin_label` dimension named
+`` `bad  name` `` is stored with its two spaces and shown with one.
+`rlang::abort()` showed the caller's bytes.
+
+`cli::format_inline()` takes `keep_whitespace`. `cli::cli_abort()` was checked
+for an equivalent and has none — and the collapsing happens in rlang's
+retrieval formatting rather than in the interpolation, so that argument would
+not reach it in any case.
+
+## cli breaks at whitespace, not inside a token
+
+At `width = 30`, a 68-character absolute path inside a diagnostic stayed whole
+on a line of its own; a 68-character identifier with no spaces in it did the
+same. Only the space before them moved.
+
+This was looked for on behalf of `.github/scripts/verify-site.R`, whose
+build-machine-path and forbidden-string scans read the page unnormalized. Every
+pattern written out in that script is whitespace-free, so a wrap cannot split
+one. The `\Q<home>\E` pattern it builds from the checking machine's own home
+directory is the exception, and carries a space only on a machine whose home
+directory does.
+
+## What the rendered site holds once every site signals through cli
+
+The site was rebuilt with `altdoc::render_docs(parallel = FALSE, freeze = FALSE)`
+against the installed working tree. `docs/vignettes/get_started.html` read back:
+
+- Seven rendered `Error in ...:` blocks, all of them wrapped, with each
+  continuation indented by two spaces. The 96-character duplicate-grouping-set
+  refusal reached the page as two lines, where the build measured before the
+  switch carried it as one.
+- No `<span>` inside any of the seven, and no escape sequence anywhere on the
+  page. So the styling question the earlier note left open stays moot for the
+  reason it was already moot: there is no styling, rather than matching that
+  accounts for one.
+
+Two of the fourteen `verify-site.R` markers quoting a diagnostic stopped
+matching as raw `fixed = TRUE` substrings, and match only with whitespace
+normalized on both sides:
+
+```text
+Add an empty `grouping_set()` to the `grouping_sets()` specification
+which can be nested: data.frame, dtplyr_step
+```
+
+Both span a break in the rebuilt page. Without the normalization the `altdoc`
+job fails on those two.

--- a/tests/testthat/_snaps/diagnostic-authoring.md
+++ b/tests/testthat/_snaps/diagnostic-authoring.md
@@ -1,0 +1,59 @@
+# the sites still assembling their own diagnostic
+
+    Code
+      cat(sprintf("%s(): %d", names(counts), counts), sep = "\n")
+    Output
+      abort_arrow_shares(): 1
+      abort_empty_composite(): 1
+      abort_empty_grouping_units(): 1
+      abort_ineligible_share_source(): 1
+      abort_invalid_grouping_spec(): 1
+      abort_margin_label_collision(): 1
+      abort_nested_grouping_spec(): 1
+      abort_selection_rename(): 1
+      abort_share_across_unpack(): 1
+      abort_share_helper_position(): 1
+      abort_share_predicate(): 1
+      abort_share_selection_error(): 1
+      abort_share_source_dialect(): 1
+      abort_share_source_name(): 3
+      abort_share_source_type(): 1
+      assert_lazy_table(): 1
+      assert_logical_scalar(): 1
+      assert_margin_input(): 1
+      assert_nest_possible(): 1
+      assert_string_scalar(): 1
+      check_across_name_count(): 1
+      check_internal_summary_names(): 1
+      check_margin_id_collision(): 1
+      check_option_named_summaries(): 2
+      check_parent_grouping_kind(): 1
+      check_parent_grouping_spec(): 1
+      check_share_scalar(): 1
+      check_summary_context_helpers(): 1
+      check_summary_group_overwrite(): 1
+      check_total_grouping_kind(): 1
+      compile_grouping_spec_impl(): 2
+      execute_margin_nest(): 1
+      grouping_bit(): 1
+      grouping_helper_vars(): 7
+      grouping_id(): 1
+      match_margin_choice(): 1
+      nest_margin_pipeline(): 2
+      normalize_grouping_input(): 3
+      normalize_margin_id(): 1
+      normalize_margin_label(): 5
+      plan_share_expressions(): 1
+      preflight_share_across_syntax(): 4
+      reject_nested_in_set(): 1
+      share_of_parent(): 1
+      share_of_total(): 1
+      validate_empty_grouping_sets(): 1
+      validate_grouping_spec_early(): 1
+      validate_margin_label(): 1
+      validate_margin_label_names(): 3
+      validate_nested_grouping_units(): 1
+      validate_share_across_syntax(): 1
+      validate_share_direct_syntax(): 2
+      validate_share_request(): 8
+

--- a/tests/testthat/test-diagnostic-authoring.R
+++ b/tests/testthat/test-diagnostic-authoring.R
@@ -1,0 +1,250 @@
+# ADR 0023 states how every Package condition is authored. Two of its rules are
+# gated, and one structural reading catches both: walk every
+# `abort_marginplyr()` call and fail any whose message argument is not a literal
+# in the source.
+#
+# The two rules are one violation seen from two sides. *Caller text is a value,
+# never part of the template* fails when a template is assembled -- a
+# `paste0()` splicing a column name produces a template a caller's braces can
+# reach into, which is why a column named `a{b}` would otherwise be answered
+# with `Could not evaluate cli {} expression` instead of the refusal. *Every
+# singular/plural choice goes through `{?}`* fails when an `if` spells a noun.
+# Neither can be written without computing the argument, so neither survives the
+# reading below.
+#
+# The line-length conditions deliberately get no gate here; ADR 0023 says why,
+# and `.github/scripts/verify-site.R` is where their failure mode shows up.
+#
+# This file is in the shape of `test-query-policy.R` and for the same reason:
+# the property is about every call site rather than about any one file, so it is
+# asserted over the loaded namespace rather than described in prose. It needs
+# the package loaded through `pkgload::load_all()` or an installed dev build.
+
+# Every call to `name` below `expr`, as the expression each passed as its
+# message argument -- the first argument, or `message =` where a site names it.
+#
+# The recursion goes through `lapply()` and never a bare `for` over a call's
+# elements, for the reason `test-query-policy.R` records: a parsed call can hold
+# the missing-argument placeholder as one of its own elements, and a `for`
+# loop's assignment preserves the internal missing flag, so reading it raises
+# "argument is missing, with no default" the moment the loop variable is looked
+# up.
+diagnostic_message_arguments <- function(expr, name) {
+  found <- list()
+  walk <- function(e) {
+    if (!is.call(e)) {
+      return(invisible(NULL))
+    }
+    head <- e[[1]]
+    if (is.name(head) && identical(as.character(head), name)) {
+      args <- as.list(e)[-1]
+      arg_names <- names(args)
+      # R's own matching for `abort_marginplyr(message, ..., class, call)`:
+      # `message =` by name, otherwise the first argument supplied without one.
+      # Reading `args[[1]]` instead would take `class` for the message at a
+      # site that named every argument it passed, and report that site clean
+      # because a class is a literal too.
+      positional <- if (is.null(arg_names)) args else args[!nzchar(arg_names)]
+      message <- if (!is.null(arg_names) && "message" %in% arg_names) {
+        args[["message"]]
+      } else if (length(positional) > 0L) {
+        positional[[1]]
+      } else {
+        NULL
+      }
+      # `c()` rather than `found[[length(found) + 1L]] <-`, which deletes
+      # instead of appending when the value is `NULL`. A call written with no
+      # message at all -- `abort_marginplyr(class = "x")` -- is exactly the
+      # site the gate must report, and that spelling would drop it.
+      found <<- c(found, list(message))
+    }
+    lapply(as.list(e)[-1], walk)
+    invisible(NULL)
+  }
+  walk(expr)
+  found
+}
+
+# Whether every string a message argument contributes is written in the source.
+#
+# A bare character literal is the common case. `c()` is admitted because it is
+# how a cli message vector is spelled -- `c("Refusal.", i = "Bullet.")` -- and
+# admitting it costs nothing: the recursion requires each of its arguments to be
+# authored too, so `c(paste0(...), i = "...")` fails exactly as a bare
+# `paste0()` does. Nothing else is admitted, because everything else computes
+# text, and computed text is what both gated rules forbid. That includes a
+# constant bound elsewhere in the package: a template has to be readable beside
+# the call that raises it, or the injection rule cannot be reviewed at the site.
+authored_template <- function(expr) {
+  if (is.character(expr)) {
+    return(TRUE)
+  }
+  if (
+    is.call(expr) &&
+      is.name(expr[[1]]) &&
+      identical(as.character(expr[[1]]), "c")
+  ) {
+    return(all(vapply(as.list(expr)[-1], authored_template, logical(1))))
+  }
+  FALSE
+}
+
+# Every function bound in the namespace, which is where the call sites are:
+# `R/` is not installed, so a scan of the shipped package would find no source
+# to read.
+marginplyr_diagnostic_sites <- function(name, ns = asNamespace("marginplyr")) {
+  functions <- Filter(
+    function(binding) is.function(get(binding, envir = ns)),
+    ls(ns, all.names = TRUE)
+  )
+  sites <- lapply(functions, function(binding) {
+    diagnostic_message_arguments(body(get(binding, envir = ns)), name)
+  })
+  stats::setNames(sites, functions)
+}
+
+# The reading, driven over source `R/` does not contain. Both halves of it are
+# asserted here rather than left to the scan below, because the scan's verdict
+# over a corpus that satisfies the rule is the same verdict a scan that read
+# nothing returns -- which is the objection this repository makes to any gate
+# whose failing branch nothing executes. While #223's phase 3 is unfinished the
+# point is sharper still: `abort_marginplyr()` has one call site in the
+# namespace, so without these fixtures neither the descent nor
+# `authored_template()`'s refusal would ever run.
+#
+# The fixtures are functions that are parsed and never called. Each one is read
+# through `body()`, exactly as the namespace scan reads a real function.
+test_that("the reading finds a site wherever it is written", {
+  fixture <- function(n) {
+    if (n > 0L) {
+      abort_marginplyr("A refusal.")
+    }
+    inner <- function() {
+      abort_marginplyr(message = c("A refusal.", i = "A bullet."))
+    }
+    inner()
+  }
+
+  found <- diagnostic_message_arguments(body(fixture), "abort_marginplyr")
+
+  # One nested inside an `if`, one inside a closure and named `message =`. A
+  # walk that stopped descending, or one that only read the first argument,
+  # loses one of the two.
+  expect_length(found, 2L)
+  expect_identical(found[[1]], "A refusal.")
+  expect_true(all(vapply(found, authored_template, logical(1))))
+})
+
+test_that("the reading refuses every shape ADR 0023's gated rules forbid", {
+  fixture <- function(columns, n) {
+    template <- "A refusal."
+    abort_marginplyr(paste0("Unknown column `", columns, "`."))
+    abort_marginplyr(sprintf("Unknown column `%s`.", columns))
+    abort_marginplyr(if (n == 1L) "One column." else "Several columns.")
+    abort_marginplyr(c("A refusal.", i = paste0("Drop ", columns, ".")))
+    abort_marginplyr(template)
+    abort_marginplyr(class = "marginplyr_nothing")
+  }
+
+  found <- diagnostic_message_arguments(body(fixture), "abort_marginplyr")
+
+  # An assembled template, twice; an `if` spelling a noun; a `c()` whose bullet
+  # is assembled, which is the case admitting `c()` has to keep refusing; a
+  # template bound elsewhere, which is readable nowhere near the refusal; and a
+  # call carrying no message at all, which reads as `NULL` and is the site an
+  # appending idiom that deletes on `NULL` would drop.
+  expect_length(found, 6L)
+  expect_false(any(vapply(found, authored_template, logical(1))))
+})
+
+test_that("every `abort_marginplyr()` message is a literal in the source", {
+  sites <- marginplyr_diagnostic_sites("abort_marginplyr")
+
+  # That the namespace was read at all. The reading itself is asserted by the
+  # fixtures above; this only rules out the scan finding no call site --
+  # a renamed constructor, or a run against a package that is not loaded --
+  # since a scan that read nothing reports exactly what a package with no
+  # violation reports.
+  expect_gt(sum(lengths(sites)), 0L)
+
+  # Named by the function that holds it and quoted as it was written, so a
+  # failure says which site to re-author rather than that some site exists.
+  assembled <- unlist(
+    lapply(names(sites), function(binding) {
+      arguments <- sites[[binding]]
+      authored <- vapply(arguments, authored_template, logical(1))
+      vapply(
+        arguments[!authored],
+        function(argument) {
+          sprintf("%s(): %s", binding, paste(deparse(argument), collapse = " "))
+        },
+        character(1)
+      )
+    }),
+    use.names = FALSE
+  )
+
+  expect_identical(as.character(assembled), character())
+})
+
+# What is left of #223's phase 3, as the functions still handing an assembled
+# string to `abort_marginplyr_flat()`. The counts are part of the record because
+# a function can hold more than one site, and a snapshot of names alone would
+# accept a second one appearing inside a function already listed.
+#
+# This only ever shrinks. Each phase-3 pull request re-authors one file and
+# removes its entries; the last one empties this and deletes
+# `abort_marginplyr_flat()` with it. A new entry is a site written in the idiom
+# the gate above exists to retire, which the gate itself cannot see -- what it
+# reads is `abort_marginplyr()`'s own argument, and inside the transitional
+# sibling that argument is a literal.
+#
+# One line per function rather than a printed vector: this record is read as a
+# diff across every phase-3 pull request, and a named vector's column layout
+# reflows on any change, which would show a file's worth of removals as a
+# rewrite of the whole snapshot.
+#
+# The gate above reads the source and this reads the namespace, so between them
+# they cover what a reviewer would check by eye. Neither one runs a diagnostic,
+# which is what the test below is for.
+test_that("the sites still assembling their own diagnostic", {
+  sites <- marginplyr_diagnostic_sites("abort_marginplyr_flat")
+  counts <- lengths(sites)
+  counts <- counts[counts > 0L]
+  expect_snapshot(
+    cat(sprintf("%s(): %d", names(counts), counts), sep = "\n")
+  )
+})
+
+# The runtime half of *Caller text is a value*, which the source-level gate
+# above can only assert a proxy for. It reads whether a template was computed,
+# and computing one is how the property gets lost from this side -- but the
+# property itself is cli's: a value it interpolates is not re-read as a
+# template. `cli (>= 3.4.0)` carries no ceiling, so nothing in DESCRIPTION
+# would stop a cli whose value semantics changed, and the source gate would
+# report clean while every diagnostic naming a brace-bearing subject answered
+# `Could not evaluate cli {} expression` instead of the refusal.
+#
+# A column name is the subject chosen because it is the one a caller most
+# obviously controls, and `a{b}` is a legal name that a template would try to
+# evaluate. The refusal is matched by the name it carries rather than by its
+# wording, so this outlives #223's phase 3 re-authoring the sentence around it
+# -- and outlives the transitional sibling, which is the point: what it asserts
+# is not the shim's behaviour but the rule the shim exists to keep true.
+test_that("a caller's braces reach a diagnostic as text", {
+  data <- data.frame(region = "E", n = 1)
+
+  raised <- expect_error(expand_with_margins(
+    data,
+    .grouping = rollup(region),
+    .margin_label = c(region = "A", "a{b}" = "A")
+  ))
+
+  expect_s3_class(raised, "marginplyr_error")
+  expect_match(conditionMessage(raised), "a{b}", fixed = TRUE)
+  expect_no_match(
+    conditionMessage(raised),
+    "Could not evaluate cli",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
#223's **phase 2b** — the implementation half, with no wording call in it. Phase
3 re-authors the diagnostics file by file; nothing here changes what any of them
says.

Closes nothing on its own. ADR 0023 (#228) is authoritative for every design
question, and this pull request implements it rather than re-deciding any part
of it.

## What changed

- `DESCRIPTION`: `cli` moves Suggests → `Imports: cli (>= 3.4.0)`. Nothing else
  in the metadata moves — `cli` was never in `optional_suggest_spec()`, and
  `AGENTS.md`'s `DBI = FALSE` example is still about DBI.
- `abort_marginplyr()` becomes the interpolating entry point:
  `cli::cli_abort()` with `.envir = rlang::caller_env()`. ADR 0015's boundary is
  untouched — it still owns the class and the blamed call, and `marginplyr_error`
  is carried through.
- All **83** call sites move to a transitional `abort_marginplyr_flat()`. This
  is the injection half of the switch, not a cosmetic step: the braces cli would
  interpret come from caller data rather than from the source literals, a column
  named `` `a{b}` `` is legal, and against an assembled string `cli_abort()`
  answers `Could not evaluate cli {} expression` instead of the refusal. Passing
  the assembled string as an interpolated *value* is what makes those braces
  inert. The sibling is self-removing: each phase-3 pull request drops it for its
  own file, and the last one deletes the function.
- `report_branch_warnings()`'s count line moves to `cli::pluralize()`, which is
  inside ADR 0023's rule because the only value it interpolates is an integer
  marginplyr counted. Byte-identical for both arms, so no pin moves with it.
- `.github/scripts/verify-site.R` matches its markers with whitespace normalized
  on both sides.
- `design/architecture.md`'s Conditions chapter gains the ADR 0023 pointer.

## The gate

`tests/testthat/test-diagnostic-authoring.R`, in the shape of
`test-query-policy.R`: walk every `abort_marginplyr()` call in the loaded
namespace and fail any whose message argument is not a literal in the source. An
assembled template and an `if`-spelled noun are one violation seen from two
sides, so this covers both of ADR 0023's gated rules. It admits `c()`, because
that is how a cli message vector is spelled, and requires each element to be
authored too.

Beside it, a snapshot of the functions still calling `abort_marginplyr_flat()`
with their counts — 83 today, one line each, shrinking with every phase-3 pull
request until it empties.

The reading itself is asserted over parsed fixtures rather than over `R/` alone.
With phase 3 unfinished there is exactly one `abort_marginplyr()` call in the
namespace, so without them neither the descent nor the predicate's refusing
branch would ever run — and a scan that read nothing returns the verdict a clean
corpus returns. One further test runs a real diagnostic, because the property
the gate stands for is cli's rather than this package's: a column named
`` `a{b}` `` has to reach the refusal as text, and `cli (>= 3.4.0)` carries no
ceiling.

## Two measurements recorded rather than fixed

**The test-side normalizing helper #223 asked for is not added.** Its premise
does not hold: `local_reproducible_output()` sets `cli.condition_width` to `Inf`
and rlang consults that ahead of `cli.width` and `width`, so a condition is not
wrapped **at all** inside `test_that()`. The 140-character NA-level refusal came
back with 0 newlines where the same call at top level gives 1. A phrase-level pin
cannot be split by a wrap that does not happen, and normalizing would not rescue
the one break that remains — a message vector's own main-line/bullet boundary,
where the bullet marker sits in the gap. `verify-site.R`'s half of that bullet
*is* load-bearing: rebuilding the site showed two markers that only match once
normalized, and the `altdoc` job reds on both without it. Recorded in ADR 0023,
in `investigation/retrieval-time-formatting-of-a-cli-diagnostic.md`, and on
#223.

**cli re-spells a caller's whitespace.** `use_cli_format` means
`conditionMessage()` formats at retrieval, and that collapses every run of
whitespace in the stored message — including inside an interpolated value. A
`.margin_label` dimension named `` `bad  name` `` is shown as `` `bad name` ``,
where `rlang::abort()` showed the caller's bytes. It reaches the 66 sites that
splice caller data, follows from `cli_abort()` rather than from the shim, and is
left open in **#230** rather than settled inside a phase told to make no wording
calls.

## Verification

| check | result |
| --- | --- |
| full test suite | green, **no pin and no snapshot edited** |
| `lintr::lint_package()` | no lints |
| `R CMD check` (tarball) | `Status: OK` |
| `verify-suite-coverage.R` | 589 tests, all executed in ≥1 of the 5 single-backend configurations |
| `verify-site.R` against a freshly rendered `docs/` | pass |
| `verify-must-error.R` | 8/8 fixtures |

The 83 call-site edits are the function name and nothing else; `stop()` stays at
18 and `warning()` at 2, as on `main`.

## Notes

- `investigation/diagnostic-wrapping-under-rlang-and-cli.md` gains a revisions
  entry pointing at the new note, per `investigation/README.md`; ADR 0023 cites
  both, in the same commit.
- Two review findings are filed rather than fixed here: **#229** (two test files
  carry their own copy of the namespace walk — fixing it means editing
  `test-query-policy.R`, which phase 2b has no reason to touch) and **#230**
  above.