### PR TITLE
Author R/share.R's diagnostics in the cli idiom

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -584,26 +584,32 @@
 #'   .grouping = grouping_sets(grouping_set(region), grouping_set(store))
 #' ))
 share_of_parent <- function(x) {
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      "`share_of_parent()` can only be used inside ",
-      "`summarize_with_margins()` with a `rollup()`. To derive a value from ",
-      "an existing Parent share, use a following `dplyr::mutate()`."
+      "{.fun share_of_parent} can only be used inside ",
+      "{.fun summarize_with_margins} with a {.fun rollup}."
+    ),
+    i = paste0(
+      "To derive a value from an existing Parent share, use a following ",
+      "{.fun dplyr::mutate}."
     )
-  )
+  ))
 }
 
 #' @rdname share_of_parent
 #' @export
 share_of_total <- function(x) {
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      "`share_of_total()` can only be used inside ",
-      "`summarize_with_margins()` with a Grouping plan that contains the ",
-      "Grand total set. To derive a value from an existing Total share, use ",
-      "a following `dplyr::mutate()`."
+      "{.fun share_of_total} can only be used inside ",
+      "{.fun summarize_with_margins} with a Grouping plan that contains the ",
+      "Grand total set."
+    ),
+    i = paste0(
+      "To derive a value from an existing Total share, use a following ",
+      "{.fun dplyr::mutate}."
     )
-  )
+  ))
 }
 
 # Returns the share kinds the call requests, which is what the verb needs to
@@ -640,19 +646,29 @@ preflight_shares <- function(dots) {
 }
 
 abort_share_helper_position <- function(kind, complete) {
-  abort_marginplyr_flat(
-    paste0(
-      share_kind_call(kind), " must be the complete right-hand side of a ",
-      "named summary, or the direct `.fns` argument of `across()`.",
-      if (complete) {
-        paste0(
-          " Create the ", share_kind_label(kind), " as its own named ",
-          "summary, then use a following `dplyr::mutate()` for derived ",
-          "values."
-        )
-      }
-    )
-  )
+  # Two calls rather than one carrying a computed bullet. The refusal is the
+  # same either way and only the remedy is conditional, so the alternative
+  # spellings are an `if` inside the template, which the structural gate
+  # refuses, or an `i` bullet whose content is sometimes empty, which renders
+  # as a bullet marker with nothing after it.
+  if (complete) {
+    abort_marginplyr(c(
+      paste0(
+        "{.fun {share_helper_name(kind)}} must be the complete right-hand ",
+        "side of a named summary, or the direct {.arg .fns} argument of ",
+        "{.fun across}."
+      ),
+      i = paste0(
+        "Create the {share_kind_label(kind)} as its own named summary, then ",
+        "use a following {.fun dplyr::mutate} for derived values."
+      )
+    ))
+  }
+  abort_marginplyr(paste0(
+    "{.fun {share_helper_name(kind)}} must be the complete right-hand side ",
+    "of a named summary, or the direct {.arg .fns} argument of ",
+    "{.fun across}."
+  ))
 }
 
 # Arrow rejects every contextual share for one reason — the numerator's source
@@ -661,18 +677,18 @@ abort_share_helper_position <- function(kind, complete) {
 # vocabulary lives here; the executor decides when to raise it.
 abort_arrow_shares <- function(kinds) {
   kinds <- intersect(share_kind_names(), kinds)
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      "Arrow backends do not support ",
-      share_kind_labels_phrase(kinds),
-      " because marginplyr cannot enforce their scalar-summary contract ",
-      "safely before an Arrow query is constructed. Other Arrow Margin ",
-      "operations remain supported. Omit ",
-      share_kind_calls_phrase(kinds),
-      " or explicitly collect the data before calling ",
-      "`summarize_with_margins()`."
+      "Arrow backends do not support {share_kind_label_plurals(kinds)} ",
+      "because marginplyr cannot enforce their scalar-summary contract ",
+      "safely before an Arrow query is constructed."
+    ),
+    i = "Other Arrow Margin operations remain supported.",
+    i = paste0(
+      "Omit {.fun {share_kind_helpers(kinds)}} or explicitly collect the ",
+      "data before calling {.fun summarize_with_margins}."
     )
-  )
+  ))
 }
 
 # Only a Parent share can be refused from the Grouping specification alone.
@@ -689,14 +705,25 @@ share_grouping_spec_validator <- function(kinds) {
 check_parent_grouping_spec <- function(grouping_spec) {
   kind <- if (is.null(grouping_spec)) NULL else grouping_spec$type
   if (!identical(kind, "rollup")) {
-    abort_marginplyr_flat(
+    # Written out here and again in `check_parent_grouping_kind()`, which
+    # refuses the same call from the compiled plan. A shared constructor would
+    # read better and is what the flat form had, but the structural gate reads
+    # `abort_marginplyr()`'s own argument and refuses a template bound
+    # elsewhere, so factoring this out would put both sites outside its view.
+    abort_marginplyr(c(
       paste0(
-        "`share_of_parent()` requires `.grouping` to be one pure `rollup()`. ",
-        "`grouping_sets()`, `cube()`, `grouping_spec()`, and other grouping ",
-        "specifications do not define one unambiguous parent. Rewrite ",
-        "`.grouping` as one `rollup()` or omit the Parent share."
+        "{.fun share_of_parent} requires {.arg .grouping} to be one pure ",
+        "{.fun rollup}."
+      ),
+      i = paste0(
+        "{.fun grouping_sets}, {.fun cube}, {.fun grouping_spec}, and other ",
+        "grouping specifications do not define one unambiguous parent."
+      ),
+      i = paste0(
+        "Rewrite {.arg .grouping} as one {.fun rollup} or omit the Parent ",
+        "share."
       )
-    )
+    ))
   }
   invisible(NULL)
 }
@@ -792,19 +819,25 @@ plan_share_expressions <- function(dots,
       preceding_shares$names
     )
     if (length(share_dependency) > 0L) {
-      abort_marginplyr_flat(
+      dependency <- share_dependency[[1L]]
+      # Read only from the cli template below, which codetools cannot see.
+      # Bound rather than written there because the expression does not fit a
+      # template line, and splitting one across the `paste0()` that keeps the
+      # line inside the margin would hide it from the reader entirely.
+      # nolint start: object_usage_linter.
+      dependency_label <- share_kind_label(share_name_kind(
+        preceding_shares,
+        dependency
+      ))
+      # nolint end
+      abort_marginplyr(c(
         paste0(
-          "Ordinary summaries cannot use an earlier ",
-          share_kind_label(share_name_kind(
-            preceding_shares,
-            share_dependency[[1L]]
-          )),
-          " (`",
-          share_dependency[[1L]],
-          "`) in the same `summarize_with_margins()` call. Use a following ",
-          "`dplyr::mutate()` for derived values."
-        )
-      )
+          "Ordinary summaries cannot use an earlier {dependency_label} ",
+          "({.var {dependency}}) in the same {.fun summarize_with_margins} ",
+          "call."
+        ),
+        i = "Use a following {.fun dplyr::mutate} for derived values."
+      ))
     }
     preceding_ordinary <- c(preceding_ordinary, analyses[[i]]$records)
   }
@@ -1240,15 +1273,19 @@ check_share_scalar <- function(value,
                                source_summary,
                                share_kind,
                                call) {
-  label <- share_kind_label(share_kind)
   if (length(value) != 1L) {
-    abort_marginplyr_flat(
-      paste0(
-        label, " `", share_output, "` requires source summary `",
-        source_summary, "` to return exactly one value per grouping row. ",
-        "Define `", source_summary, "` as one scalar summary; for multiple ",
-        "statistics, create separate named summaries and a ", label, " for ",
-        "each one."
+    abort_marginplyr(
+      c(
+        paste0(
+          "{share_kind_label(share_kind)} {.var {share_output}} requires ",
+          "source summary {.var {source_summary}} to return exactly one ",
+          "value per grouping row."
+        ),
+        i = paste0(
+          "Define {.var {source_summary}} as one scalar summary; for ",
+          "multiple statistics, create separate named summaries and a ",
+          "{share_kind_label(share_kind)} for each one."
+        )
       ),
       class = "marginplyr_share_cardinality_error",
       share_output = share_output,
@@ -1281,15 +1318,26 @@ abort_share_source_type <- function(value,
                                     source_summary,
                                     share_kind,
                                     call) {
-  detected_type <- if (is.object(value)) class(value) else typeof(value)
-  abort_marginplyr_flat(
-    paste0(
-      share_kind_label(share_kind), " `", share_output,
-      "` requires source summary `",
-      source_summary,
-      "` to be a plain integer or double scalar; detected type ",
-      paste(detected_type, collapse = "/"),
-      ". Convert it explicitly in the ordinary summary."
+  # Joined here rather than interpolated as a vector, because the slash is how
+  # a class vector is spelled rather than a list of subjects cli's defaults
+  # would serialise with an `and`. It is also why this is bound rather than
+  # written in the template: it spells a branch, and a branch inside a template
+  # is the shape ADR 0023's `{?}` rule forbids, whatever it chooses between.
+  # Read only from that template, which codetools cannot see.
+  # nolint start: object_usage_linter.
+  detected_type <- paste(
+    if (is.object(value)) class(value) else typeof(value),
+    collapse = "/"
+  )
+  # nolint end
+  abort_marginplyr(
+    c(
+      paste0(
+        "{share_kind_label(share_kind)} {.var {share_output}} requires ",
+        "source summary {.var {source_summary}} to be a plain integer or ",
+        "double scalar; detected type {detected_type}."
+      ),
+      i = "Convert it explicitly in the ordinary summary."
     ),
     share_output = share_output,
     source_summary = source_summary,
@@ -1461,14 +1509,17 @@ plan_direct_share <- function(expr,
 }
 
 validate_share_direct_syntax <- function(expr, output_name) {
+  # Read only from the cli templates below, which codetools cannot see. Bound
+  # rather than written in them because the expression does not fit beside the
+  # output name in a template line.
+  # nolint start: object_usage_linter.
   helper <- share_helper_name(share_helper_call_kind(expr))
+  # nolint end
   if (!nzchar(output_name)) {
-    abort_marginplyr_flat(
-      paste0(
-        "A direct `", helper, "()` summary must have an explicit output ",
-        "name. Rewrite it as `name = ", helper, "(source)`."
-      )
-    )
+    abort_marginplyr(c(
+      "A direct {.fun {helper}} summary must have an explicit output name.",
+      i = "Rewrite it as {.code name = {helper}(source)}."
+    ))
   }
   args <- static_call_args(expr)
   # Read through an injected quosure for the reason `unwrap_injected_quosure()`
@@ -1487,14 +1538,25 @@ validate_share_direct_syntax <- function(expr, output_name) {
   # change to an un-injected spelling and is recorded as one in ADR 0019.
   carried <- unwrap_injected_args(args)
   if (length(carried) != 1L || !is_name_part(carried[[1L]])) {
-    abort_marginplyr_flat(
+    # `injected_quosure_clause()` is a whole sentence assembled around a
+    # deparsed caller expression, so it stays an interpolated value and gains
+    # no markup: ADR 0023's injection rule is what makes a caller's braces
+    # inert, and it holds because cli reads the template and not the value. It
+    # carries its own leading space and is empty at a call that injected
+    # nothing, which is why it sits at the end of the refusal rather than in an
+    # `i` bullet that would sometimes be empty. `R/utils.R` re-authors it in a
+    # later group of #223's phase 3.
+    abort_marginplyr(c(
       paste0(
-        "`", output_name, " = ", helper, "(...)` requires exactly one ",
-        "bare name of a preceding ordinary summary. Define the scalar ",
-        "summary first, then pass its name directly to `", helper, "()`.",
-        injected_quosure_clause(args)
+        "{.code {output_name} = {helper}(...)} requires exactly one bare ",
+        "name of a preceding ordinary summary.",
+        "{injected_quosure_clause(args)}"
+      ),
+      i = paste0(
+        "Define the scalar summary first, then pass its name directly to ",
+        "{.fun {helper}}."
       )
-    )
+    ))
   }
   carried
 }
@@ -1571,13 +1633,10 @@ validate_share_across_syntax <- function(expr, env, output_name) {
       length(names_template) != 1L ||
       is.na(names_template)
   ) {
-    abort_marginplyr_flat(
-      paste0(
-        share_kind_modifier(kind),
-        " `across()` `.names` must be one non-missing character ",
-        "template."
-      )
-    )
+    abort_marginplyr(paste0(
+      "{share_kind_modifier(kind)} {.fun across} {.arg .names} must be one ",
+      "non-missing character template."
+    ))
   }
   list(args = args, names_template = names_template)
 }
@@ -1585,44 +1644,58 @@ validate_share_across_syntax <- function(expr, env, output_name) {
 preflight_share_across_syntax <- function(expr, output_name) {
   kind <- share_across_kind(expr)
   if (nzchar(output_name)) {
-    abort_marginplyr_flat(
+    abort_marginplyr(c(
       paste0(
-        "An `across()` ", share_kind_modifier(kind), " expression must be ",
-        "unnamed; use its required `.names` argument to name the output ",
-        "columns."
+        "An {.fun across} {share_kind_modifier(kind)} expression must be ",
+        "unnamed."
+      ),
+      i = paste0(
+        "Use its required {.arg .names} argument to name the output columns."
       )
-    )
+    ))
   }
   args <- parse_across_arguments(expr)
   if (!is_share_helper_function(args$fns)) {
+    # Read only from the cli template below, which codetools cannot see. Bound
+    # rather than written there because the template names it twice, once
+    # qualified, and neither spelling fits beside the other on a line.
+    # nolint start: object_usage_linter.
     helper <- share_helper_name(kind)
-    abort_marginplyr_flat(
+    # nolint end
+    abort_marginplyr(c(
       paste0(
-        "For ", share_kind_label(kind), "s, `across()` `.fns` must be `",
-        helper, "` or `marginplyr::", helper, "` directly. Use two ordered ",
-        "`across()` expressions instead of a formula, anonymous function, ",
-        "or function list."
+        "For {share_kind_label(kind)}s, {.fun across} {.arg .fns} must be ",
+        "{.code {helper}} or {.code marginplyr::{helper}} directly."
+      ),
+      i = paste0(
+        "Use two ordered {.fun across} expressions instead of a formula, ",
+        "anonymous function, or function list."
       )
-    )
+    ))
   }
   if (length(args$additional) > 0L) {
-    abort_marginplyr_flat(
+    # The arguments arrive alone in an `i` bullet, per ADR 0023's surviving
+    # line condition: how many of them there are is the caller's decision.
+    abort_marginplyr(c(
       paste0(
-        share_kind_modifier(kind),
-        " `across()` does not accept additional function arguments: ",
-        paste0("`", args$additional, "`", collapse = ", "),
-        ". Put missing-value handling in the preceding ordinary summary."
-      )
-    )
+        "{share_kind_modifier(kind)} {.fun across} does not accept ",
+        "additional function arguments:"
+      ),
+      i = "{.arg {args$additional}}.",
+      i = "Put missing-value handling in the preceding ordinary summary."
+    ))
   }
   if (is.null(args$names)) {
-    abort_marginplyr_flat(
+    # `{{` is glue's escape for a literal brace. The example names a `.names`
+    # template, and cli would otherwise read `{.col}` as inline markup of its
+    # own and refuse the refusal.
+    abort_marginplyr(c(
       paste0(
-        share_kind_modifier(kind),
-        " `across()` requires an explicit `.names` argument, ",
-        "for example `.names = \"{.col}_share\"`."
-      )
-    )
+        "{share_kind_modifier(kind)} {.fun across} requires an explicit ",
+        "{.arg .names} argument."
+      ),
+      i = "For example {.code .names = \"{{.col}}_share\"}."
+    ))
   }
   if (!is.null(args$unpack) && is.logical(args$unpack)) {
     if (length(args$unpack) != 1L || !isFALSE(args$unpack)) {
@@ -1636,13 +1709,10 @@ preflight_share_across_syntax <- function(expr, output_name) {
 }
 
 abort_share_across_unpack <- function(kind) {
-  abort_marginplyr_flat(
-    paste0(
-      share_kind_modifier(kind),
-      " `across()` requires `.unpack = FALSE` or an ",
-      "omitted `.unpack` argument."
-    )
-  )
+  abort_marginplyr(paste0(
+    "{share_kind_modifier(kind)} {.fun across} requires ",
+    "{.code .unpack = FALSE} or an omitted {.arg .unpack} argument."
+  ))
 }
 
 validate_share_request <- function(outputs,
@@ -1655,19 +1725,18 @@ validate_share_request <- function(outputs,
     return(invisible(NULL))
   }
   if (any(!nzchar(outputs))) {
-    abort_marginplyr_flat(
-      paste0(share_kind_modifier(kind), " output names must not be empty.")
+    abort_marginplyr(
+      "{share_kind_modifier(kind)} output names must not be empty."
     )
   }
   if (anyDuplicated(outputs)) {
-    abort_marginplyr_flat(
-      paste0(
-        share_kind_modifier(kind),
-        " output names must be unique; duplicate name `",
-        outputs[[anyDuplicated(outputs)]],
-        "` was generated."
+    abort_marginplyr(c(
+      "{share_kind_modifier(kind)} output names must be unique.",
+      i = paste0(
+        "Duplicate name {.var {outputs[[anyDuplicated(outputs)]]}} was ",
+        "generated."
       )
-    )
+    ))
   }
 
   preceding_names <- vapply(preceding, `[[`, character(1), "name")
@@ -1677,46 +1746,46 @@ validate_share_request <- function(outputs,
     character(1),
     "name"
   )
+  # Read only from the six cli templates below, which codetools cannot see.
+  # nolint start: object_usage_linter.
   label <- share_kind_label(kind)
+  # nolint end
   for (i in seq_along(sources)) {
     source <- sources[[i]]
     output <- outputs[[i]]
     if (source %in% shares$names) {
-      abort_marginplyr_flat(
-        paste0(
-          label, " `", output, "` cannot use ",
-          share_kind_label(share_name_kind(shares, source)), " `", source,
-          "` as its source."
-        )
-      )
+      abort_marginplyr(paste0(
+        "{label} {.var {output}} cannot use ",
+        "{share_kind_label(share_name_kind(shares, source))} ",
+        "{.var {source}} as its source."
+      ))
     }
     if (!source %in% preceding_names) {
       if (source %in% all_names) {
-        abort_marginplyr_flat(
+        abort_marginplyr(c(
           paste0(
-            label, " `", output, "` must refer to an ordinary summary ",
-            "defined before it; `", source, "` is a forward reference."
-          )
-        )
+            "{label} {.var {output}} must refer to an ordinary summary ",
+            "defined before it."
+          ),
+          i = "{.var {source}} is a forward reference."
+        ))
       }
-      abort_marginplyr_flat(
-        paste0(
-          label, " `", output, "` refers to unknown preceding ordinary ",
-          "summary `", source, "`."
-        )
-      )
+      abort_marginplyr(paste0(
+        "{label} {.var {output}} refers to unknown preceding ordinary ",
+        "summary {.var {source}}."
+      ))
     }
     if (
       !is.na(context$ordinary_counts[[source]]) &&
         context$ordinary_counts[[source]] != 1L
     ) {
-      abort_marginplyr_flat(
+      abort_marginplyr(c(
         paste0(
-          label, " `", output, "` requires source summary `", source,
-          "` to be defined exactly once. Use one uniquely named ordinary ",
-          "summary."
-        )
-      )
+          "{label} {.var {output}} requires source summary {.var {source}} ",
+          "to be defined exactly once."
+        ),
+        i = "Use one uniquely named ordinary summary."
+      ))
     }
     record <- preceding[[max(which(preceding_names == source))]]
     if (!identical(record$eligibility, "eligible")) {
@@ -1728,14 +1797,16 @@ validate_share_request <- function(outputs,
       )
     }
     if (length(record$dependencies) > 0L) {
-      abort_marginplyr_flat(
+      abort_marginplyr(c(
         paste0(
-          label, " `", output, "` cannot use source summary `", source,
-          "` because it depends on earlier summary alias `",
-          record$dependencies[[1L]],
-          "`. Combine the calculation into one ordinary summary expression."
+          "{label} {.var {output}} cannot use source summary {.var {source}} ",
+          "because it depends on earlier summary alias ",
+          "{.var {record$dependencies[[1L]]}}."
+        ),
+        i = paste0(
+          "Combine the calculation into one ordinary summary expression."
         )
-      )
+      ))
     }
   }
 
@@ -1748,13 +1819,11 @@ validate_share_request <- function(outputs,
     ))
   )
   if (length(conflicts) > 0L) {
-    abort_marginplyr_flat(
-      paste0(
-        share_kind_modifier(kind), " output name `", conflicts[[1L]],
-        "` conflicts with a grouping key, `.id`, ordinary summary, source ",
-        "summary, or earlier contextual share."
-      )
-    )
+    abort_marginplyr(paste0(
+      "{share_kind_modifier(kind)} output name {.var {conflicts[[1L]]}} ",
+      "conflicts with a grouping key, {.arg .id}, ordinary summary, source ",
+      "summary, or earlier contextual share."
+    ))
   }
   invisible(NULL)
 }
@@ -1767,21 +1836,32 @@ validate_share_request <- function(outputs,
 # it. Telling the second caller to add a top-level name would name the summary
 # they already named (#105).
 abort_ineligible_share_source <- function(label, output, source, eligibility) {
-  advice <- if (identical(eligibility, "named_across")) {
-    paste0(
-      "a named `across()` packs its outputs into one data-frame-valued ",
-      "column. Drop the `", source, " =` name so each selected column is ",
-      "named on its own, or define `", source, "` as a top-level summary."
-    )
-  } else {
-    paste0(
-      "it was expanded from a data-frame-valued summary. Rewrite it as a ",
-      "top-level named summary or a preceding `across()` output."
-    )
+  # Two calls rather than one interpolating a chosen clause: the two cases
+  # differ in the refusal and in the remedy alike, and the source summary is
+  # named in both halves, so a clause assembled here would carry a subject the
+  # style table asks for `{.var}` while the same name took it elsewhere.
+  if (identical(eligibility, "named_across")) {
+    abort_marginplyr(c(
+      paste0(
+        "{label} {.var {output}} cannot use {.var {source}} because a named ",
+        "{.fun across} packs its outputs into one data-frame-valued column."
+      ),
+      i = paste0(
+        "Drop the {.code {source} =} name so each selected column is named ",
+        "on its own, or define {.var {source}} as a top-level summary."
+      )
+    ))
   }
-  abort_marginplyr_flat(
-    paste0(label, " `", output, "` cannot use `", source, "` because ", advice)
-  )
+  abort_marginplyr(c(
+    paste0(
+      "{label} {.var {output}} cannot use {.var {source}} because it was ",
+      "expanded from a data-frame-valued summary."
+    ),
+    i = paste0(
+      "Rewrite it as a top-level named summary or a preceding ",
+      "{.fun across} output."
+    )
+  ))
 }
 
 # Each kind states what the compiled plan must provide. A call requesting both
@@ -1796,14 +1876,22 @@ check_share_grouping_kinds <- function(plan, kinds) {
 
 check_parent_grouping_kind <- function(plan) {
   if (!identical(plan$kind, "rollup")) {
-    abort_marginplyr_flat(
+    # The same refusal `check_parent_grouping_spec()` raises, written out for
+    # the reason recorded there.
+    abort_marginplyr(c(
       paste0(
-        "`share_of_parent()` requires `.grouping` to be one pure `rollup()`. ",
-        "`grouping_sets()`, `cube()`, `grouping_spec()`, and other grouping ",
-        "specifications do not define one unambiguous parent. Rewrite ",
-        "`.grouping` as one `rollup()` or omit the Parent share."
+        "{.fun share_of_parent} requires {.arg .grouping} to be one pure ",
+        "{.fun rollup}."
+      ),
+      i = paste0(
+        "{.fun grouping_sets}, {.fun cube}, {.fun grouping_spec}, and other ",
+        "grouping specifications do not define one unambiguous parent."
+      ),
+      i = paste0(
+        "Rewrite {.arg .grouping} as one {.fun rollup} or omit the Parent ",
+        "share."
       )
-    )
+    ))
   }
   invisible(NULL)
 }
@@ -1812,14 +1900,17 @@ check_total_grouping_kind <- function(plan) {
   if (length(grand_total_occurrence_ids(plan)) > 0L) {
     return(invisible(NULL))
   }
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      "`share_of_total()` requires `.grouping` to produce the Grand total ",
-      "set, in which every grouping dimension is omitted. `rollup()` and ",
-      "`cube()` always produce it. Add an empty `grouping_set()` to the ",
-      "`grouping_sets()` specification, or omit the Total share."
+      "{.fun share_of_total} requires {.arg .grouping} to produce the Grand ",
+      "total set, in which every grouping dimension is omitted."
+    ),
+    i = "{.fun rollup} and {.fun cube} always produce it.",
+    i = paste0(
+      "Add an empty {.fun grouping_set} to the {.fun grouping_sets} ",
+      "specification, or omit the Total share."
     )
-  )
+  ))
 }
 
 execute_shares <- function(operation,
@@ -2241,52 +2332,73 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
   # unrecognised verdict would otherwise be described to the caller as a
   # backend that could not be asked, which is a different fact.
   stopifnot(identical(verdict, "converts") || identical(verdict, "unknown"))
-  abort_marginplyr_flat(
-    paste0(
-      "marginplyr cannot establish that the source summaries of ",
-      share_kind_labels_phrase(kinds),
-      " are plain integer or double scalars on this backend, because ",
-      if (identical(verdict, "converts")) {
+  # Read only from the cli templates below, which codetools cannot see. Both
+  # verdicts name both of them, so writing them there would put four copies of
+  # an expression in the sentences this re-authoring exists to make readable.
+  # nolint start: object_usage_linter.
+  labels <- share_kind_label_plurals(kinds)
+  helpers <- share_kind_helpers(kinds)
+  # nolint end
+  # Two calls, because the two verdicts differ in the whole subordinate clause
+  # naming what could not be established. What they share is the refusal they
+  # begin with and the remedy they end with, and those are written out in each
+  # rather than assembled, for the reason `check_parent_grouping_spec()`
+  # records: the gate reads this call's own argument.
+  if (identical(verdict, "converts")) {
+    abort_marginplyr(
+      c(
         paste0(
-          "its SQL dialect converts a value of another type to a number ",
-          "rather than refusing it, so an ineligible source summary is ",
-          "indistinguishable from an eligible one"
+          "marginplyr cannot establish that the source summaries of {labels} ",
+          "are plain integer or double scalars on this backend, because its ",
+          "SQL dialect converts a value of another type to a number rather ",
+          "than refusing it, so an ineligible source summary is ",
+          "indistinguishable from an eligible one."
+        ),
+        i = paste0(
+          "Set {.code .check_share_source = FALSE} to calculate ",
+          "{.fun {helpers}} from sources you have established yourself, or ",
+          "explicitly collect the data before calling ",
+          "{.fun summarize_with_margins}."
         )
-      } else {
-        paste0(
-          "it could not be asked whether its SQL dialect converts a value of ",
-          "another type to a number rather than refusing it, and a dialect ",
-          "that converts rejects nothing"
-        )
-      },
-      ". Set `.check_share_source = FALSE` to calculate ",
-      share_kind_calls_phrase(kinds),
-      " from sources you have established yourself, or explicitly collect ",
-      "the data before calling `summarize_with_margins()`."
+      ),
+      call = call
+    )
+  }
+  abort_marginplyr(
+    c(
+      paste0(
+        "marginplyr cannot establish that the source summaries of {labels} ",
+        "are plain integer or double scalars on this backend, because it ",
+        "could not be asked whether its SQL dialect converts a value of ",
+        "another type to a number rather than refusing it, and a dialect ",
+        "that converts rejects nothing."
+      ),
+      i = paste0(
+        "Set {.code .check_share_source = FALSE} to calculate ",
+        "{.fun {helpers}} from sources you have established yourself, or ",
+        "explicitly collect the data before calling ",
+        "{.fun summarize_with_margins}."
+      )
     ),
     call = call
   )
 }
 
-# The two list phrases every share refusal builds from the kinds a call used:
-# the pluralised labels it names the helpers by, and the calls it tells the
+# The two lists every share refusal builds from the kinds a call used: the
+# pluralised labels it names the helpers by, and the helpers it tells the
 # caller to omit or opt out of. Both refusals -- this file's dialect one and
-# the Arrow one -- assemble the same two, so they are written once here rather
+# the Arrow one -- name the same two, so they are written once here rather
 # than kept in step by eye.
-share_kind_labels_phrase <- function(kinds) {
-  paste(
-    vapply(kinds, function(kind) {
-      paste0(share_kind_label(kind), "s")
-    }, character(1)),
-    collapse = " and "
-  )
+#
+# Each answers a vector and leaves the joining to cli, which serialises one
+# with `and` at the site (ADR 0023). The joined phrases these replaced spelled
+# that `and` themselves, and for two kinds the bytes are the same either way.
+share_kind_label_plurals <- function(kinds) {
+  paste0(vapply(kinds, share_kind_label, character(1)), "s")
 }
 
-share_kind_calls_phrase <- function(kinds) {
-  paste(
-    vapply(kinds, share_kind_call, character(1)),
-    collapse = " and "
-  )
+share_kind_helpers <- function(kinds) {
+  vapply(kinds, share_helper_name, character(1))
 }
 
 # The internal column carrying each source summary's denominator, named after
@@ -2814,10 +2926,6 @@ share_kind_modifier <- function(kind) {
   share_kind_rule(kind)$modifier
 }
 
-share_kind_call <- function(kind) {
-  paste0("`", share_helper_name(kind), "()`")
-}
-
 # The kind a written helper name resolves to, or `NULL` when it names no
 # helper.
 share_named_kind <- function(name) {
@@ -2962,10 +3070,10 @@ resolve_share_selection <- function(expr,
 abort_share_selection_error <- function(cnd, preceding, context, kind) {
   missing <- share_selection_missing_names(cnd)
   if (length(missing) == 0L) {
-    abort_marginplyr_flat(
-      paste0(
-        "Invalid ", share_kind_modifier(kind), " `across()` selection. ",
-        "Select only eligible preceding ordinary summaries by name."
+    abort_marginplyr(
+      c(
+        "Invalid {share_kind_modifier(kind)} {.fun across} selection.",
+        i = "Select only eligible preceding ordinary summaries by name."
       ),
       parent = cnd
     )
@@ -2975,7 +3083,10 @@ abort_share_selection_error <- function(cnd, preceding, context, kind) {
 }
 
 abort_share_source_name <- function(source, preceding, context, kind) {
-  helper <- share_kind_call(kind)
+  # Read only from the four cli templates below, which codetools cannot see.
+  # nolint start: object_usage_linter.
+  helper <- share_helper_name(kind)
+  # nolint end
   all_names <- vapply(
     context$all_records,
     `[[`,
@@ -2984,27 +3095,35 @@ abort_share_source_name <- function(source, preceding, context, kind) {
   )
   occurrences <- sum(all_names == source)
   if (occurrences > 1L) {
-    abort_marginplyr_flat(
-      paste0(
-        "`across()` can't select source summary `", source,
-        "` for ", helper, " because summary `", source,
-        "` was defined more than once. Define it once with a complete ",
-        "ordinary summary expression, then select that unique preceding ",
-        "summary by name."
+    abort_marginplyr(
+      c(
+        paste0(
+          "{.fun across} can't select source summary {.var {source}} for ",
+          "{.fun {helper}} because summary {.var {source}} was defined more ",
+          "than once."
+        ),
+        i = paste0(
+          "Define it once with a complete ordinary summary expression, then ",
+          "select that unique preceding summary by name."
+        )
       ),
       class = "marginplyr_share_source_duplicate_error",
       source_summary = source
     )
   }
   if (occurrences == 1L) {
-    abort_marginplyr_flat(
-      paste0(
-        "`across()` can't select source summary `", source,
-        "` for ", helper, " because summary `", source,
-        "` is not available as a unique, preceding, self-contained ordinary ",
-        "summary. Define it as a top-level named summary or a statically ",
-        "named output from a preceding `across()`. Select only eligible ",
-        "preceding ordinary summaries by name."
+    abort_marginplyr(
+      c(
+        paste0(
+          "{.fun across} can't select source summary {.var {source}} for ",
+          "{.fun {helper}} because summary {.var {source}} is not available ",
+          "as a unique, preceding, self-contained ordinary summary."
+        ),
+        i = paste0(
+          "Define it as a top-level named summary or a statically named ",
+          "output from a preceding {.fun across}."
+        ),
+        i = "Select only eligible preceding ordinary summaries by name."
       ),
       class = "marginplyr_share_source_unavailable_error",
       source_summary = source
@@ -3017,18 +3136,33 @@ abort_share_source_name <- function(source, preceding, context, kind) {
     character(1),
     "name"
   ))
-  abort_marginplyr_flat(
-    paste0(
-      "`across()` refers to unknown summary `", source,
-      "` for ", helper, ". Select only eligible preceding ordinary ",
-      "summaries by name",
-      if (length(preceding_candidates) > 0L) {
+  # Two calls, because what varies is whether the remedy can name a summary the
+  # caller could have selected. A call with none is answered by the same
+  # sentence without its example, and an `i` bullet built to carry the example
+  # conditionally would be a computed template.
+  if (length(preceding_candidates) > 0L) {
+    abort_marginplyr(
+      c(
         paste0(
-          ", such as `", preceding_candidates[[1L]], "`."
+          "{.fun across} refers to unknown summary {.var {source}} for ",
+          "{.fun {helper}}."
+        ),
+        i = paste0(
+          "Select only eligible preceding ordinary summaries by name, such ",
+          "as {.var {preceding_candidates[[1L]]}}."
         )
-      } else {
-        "."
-      }
+      ),
+      class = "marginplyr_share_source_unknown_error",
+      source_summary = source
+    )
+  }
+  abort_marginplyr(
+    c(
+      paste0(
+        "{.fun across} refers to unknown summary {.var {source}} for ",
+        "{.fun {helper}}."
+      ),
+      i = "Select only eligible preceding ordinary summaries by name."
     ),
     class = "marginplyr_share_source_unknown_error",
     source_summary = source
@@ -3083,13 +3217,16 @@ contains_selection_predicate <- function(expr) {
 }
 
 abort_share_predicate <- function(kind) {
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      share_kind_modifier(kind),
-      " `across()` only supports name-based tidyselect. Replace ",
-      "`where()` or another type/value predicate with explicit summary names."
+      "{share_kind_modifier(kind)} {.fun across} only supports name-based ",
+      "tidyselect."
+    ),
+    i = paste0(
+      "Replace {.fun where} or another type/value predicate with explicit ",
+      "summary names."
     )
-  )
+  ))
 }
 
 # A lookup the walk could not resolve is reported as a read of every alias in

--- a/R/share.R
+++ b/R/share.R
@@ -646,11 +646,16 @@ preflight_shares <- function(dots) {
 }
 
 abort_share_helper_position <- function(kind, complete) {
-  # Two calls rather than one carrying a computed bullet. The refusal is the
-  # same either way and only the remedy is conditional, so the alternative
-  # spellings are an `if` inside the template, which the structural gate
-  # refuses, or an `i` bullet whose content is sometimes empty, which renders
-  # as a bullet marker with nothing after it.
+  # The first of four sites in this file that raise from two calls rather than
+  # one, and the shape is the same at each: what varies between the two is a
+  # whole element of the message vector, or a whole clause inside one. The
+  # alternatives are both worse. An `if` inside the template is a branch the
+  # structural gate never sees, since what it reads is the source expression
+  # and this one would be inside a string; a message vector assembled around an
+  # `if` is a computed template, which the gate does see and refuses; and an
+  # `i` bullet whose content is sometimes empty renders as a bullet marker with
+  # nothing after it. What the shape costs is the element the two calls share,
+  # written out in each.
   if (complete) {
     abort_marginplyr(c(
       paste0(
@@ -685,7 +690,7 @@ abort_arrow_shares <- function(kinds) {
     ),
     i = "Other Arrow Margin operations remain supported.",
     i = paste0(
-      "Omit {.fun {share_kind_helpers(kinds)}} or explicitly collect the ",
+      "Omit {.fun {share_helper_names(kinds)}} or explicitly collect the ",
       "data before calling {.fun summarize_with_margins}."
     )
   ))
@@ -1320,10 +1325,13 @@ abort_share_source_type <- function(value,
                                     call) {
   # Joined here rather than interpolated as a vector, because the slash is how
   # a class vector is spelled rather than a list of subjects cli's defaults
-  # would serialise with an `and`. It is also why this is bound rather than
-  # written in the template: it spells a branch, and a branch inside a template
-  # is the shape ADR 0023's `{?}` rule forbids, whatever it chooses between.
-  # Read only from that template, which codetools cannot see.
+  # would serialise with an `and`.
+  #
+  # Bound rather than written in the template for a reason the structural gate
+  # cannot enforce: an `if` inside a template is a branch the gate never sees,
+  # because what it reads is the source expression and this one would be inside
+  # a string. Keeping the branch in R is what leaves it reviewable at all.
+  # Read only from the template below, which codetools cannot see.
   # nolint start: object_usage_linter.
   detected_type <- paste(
     if (is.object(value)) class(value) else typeof(value),
@@ -1335,8 +1343,12 @@ abort_share_source_type <- function(value,
       paste0(
         "{share_kind_label(share_kind)} {.var {share_output}} requires ",
         "source summary {.var {source_summary}} to be a plain integer or ",
-        "double scalar; detected type {detected_type}."
+        "double scalar."
       ),
+      # Alone in a bullet per ADR 0023's surviving line condition: a class
+      # vector is as long as the value's class chain, which the caller's data
+      # decides.
+      i = "Detected type {detected_type}.",
       i = "Convert it explicitly in the ordinary summary."
     ),
     share_output = share_output,
@@ -1541,20 +1553,23 @@ validate_share_direct_syntax <- function(expr, output_name) {
     # `injected_quosure_clause()` is a whole sentence assembled around a
     # deparsed caller expression, so it stays an interpolated value and gains
     # no markup: ADR 0023's injection rule is what makes a caller's braces
-    # inert, and it holds because cli reads the template and not the value. It
-    # carries its own leading space and is empty at a call that injected
-    # nothing, which is why it sits at the end of the refusal rather than in an
-    # `i` bullet that would sometimes be empty. `R/utils.R` re-authors it in a
-    # later group of #223's phase 3.
+    # inert, and it holds because cli reads the template and not the value.
+    #
+    # It carries its own leading space and is empty at a call that injected
+    # nothing, so it follows the remedy inside that bullet rather than taking
+    # one of its own, which would sometimes be a bullet marker with nothing
+    # after it. That is also where the flat form put it, so the clause still
+    # ends the message and every pin reading it composes as it did.
+    # `R/utils.R` re-authors it in a later group of #223's phase 3.
     abort_marginplyr(c(
       paste0(
         "{.code {output_name} = {helper}(...)} requires exactly one bare ",
-        "name of a preceding ordinary summary.",
-        "{injected_quosure_clause(args)}"
+        "name of a preceding ordinary summary."
       ),
       i = paste0(
         "Define the scalar summary first, then pass its name directly to ",
-        "{.fun {helper}}."
+        "{.fun {helper}}.",
+        "{injected_quosure_clause(args)}"
       )
     ))
   }
@@ -1649,9 +1664,7 @@ preflight_share_across_syntax <- function(expr, output_name) {
         "An {.fun across} {share_kind_modifier(kind)} expression must be ",
         "unnamed."
       ),
-      i = paste0(
-        "Use its required {.arg .names} argument to name the output columns."
-      )
+      i = "Use its required {.arg .names} argument to name the output columns."
     ))
   }
   args <- parse_across_arguments(expr)
@@ -1746,10 +1759,7 @@ validate_share_request <- function(outputs,
     character(1),
     "name"
   )
-  # Read only from the six cli templates below, which codetools cannot see.
-  # nolint start: object_usage_linter.
   label <- share_kind_label(kind)
-  # nolint end
   for (i in seq_along(sources)) {
     source <- sources[[i]]
     output <- outputs[[i]]
@@ -1803,9 +1813,7 @@ validate_share_request <- function(outputs,
           "because it depends on earlier summary alias ",
           "{.var {record$dependencies[[1L]]}}."
         ),
-        i = paste0(
-          "Combine the calculation into one ordinary summary expression."
-        )
+        i = "Combine the calculation into one ordinary summary expression."
       ))
     }
   }
@@ -1836,10 +1844,10 @@ validate_share_request <- function(outputs,
 # it. Telling the second caller to add a top-level name would name the summary
 # they already named (#105).
 abort_ineligible_share_source <- function(label, output, source, eligibility) {
-  # Two calls rather than one interpolating a chosen clause: the two cases
-  # differ in the refusal and in the remedy alike, and the source summary is
-  # named in both halves, so a clause assembled here would carry a subject the
-  # style table asks for `{.var}` while the same name took it elsewhere.
+  # Two calls, in the shape `abort_share_helper_position()` records. Here the
+  # two cases differ in the refusal and in the remedy alike, and the source
+  # summary is named in both, so a clause assembled around it would carry a
+  # subject flat where the same name takes `{.var}` everywhere else.
   if (identical(eligibility, "named_across")) {
     abort_marginplyr(c(
       paste0(
@@ -2337,13 +2345,12 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
   # an expression in the sentences this re-authoring exists to make readable.
   # nolint start: object_usage_linter.
   labels <- share_kind_label_plurals(kinds)
-  helpers <- share_kind_helpers(kinds)
+  helpers <- share_helper_names(kinds)
   # nolint end
-  # Two calls, because the two verdicts differ in the whole subordinate clause
-  # naming what could not be established. What they share is the refusal they
-  # begin with and the remedy they end with, and those are written out in each
-  # rather than assembled, for the reason `check_parent_grouping_spec()`
-  # records: the gate reads this call's own argument.
+  # Two calls, in the shape `abort_share_helper_position()` records. Here the
+  # verdicts differ in the whole subordinate clause naming what could not be
+  # established, so what they share is the opening of the refusal and the
+  # remedy that follows it.
   if (identical(verdict, "converts")) {
     abort_marginplyr(
       c(
@@ -2397,7 +2404,7 @@ share_kind_label_plurals <- function(kinds) {
   paste0(vapply(kinds, share_kind_label, character(1)), "s")
 }
 
-share_kind_helpers <- function(kinds) {
+share_helper_names <- function(kinds) {
   vapply(kinds, share_helper_name, character(1))
 }
 
@@ -3136,10 +3143,10 @@ abort_share_source_name <- function(source, preceding, context, kind) {
     character(1),
     "name"
   ))
-  # Two calls, because what varies is whether the remedy can name a summary the
-  # caller could have selected. A call with none is answered by the same
-  # sentence without its example, and an `i` bullet built to carry the example
-  # conditionally would be a computed template.
+  # Two calls, in the shape `abort_share_helper_position()` records. Here what
+  # varies is whether the remedy can name a summary the caller could have
+  # selected; a call with none is answered by the same sentence without its
+  # example.
   if (length(preceding_candidates) > 0L) {
     abort_marginplyr(
       c(

--- a/R/share.R
+++ b/R/share.R
@@ -710,12 +710,26 @@ share_grouping_spec_validator <- function(kinds) {
 check_parent_grouping_spec <- function(grouping_spec) {
   kind <- if (is.null(grouping_spec)) NULL else grouping_spec$type
   if (!identical(kind, "rollup")) {
-    # Written out here and again in `check_parent_grouping_kind()`, which
-    # refuses the same call from the compiled plan. A shared constructor would
-    # read better and is what the flat form had, but the structural gate reads
-    # `abort_marginplyr()`'s own argument and refuses a template bound
-    # elsewhere, so factoring this out would put both sites outside its view.
-    abort_marginplyr(c(
+    abort_ambiguous_parent()
+  }
+  invisible(NULL)
+}
+
+# One refusal with two raising sites, because a Parent share can be refused
+# from the Grouping specification alone and again from the compiled plan, and
+# the caller has made one mistake either way. The flat form wrote the sentence
+# out at both; nothing required that, and nothing requires it now. The
+# structural gate reads the message argument of every `abort_marginplyr()` call
+# in the namespace, so a literal at this call is in its view exactly as a
+# literal at each site would be -- what the gate refuses is a template computed
+# or bound elsewhere, which this is not.
+#
+# `call` defaults to the call of this function's own caller, so the refusal
+# blames the site rather than this constructor, which is what raising it at
+# each site does and what `abort_marginplyr_flat()` did for the same reason.
+abort_ambiguous_parent <- function(call = rlang::caller_call()) {
+  abort_marginplyr(
+    c(
       paste0(
         "{.fun share_of_parent} requires {.arg .grouping} to be one pure ",
         "{.fun rollup}."
@@ -728,9 +742,9 @@ check_parent_grouping_spec <- function(grouping_spec) {
         "Rewrite {.arg .grouping} as one {.fun rollup} or omit the Parent ",
         "share."
       )
-    ))
-  }
-  invisible(NULL)
+    ),
+    call = call
+  )
 }
 
 plan_share_expressions <- function(dots,
@@ -1884,22 +1898,7 @@ check_share_grouping_kinds <- function(plan, kinds) {
 
 check_parent_grouping_kind <- function(plan) {
   if (!identical(plan$kind, "rollup")) {
-    # The same refusal `check_parent_grouping_spec()` raises, written out for
-    # the reason recorded there.
-    abort_marginplyr(c(
-      paste0(
-        "{.fun share_of_parent} requires {.arg .grouping} to be one pure ",
-        "{.fun rollup}."
-      ),
-      i = paste0(
-        "{.fun grouping_sets}, {.fun cube}, {.fun grouping_spec}, and other ",
-        "grouping specifications do not define one unambiguous parent."
-      ),
-      i = paste0(
-        "Rewrite {.arg .grouping} as one {.fun rollup} or omit the Parent ",
-        "share."
-      )
-    ))
+    abort_ambiguous_parent()
   }
   invisible(NULL)
 }
@@ -2351,6 +2350,14 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
   # verdicts differ in the whole subordinate clause naming what could not be
   # established, so what they share is the opening of the refusal and the
   # remedy that follows it.
+  #
+  # Binding the clause in R and interpolating it would remove that repetition,
+  # and it is what `abort_share_source_type()` does twenty lines up -- but what
+  # it binds there is a *value*, the class the data turned out to hold. This
+  # clause is prose marginplyr wrote, and prose belongs in the template, where
+  # the idiom ADR 0023 states applies to it and a reviewer reads it beside the
+  # refusal it completes. A sentence half in a template and half in an R string
+  # is authored in neither.
   if (identical(verdict, "converts")) {
     abort_marginplyr(
       c(

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -76,16 +76,30 @@ argument is condition 3's second sentence, above.
 
 ## Amendment: a template may be split at a space, and the gate says so
 
-*Two rules are gated* below reads "fail any whose message argument is not a
-literal in the source", and gives `paste0()` as one of the two faces of a single
-violation. The gate admits `paste()` and `paste0()` as of #223's phase 3, on the
-same terms it already admitted `c()`: by recursion over their arguments. The
-sentence that goes is the parenthetical treating the call itself as the
-violation. What the gate refuses is unchanged, because the recursion and not the
-name of the call is what enforces both rules — caller-derived text is a symbol
-rather than a literal wherever it appears, so `paste0("Unknown column `",
-columns, "`.")` is refused exactly as before, and an `if` spelling a noun is
-refused inside an admitted call too. Both are fixtures in
+The gate admits `paste()` and `paste0()` as of #223's phase 3, on the same terms
+it already admitted `c()`: by recursion over their arguments. Two sentences of
+*Two rules are gated* below go with that.
+
+"Fail any whose message argument is not a literal in the source" is replaced by
+*fail any whose message argument is not authored in the source* — a literal, or
+a `c()`, `paste()`, or `paste0()` over arguments that are each authored in turn.
+`authored_template()` in `test-diagnostic-authoring.R` is the definition, and
+this ADR does not restate it, because a rule about which calls are admitted ages
+with the code and not with a decision.
+
+"A `paste0()`-assembled template and an `if`-spelled noun are the same violation
+seen from two sides, because neither can be written without computing the
+argument" goes whole. Its reasoning was sound and its example is no longer one:
+`paste0("a ", "b")` computes nothing a reader cannot see. What survives is the
+claim it was making, which the replacement above still supports — an `if`
+spelling a noun cannot be written without computing the argument, and neither
+can a template splicing caller text.
+
+What the gate refuses is unchanged, because the recursion and not the name of
+the call is what enforces both rules — caller-derived text is a symbol rather
+than a literal wherever it appears, so `paste0("Unknown column `", columns,
+"`.")` is refused exactly as before, and an `if` spelling a noun is refused
+inside an admitted call too. Both are fixtures in
 `test-diagnostic-authoring.R`.
 
 The reason is a measurement neither this ADR nor #223 had taken, and it binds
@@ -100,11 +114,12 @@ measure 83 to 119 characters before any markup is added. `lintr`'s default
 repository has no `.lintr`.
 
 The alternatives were all worse, which is why this is the amendment rather than
-one of them. A `.lintr` raising or excluding the limit stops it measuring
-thousands of lines of real code, for a property only diagnostics have. A
-suppression reaches about half the message elements in the package, and
-`AGENTS.md` asks each `# nolint` to record a fact about *one* expression, which
-a reason repeated eighty times is not. Rewording is what #223 exists to forbid.
+one of them. A `.lintr` is repository-wide, so raising or excluding the limit
+stops it measuring every line of `R/` and `tests/`, for a property only
+diagnostics have. A suppression reaches about half the message elements in the
+package, and `AGENTS.md` asks each `# nolint` to record a fact about *one*
+expression, which a reason repeated eighty times is not. Rewording is what #223
+exists to forbid.
 
 What is genuinely lost is small and worth naming: a template is no longer one
 literal a reader's eye lands on whole, but a sentence split at a space. It is

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -74,6 +74,43 @@ commit: rebuilding the site after ADR 0024 shows seven rendered diagnostics with
 no wrap in them, and both markers matching raw again. What survives of that
 argument is condition 3's second sentence, above.
 
+## Amendment: a template may be split at a space, and the gate says so
+
+*Two rules are gated* below reads "fail any whose message argument is not a
+literal in the source", and gives `paste0()` as one of the two faces of a single
+violation. The gate admits `paste()` and `paste0()` as of #223's phase 3, on the
+same terms it already admitted `c()`: by recursion over their arguments. The
+sentence that goes is the parenthetical treating the call itself as the
+violation. What the gate refuses is unchanged, because the recursion and not the
+name of the call is what enforces both rules — caller-derived text is a symbol
+rather than a literal wherever it appears, so `paste0("Unknown column `",
+columns, "`.")` is refused exactly as before, and an `if` spelling a noun is
+refused inside an admitted call too. Both are fixtures in
+`test-diagnostic-authoring.R`.
+
+The reason is a measurement neither this ADR nor #223 had taken, and it binds
+every file phase 3 reaches. A template has to be one string literal per message
+element, because ADR 0024 expands it with `cli::format_inline()`, whose
+`keep_whitespace = TRUE` is the whole of how a caller's spelling survives — so a
+source line break inside a template is a line break in the refusal, and glue's
+`\` continuation is part of the trimming that flag turns off. Meanwhile the
+amendment above demoted condition 1 to style advice, and the shipped sentences
+measure 83 to 119 characters before any markup is added. `lintr`'s default
+`line_length_linter(80)` therefore has no spelling to accept, and this
+repository has no `.lintr`.
+
+The alternatives were all worse, which is why this is the amendment rather than
+one of them. A `.lintr` raising or excluding the limit stops it measuring
+thousands of lines of real code, for a property only diagnostics have. A
+suppression reaches about half the message elements in the package, and
+`AGENTS.md` asks each `# nolint` to record a fact about *one* expression, which
+a reason repeated eighty times is not. Rewording is what #223 exists to forbid.
+
+What is genuinely lost is small and worth naming: a template is no longer one
+literal a reader's eye lands on whole, but a sentence split at a space. It is
+still written beside the call that raises it, which is the property *Two rules
+are gated* asks a template for — a constant bound elsewhere stays refused.
+
 ## The migration introduces wrapping, so a line is authored to survive it
 
 `rlang::abort()` wraps nothing. `cli_abort()` wraps at retrieval time, at

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -401,10 +401,13 @@ keeps the caller's spelling, at the cost of wrapping to the reader's width. See
 also records the two spellings no route keeps.
 
 `test-diagnostic-authoring.R` gates the injection and plural rules together, by
-failing any `abort_marginplyr()` call whose message argument is not a literal in
-the source: an assembled template and an `if`-spelled noun are one violation
-seen from two sides. It pins the spelling promise beside them, in both
-directions.
+failing any `abort_marginplyr()` call whose message argument is not authored in
+the source: a literal, or a `c()`, `paste()`, or `paste0()` over arguments that
+are each authored in turn. So a template splicing a computed value and an
+`if`-spelled noun are one violation seen from two sides, while a sentence split
+at a space to fit the margin is not one — ADR 0023's second amendment records
+why that split is unavoidable. It pins the spelling promise beside them, in
+both directions.
 Sites that still assemble their own string pass through
 `abort_marginplyr_flat()`, which interpolates it as a value; that function is
 transitional, and the snapshot beside the gate is what is left of #223.

--- a/tests/testthat/_snaps/diagnostic-authoring.md
+++ b/tests/testthat/_snaps/diagnostic-authoring.md
@@ -3,21 +3,12 @@
     Code
       cat(sprintf("%s(): %d", names(counts), counts), sep = "\n")
     Output
-      abort_arrow_shares(): 1
       abort_empty_composite(): 1
       abort_empty_grouping_units(): 1
-      abort_ineligible_share_source(): 1
       abort_invalid_grouping_spec(): 1
       abort_margin_label_collision(): 1
       abort_nested_grouping_spec(): 1
       abort_selection_rename(): 1
-      abort_share_across_unpack(): 1
-      abort_share_helper_position(): 1
-      abort_share_predicate(): 1
-      abort_share_selection_error(): 1
-      abort_share_source_dialect(): 1
-      abort_share_source_name(): 3
-      abort_share_source_type(): 1
       assert_lazy_table(): 1
       assert_logical_scalar(): 1
       assert_margin_input(): 1
@@ -27,12 +18,8 @@
       check_internal_summary_names(): 1
       check_margin_id_collision(): 1
       check_option_named_summaries(): 2
-      check_parent_grouping_kind(): 1
-      check_parent_grouping_spec(): 1
-      check_share_scalar(): 1
       check_summary_context_helpers(): 1
       check_summary_group_overwrite(): 1
-      check_total_grouping_kind(): 1
       compile_grouping_spec_impl(): 2
       execute_margin_nest(): 1
       grouping_bit(): 1
@@ -43,17 +30,10 @@
       normalize_grouping_input(): 3
       normalize_margin_id(): 1
       normalize_margin_label(): 5
-      plan_share_expressions(): 1
-      preflight_share_across_syntax(): 4
       reject_nested_in_set(): 1
-      share_of_parent(): 1
-      share_of_total(): 1
       validate_empty_grouping_sets(): 1
       validate_grouping_spec_early(): 1
       validate_margin_label(): 1
       validate_margin_label_names(): 3
       validate_nested_grouping_units(): 1
-      validate_share_across_syntax(): 1
-      validate_share_direct_syntax(): 2
-      validate_share_request(): 8
 

--- a/tests/testthat/_snaps/share-backends.md
+++ b/tests/testthat/_snaps/share-backends.md
@@ -3,21 +3,21 @@
     Code
       conditionMessage(error)
     Output
-      [1] "Arrow backends do not support Parent shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed. Other Arrow Margin operations remain supported. Omit `share_of_parent()` or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "Arrow backends do not support Parent shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_parent()` or explicitly collect the data before calling `summarize_with_margins()`."
 
 # RSQLite refuses a share its dialect cannot establish
 
     Code
       conditionMessage(refusal)
     Output
-      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because its SQL dialect converts a value of another type to a number rather than refusing it, so an ineligible source summary is indistinguishable from an eligible one. Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because its SQL dialect converts a value of another type to a number rather than refusing it, so an ineligible source summary is indistinguishable from an eligible one.\ni Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
 
 # a lazy backend that answers nothing refuses to establish a share
 
     Code
       conditionMessage(refusal)
     Output
-      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because it could not be asked whether its SQL dialect converts a value of another type to a number rather than refusing it, and a dialect that converts rejects nothing. Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because it could not be asked whether its SQL dialect converts a value of another type to a number rather than refusing it, and a dialect that converts rejects nothing.\ni Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
 
 # DuckDB reports an ineligible share source against its summary
 
@@ -32,12 +32,12 @@
     Code
       conditionMessage(error)
     Output
-      [1] "Arrow backends do not support Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed. Other Arrow Margin operations remain supported. Omit `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "Arrow backends do not support Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`."
 
 ---
 
     Code
       conditionMessage(both)
     Output
-      [1] "Arrow backends do not support Parent shares and Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed. Other Arrow Margin operations remain supported. Omit `share_of_parent()` and `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "Arrow backends do not support Parent shares and Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_parent()` and `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`."
 

--- a/tests/testthat/_snaps/share.md
+++ b/tests/testthat/_snaps/share.md
@@ -3,54 +3,54 @@
     Code
       conditionMessage(cardinality_error)
     Output
-      [1] "Parent share `share` requires source summary `total` to return exactly one value per grouping row. Define `total` as one scalar summary; for multiple statistics, create separate named summaries and a Parent share for each one."
+      [1] "Parent share `share` requires source summary `total` to return exactly one value per grouping row.\ni Define `total` as one scalar summary; for multiple statistics, create separate named summaries and a Parent share for each one."
 
 # Parent-share across classifies source-name failures
 
     Code
       conditionMessage(duplicate_error)
     Output
-      [1] "`across()` can't select source summary `total` for `share_of_parent()` because summary `total` was defined more than once. Define it once with a complete ordinary summary expression, then select that unique preceding summary by name."
+      [1] "`across()` can't select source summary `total` for `share_of_parent()` because summary `total` was defined more than once.\ni Define it once with a complete ordinary summary expression, then select that unique preceding summary by name."
 
 ---
 
     Code
       conditionMessage(unavailable_error)
     Output
-      [1] "`across()` can't select source summary `hidden` for `share_of_parent()` because summary `hidden` is not available as a unique, preceding, self-contained ordinary summary. Define it as a top-level named summary or a statically named output from a preceding `across()`. Select only eligible preceding ordinary summaries by name."
+      [1] "`across()` can't select source summary `hidden` for `share_of_parent()` because summary `hidden` is not available as a unique, preceding, self-contained ordinary summary.\ni Define it as a top-level named summary or a statically named output from a preceding `across()`.\ni Select only eligible preceding ordinary summaries by name."
 
 ---
 
     Code
       conditionMessage(unknown_error)
     Output
-      [1] "`across()` refers to unknown summary `missing` for `share_of_parent()`. Select only eligible preceding ordinary summaries by name, such as `total`."
+      [1] "`across()` refers to unknown summary `missing` for `share_of_parent()`.\ni Select only eligible preceding ordinary summaries by name, such as `total`."
 
 ---
 
     Code
       conditionMessage(predicate_error)
     Output
-      [1] "Parent-share `across()` only supports name-based tidyselect. Replace `where()` or another type/value predicate with explicit summary names."
+      [1] "Parent-share `across()` only supports name-based tidyselect.\ni Replace `where()` or another type/value predicate with explicit summary names."
 
 # Total-share diagnostics name the helper the caller wrote
 
     Code
       conditionMessage(cardinality_error)
     Output
-      [1] "Total share `whole` requires source summary `total` to return exactly one value per grouping row. Define `total` as one scalar summary; for multiple statistics, create separate named summaries and a Total share for each one."
+      [1] "Total share `whole` requires source summary `total` to return exactly one value per grouping row.\ni Define `total` as one scalar summary; for multiple statistics, create separate named summaries and a Total share for each one."
 
 ---
 
     Code
       conditionMessage(predicate_error)
     Output
-      [1] "Total-share `across()` only supports name-based tidyselect. Replace `where()` or another type/value predicate with explicit summary names."
+      [1] "Total-share `across()` only supports name-based tidyselect.\ni Replace `where()` or another type/value predicate with explicit summary names."
 
 ---
 
     Code
       conditionMessage(unknown_error)
     Output
-      [1] "`across()` refers to unknown summary `missing` for `share_of_total()`. Select only eligible preceding ordinary summaries by name, such as `total`."
+      [1] "`across()` refers to unknown summary `missing` for `share_of_total()`.\ni Select only eligible preceding ordinary summaries by name, such as `total`."
 

--- a/tests/testthat/test-diagnostic-authoring.R
+++ b/tests/testthat/test-diagnostic-authoring.R
@@ -70,11 +70,33 @@ diagnostic_message_arguments <- function(expr, name) {
 # A bare character literal is the common case. `c()` is admitted because it is
 # how a cli message vector is spelled -- `c("Refusal.", i = "Bullet.")` -- and
 # admitting it costs nothing: the recursion requires each of its arguments to be
-# authored too, so `c(paste0(...), i = "...")` fails exactly as a bare
-# `paste0()` does. Nothing else is admitted, because everything else computes
-# text, and computed text is what both gated rules forbid. That includes a
-# constant bound elsewhere in the package: a template has to be readable beside
-# the call that raises it, or the injection rule cannot be reviewed at the site.
+# authored too, so `c(paste0(x), i = "...")` fails exactly as a bare `paste0(x)`
+# does. Nothing else is admitted, because everything else computes text, and
+# computed text is what both gated rules forbid. That includes a constant bound
+# elsewhere in the package: a template has to be readable beside the call that
+# raises it, or the injection rule cannot be reviewed at the site.
+#
+# `paste()` and `paste0()` are admitted on the same terms, and for a reason that
+# only appeared once #223's phase 3 began re-authoring a file. A template has to
+# be one string literal per message element, because `abort_marginplyr()`
+# expands it with `cli::format_inline()`, whose `keep_whitespace = TRUE` is what
+# ADR 0024 keeps a caller's spelling with -- so a source line break inside a
+# template is a line break in the refusal, and glue's `\` continuation is part
+# of the trimming that flag turns off. Meanwhile ADR 0023's amendment demoted
+# its 80-column condition to style advice, so the shipped sentences are 83 to
+# 119 characters before markup. Those two facts leave a re-authored element with
+# no spelling that fits `line_length_linter()`, and the alternatives were a
+# `.lintr` that stops measuring 3600 lines of real code, a `# nolint` at half
+# the elements in the package, or rewording the sentences #223 says to preserve.
+#
+# Nothing about either gated rule is weaker for it, because the recursion is
+# what enforces them and not the name of the call. Caller-derived text is a
+# symbol rather than a literal wherever it appears, so
+# `paste0("Unknown column `", columns, "`.")` is refused exactly as before, and
+# an `if` spelling a noun is refused wherever it sits, `paste0()` included. What
+# is admitted is a sentence the author wrote, split at a space to fit the
+# margin, and still readable beside the call that raises it -- which is the
+# property the paragraph above asks a template for.
 authored_template <- function(expr) {
   if (is.character(expr)) {
     return(TRUE)
@@ -82,7 +104,7 @@ authored_template <- function(expr) {
   if (
     is.call(expr) &&
       is.name(expr[[1]]) &&
-      identical(as.character(expr[[1]]), "c")
+      as.character(expr[[1]]) %in% c("c", "paste", "paste0")
   ) {
     return(all(vapply(as.list(expr)[-1], authored_template, logical(1))))
   }
@@ -123,14 +145,21 @@ test_that("the reading finds a site wherever it is written", {
       abort_marginplyr(message = c("A refusal.", i = "A bullet."))
     }
     inner()
+    abort_marginplyr(c(
+      paste0("A refusal too long to ", "spell on one source line."),
+      i = paste0("A bullet in the same ", "position.")
+    ))
   }
 
   found <- diagnostic_message_arguments(body(fixture), "abort_marginplyr")
 
   # One nested inside an `if`, one inside a closure and named `message =`. A
   # walk that stopped descending, or one that only read the first argument,
-  # loses one of the two.
-  expect_length(found, 2L)
+  # loses one of the two. The third is the shape a re-authored site actually
+  # takes, and it is here so that the admitting branch for `paste0()` is
+  # executed by something other than the package -- the refusing branch has six
+  # fixtures below and would otherwise be the only one this file runs.
+  expect_length(found, 3L)
   expect_identical(found[[1]], "A refusal.")
   expect_true(all(vapply(found, authored_template, logical(1))))
 })
@@ -142,6 +171,7 @@ test_that("the reading refuses every shape ADR 0023's gated rules forbid", {
     abort_marginplyr(sprintf("Unknown column `%s`.", columns))
     abort_marginplyr(if (n == 1L) "One column." else "Several columns.")
     abort_marginplyr(c("A refusal.", i = paste0("Drop ", columns, ".")))
+    abort_marginplyr(paste0("One column", if (n == 1L) "" else "s", "."))
     abort_marginplyr(template)
     abort_marginplyr(class = "marginplyr_nothing")
   }
@@ -149,11 +179,14 @@ test_that("the reading refuses every shape ADR 0023's gated rules forbid", {
   found <- diagnostic_message_arguments(body(fixture), "abort_marginplyr")
 
   # An assembled template, twice; an `if` spelling a noun; a `c()` whose bullet
-  # is assembled, which is the case admitting `c()` has to keep refusing; a
-  # template bound elsewhere, which is readable nowhere near the refusal; and a
-  # call carrying no message at all, which reads as `NULL` and is the site an
-  # appending idiom that deletes on `NULL` would drop.
-  expect_length(found, 6L)
+  # is assembled, which is the case admitting `c()` has to keep refusing; an
+  # `if` spelling a noun inside a `paste0()`, which is the case admitting
+  # `paste0()` has to keep refusing, and the one both gated rules would be lost
+  # through if the recursion stopped at the admitted call; a template bound
+  # elsewhere, which is readable nowhere near the refusal; and a call carrying
+  # no message at all, which reads as `NULL` and is the site an appending idiom
+  # that deletes on `NULL` would drop.
+  expect_length(found, 7L)
   expect_false(any(vapply(found, authored_template, logical(1))))
 })
 

--- a/tests/testthat/test-diagnostic-authoring.R
+++ b/tests/testthat/test-diagnostic-authoring.R
@@ -1,7 +1,8 @@
 # ADR 0023 states how every Package condition is authored. Two of its rules are
 # gated, and one structural reading catches both: walk every
-# `abort_marginplyr()` call and fail any whose message argument is not a literal
-# in the source.
+# `abort_marginplyr()` call and fail any whose message argument is not authored
+# in the source -- a literal, or a call over arguments that are each authored in
+# turn, which `authored_template()` below defines exactly.
 #
 # The two rules are one violation seen from two sides. *Caller text is a value,
 # never part of the template* fails when a template is assembled -- a
@@ -86,8 +87,10 @@ diagnostic_message_arguments <- function(expr, name) {
 # its 80-column condition to style advice, so the shipped sentences are 83 to
 # 119 characters before markup. Those two facts leave a re-authored element with
 # no spelling that fits `line_length_linter()`, and the alternatives were a
-# `.lintr` that stops measuring 3600 lines of real code, a `# nolint` at half
-# the elements in the package, or rewording the sentences #223 says to preserve.
+# `.lintr`, which is repository-wide and would stop measuring every line of
+# `R/` and `tests/` for a property only diagnostics have, a `# nolint` at about
+# half the message elements in the package, or rewording the sentences #223
+# says to preserve.
 #
 # Nothing about either gated rule is weaker for it, because the recursion is
 # what enforces them and not the name of the call. Caller-derived text is a
@@ -157,8 +160,8 @@ test_that("the reading finds a site wherever it is written", {
   # walk that stopped descending, or one that only read the first argument,
   # loses one of the two. The third is the shape a re-authored site actually
   # takes, and it is here so that the admitting branch for `paste0()` is
-  # executed by something other than the package -- the refusing branch has six
-  # fixtures below and would otherwise be the only one this file runs.
+  # executed by something other than the package -- every fixture in the test
+  # below is a refusal, so without this one only that branch would run.
   expect_length(found, 3L)
   expect_identical(found[[1]], "A refusal.")
   expect_true(all(vapply(found, authored_template, logical(1))))

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -2379,3 +2379,126 @@ test_that("a share selection tidyselect rejects keeps tidyselect's condition", {
   )
   expect_s3_class(renamed$parent, class(rejected))
 })
+
+# The five refusals in `R/share.R` that nothing executed. #223's phase 3 is what
+# made them visible rather than what left them unrun: re-authoring split each
+# into its own lines, so a branch that had always been dead started being
+# counted as one. Three are reachable from the verb and were simply never
+# written down. Two are second lines of defence, and are asserted by calling the
+# function that holds them, the way `share_selection_missing_names()`'s empty
+# answer is above -- the objection is the one this repository makes everywhere,
+# that a branch nothing runs is a branch nothing has ever checked.
+test_that("an `across()` share is named by `.names`, not by the caller", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+
+  named <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      out = dplyr::across(
+        total,
+        share_of_parent,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(named),
+    "An `across()` Parent-share expression must be unnamed.",
+    fixed = TRUE
+  )
+  expect_match(
+    conditionMessage(named),
+    "Use its required `.names` argument",
+    fixed = TRUE
+  )
+})
+
+test_that("a direct share names a source no summary in the call defines", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+
+  # Neither a forward reference nor an ineligible source: `absent` is defined
+  # nowhere in the call, which is the branch under both of those.
+  unknown <- expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      share = share_of_parent(absent),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(unknown),
+    paste0(
+      "Parent share `share` refers to unknown preceding ordinary ",
+      "summary `absent`."
+    ),
+    fixed = TRUE
+  )
+})
+
+test_that("an unknown selection with nothing to offer names no example", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+
+  # The sibling branch names a summary the caller could have selected instead.
+  # This one cannot, the call defining no ordinary summary before the
+  # `across()`, and the difference is the whole reason there are two.
+  bare <- expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(
+        missing,
+        share_of_parent,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_share_source_unknown_error"
+  )
+  expect_match(
+    conditionMessage(bare),
+    "refers to unknown summary `missing`",
+    fixed = TRUE
+  )
+  expect_false(grepl("such as", conditionMessage(bare), fixed = TRUE))
+  expect_identical(bare$source_summary, "missing")
+})
+
+test_that("the two share refusals a verb reaches only as a second line", {
+  # `summarize_with_margins()` runs `preflight_shares()` before it plans, and
+  # that raises the complete form of this refusal for the same expression. The
+  # incomplete form is what would answer a caller who reached planning without
+  # it, and it differs by withholding the rewrite -- there being nothing to
+  # rewrite when the share is not the whole right-hand side.
+  incomplete <- expect_error(
+    abort_share_helper_position("parent", complete = FALSE),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(incomplete),
+    "must be the complete right-hand side",
+    fixed = TRUE
+  )
+  expect_false(grepl(
+    "as its own named summary",
+    conditionMessage(incomplete),
+    fixed = TRUE
+  ))
+
+  # A Parent share installs `check_parent_grouping_spec()` as the Grouping
+  # specification's validator, which refuses anything but a pure `rollup()`
+  # before a plan is compiled. So this refuses a plan no accepted
+  # specification could have produced.
+  plan_kind <- expect_error(
+    check_parent_grouping_kind(list(kind = "cube")),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(plan_kind),
+    "do not define one unambiguous parent",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -1121,7 +1121,7 @@ test_that("semantic and nonnumeric classes are not Parent-share sources", {
     expect_s3_class(error, "marginplyr_error")
     expect_match(
       conditionMessage(error),
-      paste0("detected type ", source_type)
+      paste0("Detected type ", source_type)
     )
   }
 })

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -603,26 +603,14 @@ test_that("an injected quosure carrying no bare name is refused as written", {
         rlang::new_quosure(shapes[[index]], env = rlang::empty_env())
       ))
       expect_s3_class(injected, "marginplyr_error")
-      # The clause lands at the end of the refusal rather than at the end of
-      # the message, which is a distinction only a re-authored helper draws:
-      # `share_of_parent()` and `share_of_total()` carry their remedy in an `i`
-      # bullet after it (#223), while the grouping helpers are still one line
-      # and the two positions coincide. Written over the lines so that both
-      # shapes are the one rule, and byte-exact either way.
-      written_lines <- strsplit(
-        conditionMessage(written),
-        "\n",
-        fixed = TRUE
-      )[[1L]]
-      written_lines[[1L]] <- paste0(
-        written_lines[[1L]],
-        " The injected quosure carries `",
-        deparse1(shapes[[index]]),
-        "`, which is not a bare name."
-      )
       expect_identical(
         conditionMessage(injected),
-        paste(written_lines, collapse = "\n"),
+        paste0(
+          conditionMessage(written),
+          " The injected quosure carries `",
+          deparse1(shapes[[index]]),
+          "`, which is not a bare name."
+        ),
         info = helper
       )
       refusals[[index]] <- injected

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -603,14 +603,26 @@ test_that("an injected quosure carrying no bare name is refused as written", {
         rlang::new_quosure(shapes[[index]], env = rlang::empty_env())
       ))
       expect_s3_class(injected, "marginplyr_error")
+      # The clause lands at the end of the refusal rather than at the end of
+      # the message, which is a distinction only a re-authored helper draws:
+      # `share_of_parent()` and `share_of_total()` carry their remedy in an `i`
+      # bullet after it (#223), while the grouping helpers are still one line
+      # and the two positions coincide. Written over the lines so that both
+      # shapes are the one rule, and byte-exact either way.
+      written_lines <- strsplit(
+        conditionMessage(written),
+        "\n",
+        fixed = TRUE
+      )[[1L]]
+      written_lines[[1L]] <- paste0(
+        written_lines[[1L]],
+        " The injected quosure carries `",
+        deparse1(shapes[[index]]),
+        "`, which is not a bare name."
+      )
       expect_identical(
         conditionMessage(injected),
-        paste0(
-          conditionMessage(written),
-          " The injected quosure carries `",
-          deparse1(shapes[[index]]),
-          "`, which is not a bare name."
-        ),
+        paste(written_lines, collapse = "\n"),
         info = helper
       )
       refusals[[index]] <- injected
@@ -1911,7 +1923,8 @@ test_that("an unnamed `across()` argument is numbered by its own position", {
   )
   # dplyr names an argument passed on to the function by its position among
   # those arguments, so the unnamed one here -- second of the two -- is `..2`.
-  expect_match(conditionMessage(error), "`na.rm`, `..2`", fixed = TRUE)
+  # The `and` is cli's serial join, which ADR 0023 adopts unchanged.
+  expect_match(conditionMessage(error), "`na.rm` and `..2`", fixed = TRUE)
 })
 
 test_that("`across()` argument numbering holds without a mix of names", {
@@ -1942,7 +1955,7 @@ test_that("`across()` argument numbering holds without a mix of names", {
     )),
     "does not accept additional function arguments"
   )
-  expect_match(conditionMessage(all_unnamed), "`..1`, `..2`", fixed = TRUE)
+  expect_match(conditionMessage(all_unnamed), "`..1` and `..2`", fixed = TRUE)
 
   all_named <- expect_error(
     base_call(dplyr::across(


### PR DESCRIPTION
#223's phase 3, first file. All 33 of `R/share.R`'s `abort_marginplyr_flat()`
sites become `abort_marginplyr()` templates authored against ADR 0023.

Every refusal says what its predecessor said, in the same words. Verified by
executing both trees and diffing every rendered message: the only deltas are the
`.` and capital a re-split gives a bullet, and cli's serial `and` where a vector
is joined — which ADR 0023 adopts unchanged. The snapshots are byte-identical
once `". "` is read as `".\ni "`, and no word changed in any of the eight.

## The one correction this makes to the ticket

Recorded in full at
https://github.com/sayuks/marginplyr/issues/223#issuecomment-5342965786, with
the measurements.

A template has to be one string literal per message element, because ADR 0024
expands it with `cli::format_inline()`, whose `keep_whitespace = TRUE` is the
whole of how a caller's spelling survives — a source line break inside a
template is a line break in the refusal, and glue's `\` continuation is part of
the trimming that flag turns off. ADR 0023's first amendment meanwhile demoted
its 80-column condition to style advice, and the shipped sentences measure 83 to
119 characters before markup: of the 58 sentences these 33 sites hold, 28 exceed
73 columns with interpolation removed. No re-authored element has a spelling
that fits lintr's default `line_length_linter(80)`, and this repository has no
`.lintr`.

So `authored_template()` admits `paste()` and `paste0()` on the same terms it
already admitted `c()`: by recursion over their arguments. Neither gated rule is
weaker for it — caller-derived text is a symbol rather than a literal wherever
it appears, so `paste0("Unknown column `", columns, "`.")` is refused exactly as
before, and an `if` spelling a noun is refused inside an admitted call too.
`test-diagnostic-authoring.R` gained a fixture for the second, which is the one
shape the widening could have lost both rules through.

`design/adr/0023-*.md` gains a second amendment recording this;
`design/architecture.md`'s Conditions chapter and the gate's own header comment
were updated with it, all three having described the gate as failing a message
argument that "is not a literal in the source". The ticket's definition-of-done
bullet needs the same change and is issue text, so the comment above proposes
the wording.

## Also in this pull request

- `share_kind_labels_phrase()` and `share_kind_calls_phrase()` joined their
  lists by hand; they become `share_kind_label_plurals()` and
  `share_helper_names()`, answering vectors that cli joins at the site. For the
  two kinds this corpus has, the bytes are the same either way.
  `share_kind_call()` existed only to put backticks round a helper name, which
  `{.fun}` now does, so it goes.
- The Parent-grouping refusal is written once, in `abort_ambiguous_parent()`.
  Both raising sites had a copy on `main` too; nothing required that. `call`
  defaults to the caller's call, so both sites blame what they blamed —
  measured identical before and after.
- Six `# nolint: object_usage_linter.` blocks, in the form `R/factor.R` and
  `R/grouping-adapter-native.R` already use: a value read only from a cli
  template is invisible to codetools, and lintr's glue extension reads
  `glue::glue()` alone. Every other interpolated value is written in the
  template, where the flat form wrote it. There are no line-length
  suppressions.
- Re-pinned in place, none moved to a snapshot: `test-share.R`'s type pin,
  `test-static-expression-analysis.R`'s two vector pins. The byte-exact
  injected-quosure equality there is untouched, the clause still ending the
  message as the flat form had it.

## Phase-3 criteria

1. re-authors its own file's sites — 33, and nothing else in `R/`;
2. that file's byte-exact pins rewritten — three, none moved to a snapshot;
3. `test-diagnostic-pluralization.R` untouched — there is no share arm in it;
4. no vignette needed re-rendering for its markers to hold: both
   `verify-site.R` markers quoting this file survive unmoved, each contiguous
   inside an uninterpolated `i` bullet. Checked against a rebuilt `docs/`;
5. `abort_marginplyr_flat()`'s snapshot loses exactly 33 sites;
6. no new skips.

## Verification

`lintr::lint_package()` 0 lints · suite 4768 passed, 0 failed, 0 skipped ·
`verify-must-error.R` 8 fixtures · `verify-suite-coverage.R` 594 tests over 5
single-backend configurations · `verify-site.R` 19 pages against a rebuilt
`docs/`.

Reviewed twice on the Standards and Spec axes before opening; the second and
third commits are what those passes changed.
