### PR TITLE
Spell a caller's subject as the caller wrote it

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -19,8 +19,6 @@
 # succeeds while executing nothing. A page absent from `markers` still gets
 # everything above. A `markers` key naming no derived page is an error, so
 # renaming a vignette cannot quietly drop its markers instead of moving them.
-# A marker is matched with whitespace normalized on both sides, for the reason
-# `normalize_whitespace()` below records.
 
 source(".github/scripts/ci-helpers.R")
 
@@ -224,45 +222,26 @@ forbidden <- c(
   "union_all_with_margins"
 )
 
-# Runs of whitespace collapsed to one space, which is what makes a marker
-# insensitive to where a line broke.
+# A marker is matched against the page as it was written. That was briefly not
+# so: adopting `cli::cli_abort()` put a wrap into every rendered diagnostic and
+# two markers stopped matching as raw substrings, so the matching normalized
+# whitespace on both sides. ADR 0024 moved the expansion to raise time, and a
+# diagnostic this package writes reaches the page as the one line it was
+# authored as, so both match raw again and the normalization is gone. The
+# External conditions the site also renders do still wrap, but the markers
+# quoting them are `Error in ...:` headers, which cannot span a break.
 #
-# marginplyr signals through `cli::cli_abort()`, which wraps a diagnostic at
-# retrieval time to whatever width the renderer had (ADR 0023) -- so a sentence
-# this package authors reaches the page broken across lines, with a bullet's
-# continuation indented by two spaces, where the source holds one line. Markers
-# are also chosen from a run of uninterpolated prose, per that ADR's third line
-# condition, and the two are not the same protection: the choice keeps a marker
-# short enough that it is unlikely to span a break, and this keeps it matching
-# when it does anyway.
-#
-# Applied to both sides, so a marker written with a break in it matches too, and
-# so that nothing this accepts depends on how the marker was typed. It can only
-# widen what matches: a marker that matched the raw page still matches the
-# normalized one.
-#
-# `assert_no_match()`'s two scans below deliberately keep reading the raw page.
-# A wrap cannot split what either of them looks for: cli breaks a line at
-# whitespace and not inside a token -- measured at width 30 against a
-# 68-character path, which stayed whole on a line of its own -- and every
-# pattern written out here is whitespace-free, the home-directory one excluding
-# whitespace explicitly.
-#
-# The one pattern that is not written out here is the `\Q<home>\E` built below
-# from the checking machine's own home directory, and it carries a space when
-# that directory does. A wrap at that space would evade this scan, and
-# normalizing would close it. It is left raw because that gap is neither this
-# commit's nor cli's -- a rendered page has wrapped in a dozen other ways since
-# #99, and the pattern only carries a space on a machine whose home does --
-# while a leak scan reporting the text it matched is worth keeping exact.
-normalize_whitespace <- function(text) {
-  gsub("[[:space:]]+", " ", text)
-}
-
+# The same reading covers `assert_no_match()`'s two scans above, which never
+# normalized: cli breaks a line at whitespace and not inside a token -- measured
+# at width 30 against a 68-character path, which stayed whole on a line of its
+# own -- and every pattern written out here is whitespace-free, the
+# home-directory one excluding whitespace explicitly. The one pattern that is
+# not written out here is the `\Q<home>\E` built below from the checking
+# machine's own home directory, which carries a space only on a machine whose
+# home does.
 assert_markers <- function(text, markers, page) {
-  text <- normalize_whitespace(text)
   absent <- markers[!vapply(
-    normalize_whitespace(markers),
+    markers,
     grepl,
     logical(1),
     x = text,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -174,7 +174,11 @@ _Avoid_: Choice argument, enum argument, flag argument, mode argument
 An error marginplyr itself raises, inheriting the `marginplyr_error` base
 class. It reports something the caller can avoid by rewriting the call within
 the documented public interface. It is always an error: marginplyr states what
-it will not do by refusing, and raises no warning of its own.
+it will not do by refusing, and raises no warning of its own. A subject it
+names that the caller supplied — a column, a value, an argument — is spelled as
+the caller spelled it, up to the two whitespace characters `?marginplyr` names,
+so that what a reader searches for is what they wrote. The wording around that
+subject is marginplyr's own and carries no promise.
 _Avoid_: Package error, internal error, user-facing error
 
 **External condition**:

--- a/NEWS.md
+++ b/NEWS.md
@@ -124,10 +124,12 @@
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording
-  remain implementation details. Errors from your summary expressions,
-  tidyselect, dplyr, or a backend keep their original class, diagnostic, and
-  cause, and so do internal invariant checks that no change to the call can
-  avoid.
+  remain implementation details. The columns, values, and arguments such an
+  error quotes are yours, though, and it spells them as you spelled them —
+  except that a line break and a no-break space inside a name are both shown as
+  an ordinary space. Errors from your summary expressions, tidyselect, dplyr,
+  or a backend keep their original class, diagnostic, and cause, and so do
+  internal invariant checks that no change to the call can avoid.
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -10,23 +10,49 @@
 # public class.
 #
 # It is also the interpolating entry point: `message` is a cli template a call
-# site passes unexpanded, and `.envir` is what lets cli evaluate the template's
+# site passes unexpanded, and `env` is what lets cli evaluate the template's
 # `{}` expressions in that site's own frame. ADR 0023 is authoritative for the
 # idiom every template is authored in -- the short refusal plus `i` bullets, the
 # inline style each subject takes, `{?}` for every plural, and the rule that
 # caller-derived text is interpolated as a value and never concatenated into the
 # template. ADR 0015's boundary is untouched by that: this still owns the class
-# and the blamed call, and `cli_abort()` carries `marginplyr_error` through.
+# and the blamed call.
+#
+# The template is expanded here, as the condition is raised, rather than by
+# `cli::cli_abort()` when the condition is read. That is what keeps a subject
+# spelled the way the caller spelled it: `cli_abort()` sets `use_cli_format`,
+# and the retrieval-time formatting collapses a run of whitespace inside an
+# interpolated value as readily as inside the template, so a column named
+# `a  b` was named `a b` in the refusal. ADR 0024 records the decision and what
+# it costs -- there is no wrapping to a reader's width any more, and styling is
+# fixed by the raising session rather than the reading one.
+#
+# `format_inline()` is the inline half of cli and does not consult the width, so
+# every element comes back as the one line it was written as. Names carry the
+# bullet markers and are reattached, `vapply()` having dropped them.
 abort_marginplyr <- function(message,
                              ...,
                              class = NULL,
                              call = rlang::caller_call()) {
-  cli::cli_abort(
-    message = message,
+  env <- rlang::caller_env()
+  expanded <- vapply(
+    message,
+    cli::format_inline,
+    character(1),
+    .envir = env,
+    USE.NAMES = FALSE
+  )
+  names(expanded) <- names(message)
+  rlang::abort(
+    message = expanded,
     ...,
     class = c(class, "marginplyr_error"),
     call = call,
-    .envir = rlang::caller_env()
+    # Spelled although `rlang::abort()` has a default, because the default is
+    # this function's own caller as seen from `abort()` -- one frame deeper than
+    # the site -- which leaves the raising call in the backtrace that
+    # `cli_abort(.envir =)` trimmed.
+    .frame = env
   )
 }
 
@@ -35,13 +61,10 @@ abort_marginplyr <- function(message,
 # injection surface rather than a formatting choice: the braces cli would
 # interpret do not come from the source literals -- an AST walk over `R/` found
 # none -- they come from caller data, and a column named `a{b}` is legal.
-# Against an assembled string `cli_abort()` answers `Could not evaluate cli {}
-# expression` instead of the refusal, so every not-yet-re-authored site passes
-# through here, where the string is interpolated as a *value*, which is what
-# makes a caller's braces inert. Inert is not untouched: cli's formatter
-# collapses a run of whitespace inside a value as it does inside the template,
-# which is a property of signalling through `cli_abort()` at all rather than of
-# this sibling, and is recorded in ADR 0023's consequences.
+# Against an assembled string cli answers `Could not evaluate cli {} expression`
+# instead of the refusal, so every not-yet-re-authored site passes through here,
+# where the string is interpolated as a *value*, which is what makes a caller's
+# braces inert.
 #
 # This exists to be deleted. #223's phase 3 re-authors `R/` file by file, and
 # each of those pull requests drops this for its own sites; the last one removes
@@ -311,10 +334,10 @@ message_line_runs <- function(lines) {
 # in ADR 0022 beside the wrapping such a line already loses.
 #
 # cli needs no availability guard: it is an Import of this package, and every
-# error path crosses it since `abort_marginplyr()` above signals through
-# `cli_abort()`. That is a change of mechanism rather than of fact -- it was
-# already unable to be absent as an Import of both dplyr and tidyselect, the
-# `DBI = FALSE` case in `AGENTS.md`'s dependency metadata that
+# error path crosses it, `abort_marginplyr()` above expanding its template
+# through `cli::format_inline()`. That is a change of mechanism rather than of
+# fact -- it was already unable to be absent as an Import of both dplyr and
+# tidyselect, the `DBI = FALSE` case in `AGENTS.md`'s dependency metadata that
 # `share_dialect_can_be_asked()` still is -- and the difference is that the
 # floor now binds. DESCRIPTION states `cli (>= 3.4.0)`, which the installer
 # reads, where a Suggests floor would have been read only by

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -55,6 +55,12 @@
 #' can change without a deprecation cycle, so match on the class rather than on
 #' message text.
 #'
+#' The wording is marginplyr's to change; the columns, values, and arguments a
+#' message quotes are yours, and a marginplyr error spells them as you spelled
+#' them. Two spellings it cannot keep: a line break and a no-break space inside
+#' a name are both shown as an ordinary space. This says nothing about the
+#' errors below, which marginplyr does not write.
+#'
 #' Two kinds of error deliberately fall outside the class. Errors raised by
 #' your own summary expressions, by tidyselect, by dplyr, or by a database
 #' backend propagate with their original class, diagnostic, and cause intact.

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -29,6 +29,51 @@ measured once every site had moved,
 rather than restated because each is a fact about rlang, cli, or testthat, and
 ages when one of those moves rather than when `R/` does.
 
+## Amendment: the template is expanded when the condition is raised
+
+[ADR 0024](0024-spell-a-callers-subject-as-the-caller-wrote-it.md) found that
+`cli_abort()`'s retrieval-time formatting collapses a run of whitespace inside
+an interpolated value as readily as inside the template — so a column the caller
+named `a  b` was named `a b` in the refusal. Every sentence below that names
+`cli_abort()` as the call, or rests on the wrapping it did, is superseded by it.
+What stands is the whole of the idiom: the style table, the injection rule, the
+`{?}` rule, the vector defaults, cli as an Import with its floor, and the
+structural gate. The template is the same template; what moved is when it is
+expanded.
+
+**Every naming of the call** goes: "signalled through `cli::cli_abort()`" and
+"it wraps `cli::cli_abort()` with `.envir = rlang::caller_env()`" in the opening
+section, and "`cli_abort()`'s `class` argument carries it through" in
+*Consequences*. `abort_marginplyr()` expands its template with
+`cli::format_inline()` and raises through `rlang::abort()`, whose `class`
+argument carries `marginplyr_error` exactly as `cli_abort()`'s did — the
+`must_error` hook and its twenty vignette chunks are untouched either way.
+
+**The line conditions** were written against wrapping that no longer happens,
+and two of them go with it. Condition 1, that the authored prose of a line fits
+in 80 columns, is now style advice rather than a requirement. So is the first
+sentence of condition 3, that no pin and no marker spans a wrap point — there
+are no wrap points. Condition 2 survives whole and matters more than it did: a
+part whose length the caller decides goes alone in an `i` bullet, which without
+wrapping is the only thing between a long vector and a very long line. So does
+the second sentence of condition 3, that a marker is chosen from a run of
+uninterpolated prose, which was never about wrapping — a marker quoting an
+interpolated part varies with the data at any width.
+
+**The paragraph in *Consequences* beginning "Wrapping is not the whole of what
+retrieval-time formatting costs"** recorded the collapsing and left the trade
+open in #230. It is settled: the collapsing is a defect, and ADR 0024 is the
+remedy. Two spellings survive neither route and are stated in `?marginplyr` — a
+line break and a no-break space inside a name are shown as an ordinary space.
+
+**The normalization *Consequences* asks of `verify-site.R`** is removed with the
+wrapping that needed it. The paragraph saying the marker matching "is where a
+whitespace-normalizing comparison is needed", and the one citing two site
+markers that "only match once normalized", both describe a state that lasted one
+commit: rebuilding the site after ADR 0024 shows seven rendered diagnostics with
+no wrap in them, and both markers matching raw again. What survives of that
+argument is condition 3's second sentence, above.
+
 ## The migration introduces wrapping, so a line is authored to survive it
 
 `rlang::abort()` wraps nothing. `cli_abort()` wraps at retrieval time, at

--- a/design/adr/0024-spell-a-callers-subject-as-the-caller-wrote-it.md
+++ b/design/adr/0024-spell-a-callers-subject-as-the-caller-wrote-it.md
@@ -1,0 +1,141 @@
+# Spell a caller's subject as the caller wrote it in a Package condition
+
+A Package condition names a column, a value, or an argument the caller supplied
+using the caller's own spelling. `abort_marginplyr()` therefore expands its cli
+template when the condition is *raised*, through `cli::format_inline()` and
+`rlang::abort()`, rather than leaving `cli::cli_abort()` to expand it when the
+condition is *read*. The idiom every template is authored in does not change:
+ADR 0023's style table, its `{?}` rule, its vector defaults, and its rule that
+caller-derived text is an interpolated value all stand, and cli remains an
+Import.
+
+Two spellings survive neither route, and `?marginplyr` states them rather than
+promising more than this keeps: a line break and a no-break space inside a name
+are both shown as an ordinary space, because cli's glue pass rewrites them
+before any marginplyr code sees the result.
+
+## What retrieval-time formatting was doing
+
+`cli_abort()` sets `use_cli_format`, so `conditionMessage()` formats the stored
+message when it is read. That formatting collapses every run of whitespace —
+and it does not distinguish the template from the values interpolated into it.
+A `.margin_label` dimension the caller named `` `bad  name` `` was stored with
+its two spaces and named `` `bad name` `` in the refusal.
+
+This is the failure a refusal exists to prevent, run backwards: the reader is
+sent looking for a column that does not exist in their data, by the sentence
+telling them the column does not exist. `rlang::abort()`, which
+`abort_marginplyr()` used before ADR 0023, showed the caller's bytes.
+
+`CONTEXT.md` already held the value this violates, in *Condition context*: a
+Margin verb owes the caller a context "written in the names and the expressions
+the caller can act on", so "an argument is quoted as the caller spelled it".
+That term scopes the value to an External condition's context because that is
+where the problem was first noticed (ADR 0021, ADR 0022), not because a Package
+condition was considered and excluded. The glossary now states it of *Package
+condition* too, in that term rather than by widening *Condition context*, which
+names a precise thing — the lines an External condition carries — and would be
+blurred by carrying a second subject.
+
+## Why the fix is a move in time rather than a change of style
+
+Ten inline styles were measured against a two-space name. Every one of them —
+`{.var}`, `{.code}`, `{.val}`, `{.arg}`, `{.field}`, `{.str}`, `{.q}`,
+`{.path}`, `{.file}`, `{.emph}` — stored the spelling and showed it collapsed.
+There is no style that survives, so nothing about ADR 0023's style table could
+have been chosen differently to avoid this.
+
+`cli_abort(use_cli_format = FALSE)` is not available either: `cli_abort()`
+passes that argument itself, so supplying it is a duplicate-argument error. The
+one remaining place to intervene is where the expansion happens, and
+`cli::format_inline()` is the inline half of cli — it expands a template and
+consults no width. Expanding there and handing the result to `rlang::abort()`
+keeps the whole authoring idiom, because the template is the same template.
+
+## What this costs
+
+**A diagnostic no longer wraps to the reader's width.** The message is fixed at
+the width it was written, which is no width at all: each element is the one line
+it was authored as. This is what marginplyr shipped before ADR 0023 —
+`rlang::abort()` wraps nothing — so it is a return rather than a regression, and
+how long such a line can get is bounded by a decision ADR 0023 already made.
+`vec-trunc` stays at cli's default of 20, so the length stops tracking the
+caller's vector there: the longest vector-bearing bullet in this corpus measures
+269 characters at twenty `column_N` names and 275 at a thousand, because what
+grows past the truncation is cli's `and N more` count.
+
+**Styling is fixed by the raising session rather than the reading one, for the
+styles that emit any.** With `cli_abort()` the stored message is escape-free
+and colour is applied on the way out; here a session with colour bakes the
+escapes into `$message`, so a condition captured in a terminal and written to a
+file later carries them.
+
+The exposure is narrower than that reads, twice over. `num_ansi_colors()` is 1
+in every non-interactive run, so nothing is frozen under `R CMD check`, in CI,
+or in a rendered vignette. And of the styles the table above names, only
+`{.val}` emits an escape at 256 colours at all — `{.var}`, `{.arg}`, `{.code}`,
+and `{.fun}` emit none. It is accepted because the alternative is the sentence
+in *What retrieval-time formatting was doing* above, and because this package
+already treats a frozen escape as something to strip rather than something that
+cannot happen (ADR 0022, #217).
+
+## Consequences
+
+ADR 0023's line conditions were written against wrapping that no longer
+happens, and its own amendment records which of them go. One survives whole —
+a part whose length the caller decides goes alone in an `i` bullet — and it
+matters more here than it did there: without wrapping, that is the only thing
+standing between a long vector and a very long line. So does the second
+sentence of its third condition, that a marker is chosen from a run of
+uninterpolated prose, which was never about wrapping: a marker quoting an
+interpolated part varies with the data whatever the width.
+
+`.github/scripts/verify-site.R` loses the whitespace normalization added with
+ADR 0023's adoption. The two markers that needed it were both marginplyr's own
+diagnostics, and neither wraps now. The External conditions the site also
+renders do still wrap, but the markers quoting them are `Error in ...:` headers,
+which cannot span a break.
+
+The promise is pinned in both directions in `test-diagnostic-authoring.R`: the
+spellings a refusal keeps — a run of spaces, a tab, a carriage return, leading
+and trailing space, an ideographic and a thin space, a brace, a backtick — and
+the two it cannot. Only the first list would pass a package that had quietly
+stopped expanding at raise time; only the second would pass one that had lost
+the promise entirely. A spelling moving between the lists is a change to
+`?marginplyr` and fails here first.
+
+Nothing about how a diagnostic is authored changes, so #223's phase 3 is
+unaffected except in what it may cite: its per-pull-request criteria name ADR
+0023's third condition, of which only the second sentence survives.
+
+`abort_marginplyr_flat()` is untouched. The injection rule it exists for is a
+property of the template, which is still glue-interpreted, so an assembled
+string still has to reach cli as a value. Its invariant — one unnamed string —
+holds for the same reason it did: `format_inline()` joins a longer vector with a
+serial `and` and drops the names bullets are carried in.
+
+The measurements are in
+`investigation/expanding-a-diagnostic-when-it-is-raised.md`.
+
+## Considered Options
+
+**Accept the collapsing and document it** — the option #230 opened with, and the
+cheap one. Rejected because the documentation it needs is a sentence widening
+`?marginplyr`'s existing disclaimer from "the wording of any message" to the
+names the caller passed in. That disclaimer exists so a caller matches on class
+instead of grepping prose; stretching it to cover their own data says something
+quite different, and nothing about a refusal is improved by being allowed to
+misname its subject.
+
+**Quote the subject through a style that survives** — #230's second option,
+withdrawn on measurement. All ten styles collapse.
+
+**Pre-render the whole message with `cli::format_message()`** — rejected. It is
+the block-level formatter, so it collapses exactly as retrieval does; it only
+moves *when* the wrap is chosen, not whether the spelling survives.
+
+**Call `cli::format_inline()` at each of the eighty-three sites** — the option
+ADR 0023 rejected, and still rejected, for the reason it gave: it is the same
+boilerplate written eighty-three times and it removes the single point where the
+injection rule can be gated. Doing it once inside the constructor is a different
+shape, and is what this decides.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -385,16 +385,26 @@ public contract, and an invariant promoted to `abort_marginplyr()` silently
 enters it.
 
 It is also the interpolating entry point. A call site passes an unexpanded cli
-template and `cli::cli_abort()` expands it in the site's own frame, so the
-constructor owns the message's shape as well as its class: a short refusal plus
-`i` bullets, one inline style per subject, `{?}` for every plural, and
-caller-derived text interpolated as a value rather than concatenated into the
-template. See
+template and the constructor expands it in the site's own frame, so it owns the
+message's shape as well as its class: a short refusal plus `i` bullets, one
+inline style per subject, `{?}` for every plural, and caller-derived text
+interpolated as a value rather than concatenated into the template. See
 [ADR 0023](adr/0023-author-diagnostics-in-the-cli-idiom.md).
-`test-diagnostic-authoring.R` gates the last two of those together, by failing
-any `abort_marginplyr()` call whose message argument is not a literal in the
-source: an assembled template and an `if`-spelled noun are one violation seen
-from two sides.
+
+The expansion happens as the condition is raised — `cli::format_inline()` per
+element, then `rlang::abort()` — rather than when it is read.
+`cli::cli_abort()` would format at retrieval, and that pass collapses a run of
+whitespace inside an interpolated value as readily as inside the template, so a
+column the caller named `a  b` was named `a b` in the refusal. Raising expanded
+keeps the caller's spelling, at the cost of wrapping to the reader's width. See
+[ADR 0024](adr/0024-spell-a-callers-subject-as-the-caller-wrote-it.md), which
+also records the two spellings no route keeps.
+
+`test-diagnostic-authoring.R` gates the injection and plural rules together, by
+failing any `abort_marginplyr()` call whose message argument is not a literal in
+the source: an assembled template and an `if`-spelled noun are one violation
+seen from two sides. It pins the spelling promise beside them, in both
+directions.
 Sites that still assemble their own string pass through
 `abort_marginplyr_flat()`, which interpolates it as a value; that function is
 transitional, and the snapshot beside the gate is what is left of #223.

--- a/investigation/expanding-a-diagnostic-when-it-is-raised.md
+++ b/investigation/expanding-a-diagnostic-when-it-is-raised.md
@@ -1,0 +1,152 @@
+# Expanding a cli template when the condition is raised
+
+Investigated: 2026-08-19
+
+`investigation/retrieval-time-formatting-of-a-cli-diagnostic.md` established
+that `cli::cli_abort()`'s retrieval-time formatting collapses a run of
+whitespace inside an interpolated value, so a column the caller named `a  b` is
+named `a b` in the refusal, and left the question of what to do about it to
+#230. This note is the measuring that question asked for: whether any cli style
+avoids it, whether `cli_abort()` can be told not to format at retrieval, and
+what an alternative would cost.
+
+Environment: R 4.6.1 (2026-06-24), cli 3.6.6, rlang 1.3.0, testthat 3.3.2, on
+macOS.
+
+## No inline style survives the retrieval pass
+
+A `.margin_label` dimension named `bad  name`, through `cli_abort()`, in every
+style ADR 0023's table names and several it does not:
+
+| template | stored `$message` | `conditionMessage()` |
+| --- | --- | --- |
+| `{x}`, `{.field {x}}`, `{.emph {x}}` | `bad  name` | `bad name` |
+| `{.var {x}}`, `{.code {x}}`, `{.arg {x}}` | `` `bad  name` `` | `` `bad name` `` |
+| `{.val {x}}`, `{.str {x}}`, `{.q {x}}` | `"bad  name"` | `"bad name"` |
+| `{.path {x}}`, `{.file {x}}` | `'bad  name'` | `'bad name'` |
+
+Ten styles, one answer. The spelling reaches the condition intact in every case
+and is rewritten on the way out, so the choice of style cannot avoid it.
+
+## `cli_abort()` cannot be told to skip the retrieval pass
+
+`cli::cli_abort(msg, use_cli_format = FALSE)` fails with
+
+```text
+formal argument "use_cli_format" matched by multiple actual arguments
+```
+
+because `cli_abort()` passes that argument to `rlang::abort()` itself.
+
+`cli::format_message()` was measured as a pre-rendering alternative and does not
+help: it is the block-level formatter, so it collapses exactly as retrieval
+does. Only `cli::format_inline()` preserves the spelling, and it consults no
+width.
+
+## What expanding at raise time keeps and loses
+
+The shape measured is `vapply(message, cli::format_inline, .envir = <caller>)`
+followed by `rlang::abort()`, against a three-element message: a main line with
+`{length(cols)}` and `{?s}`, an `i` bullet interpolating a 12-element column
+vector, and an `i` bullet naming `bad  name`.
+
+Kept: `{.arg}` and `{.var}` styling, `{?s}` agreeing with the quantity, cli's
+serial `and` between vector elements, the `i` bullet markers, the
+`marginplyr_error` class, and the blamed call. Rendered `Error in ...:` header
+and `!` prefix are byte-identical to `cli_abort()`'s.
+
+Lost: wrapping. The same condition read at `width = 80` and at `width = 40`
+carries 2 newlines both times, and both are bullet boundaries. Under
+`cli_abort()` the same message carries 3 newlines at 80 and more at 40.
+
+A frame is gained in the backtrace unless `.frame` is passed: `rlang::abort()`'s
+default resolves to one frame deeper than `cli_abort(.envir =)` did, which
+leaves the raising call visible.
+
+## Styling is fixed by the raising session
+
+| `cli.num_colors` | escapes in stored `$message` | escapes in `conditionMessage()` |
+| --- | --- | --- |
+| raise-time expansion, 1 | no | no |
+| raise-time expansion, 256 | **yes** | yes |
+| `cli_abort()`, 1 | no | no |
+| `cli_abort()`, 256 | no | yes |
+
+`num_ansi_colors()` was 1 in a plain `Rscript` run, which is what `R CMD check`,
+CI, and a rendered vignette get.
+
+Which styles emit an escape at 256 colours is narrower than the table suggests.
+Of ADR 0023's five, only `{.val}` does; `{.var}`, `{.arg}`, `{.code}`, and
+`{.fun}` emit none, and neither does `{.str}`. `{.field}` and `{.emph}`, which
+that table does not name, do.
+
+## Which spellings survive, to the codepoint
+
+Through the raise-time expansion, a `.margin_label` dimension name:
+
+| spelling | result |
+| --- | --- |
+| two spaces, tab, carriage return | preserved |
+| leading space, trailing space | preserved |
+| ideographic space U+3000, thin space U+2009, zero-width space U+200B | preserved |
+| brace, backtick, emoji | preserved |
+| **newline U+000A** | **shown as U+0020** |
+| **no-break space U+00A0** | **shown as U+0020** |
+
+The two rewritten ones go in cli's glue pass, before any marginplyr code sees
+the result. Every row is a codepoint dump of the quoted name rather than a
+visual comparison: an intermediate reading of the no-break space during this
+session reported it preserved, because the literal reached R as an ordinary
+space through the shell, and only dumping the codepoints showed it.
+
+## How long an unwrapped bullet gets
+
+`cli::format_inline("Remove {.var {cols}} from it.")`, which is the shape of the
+longest vector-bearing bullet in this package's corpus:
+
+| elements | characters, short names | characters, `column_N` names |
+| --- | --- | --- |
+| 3 | 42 | 50 |
+| 8 | 82 | 118 |
+| 20 | 189 | 269 |
+| 100 | — | 273 |
+| 1000 | — | 275 |
+
+`vec-trunc` is 20 by cli's default, which ADR 0023 adopted, so the length stops
+tracking the caller's vector at twenty elements. It is not a ceiling: cli
+appends `and N more`, and that count widens, so the same bullet grows about six
+characters between 20 elements and 1000. What is bounded is the growth, not the
+length.
+
+## What the rendered site holds after the move
+
+The site was rebuilt with `altdoc::render_docs(parallel = FALSE, freeze = FALSE)`
+against the installed working tree. `docs/vignettes/get_started.html` carries
+seven rendered `Error in ...:` blocks and **no wrap in any of them**, where the
+same page built through `cli_abort()` wrapped all seven with two-space
+continuations. The 96-character duplicate-grouping-set refusal is back on one
+line.
+
+The two markers `.github/scripts/verify-site.R` could only match with whitespace
+normalized —
+`` Add an empty `grouping_set()` to the `grouping_sets()` specification `` and
+`which can be nested: data.frame, dtplyr_step` — match as raw `fixed = TRUE`
+substrings again.
+
+## An expectation that passed for a reason not established
+
+While pinning the two rewritten spellings, an assertion written as
+
+```r
+expect_true(grepl(gsub("[\n ]", " ", name), message, fixed = TRUE))
+```
+
+passed inside `test_that()` for the no-break-space case although the same
+expression, evaluated by `cat()` on the line above it in the same loop,
+returned `FALSE`; a deliberately failing expectation added to the same file was
+reported normally, so failures were not being swallowed. The cause was not
+found. The assertion was rewritten to build the expected string with `chartr()`
+over codepoints given as escapes, which is unambiguous, and both directions of
+the pin were then mutation-checked: moving a preserved spelling into the
+rewritten set fails the rewritten test, and moving a rewritten spelling into the
+preserved set fails the preserved test.

--- a/investigation/retrieval-time-formatting-of-a-cli-diagnostic.md
+++ b/investigation/retrieval-time-formatting-of-a-cli-diagnostic.md
@@ -1,6 +1,7 @@
 # What happens to a cli diagnostic between raising it and reading it
 
 Investigated: 2026-08-19
+Revised: 2026-08-19 — investigation/expanding-a-diagnostic-when-it-is-raised.md
 
 `investigation/diagnostic-wrapping-under-rlang-and-cli.md` established, earlier
 the same day, that `rlang::abort()` wraps nothing and `cli::cli_abort()` wraps
@@ -72,6 +73,26 @@ the shipped unknown-dimension refusal, a `.margin_label` dimension named
 for an equivalent and has none — and the collapsing happens in rlang's
 retrieval formatting rather than in the interpolation, so that argument would
 not reach it in any case.
+
+## Revisions (2026-08-19)
+
+`investigation/expanding-a-diagnostic-when-it-is-raised.md` was taken later the
+same day, to answer what #230 should do about the section above. It sharpens
+that section and settles the question.
+
+What the section established was that a run of whitespace collapses. The
+successor measures which spellings, to the codepoint, and the answer is narrower
+than "whitespace": U+000A and U+00A0 are rewritten to U+0020, while a tab, a
+carriage return, a leading or trailing space, U+2009, U+200B, and U+3000 all
+survive.
+
+What it settles: no cli inline style avoids the collapsing, `cli_abort()` cannot
+be told to skip its retrieval pass, and expanding the template with
+`cli::format_inline()` at raise time keeps the caller's spelling and the whole
+authoring idiom at the cost of wrapping. ADR 0024 is the decision, and it also
+retires the wrapping this note's last two sections measured: a diagnostic this
+package writes reaches a rendered vignette unwrapped again, and
+`.github/scripts/verify-site.R`'s marker normalization is removed with it.
 
 ## cli breaks at whitespace, not inside a token
 

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -66,6 +66,12 @@ subclasses and the wording of any message are implementation details that
 can change without a deprecation cycle, so match on the class rather than on
 message text.
 
+The wording is marginplyr's to change; the columns, values, and arguments a
+message quotes are yours, and a marginplyr error spells them as you spelled
+them. Two spellings it cannot keep: a line break and a no-break space inside
+a name are both shown as an ordinary space. This says nothing about the
+errors below, which marginplyr does not write.
+
 Two kinds of error deliberately fall outside the class. Errors raised by
 your own summary expressions, by tidyselect, by dplyr, or by a database
 backend propagate with their original class, diagnostic, and cause intact.

--- a/tests/testthat/test-diagnostic-authoring.R
+++ b/tests/testthat/test-diagnostic-authoring.R
@@ -248,3 +248,79 @@ test_that("a caller's braces reach a diagnostic as text", {
     fixed = TRUE
   )
 })
+
+# The promise `?marginplyr` makes about a subject the caller supplied: a Package
+# condition names it as the caller spelled it. ADR 0024 decides it and records
+# why `abort_marginplyr()` expands its template when the condition is raised
+# rather than when it is read -- `cli::cli_abort()` collapses a run of
+# whitespace inside an interpolated value at retrieval, which named a column
+# `a b` that the caller had named `a  b`.
+#
+# Both directions are pinned, in the shape `test-diagnostic-pluralization.R`
+# uses for a pluralizing diagnostic's two arms. Only asserting the preserved
+# spellings would pass a package that stopped expanding at raise time in some
+# future where nothing wrapped anyway; only asserting the residue would pass one
+# that lost the promise entirely. `?marginplyr` states the residue rather than
+# claiming more than it keeps, so a spelling moving from one list to the other
+# is a documentation change and fails here first.
+#
+# The subject is a `.margin_label` dimension name, because that is a name the
+# caller writes directly into the call and the shortest path to a refusal that
+# quotes it.
+unknown_dimension_message <- function(name) {
+  data <- data.frame(region = "E", n = 1)
+  # `region` is a column of the frame, which codetools reads as an undefined
+  # global wherever a verb's arguments are written inside a function.
+  # nolint start: object_usage_linter.
+  conditionMessage(expect_error(
+    expand_with_margins(
+      data,
+      .grouping = rollup(region),
+      .margin_label = stats::setNames(c("A", "A"), c("region", name))
+    ),
+    # The class, because the tests below read the message for a name they put
+    # into the call: an unrelated error quoting that name back would satisfy
+    # them, and the promise is about a Package condition rather than about any
+    # error that happens to mention the subject.
+    class = "marginplyr_error"
+  ))
+  # nolint end
+}
+
+test_that("a Package condition spells a subject as the caller spelled it", {
+  preserved <- c(
+    "two  spaces",
+    "a\ttab",
+    "a\rcarriage return",
+    " leading",
+    "trailing ",
+    "an\u3000ideographic space",
+    "a\u2009thin space",
+    "a{brace}",
+    "a`backtick"
+  )
+
+  for (name in preserved) {
+    expect_true(
+      grepl(name, unknown_dimension_message(name), fixed = TRUE),
+      label = sprintf("the refusal quotes %s", encodeString(name, quote = '"'))
+    )
+  }
+})
+
+test_that("the two spellings a Package condition cannot keep", {
+  # cli's glue pass turns both of these into an ordinary space before any
+  # marginplyr code sees the result, so the refusal names a subject one
+  # character different from the one the caller wrote. `?marginplyr` says so
+  # rather than promising more than it keeps.
+  newline_and_nbsp <- c("\n", "\u00a0")
+  rewritten <- paste0("a", newline_and_nbsp, "spelling")
+  newline_and_nbsp <- paste(newline_and_nbsp, collapse = "")
+
+  for (name in rewritten) {
+    quoted <- unknown_dimension_message(name)
+    as_spaces <- chartr(newline_and_nbsp, "  ", name)
+    expect_false(grepl(name, quoted, fixed = TRUE))
+    expect_true(grepl(as_spaces, quoted, fixed = TRUE))
+  }
+})


### PR DESCRIPTION
Closes #230.

`abort_marginplyr()` expands its cli template when the condition is **raised** —
`cli::format_inline()` per element, then `rlang::abort()` — instead of leaving
`cli::cli_abort()` to expand it when the condition is **read**.

## The defect

`cli_abort()` sets `use_cli_format`, so `conditionMessage()` formats the stored
message on the way out. That pass collapses every run of whitespace, and it does
not distinguish the template from the values interpolated into it:

```r
summarize_with_margins(data, .grouping = rollup(region),
                       .margin_label = c(region = "A", "bad  name" = "A"))
#> before: `.margin_label` has unknown dimension name `bad name`
#> after:  `.margin_label` has unknown dimension name `bad  name`
```

It reached the 66 sites that splice caller data, and it is the failure a refusal
exists to prevent run backwards — the reader sent looking for a column that does
not exist, by the sentence telling them it does not exist.

`CONTEXT.md` already held the value this violates, in *Condition context*: "an
argument is quoted as the caller spelled it". That term scopes it to an External
condition's context because that is where the problem was first noticed (ADR
0021, ADR 0022), not because a Package condition was considered and excluded.
*Package condition* now states it too — in that term, rather than by widening
*Condition context*, which names a precise thing and would be blurred by
carrying a second subject.

## Measured before deciding

`investigation/expanding-a-diagnostic-when-it-is-raised.md`:

- **All ten inline styles collapse it.** `{.var}`, `{.code}`, `{.val}`,
  `{.arg}`, `{.field}`, `{.str}`, `{.q}`, `{.path}`, `{.file}`, `{.emph}` — the
  spelling reaches the condition intact and is rewritten on the way out. No
  style table could have avoided this.
- **`cli_abort(use_cli_format = FALSE)` is a duplicate-argument error**, and
  `format_message()` collapses exactly as retrieval does. `format_inline()` is
  the one place left to intervene.
- **The residue, to the codepoint**: U+000A and U+00A0 become U+0020, in cli's
  glue pass. A tab, a carriage return, leading and trailing space, U+2009,
  U+200B, U+3000, braces, backticks, and emoji all survive.

## What does not change

The whole authoring idiom. ADR 0023's style table, `{?}` rule, vector defaults,
injection rule, cli as an Import with its floor, and the structural gate all
stand — the template is the same template. `abort_marginplyr_flat()` and its
invariant are untouched, the injection rule being a property of the template.

That is why this is a **new ADR** rather than a rewrite of 0023, with an
`## Amendment:` on 0023 naming what stops holding there: every sentence that
names `cli_abort()` as the call, line conditions 1 and 3's first sentence, the
paragraph that left this trade open in #230, and the normalization it asked of
`verify-site.R`. Condition 2 survives whole, and so does condition 3's second
sentence — a marker is chosen from uninterpolated prose, which was never about
wrapping.

## What it costs

**No wrapping to the reader's width.** This is what shipped before ADR 0023 —
`rlang::abort()` wraps nothing. `vec-trunc = 20` stops the length tracking the
caller's vector, so the longest bullet in this corpus is 269 characters at
twenty names and 275 at a thousand.

**Styling fixed by the raising session.** `num_ansi_colors()` is 1 in every
non-interactive run, so nothing freezes under `R CMD check`, in CI, or in a
rendered vignette — and of ADR 0023's five styles only `{.val}` emits an escape
at all.

## The promise, and the test that holds it

`?marginplyr` and `NEWS.md` state it, scoped to Package conditions (External
conditions propagate untouched, and dplyr's own formatting still collapses), and
they name the two spellings it cannot keep rather than promising more than it
keeps.

`test-diagnostic-authoring.R` pins **both directions** against the
`marginplyr_error` class, in the shape `test-diagnostic-pluralization.R` uses for
a pluralizing diagnostic's two arms. Only the preserved list would pass a package
that quietly stopped expanding at raise time; only the residue list would pass
one that lost the promise entirely. Both were mutation-checked: moving a spelling
between the lists fails the test it moved out of, and breaking the class
assertion fails too.

## Verification

| check | result |
| --- | --- |
| full test suite | green, **no pin or snapshot edited** |
| `lintr::lint_package()` | no lints |
| `R CMD check` (tarball) | `Status: OK` |
| `verify-suite-coverage.R` | 594 tests, all executed in ≥1 of the 5 single-backend configurations |
| `verify-site.R` against a freshly rendered `docs/` | pass — **7 rendered diagnostics, 0 wraps**, both previously-normalized markers matching raw |
| `verify-must-error.R` | 8/8 |

## Notes

- `design/architecture.md`'s Conditions chapter and the cli availability
  paragraph in `R/conditions.R` move with the mechanism.
- `investigation/retrieval-time-formatting-of-a-cli-diagnostic.md` gains a
  revisions entry pointing at the new note, per `investigation/README.md`; ADR
  0024 and ADR 0023 cite both.
- #223 has a comment correcting its phase-3 criterion 4, which cited ADR 0023's
  condition 3.
- The new note records one thing that was **not** established: an earlier form
  of the residue pin passed for a reason I could not account for. It was
  replaced with a `chartr()` form over escaped codepoints and mutation-checked;
  the note says what was tried.