### PR TITLE
Author R/margin-label.R's diagnostics in the cli idiom

### DIFF
--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -175,7 +175,11 @@ check_declared_label_collision <- function(margin_labels,
     return(invisible(NULL))
   }
 
-  abort_margin_label_collision(margin_labels, declared, kind = "declared")
+  abort_margin_label_collision(
+    margin_labels,
+    declared,
+    on_collision = abort_declared_label_collision
+  )
 }
 
 check_observed_label_collision <- function(data,
@@ -235,42 +239,47 @@ check_observed_label_collision <- function(data,
     return(invisible(NULL))
   }
 
-  abort_margin_label_collision(margin_labels, found, kind = "observed")
+  abort_margin_label_collision(
+    margin_labels,
+    found,
+    on_collision = abort_observed_label_collision
+  )
 }
 
-abort_margin_label_collision <- function(margin_labels, found, kind) {
-  stopifnot(
-    is.logical(found),
-    any(found),
-    identical(kind, "declared") || identical(kind, "observed")
-  )
+# The columns a collision was found in and the labels that collided with them,
+# which is what both refusals below name. Each caller hands in the refusal that
+# speaks for its own kind rather than a word naming that kind -- the shape
+# `R/grouping-plan.R`'s two renaming refusals take, since a discriminator this
+# function would only translate back into a call is one neither caller needs to
+# compute.
+abort_margin_label_collision <- function(margin_labels, found, on_collision) {
+  stopifnot(is.logical(found), any(found), is.function(on_collision))
 
   bad_cols <- names(found)[found]
-  # `vapply()` rather than `unlist()`, which would silently drop a `NULL` and
-  # leave the arms below reading a shorter vector. No caller can pass one --
-  # a missing label is filtered out before either collision is looked for --
-  # so the shape it would arrive in is a defect, and this stops on it.
   bad_labels <- vapply(
     margin_labels[bad_cols],
     identity,
     character(1),
     USE.NAMES = FALSE
   )
-  if (identical(kind, "declared")) {
-    abort_declared_label_collision(bad_cols, bad_labels)
-  }
-  abort_observed_label_collision(bad_cols, bad_labels)
+  on_collision(bad_cols, bad_labels)
 }
 
-# The two kinds are written out rather than shared, in the shape `R/share.R`
-# uses wherever two calls differ by a whole clause: the kind chooses how the
-# collision is named, and under the declared kind that clause pluralizes with
-# the subject, so one template would have to pick between two noun pairs. The
-# subject is the same shape one level down -- either the one colliding label or
-# a plural noun standing in for several distinct ones -- which is a whole
-# element rather than a plural of one word, and `{?}` cannot interpolate a
-# value into the arm it picks. What the shape costs is the bullet the two arms
-# share, written out in each.
+# Four arms across the two refusals below, rather than one template with two
+# branches inside it. Both branches choose a whole clause: the kind chooses how
+# the collision is named, and under the declared kind that clause pluralizes
+# with the subject, so one template would have to pick between two noun pairs;
+# and the subject is either the one colliding label, which is interpolated, or
+# the words standing in for several distinct ones, which is not, so `{?}`
+# cannot write both -- the arm it picks is literal text and is never re-read as
+# a template. ADR 0023's third amendment records the measurement and why a
+# branch on a count is still inside its `{?}` rule.
+#
+# What the shape costs is every element the arms share, written out in each:
+# the bullet carrying the columns four times, the noun `column{?s}` inflects
+# four times, and each remedy twice. The structural gate is what leaves no
+# cheaper spelling, since a template hoisted out of the arms is a template
+# bound elsewhere and it refuses one.
 #
 # `.check_margin_label = FALSE` is offered only where it is a remedy. It turns
 # off the read, and a declared collision is not found by reading, so naming it

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -3,36 +3,29 @@ normalize_margin_label <- function(.margin_label) {
     return(NULL)
   }
   if (!is.character(.margin_label) || length(.margin_label) == 0L) {
-    abort_marginplyr_flat(
-      paste0(
-        "`.margin_label` must be `NULL`, an unnamed character scalar, or a ",
-        "named character vector."
-      )
-    )
+    abort_marginplyr(paste0(
+      "{.arg .margin_label} must be {.code NULL}, an unnamed character ",
+      "scalar, or a named character vector."
+    ))
   }
   label_names <- names(.margin_label)
   if (is.null(label_names)) {
     if (length(.margin_label) != 1L) {
-      abort_marginplyr_flat(
-        "An unnamed `.margin_label` must be a character vector of length 1."
-      )
+      abort_marginplyr(paste0(
+        "An unnamed {.arg .margin_label} must be a character vector of ",
+        "length 1."
+      ))
     }
     return(.margin_label)
   }
   if (anyNA(label_names)) {
-    abort_marginplyr_flat(
-      "`.margin_label` names must not be missing."
-    )
+    abort_marginplyr("{.arg .margin_label} names must not be missing.")
   }
   if (any(!nzchar(label_names))) {
-    abort_marginplyr_flat(
-      "`.margin_label` names must not be empty."
-    )
+    abort_marginplyr("{.arg .margin_label} names must not be empty.")
   }
   if (anyDuplicated(label_names)) {
-    abort_marginplyr_flat(
-      "`.margin_label` names must not be duplicated."
-    )
+    abort_marginplyr("{.arg .margin_label} names must not be duplicated.")
   }
   .margin_label
 }
@@ -60,37 +53,35 @@ validate_margin_label_names <- function(.margin_label, dimensions, by) {
   }
 
   label_names <- names(.margin_label)
+  # Each refusal below names whichever names it is refusing, and each carries
+  # them in an `i` bullet rather than in its main line, per ADR 0023's
+  # surviving line condition: how many of them arrive is the caller's decision.
   fixed_names <- intersect(label_names, by)
   if (length(fixed_names) > 0L) {
-    abort_marginplyr_flat(
+    abort_marginplyr(c(
       paste0(
-        "`.margin_label` must not name fixed `.by` column",
-        if (length(fixed_names) == 1L) " " else "s ",
-        paste0("`", fixed_names, "`", collapse = ", "),
-        "."
-      )
-    )
+        "{.arg .margin_label} must not name fixed {.arg .by} ",
+        "{cli::qty(length(fixed_names))}column{?s}:"
+      ),
+      i = "{.var {fixed_names}}."
+    ))
   }
   unknown_names <- setdiff(label_names, dimensions)
   if (length(unknown_names) > 0L) {
-    abort_marginplyr_flat(
+    abort_marginplyr(c(
       paste0(
-        "`.margin_label` has unknown dimension name",
-        if (length(unknown_names) == 1L) " " else "s ",
-        paste0("`", unknown_names, "`", collapse = ", "),
-        "."
-      )
-    )
+        "{.arg .margin_label} has unknown dimension ",
+        "{cli::qty(length(unknown_names))}name{?s}:"
+      ),
+      i = "{.var {unknown_names}}."
+    ))
   }
   missing_names <- setdiff(dimensions, label_names)
   if (length(missing_names) > 0L) {
-    abort_marginplyr_flat(
-      paste0(
-        "`.margin_label` must name every Margin dimension; missing ",
-        paste0("`", missing_names, "`", collapse = ", "),
-        "."
-      )
-    )
+    abort_marginplyr(c(
+      "{.arg .margin_label} must name every Margin dimension.",
+      i = "Missing {.var {missing_names}}."
+    ))
   }
   invisible(NULL)
 }
@@ -130,15 +121,17 @@ validate_margin_label <- function(.data,
     )
     na_level_cols <- vapply(na_level_cols, function(x) x$col, character(1))
     if (length(na_level_cols) > 0L) {
-      abort_marginplyr_flat(
+      abort_marginplyr(c(
         paste0(
-          "`NA_character_` is already a factor level in grouping column",
-          if (length(na_level_cols) == 1L) " " else "s ",
-          paste0("`", na_level_cols, "`", collapse = ", "),
-          ". Use `NULL` for a typed-missing Margin label while preserving ",
-          "the NA level."
+          "{.code NA_character_} is already a factor level in grouping ",
+          "{cli::qty(length(na_level_cols))}column{?s}:"
+        ),
+        i = "{.var {na_level_cols}}.",
+        i = paste0(
+          "Use {.code NULL} for a typed-missing Margin label while ",
+          "preserving the NA level."
         )
-      )
+      ))
     }
   }
 
@@ -252,42 +245,82 @@ abort_margin_label_collision <- function(margin_labels, found, kind) {
     identical(kind, "declared") || identical(kind, "observed")
   )
 
-  bad_cols <- paste0("`", names(found)[found], "`", collapse = ", ")
-  bad_labels <- margin_labels[names(found)[found]]
-  label_values <- vapply(
-    bad_labels,
-    function(label) if (is.na(label)) "NA" else paste0('"', label, '"'),
-    character(1)
+  bad_cols <- names(found)[found]
+  # `vapply()` rather than `unlist()`, which would silently drop a `NULL` and
+  # leave the arms below reading a shorter vector. No caller can pass one --
+  # a missing label is filtered out before either collision is looked for --
+  # so the shape it would arrive in is a defect, and this stops on it.
+  bad_labels <- vapply(
+    margin_labels[bad_cols],
+    identity,
+    character(1),
+    USE.NAMES = FALSE
   )
-  one_label <- length(unique(label_values)) == 1L
-  label <- if (one_label) unique(label_values) else "Margin labels"
-  verb <- if (one_label) " is" else " are"
-  presence <- if (identical(kind, "declared")) {
-    if (one_label) " a factor level in" else " factor levels in"
-  } else {
-    " present in"
+  if (identical(kind, "declared")) {
+    abort_declared_label_collision(bad_cols, bad_labels)
   }
-  # `.check_margin_label = FALSE` is offered only where it is a remedy. It
-  # turns off the read, and a declared collision is not found by reading, so
-  # naming it there would send a caller to an argument that changes nothing.
-  remedy <- if (identical(kind, "declared")) {
-    "Choose another `.margin_label`."
-  } else {
-    "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+  abort_observed_label_collision(bad_cols, bad_labels)
+}
+
+# The two kinds are written out rather than shared, in the shape `R/share.R`
+# uses wherever two calls differ by a whole clause: the kind chooses how the
+# collision is named, and under the declared kind that clause pluralizes with
+# the subject, so one template would have to pick between two noun pairs. The
+# subject is the same shape one level down -- either the one colliding label or
+# a plural noun standing in for several distinct ones -- which is a whole
+# element rather than a plural of one word, and `{?}` cannot interpolate a
+# value into the arm it picks. What the shape costs is the bullet the two arms
+# share, written out in each.
+#
+# `.check_margin_label = FALSE` is offered only where it is a remedy. It turns
+# off the read, and a declared collision is not found by reading, so naming it
+# here would send a caller to an argument that changes nothing.
+abort_declared_label_collision <- function(bad_cols, bad_labels) {
+  if (length(unique(bad_labels)) == 1L) {
+    abort_marginplyr(c(
+      paste0(
+        "{.val {unique(bad_labels)}} is already a factor level in grouping ",
+        "{cli::qty(length(bad_cols))}column{?s}:"
+      ),
+      i = "{.var {bad_cols}}.",
+      i = "Choose another {.arg .margin_label}."
+    ))
   }
-  abort_marginplyr_flat(
+  abort_marginplyr(c(
     paste0(
-      label,
-      verb,
-      " already",
-      presence,
-      " grouping column",
-      if (sum(found) == 1L) " " else "s ",
-      bad_cols,
-      ". ",
-      remedy
+      "Margin labels are already factor levels in grouping ",
+      "{cli::qty(length(bad_cols))}column{?s}:"
+    ),
+    i = "{.var {bad_cols}}.",
+    i = "Choose another {.arg .margin_label}."
+  ))
+}
+
+abort_observed_label_collision <- function(bad_cols, bad_labels) {
+  if (length(unique(bad_labels)) == 1L) {
+    abort_marginplyr(c(
+      paste0(
+        "{.val {unique(bad_labels)}} is already present in grouping ",
+        "{cli::qty(length(bad_cols))}column{?s}:"
+      ),
+      i = "{.var {bad_cols}}.",
+      i = paste0(
+        "Choose another {.arg .margin_label} or set ",
+        "{.code .check_margin_label = FALSE}."
+      )
+    ))
+  }
+  abort_marginplyr(c(
+    paste0(
+      "Margin labels are already present in grouping ",
+      "{cli::qty(length(bad_cols))}column{?s}:"
+    ),
+    i = "{.var {bad_cols}}.",
+    i = paste0(
+      "Choose another {.arg .margin_label} or set ",
+      "{.code .check_margin_label = FALSE}."
     )
-  )
+  ))
 }
 
 label_margin_branch <- function(.data,

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -126,6 +126,53 @@ literal a reader's eye lands on whole, but a sentence split at a space. It is
 still written beside the call that raises it, which is the property *Two rules
 are gated* asks a template for — a constant bound elsewhere stays refused.
 
+## Amendment: a branch on a count may choose a subject `{?}` cannot write
+
+`R/margin-label.R`'s collision refusal, re-authored in #223's phase 3, branches
+on a count. `length(unique(bad_labels)) == 1L` picks between two
+`abort_marginplyr()` calls — one saying `{.val {...}} is already a factor
+level`, the other `Margin labels are already factor levels` — and both arms
+spell a noun, which *Every singular/plural choice goes through cli's `{?}`*
+below forbids an R branch to do.
+
+It is admitted, and what the boundary turns on is what the two arms differ by
+rather than what the branch reads. `{?a/b}` chooses between two literal
+alternatives, and the alternative it picks is never re-read as a template:
+measured on 2026-08-20 with cli 3.6.6,
+`{cli::qty(n)}{?{.val {lab}}/Margin labels}` renders its singular arm as the
+uninterpolated text `{.val {lab}}`. The two arms here name different subjects —
+the one colliding label, which is interpolated, against the words `Margin
+labels` standing in for several distinct ones, which is not — so no single
+template can write both. The count is how that subject gets chosen; it is not
+something being inflected.
+
+So the rule stands where it bites, and `design/architecture.md`'s "`{?}` for
+every plural" stays literally true. A noun that inflects still goes through
+`{?}`, as `column{?s}` behind `cli::qty()` does in each of the four arms rather
+than being branched on. What an R branch may choose is a whole element or a
+whole clause, which is what `R/share.R`'s helper-position refusal and
+`R/grouping-plan.R`'s two renaming refusals already do; that those two read a
+boolean and this one reads a count is not a distinction this ADR draws.
+
+**The inventory in that section** is what goes: "`{?s}` covers the nine sites
+that suffix one, `{?is/are}` the one that also inflects a verb, and `{?a/b}`
+the two that switch a whole phrase or pick between two different nouns." It is
+a census of the corpus taken before any of it was re-authored, it already
+undercounted — the collision refusal switches a whole phrase and sits in none
+of its three columns — and #223's phase 3 moves the rest of it, since #235
+dissolved `abort_selection_rename()`'s noun pair into `{?s}`. Nothing reads the
+sentence, so nothing failed either time. It is struck rather than recounted,
+because the rule is deliberately stated over the construction and a recount
+would be stale again by the next file. Whether anything should count these
+sites is left open in [#236](https://github.com/sayuks/marginplyr/issues/236).
+
+The cost is the one those two precedents already pay, doubled, because the
+subject and the collision kind are two branches rather than one: four arms,
+each repeating the bullet that carries the columns, the noun that inflects
+beside it, and the remedy that follows. The structural gate is what leaves no
+cheaper spelling — a template hoisted out of the arms is a template bound
+elsewhere, which it refuses.
+
 ## The migration introduces wrapping, so a line is authored to survive it
 
 `rlang::abort()` wraps nothing. `cli_abort()` wraps at retrieval time, at

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -137,22 +137,32 @@ below forbids an R branch to do.
 
 It is admitted, and what the boundary turns on is what the two arms differ by
 rather than what the branch reads. `{?a/b}` chooses between two literal
-alternatives, and the alternative it picks is never re-read as a template:
-measured on 2026-08-20 with cli 3.6.6,
-`{cli::qty(n)}{?{.val {lab}}/Margin labels}` renders its singular arm as the
-uninterpolated text `{.val {lab}}`. The two arms here name different subjects —
+alternatives, and the alternative it picks is never re-read as a template, so
+nothing can be interpolated into it —
+`investigation/a-pluralization-alternative-is-literal-text.md` measures that,
+and records that cli documents `{?}` over word forms only, so it is a
+behaviour rather than a promise. The two arms here name different subjects —
 the one colliding label, which is interpolated, against the words `Margin
 labels` standing in for several distinct ones, which is not — so no single
 template can write both. The count is how that subject gets chosen; it is not
 something being inflected.
 
-So the rule stands where it bites, and `design/architecture.md`'s "`{?}` for
-every plural" stays literally true. A noun that inflects still goes through
-`{?}`, as `column{?s}` behind `cli::qty()` does in each of the four arms rather
-than being branched on. What an R branch may choose is a whole element or a
-whole clause, which is what `R/share.R`'s helper-position refusal and
-`R/grouping-plan.R`'s two renaming refusals already do; that those two read a
-boolean and this one reads a count is not a distinction this ADR draws.
+So the rule stands where it bites. What an R branch may choose is a whole
+element or a whole clause, which is what `R/share.R`'s helper-position refusal
+and `R/grouping-plan.R`'s two renaming refusals already do; that those two read
+a boolean and this one reads a count is not a distinction this ADR draws. What
+it may not do is leave a plural inside a template for an `if` to spell, and none
+of the four arms does: the noun still free once an arm has been chosen —
+`column{?s}`, on the number of colliding columns — goes through `{?}` behind
+`cli::qty()` in every one of them.
+
+`design/architecture.md`'s "`{?}` for every plural" is therefore read as a
+property of a template rather than of a diagnostic, and on that reading it needs
+no edit. Read of the diagnostic it would be false here, and saying so is the
+honest form of this amendment: `is`/`are` and `a factor level`/`factor levels`
+do vary with the data, and the branch is what picks them. What stays true, and
+what the structural gate can check, is that no template contains a plural an
+`if` decides.
 
 **The inventory in that section** is what goes: "`{?s}` covers the nine sites
 that suffix one, `{?is/are}` the one that also inflects a verb, and `{?a/b}`

--- a/investigation/a-pluralization-alternative-is-literal-text.md
+++ b/investigation/a-pluralization-alternative-is-literal-text.md
@@ -1,0 +1,67 @@
+# A pluralization alternative is literal text
+
+Investigated: 2026-08-20
+
+`{?a/b}` picks between two spellings, and #223's phase 3 needed to know whether
+the spelling it picks is re-read as a cli template before it could decide the
+shape of `R/margin-label.R`'s collision refusal. That refusal has two arms —
+one naming the single colliding label, which has to be interpolated, and one
+naming the words `Margin labels`, which does not — chosen by a count. If an
+alternative were re-read, the two arms would be one template with a `{?}` in
+it, and the R branch that chooses between them could go, which is what ADR
+0023's rule that no R branch spells a noun would prefer.
+
+An alternative is not re-read. It is emitted as the bytes it was written as, so
+no interpolation can happen inside the arm `{?}` picks, and a subject that
+differs between arms cannot be written in one template.
+
+Environment: R 4.6.1 (2026-06-24), cli 3.6.6, rlang 1.3.0, macOS, C.UTF-8
+locale, repository at `5e29006`.
+
+## What was measured
+
+Each row is `cli::format_inline(<template>)` with `lab <- "All"` bound in the
+evaluation frame, at both quantities. The first two rows are the question; the
+last two are the controls, showing that the same call interpolates and
+inflects normally everywhere else in the template.
+
+| template | `n = 1` | `n = 2` |
+| --- | --- | --- |
+| `{cli::qty(n)}{?{.val {lab}}/Margin labels}` | `{.val {lab}}` | `Margin labels` |
+| `{cli::qty(n)}{?{lab}/Margin labels}` | `{lab}` | `Margin labels` |
+| `{cli::qty(n)}{?is/are} already` | `is already` | `are already` |
+| `{cli::qty(n)}column{?s}` | `column` | `columns` |
+
+The singular arm comes back with its braces intact in both of the first two
+rows. Nothing is raised — no `Could not evaluate cli {} expression`, no warning
+— so a template written this way would ship the brace text to a reader rather
+than failing where an author could see it. `cli::pluralize()` was measured on
+the second row and answered `{lab}` as well, so this is the pluralization pass
+rather than something `format_inline()` does on top of it.
+
+The plural arm interpolating nothing is not evidence either way here, `Margin
+labels` holding no `{}`.
+
+## What cli documents
+
+`?cli::pluralization` presents `{?}` only over word forms — `file{?s}`,
+`director{?y/ies}`, `{?is/are}` — and `?cli::pluralize` adds nothing about the
+content of an alternative. So the behaviour above is established by measurement
+and not by a documented promise, which is the reason to record it here rather
+than to cite a page.
+
+Two consequences follow for a reader deciding how far to trust it. It is not a
+contract cli has made, so it can move without cli considering it a breaking
+change; and the failure mode if it does move is loud in the other direction —
+a template whose alternatives suddenly interpolated would evaluate `{lab}` in
+the raising frame, which is exactly what the arms of this refusal do not want
+in the plural case. Nothing in marginplyr writes an alternative containing
+braces, so nothing here would break; what would change is that a shorter
+spelling became available.
+
+## What this decided
+
+ADR 0023's third amendment, in the same commit. The branch on a count stays,
+because it chooses a subject rather than inflecting a noun, and every noun that
+does inflect still goes through `{?}` — `column{?s}` behind `cli::qty()` in
+each of the refusal's four arms.

--- a/tests/testthat/_snaps/diagnostic-authoring.md
+++ b/tests/testthat/_snaps/diagnostic-authoring.md
@@ -3,7 +3,6 @@
     Code
       cat(sprintf("%s(): %d", names(counts), counts), sep = "\n")
     Output
-      abort_margin_label_collision(): 1
       assert_lazy_table(): 1
       assert_logical_scalar(): 1
       assert_margin_input(): 1
@@ -22,7 +21,4 @@
       match_margin_choice(): 1
       nest_margin_pipeline(): 2
       normalize_margin_id(): 1
-      normalize_margin_label(): 5
-      validate_margin_label(): 1
-      validate_margin_label_names(): 3
 

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -113,7 +113,10 @@ test_that("the fixed `.by` label refusal pluralizes its column noun", {
   ))
   expect_identical(
     conditionMessage(singular),
-    "`.margin_label` must not name fixed `.by` column `region`."
+    paste0(
+      "`.margin_label` must not name fixed `.by` column:\n",
+      "i `region`."
+    )
   )
 
   plural <- expect_error(expand_with_margins(
@@ -124,7 +127,10 @@ test_that("the fixed `.by` label refusal pluralizes its column noun", {
   ))
   expect_identical(
     conditionMessage(plural),
-    "`.margin_label` must not name fixed `.by` columns `region`, `grade`."
+    paste0(
+      "`.margin_label` must not name fixed `.by` columns:\n",
+      "i `region` and `grade`."
+    )
   )
 })
 
@@ -137,13 +143,19 @@ test_that("the unknown label dimension refusal pluralizes its name noun", {
   singular <- expect_error(operation(c(region = "A", u = "A")))
   expect_identical(
     conditionMessage(singular),
-    "`.margin_label` has unknown dimension name `u`."
+    paste0(
+      "`.margin_label` has unknown dimension name:\n",
+      "i `u`."
+    )
   )
 
   plural <- expect_error(operation(c(region = "A", u = "A", v = "A")))
   expect_identical(
     conditionMessage(plural),
-    "`.margin_label` has unknown dimension names `u`, `v`."
+    paste0(
+      "`.margin_label` has unknown dimension names:\n",
+      "i `u` and `v`."
+    )
   )
 })
 
@@ -169,8 +181,9 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(singular),
     paste0(
-      "`NA_character_` is already a factor level in grouping column `g`. ",
-      "Use `NULL` for a typed-missing Margin label while preserving the NA ",
+      "`NA_character_` is already a factor level in grouping column:\n",
+      "i `g`.\n",
+      "i Use `NULL` for a typed-missing Margin label while preserving the NA ",
       "level."
     )
   )
@@ -179,21 +192,26 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(plural),
     paste0(
-      "`NA_character_` is already a factor level in grouping columns `g`, ",
-      "`h`. Use `NULL` for a typed-missing Margin label while preserving ",
-      "the NA level."
+      "`NA_character_` is already a factor level in grouping columns:\n",
+      "i `g` and `h`.\n",
+      "i Use `NULL` for a typed-missing Margin label while preserving the NA ",
+      "level."
     )
   )
 })
 
-# Both `kind` values are pinned, because the pluralized noun sits between words
-# the kind chooses and a re-authoring reads the whole sentence rather than the
-# branch it came from. The mixed cases are the builder's other subject arm:
-# labels that are not all one value replace the quoted label with a plural
-# subject carrying its own verb, and under the declared kind a second noun
-# pluralizes with it. That arm exists under both kinds and is plural-only,
-# since two distinct label values need two columns, so both are recorded and
-# neither stands in for the other.
+# Both `kind` values are pinned, and #223's re-authoring of this file made the
+# reason a stronger one rather than retiring it. The pluralized noun sat
+# between words the kind chose, so reading the whole sentence was what a
+# re-wording called for; now each kind is a template of its own, and the
+# pluralized column noun, the clause naming the collision, and the remedy are
+# each written out once per kind, so neither arm's pin reads the other's words
+# at all. The mixed cases are each builder's other subject arm: labels that are
+# not all one value replace the quoted label with a plural subject carrying its
+# own verb, and under the declared kind a second noun pluralizes with it. That
+# arm exists under both kinds and is plural-only, since two distinct label
+# values need two columns, so both are recorded and neither stands in for the
+# other.
 test_that("the margin label collision pluralizes its grouping column noun", {
   declared <- data.frame(
     a = factor(c("All", "x")),
@@ -224,8 +242,9 @@ test_that("the margin label collision pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(declared_singular),
     paste0(
-      "\"All\" is already a factor level in grouping column `a`. ",
-      "Choose another `.margin_label`."
+      "\"All\" is already a factor level in grouping column:\n",
+      "i `a`.\n",
+      "i Choose another `.margin_label`."
     )
   )
 
@@ -233,8 +252,9 @@ test_that("the margin label collision pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(declared_plural),
     paste0(
-      "\"All\" is already a factor level in grouping columns `a`, `b`. ",
-      "Choose another `.margin_label`."
+      "\"All\" is already a factor level in grouping columns:\n",
+      "i `a` and `b`.\n",
+      "i Choose another `.margin_label`."
     )
   )
 
@@ -242,8 +262,9 @@ test_that("the margin label collision pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(declared_mixed),
     paste0(
-      "Margin labels are already factor levels in grouping columns `a`, ",
-      "`b`. Choose another `.margin_label`."
+      "Margin labels are already factor levels in grouping columns:\n",
+      "i `a` and `b`.\n",
+      "i Choose another `.margin_label`."
     )
   )
 
@@ -251,8 +272,10 @@ test_that("the margin label collision pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(observed_singular),
     paste0(
-      "\"All\" is already present in grouping column `a`. ",
-      "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+      "\"All\" is already present in grouping column:\n",
+      "i `a`.\n",
+      "i Choose another `.margin_label` or set ",
+      "`.check_margin_label = FALSE`."
     )
   )
 
@@ -260,8 +283,10 @@ test_that("the margin label collision pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(observed_plural),
     paste0(
-      "\"All\" is already present in grouping columns `a`, `b`. ",
-      "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+      "\"All\" is already present in grouping columns:\n",
+      "i `a` and `b`.\n",
+      "i Choose another `.margin_label` or set ",
+      "`.check_margin_label = FALSE`."
     )
   )
 
@@ -269,8 +294,10 @@ test_that("the margin label collision pluralizes its grouping column noun", {
   expect_identical(
     conditionMessage(observed_mixed),
     paste0(
-      "Margin labels are already present in grouping columns `a`, `b`. ",
-      "Choose another `.margin_label` or set `.check_margin_label = FALSE`."
+      "Margin labels are already present in grouping columns:\n",
+      "i `a` and `b`.\n",
+      "i Choose another `.margin_label` or set ",
+      "`.check_margin_label = FALSE`."
     )
   )
 })

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -200,8 +200,8 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
   )
 })
 
-# Both `kind` values are pinned, and #223's re-authoring of this file made the
-# reason a stronger one rather than retiring it. The pluralized noun sat
+# Both collision kinds are pinned, and #223's re-authoring of this file made
+# the reason a stronger one rather than retiring it. The pluralized noun sat
 # between words the kind chose, so reading the whole sentence was what a
 # re-wording called for; now each kind is a template of its own, and the
 # pluralized column noun, the clause naming the collision, and the remedy are

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -475,7 +475,7 @@ test_that("dtplyr checks margin labels across all dimensions", {
       .grouping = rollup(first, second),
       .check_margin_label = TRUE
     ),
-    "grouping columns `first`, `second`"
+    "grouping columns:\ni `first` and `second`"
   )
 })
 
@@ -488,7 +488,7 @@ test_that("Arrow checks margin labels across all dimensions", {
       .grouping = rollup(first, second),
       .check_margin_label = TRUE
     ),
-    "grouping columns `first`, `second`"
+    "grouping columns:\ni `first` and `second`"
   )
 })
 
@@ -510,7 +510,7 @@ test_that("DuckDB checks margin labels across all dimensions", {
       .grouping = rollup(first, second),
       .check_margin_label = TRUE
     ),
-    "grouping columns `first`, `second`"
+    "grouping columns:\ni `first` and `second`"
   )
 })
 

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -395,7 +395,7 @@ test_that("margin label checks handle missing and non-syntactic columns", {
       .grouping = rollup(`first group`, `second group`),
       .margin_label = NA_character_
     ),
-    "grouping columns `first group`, `second group`"
+    "grouping columns:\ni `first group` and `second group`"
   )
 
   # A value of a factor column is a level of it, so this collision is declared

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -167,14 +167,14 @@ test_that("named Margin labels require exact dimension coverage", {
     )
   }
 
-  expect_error(operation(c(first = "All")), "missing `second`")
+  expect_error(operation(c(first = "All")), "Missing `second`")
   expect_error(
     operation(c(first = "All", second = "All", unknown = "All")),
-    "unknown dimension name `unknown`"
+    "unknown dimension name:\ni `unknown`"
   )
   expect_error(
     operation(c(fixed = "All", first = "All", second = "All")),
-    "fixed `.by` column `fixed`"
+    "fixed `.by` column:\ni `fixed`"
   )
   expect_error(
     operation(stats::setNames(c("All", "All"), c("first", ""))),
@@ -204,7 +204,7 @@ test_that("factor collisions include unused levels and stay column-specific", {
       .grouping = rollup(first, second),
       .margin_label = c(first = "All first", second = "New second")
     ),
-    "grouping column `first`"
+    "grouping column:\ni `first`"
   )
   expect_match(
     deparse1(conditionCall(error)),
@@ -219,7 +219,7 @@ test_that("factor collisions include unused levels and stay column-specific", {
       .grouping = rollup(first, second),
       .margin_label = c(first = "All first", second = "All second")
     ),
-    "grouping columns `first`, `second`"
+    "grouping columns:\ni `first` and `second`"
   )
   expect_match(conditionMessage(both), "are already factor levels")
 })
@@ -242,7 +242,7 @@ test_that("a declared collision is rejected however the label check is set", {
         .margin_label = "All",
         .check_margin_label = check
       ),
-      "already a factor level in grouping column `group`",
+      "already a factor level in grouping column:\ni `group`",
       fixed = TRUE
     )
     expect_s3_class(error, "marginplyr_error")
@@ -306,7 +306,7 @@ test_that("dtplyr rejects a declared collision and stays silent on a value", {
       n = dplyr::n(),
       .grouping = rollup(declared)
     ),
-    "already a factor level in grouping column `declared`",
+    "already a factor level in grouping column:\ni `declared`",
     fixed = TRUE
   )
   expect_s3_class(error, "marginplyr_error")
@@ -331,7 +331,7 @@ test_that("dtplyr rejects a declared collision and stays silent on a value", {
       .grouping = rollup(observed),
       .check_margin_label = TRUE
     ),
-    "already present in grouping column `observed`",
+    "already present in grouping column:\ni `observed`",
     fixed = TRUE
   )
 })
@@ -363,7 +363,7 @@ test_that("DuckDB rejects a declared collision without being asked", {
       .grouping = rollup(g),
       .margin_label = "(all)"
     ),
-    "already a factor level in grouping column `g`",
+    "already a factor level in grouping column:\ni `g`",
     fixed = TRUE
   )
 
@@ -422,7 +422,7 @@ test_that("RSQLite leaves an observed collision silent until it is asked", {
       .grouping = rollup(group),
       .check_margin_label = TRUE
     ),
-    "already present in grouping column `group`",
+    "already present in grouping column:\ni `group`",
     fixed = TRUE
   )
 })
@@ -682,15 +682,15 @@ test_that("Margin label option errors use the package condition seam", {
     ),
     list(
       label = c(fixed = "All", first = "All", second = "All"),
-      message = "must not name fixed `\\.by` column `fixed`"
+      message = "must not name fixed `\\.by` column:\ni `fixed`"
     ),
     list(
       label = c(first = "All", second = "All", unknown = "All"),
-      message = "unknown dimension name `unknown`"
+      message = "unknown dimension name:\ni `unknown`"
     ),
     list(
       label = c(first = "All"),
-      message = "must name every Margin dimension; missing `second`"
+      message = "must name every Margin dimension\\.\ni Missing `second`"
     )
   )
 


### PR DESCRIPTION
#223's phase 3, third file. All 10 of `R/margin-label.R`'s
`abort_marginplyr_flat()` sites become `abort_marginplyr()` templates authored
against ADR 0023. Every refusal says what its predecessor said, in the same
words; what moved is the split into a refusal plus `i` bullets, the inline style
of each subject, the joining of a vector, and the R branches that spelled a
noun.

Four of `test-diagnostic-pluralization.R`'s eight diagnostics are raised from
here, which is the largest block of that baseline any phase-3 pull request
rewrites. All sixteen arms were executed against both trees and read word by
word; the only deltas are the `.`/capital a re-split gives a bullet and cli's
serial `and`.

## The one thing this file decided that the ADR had not

`abort_margin_label_collision()` branches on a **count** — the first phase-3
site that does — and each arm spells its own nouns, which ADR 0023's `{?}` rule
forbids an R branch to do. It is forced. Measured with cli 3.6.6,
`{cli::qty(n)}{?{.val {lab}}/Margin labels}` renders its singular arm as the
uninterpolated text `{.val {lab}}`: an alternative `{?}` picks is literal and is
never re-read as a template. The two arms name different subjects — one an
interpolated label, one the words standing in for several — so no single
template writes both, and the count is how the subject is chosen rather than
something being inflected.

ADR 0023 gains a third amendment saying so, and
`investigation/a-pluralization-alternative-is-literal-text.md` carries the
measurement, the controls, and what `?cli::pluralization` does not say — cli
documents `{?}` over word forms only, so this is a behaviour and not a promise.

The amendment also **strikes** that section's census of pluralizing sites. It
undercounted when written — this refusal switches a whole phrase and sits in
none of its three columns — and #235 has since moved
`abort_selection_rename()` between two of them. Nothing reads the sentence, so
nothing failed either time. Whether anything should count these sites is left
open in #236 rather than settled here.

The amendment says outright what it does not claim: read of a *diagnostic*,
"`{?}` for every plural" is false here, because `is`/`are` and `a factor
level`/`factor levels` do vary with the data. What stays true, and what the
structural gate can check, is that no *template* contains a plural an `if`
decides. `design/architecture.md` needs no edit on that reading.

## The rest

Five vectors move alone into an `i` bullet, per ADR 0023's surviving line
condition. The missing-dimension refusal is the one whose sentence already had
its own break, a `;`, and it splits there. Four suffixing pluralizations
dissolve into `{?s}` behind `cli::qty()`.

`abort_margin_label_collision()` takes `on_collision =` and each caller hands in
the refusal that speaks for it — the shape `3e69c21` introduced for the two
renaming refusals — so the `kind` string is gone. The `{.val}`/`{.code}`
boundary ADR 0023 says this refusal already drew by hand is now drawn by the
markup: `{.val}` writes `"All"` and `NA` exactly as the old
`paste0('"', label, '"')` did, while `NA_character_` stays `{.code}`.

Re-pinned in place, none moved to a snapshot: twelve byte-exact
`conditionMessage()` equalities across four blocks of
`test-diagnostic-pluralization.R`, and seventeen phrase pins the split moved
across the main-line/bullet boundary. The `abort_marginplyr_flat()` snapshot
loses exactly 10 sites.

**No `verify-site.R` marker moves, and that is a finding rather than an
omission.** None of `get_started.html`'s markers quote this file; the one
`must_error` chunk that raises from here (`database_backends.qmd`'s
`declared-level-rejected`, behind `has_duckdb`) carries no marker, for the
reason that section already gives; and `man/summarize_with_margins.html`'s
"NA is already a factor level" is `R/summarize_with_margins.R`'s roxygen table
paraphrasing the NA-level refusal, which still paraphrases it — those words are
the main line, and the columns that moved into a bullet were never in it.

## Checks

`lintr::lint_package()` clean. Suite 4791 passed, 0 failed, 0 skipped.
`verify-suite-coverage.R` verified all 599 tests. `verify-must-error.R` green
over its 8 fixtures. `verify-site.R` green against a freshly rendered `docs/`,
where the DuckDB chunk renders the re-authored refusal unwrapped.

Two review rounds ran on both the Standards and Spec axes; findings from each
are answered in the second and third commits.

Part of #223.