### PR TITLE
Author R/grouping-plan.R's diagnostics in the cli idiom

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -294,7 +294,7 @@ markers <- list(
     "Error in `summarize_with_margins()`",
     "Error in `nest_with_margins()`",
     "does not support `cur_group_id()`",
-    "Duplicate grouping sets were produced at positions",
+    "Duplicate grouping sets were produced at",
     "Can't supply `.by` when `.data` is grouped",
     "Grouped input created with `.drop = FALSE` is not supported",
     "do not define one unambiguous parent",

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -3,13 +3,10 @@ validate_grouping_spec_early <- function(grouping_spec) {
     return(invisible(NULL))
   }
   if (!inherits(grouping_spec, "margin_grouping_spec")) {
-    abort_marginplyr_flat(
-      paste0(
-        "`.grouping` must be created with ",
-        format_grouping_constructors(),
-        "."
-      )
-    )
+    abort_marginplyr(paste0(
+      "{.arg .grouping} must be created with ",
+      "{.or {.fun {grouping_constructor_names()}}}."
+    ))
   }
 
   kind <- grouping_spec$type
@@ -32,37 +29,32 @@ validate_grouping_spec_early <- function(grouping_spec) {
 }
 
 abort_invalid_grouping_spec <- function() {
-  abort_marginplyr_flat(
-    "Invalid grouping specification."
-  )
+  abort_marginplyr("Invalid grouping specification.")
 }
 
 normalize_grouping_input <- function(.data, by_quo) {
   stopifnot(rlang::is_quosure(by_quo))
 
   if (inherits(.data, "rowwise_df")) {
-    abort_marginplyr_flat(
-      "`rowwise()` input is not supported. Call `dplyr::ungroup()` first."
-    )
+    abort_marginplyr(c(
+      "{.fun rowwise} input is not supported.",
+      i = "Call {.fun dplyr::ungroup} first."
+    ))
   }
 
   if (!dplyr::group_by_drop_default(.data)) {
-    abort_marginplyr_flat(
-      paste0(
-        "Grouped input created with `.drop = FALSE` is not supported. ",
-        "Call `dplyr::ungroup()` first."
-      )
-    )
+    abort_marginplyr(c(
+      "Grouped input created with {.code .drop = FALSE} is not supported.",
+      i = "Call {.fun dplyr::ungroup} first."
+    ))
   }
 
   input_groups <- dplyr::group_vars(.data)
   if (length(input_groups) > 0L && !rlang::quo_is_null(by_quo)) {
-    abort_marginplyr_flat(
-      paste0(
-        "Can't supply `.by` when `.data` is grouped. ",
-        "Call `dplyr::ungroup()` first."
-      )
-    )
+    abort_marginplyr(c(
+      "Can't supply {.arg .by} when {.arg .data} is grouped.",
+      i = "Call {.fun dplyr::ungroup} first."
+    ))
   }
 
   .data <- dplyr::ungroup(.data)
@@ -101,7 +93,11 @@ resolve_fixed_keys <- function(by_quo, group_vars, data_vars) {
 # `get_col_names()`'s other callers read back names dplyr assigned on purpose,
 # so the check belongs on this resolution rather than in that helper.
 resolve_by_selection <- function(by_quo, data_proxy) {
-  resolve_column_selection(by_quo, data_proxy, labels = by_rename_labels())
+  resolve_column_selection(
+    by_quo,
+    data_proxy,
+    on_rename = abort_by_rename
+  )
 }
 
 prepare_grouping_plan <- function(.data,
@@ -194,14 +190,12 @@ prepare_grouping_plan <- function(.data,
 }
 
 abort_empty_grouping_units <- function(kind) {
-  abort_marginplyr_flat(
-    sprintf("`%s()` requires at least one dimension.", kind)
-  )
+  abort_marginplyr("{.fun {kind}} requires at least one dimension.")
 }
 
 abort_empty_composite <- function() {
-  abort_marginplyr_flat(
-    "An empty `grouping_set()` cannot be a composite dimension."
+  abort_marginplyr(
+    "An empty {.fun grouping_set} cannot be a composite dimension."
   )
 }
 
@@ -211,12 +205,10 @@ allow_empty_grouping <- function(spec) {
 
 validate_empty_grouping_sets <- function(spec) {
   if (length(spec$args) == 0L) {
-    abort_marginplyr_flat(
-      paste0(
-        "`grouping_sets()` requires at least one set. Use `grouping_set()` ",
-        "for the empty grouping set."
-      )
-    )
+    abort_marginplyr(c(
+      "{.fun grouping_sets} requires at least one set.",
+      i = "Use {.fun grouping_set} for the empty grouping set."
+    ))
   }
   invisible(NULL)
 }
@@ -229,11 +221,8 @@ validate_empty_grouping_units <- function(spec) {
 }
 
 reject_nested_in_set <- function(parent, nested) {
-  abort_marginplyr_flat(
-    paste0(
-      "A `grouping_set()` can contain columns, not another ",
-      "grouping family."
-    )
+  abort_marginplyr(
+    "A {.fun grouping_set} can contain columns, not another grouping family."
   )
 }
 
@@ -243,15 +232,10 @@ allow_nested_grouping <- function(parent, nested) {
 
 validate_nested_grouping_units <- function(parent, nested) {
   if (!identical(nested$type, "set")) {
-    abort_marginplyr_flat(
-      sprintf(
-        paste0(
-          "`%s()` only accepts columns or `grouping_set()` ",
-          "composite dimensions."
-        ),
-        parent$type
-      )
-    )
+    abort_marginplyr(paste0(
+      "{.fun {parent$type}} only accepts columns or {.fun grouping_set} ",
+      "composite dimensions."
+    ))
   }
   if (length(nested$args) == 0L) {
     abort_empty_composite()
@@ -436,13 +420,12 @@ compile_grouping_spec_impl <- function(.grouping,
 
   overlap <- intersect(.by, dimensions)
   if (length(overlap) > 0L) {
-    abort_marginplyr_flat(
-      paste0(
-        "Columns cannot appear in both `.by` and `.grouping`: ",
-        paste0("`", overlap, "`", collapse = ", "),
-        "."
-      )
-    )
+    # The columns arrive alone in an `i` bullet, per ADR 0023's surviving line
+    # condition: how many of them there are is the caller's decision.
+    abort_marginplyr(c(
+      "Columns cannot appear in both {.arg .by} and {.arg .grouping}:",
+      i = "{.var {overlap}}."
+    ))
   }
 
   normalized <- lapply(
@@ -458,24 +441,32 @@ compile_grouping_spec_impl <- function(.grouping,
 
   if (any(duplicate_keys) && identical(.duplicates, "error")) {
     groups <- split(which(duplicate_keys), keys[duplicate_keys])
-    positions <- vapply(groups, paste, collapse = ", ", character(1))
     # The policies this caller could have asked for instead, which is every
     # value of its own vocabulary but the one that raised this. Reading them
     # from the vocabulary is what keeps the nesting verbs, whose `.duplicates`
     # excludes `"keep"`, from being offered it here (#110).
     alternatives <- setdiff(duplicates_choices, .duplicates)
-    offered <- paste0("`\"", alternatives, "\"`")
-    offered[[1L]] <- paste0("`.duplicates = \"", alternatives[[1L]], "\"`")
-    abort_marginplyr_flat(
-      paste0(
-        "Duplicate grouping sets were produced at position",
-        if (length(groups) == 1L) "s " else " groups ",
-        paste(positions, collapse = "; "),
-        ". Use ",
-        paste(offered, collapse = " or "),
-        "."
-      )
+    # Both are read only from the cli template below, which codetools cannot
+    # see. `positions` is joined here rather than interpolated as a vector,
+    # because a group is itself a comma-joined list of positions, so cli's
+    # defaults would serialise the groups with an `and` inside one -- the
+    # reason `R/share.R` joins a class vector on its own slash.
+    # nolint start: object_usage_linter.
+    positions <- paste(
+      vapply(groups, paste, collapse = ", ", character(1)),
+      collapse = "; "
     )
+    offered <- paste0("\"", alternatives, "\"")
+    offered[[1L]] <- paste0(".duplicates = ", offered[[1L]])
+    # nolint end
+    abort_marginplyr(c(
+      paste0(
+        "Duplicate grouping sets were produced at ",
+        "{cli::qty(length(groups))}{?positions/position groups}:"
+      ),
+      i = "{positions}.",
+      i = "Use {.or {.code {offered}}}."
+    ))
   }
 
   if (identical(.duplicates, "drop")) {
@@ -699,16 +690,6 @@ grouping_constructor_names <- function() {
   ))
 }
 
-format_grouping_constructors <- function() {
-  constructors <- paste0("`", grouping_constructor_names(), "()`")
-  last <- length(constructors)
-  paste0(
-    paste(constructors[-last], collapse = ", "),
-    ", or ",
-    constructors[[last]]
-  )
-}
-
 grouping_arg_spec <- function(arg, data_vars) {
   expr <- rlang::quo_get_expr(arg)
   if (
@@ -766,7 +747,7 @@ resolve_grouping_selection <- function(arg, data_proxy) {
     resolve_column_selection(
       arg,
       data_proxy,
-      labels = grouping_rename_labels()
+      on_rename = abort_grouping_rename
     ),
     error = function(cnd) {
       label <- rlang::as_label(rlang::quo_get_expr(arg))
@@ -801,15 +782,16 @@ is_grouping_spec_subscript <- function(cnd, label) {
 }
 
 abort_nested_grouping_spec <- function(label) {
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      "`", label, "` is a grouping specification, but a nested position ",
+      "{.code {label}} is a grouping specification, but a nested position ",
       "recognizes one only when it is a call to ",
-      format_grouping_constructors(), ", or a name bound to a specification. ",
-      "Anything else is read as a column selection. Assign the specification ",
-      "to a name first, then use that name here."
-    )
-  )
+      "{.or {.fun {grouping_constructor_names()}}}, or a name bound to a ",
+      "specification."
+    ),
+    i = "Anything else is read as a column selection.",
+    i = "Assign the specification to a name first, then use that name here."
+  ))
 }
 
 # tidyselect reports a selection under the names the caller gave it, so
@@ -821,7 +803,7 @@ abort_nested_grouping_spec <- function(label) {
 # diagnostic says only that renaming is disallowed and never names the pair the
 # caller has to fix. A name that repeats its own column renames nothing and is
 # left alone.
-resolve_column_selection <- function(arg, data_proxy, labels) {
+resolve_column_selection <- function(arg, data_proxy, on_rename) {
   selected <- tidyselect::eval_select(
     arg,
     data = data_proxy,
@@ -834,46 +816,46 @@ resolve_column_selection <- function(arg, data_proxy, labels) {
   source_names <- names(tidyselect::tidyselect_data_proxy(data_proxy))[selected]
   renamed <- selected_names != source_names
   if (any(renamed)) {
-    abort_selection_rename(
-      selected_names[renamed],
-      source_names[renamed],
-      labels = labels
-    )
+    on_rename(selected_names[renamed], source_names[renamed])
   }
   selected_names
 }
 
 # One caller mistake, one diagnostic: `.grouping` and `.by` refuse a renaming
 # selection for the same reason, and only the noun and the rule it states
-# differ.
-grouping_rename_labels <- function() {
-  list(
-    singular = "grouping dimension",
-    plural = "grouping dimensions",
-    rule = "Grouping dimensions must name existing columns."
-  )
+# differ. That difference used to be a labels list the refusal read a singular
+# or a plural noun out of; it is now two refusals, and the resolution above is
+# handed whichever one speaks for its selection.
+#
+# Written out rather than kept as one template with the noun interpolated,
+# because the noun is what pluralizes. `{?s}` reads the quantity beside it, so
+# a shared template would have to choose between two noun pairs, which is the
+# branch ADR 0023's `{?}` rule dissolves rather than relocates. Writing them
+# out also keeps both inside the structural gate, which reads
+# `abort_marginplyr()`'s own argument and refuses a template bound elsewhere --
+# the reason `R/share.R`'s two Parent-share refusals are written out twice.
+#
+# The pairs arrive alone in an `i` bullet, per ADR 0023's surviving line
+# condition: how many of them there are is the caller's decision.
+abort_grouping_rename <- function(selected_names, source_names) {
+  abort_marginplyr(c(
+    "Can't rename {cli::qty(length(selected_names))}grouping dimension{?s}:",
+    i = "{.code {selection_rename_pairs(selected_names, source_names)}}.",
+    i = "Grouping dimensions must name existing columns."
+  ))
 }
 
-by_rename_labels <- function() {
-  list(
-    singular = "`.by` column",
-    plural = "`.by` columns",
-    rule = "Fixed `.by` keys must name existing columns."
-  )
+abort_by_rename <- function(selected_names, source_names) {
+  abort_marginplyr(c(
+    "Can't rename {cli::qty(length(selected_names))}{.arg .by} column{?s}:",
+    i = "{.code {selection_rename_pairs(selected_names, source_names)}}.",
+    i = "Fixed {.arg .by} keys must name existing columns."
+  ))
 }
 
-abort_selection_rename <- function(selected_names, source_names, labels) {
-  abort_marginplyr_flat(
-    paste0(
-      "Can't rename ",
-      if (length(selected_names) == 1L) labels$singular else labels$plural,
-      " ",
-      paste0(
-        "`", selected_names, " = ", source_names, "`",
-        collapse = ", "
-      ),
-      ". ",
-      labels$rule
-    )
-  )
+# The renaming a selection asked for, in the spelling the caller would write to
+# fix it. Both halves are caller text, so this is an interpolated value and
+# carries no markup of its own; the templates above give it `{.code}`.
+selection_rename_pairs <- function(selected_names, source_names) {
+  paste0(selected_names, " = ", source_names)
 }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -446,19 +446,19 @@ compile_grouping_spec_impl <- function(.grouping,
     # from the vocabulary is what keeps the nesting verbs, whose `.duplicates`
     # excludes `"keep"`, from being offered it here (#110).
     alternatives <- setdiff(duplicates_choices, .duplicates)
-    # Both are read only from the cli template below, which codetools cannot
-    # see. `positions` is joined here rather than interpolated as a vector,
-    # because a group is itself a comma-joined list of positions, so cli's
-    # defaults would serialise the groups with an `and` inside one -- the
-    # reason `R/share.R` joins a class vector on its own slash.
+    # Joined here rather than interpolated as a vector, because a group is
+    # itself a comma-joined list of positions, so cli's defaults would
+    # serialise the groups with an `and` inside one -- the reason `R/share.R`
+    # joins a class vector on its own slash. Read only from the cli template
+    # below, which codetools cannot see.
     # nolint start: object_usage_linter.
     positions <- paste(
       vapply(groups, paste, collapse = ", ", character(1)),
       collapse = "; "
     )
+    # nolint end
     offered <- paste0("\"", alternatives, "\"")
     offered[[1L]] <- paste0(".duplicates = ", offered[[1L]])
-    # nolint end
     abort_marginplyr(c(
       paste0(
         "Duplicate grouping sets were produced at ",

--- a/tests/testthat/_snaps/diagnostic-authoring.md
+++ b/tests/testthat/_snaps/diagnostic-authoring.md
@@ -3,12 +3,7 @@
     Code
       cat(sprintf("%s(): %d", names(counts), counts), sep = "\n")
     Output
-      abort_empty_composite(): 1
-      abort_empty_grouping_units(): 1
-      abort_invalid_grouping_spec(): 1
       abort_margin_label_collision(): 1
-      abort_nested_grouping_spec(): 1
-      abort_selection_rename(): 1
       assert_lazy_table(): 1
       assert_logical_scalar(): 1
       assert_margin_input(): 1
@@ -20,20 +15,14 @@
       check_option_named_summaries(): 2
       check_summary_context_helpers(): 1
       check_summary_group_overwrite(): 1
-      compile_grouping_spec_impl(): 2
       execute_margin_nest(): 1
       grouping_bit(): 1
       grouping_helper_vars(): 7
       grouping_id(): 1
       match_margin_choice(): 1
       nest_margin_pipeline(): 2
-      normalize_grouping_input(): 3
       normalize_margin_id(): 1
       normalize_margin_label(): 5
-      reject_nested_in_set(): 1
-      validate_empty_grouping_sets(): 1
-      validate_grouping_spec_early(): 1
       validate_margin_label(): 1
       validate_margin_label_names(): 3
-      validate_nested_grouping_units(): 1
 

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -7,11 +7,13 @@
 # set is visible at once, and a file-by-file re-authoring edits a contiguous
 # block of it (#224).
 #
-# Suffixing is what bounds the set, not pluralizing, and two diagnostics
-# pluralize by another construction. `abort_selection_rename()` picks between a
-# singular and a plural noun held in a labels list; all four of its messages
-# are already pinned exactly in `test-grouping-plan.R`, so recording them again
-# would buy nothing. The duplicate-grouping-set refusal switches a whole phrase
+# Suffixing is what bounds the set, not pluralizing, and two diagnostics stay
+# out of it for their own reasons. The two renaming-selection refusals suffix
+# their noun as well, but all four of their messages are already pinned exactly
+# in `test-grouping-plan.R`, so recording them again would buy nothing. They
+# reached that spelling from a singular/plural pair a labels list held, which
+# `{?s}` dissolved when #223 re-authored `R/grouping-plan.R`. The
+# duplicate-grouping-set refusal switches a whole phrase
 # rather than suffixing one; both of its arms are pinned in
 # `test-grouping-plan.R`, the plural one separately from this file because it
 # needs a specification shape none of these eight do (#225).

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -7,16 +7,21 @@
 # set is visible at once, and a file-by-file re-authoring edits a contiguous
 # block of it (#224).
 #
-# Suffixing is what bounds the set, not pluralizing, and two diagnostics stay
-# out of it for their own reasons. The two renaming-selection refusals suffix
-# their noun as well, but all four of their messages are already pinned exactly
-# in `test-grouping-plan.R`, so recording them again would buy nothing. They
-# reached that spelling from a singular/plural pair a labels list held, which
-# `{?s}` dissolved when #223 re-authored `R/grouping-plan.R`. The
-# duplicate-grouping-set refusal switches a whole phrase
-# rather than suffixing one; both of its arms are pinned in
-# `test-grouping-plan.R`, the plural one separately from this file because it
-# needs a specification shape none of these eight do (#225).
+# Suffixing is what chose the eight, and two diagnostics were left out of them.
+# One is still out for the reason it was: the duplicate-grouping-set refusal
+# switches a whole phrase rather than suffixing one; both of its arms are
+# pinned in `test-grouping-plan.R`, the plural one separately from this file
+# because it needs a specification shape none of these eight do (#225).
+#
+# The other no longer has the construction it was described by. The
+# renaming-selection refusal -- one caller mistake, written out once for
+# `.grouping` and once for `.by` -- picked between a singular and a plural noun
+# held in a labels list, and #223 dissolved that pair into `{?s}` when it
+# re-authored `R/grouping-plan.R`, so it suffixes now as these eight do. Its
+# reason for being out is untouched by that: all four of its messages are
+# already pinned exactly in `test-grouping-plan.R`, so recording them again
+# would buy nothing. Suffixing is therefore where this set came from rather
+# than a test a ninth diagnostic is admitted by.
 #
 # The pins already beside each site stay where they are. Most match a phrase
 # rather than a whole message, which is enough to assert that a caller reaches

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -20,8 +20,12 @@
 # re-authored `R/grouping-plan.R`, so it suffixes now as these eight do. Its
 # reason for being out is untouched by that: all four of its messages are
 # already pinned exactly in `test-grouping-plan.R`, so recording them again
-# would buy nothing. Suffixing is therefore where this set came from rather
-# than a test a ninth diagnostic is admitted by.
+# would buy nothing. That is a thinner reason than the one the paragraph below
+# gives for recording three of these eight at both sites, and it is #224's to
+# revisit: re-authoring how a diagnostic is spelled is not where the question
+# of which diagnostics this baseline covers gets decided. Suffixing is
+# therefore where this set came from rather than a test a ninth diagnostic is
+# admitted by.
 #
 # The pins already beside each site stay where they are. Most match a phrase
 # rather than a whole message, which is enough to assert that a caller reaches

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -374,16 +374,18 @@ test_that("a lazy selection proxy resolves renames against its columns", {
   expect_identical(
     conditionMessage(error),
     paste0(
-      "Can't rename grouping dimension `area = region`. ",
-      "Grouping dimensions must name existing columns."
+      "Can't rename grouping dimension:\n",
+      "i `area = region`.\n",
+      "i Grouping dimensions must name existing columns."
     )
   )
 })
 
 backend_by_rename_message <- function() {
   paste0(
-    "Can't rename `.by` column `area = region`. ",
-    "Fixed `.by` keys must name existing columns."
+    "Can't rename `.by` column:\n",
+    "i `area = region`.\n",
+    "i Fixed `.by` keys must name existing columns."
   )
 }
 

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -419,6 +419,57 @@ test_that("invalid grouping input lists every supported constructor", {
   )
 })
 
+# The one refusal in `R/grouping-plan.R` that nothing executed. #223's phase 3
+# is what made it visible rather than what left it unrun: re-authoring gave the
+# body its own line, where the flat form spread one dead call over three.
+#
+# It is a second line of defence behind the test above, which refuses an object
+# that is not a specification at all. This one refuses an object that says it
+# is: `new_grouping_spec()` is the only constructor, so a specification whose
+# `type` is not one name, or is a name no rule answers, reaches the compiler
+# only from a hand-built object. That is why the guard is here, and why nothing
+# had run it. It is not promoted to a bare `stop()` -- that would move a site
+# across ADR 0015's boundary, which #223's phase 3 may not do -- so what is
+# left is to run it.
+#
+# Both guards are reached. They read different things, the shape of the
+# specification's own fields and whether its kind names a rule, and answer with
+# the same sentence, so either one running alone would leave the other unrun
+# and report nothing about it.
+test_that("a malformed grouping specification is refused by both guards", {
+  compile <- function(spec) {
+    compile_grouping_spec(
+      spec,
+      "a",
+      duplicates_choices = margin_duplicates_choices
+    )
+  }
+  malformed <- list(
+    # A `type` that is not one name, and `args` that are not a list: the two
+    # halves of the first guard's condition, which no single object fails both
+    # of while still reaching the second.
+    structure(
+      list(type = character(), args = list()),
+      class = "margin_grouping_spec"
+    ),
+    structure(
+      list(type = "set", args = "not a list"),
+      class = "margin_grouping_spec"
+    ),
+    # One name, and every field the right shape, but no rule answers it.
+    structure(
+      list(type = "pivot", args = list()),
+      class = "margin_grouping_spec"
+    )
+  )
+
+  for (spec in malformed) {
+    error <- expect_error(compile(spec))
+    expect_s3_class(error, "marginplyr_error")
+    expect_identical(conditionMessage(error), "Invalid grouping specification.")
+  }
+})
+
 test_that("selectors and fixed .by columns are resolved once", {
   selected <- c("a", "b")
   plan <- compile_grouping_spec(

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -167,9 +167,9 @@ test_that("a nested specification position recognizes a spelling or a name", {
       "`spec_from_caller(region)` is a grouping specification, but a nested ",
       "position recognizes one only when it is a call to `grouping_set()`, ",
       "`grouping_sets()`, `rollup()`, `cube()`, or `grouping_spec()`, or a ",
-      "name bound to a specification. Anything else is read as a column ",
-      "selection. Assign the specification to a name first, then use that ",
-      "name here."
+      "name bound to a specification.\n",
+      "i Anything else is read as a column selection.\n",
+      "i Assign the specification to a name first, then use that name here."
     )
   )
 
@@ -340,8 +340,8 @@ test_that("empty grouping rules preserve their phase and error precedence", {
   expect_identical(
     conditionMessage(sets_error),
     paste0(
-      "`grouping_sets()` requires at least one set. Use `grouping_set()` ",
-      "for the empty grouping set."
+      "`grouping_sets()` requires at least one set.\n",
+      "i Use `grouping_set()` for the empty grouping set."
     )
   )
 
@@ -439,8 +439,9 @@ test_that("selectors and fixed .by columns are resolved once", {
 test_that("a renaming grouping selection is refused by every constructor", {
   data_vars <- c("region", "year", "value")
   renamed_message <- paste0(
-    "Can't rename grouping dimension `area = region`. ",
-    "Grouping dimensions must name existing columns."
+    "Can't rename grouping dimension:\n",
+    "i `area = region`.\n",
+    "i Grouping dimensions must name existing columns."
   )
   renaming_calls <- list(
     quote(tidyselect::all_of(c(area = "region"))),
@@ -488,8 +489,9 @@ test_that("a renaming grouping selection is refused by every constructor", {
   expect_identical(
     conditionMessage(several),
     paste0(
-      "Can't rename grouping dimensions `area = region`, `when = year`. ",
-      "Grouping dimensions must name existing columns."
+      "Can't rename grouping dimensions:\n",
+      "i `area = region` and `when = year`.\n",
+      "i Grouping dimensions must name existing columns."
     )
   )
 })
@@ -548,8 +550,9 @@ by_rename_vars <- function() {
 
 by_rename_message <- function() {
   paste0(
-    "Can't rename `.by` column `area = region`. ",
-    "Fixed `.by` keys must name existing columns."
+    "Can't rename `.by` column:\n",
+    "i `area = region`.\n",
+    "i Fixed `.by` keys must name existing columns."
   )
 }
 
@@ -588,8 +591,9 @@ test_that("a renaming .by selection is refused", {
   expect_identical(
     conditionMessage(several),
     paste0(
-      "Can't rename `.by` columns `area = region`, `size = value`. ",
-      "Fixed `.by` keys must name existing columns."
+      "Can't rename `.by` columns:\n",
+      "i `area = region` and `size = value`.\n",
+      "i Fixed `.by` keys must name existing columns."
     )
   )
 })
@@ -710,8 +714,9 @@ test_that("duplicated grouping sets in more than one group name their groups", {
   expect_identical(
     conditionMessage(duplicated),
     paste0(
-      "Duplicate grouping sets were produced at position groups 2, 4; 1, 3. ",
-      "Use `.duplicates = \"drop\"` or `\"keep\"`."
+      "Duplicate grouping sets were produced at position groups:\n",
+      "i 2, 4; 1, 3.\n",
+      "i Use `.duplicates = \"drop\"` or `\"keep\"`."
     )
   )
 })
@@ -856,8 +861,9 @@ test_that("compile_grouping_spec() reads a narrowed duplicates vocabulary", {
   expect_identical(
     conditionMessage(duplicated),
     paste0(
-      "Duplicate grouping sets were produced at positions 1, 2. ",
-      "Use `.duplicates = \"drop\"`."
+      "Duplicate grouping sets were produced at positions:\n",
+      "i 1, 2.\n",
+      "i Use `.duplicates = \"drop\"`."
     )
   )
 

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -230,8 +230,9 @@ renaming_grouping_data <- function() {
 
 renaming_grouping_message <- function() {
   paste0(
-    "Can't rename grouping dimension `area = region`. ",
-    "Grouping dimensions must name existing columns."
+    "Can't rename grouping dimension:\n",
+    "i `area = region`.\n",
+    "i Grouping dimensions must name existing columns."
   )
 }
 
@@ -312,8 +313,9 @@ renaming_by_data <- function() {
 
 renaming_by_message <- function() {
   paste0(
-    "Can't rename `.by` column `area = region`. ",
-    "Fixed `.by` keys must name existing columns."
+    "Can't rename `.by` column:\n",
+    "i `area = region`.\n",
+    "i Fixed `.by` keys must name existing columns."
   )
 }
 


### PR DESCRIPTION
#223's phase 3, second file. All 14 of `R/grouping-plan.R`'s
`abort_marginplyr_flat()` sites become `abort_marginplyr()` templates authored
against ADR 0023.

Every refusal says what its predecessor said, in the same words. Verified by
executing both trees and diffing every rendered message, condition class,
blamed call, and handler-visible field: the only deltas are the `.` or `:` a
re-split gives a bullet, and cli's serial `and` where a vector is joined —
which ADR 0023 adopts unchanged.

The two sites this file holds outside the idiom are untouched, per the
exclusion ADR 0015 draws and ADR 0023 repeats: the `Unknown `.by` column(s)`
invariant and `expand_grouping_family()`'s unknown-kind guard both stay bare
`stop()`. `test-diagnostic-pluralization.R`'s arm for the first of those does
not move.

## Two pluralizations dissolve into `{?}`

Neither is the suffixing shape the eight in `test-diagnostic-pluralization.R`
have, and ADR 0023 names both.

The duplicate-grouping-set refusal switched a whole phrase on the number of
position groups — `"positions "` against `" position groups "` — and is now
`{cli::qty(length(groups))}{?positions/position groups}`.

`abort_selection_rename()` read a singular or a plural noun out of a labels
list, which is #206's idiom rather than a suffix, and becomes two refusals:
`abort_grouping_rename()` and `abort_by_rename()`, each suffixing its own noun
with `{?s}`. They are written out rather than sharing one template because the
noun is what pluralizes — `{?s}` reads the quantity beside it, so an
interpolated noun resets it — and because the structural gate reads
`abort_marginplyr()`'s own argument and refuses a template bound elsewhere.
`R/share.R`'s twin Parent-share refusals are the precedent.
`resolve_column_selection()` is handed whichever refusal speaks for its
selection, so `grouping_rename_labels()` and `by_rename_labels()` go with the
branch they existed for.

## Also in this pull request

- `format_grouping_constructors()` joined the constructor list by hand and
  goes: `{.or {.fun {grouping_constructor_names()}}}` writes the same bytes
  over the vector `R/contextual-helpers.R` already reads.
- Three vectors move alone into an `i` bullet, per ADR 0023's surviving line
  condition — the renamed pairs, the `.by`/`.grouping` overlap, and the
  duplicated position groups. Where a list follows, the main line ends with the
  colon the sentence already had or gains one, and the bullet carries the
  sentence's period: the shape `R/share.R`'s `across()`-arguments refusal took.
- The position groups stay joined by hand. A group is itself a comma-joined
  list of positions, so cli's defaults would serialise the groups with an `and`
  inside one — the reason `R/share.R` joins a class vector on its own slash.
- One `# nolint: object_usage_linter.` block, covering the one expression
  codetools cannot see. There are no line-length suppressions.
- Re-pinned in place, none moved to a snapshot: nine byte-exact
  `conditionMessage()` equalities in `test-grouping-plan.R`, and the three
  rename helpers in `test-grouping-backends.R` and `test-inspect-grouping.R`.
  Two of them read cli's serial `and`.
- The `abort_marginplyr_flat()` snapshot loses exactly this file's 14 sites.
- `test-diagnostic-pluralization.R`'s header is corrected and nothing else in
  it changes: it described the rename refusal by a construction this pull
  request dissolved. It draws no rule for admitting a ninth diagnostic, and
  names the tension between its own exclusion reason and the paragraph below
  it, which is #224's to revisit rather than a re-authoring's.

## Site

`verify-site.R`'s marker for the duplicate refusal is trimmed to `"Duplicate
grouping sets were produced at"`. `positions` is now chosen by
`{?positions/position groups}`, and ADR 0023's surviving condition 3 asks a
marker to sit in a run of uninterpolated prose.

The other two markers quoting this file survive unmoved, each contiguous in a
main line whose `{.arg}`/`{.code}` markup renders the backticks the flat text
already had. Checked against a rebuilt `docs/`, with no ANSI on the page.

## Checks

`lintr::lint_package()` clean, `devtools::test()` green with no new skips
(FAIL 0, WARN 0, SKIP 0, PASS 4782), `verify-site.R`, `verify-must-error.R`,
and `verify-suite-coverage.R` all passing.