### PR TITLE
Author R/grouping-context.R's diagnostics in the cli idiom

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -106,17 +106,19 @@
 #'   .margin_label = NULL
 #' )
 grouping_bit <- function(x) {
-  abort_marginplyr_flat(
-    "`grouping_bit()` can only be used inside `summarize_with_margins()`."
-  )
+  abort_marginplyr(paste0(
+    "{.fun grouping_bit} can only be used inside ",
+    "{.fun summarize_with_margins}."
+  ))
 }
 
 #' @rdname grouping_bit
 #' @export
 grouping_id <- function(...) {
-  abort_marginplyr_flat(
-    "`grouping_id()` can only be used inside `summarize_with_margins()`."
-  )
+  abort_marginplyr(paste0(
+    "{.fun grouping_id} can only be used inside ",
+    "{.fun summarize_with_margins}."
+  ))
 }
 
 rewrite_grouping_dots <- function(dots,
@@ -221,10 +223,6 @@ grouping_helper_vars <- function(args, helper, plan) {
   # message reads the arguments as written, because whether one arrived injected
   # is the fact the unwrapping discards.
   carried <- unwrap_injected_args(args)
-  not_a_column_message <- paste0(
-    sprintf("`%s()` only accepts bare grouping columns.", helper),
-    injected_quosure_clause(args)
-  )
 
   # The empty argument is refused ahead of the arity checks so that the answer
   # does not depend on which check runs first. `grouping_bit(, )` is two
@@ -234,18 +232,14 @@ grouping_helper_vars <- function(args, helper, plan) {
   # -- still reaches the arity diagnostic first, which is the one a caller
   # passing two of anything needs.
   if (any(vapply(carried, rlang::is_missing, logical(1)))) {
-    abort_marginplyr_flat(not_a_column_message)
+    abort_not_a_grouping_column(helper, args)
   }
 
   if (identical(helper, "grouping_bit") && length(carried) != 1L) {
-    abort_marginplyr_flat(
-      "`grouping_bit()` requires exactly one column."
-    )
+    abort_marginplyr("{.fun grouping_bit} requires exactly one column.")
   }
   if (identical(helper, "grouping_id") && length(carried) == 0L) {
-    abort_marginplyr_flat(
-      "`grouping_id()` requires at least one column."
-    )
+    abort_marginplyr("{.fun grouping_id} requires at least one column.")
   }
 
   # The compound question, asked here even though the check above has already
@@ -255,34 +249,68 @@ grouping_helper_vars <- function(args, helper, plan) {
   # make the reordering above load-bearing for correctness rather than for which
   # diagnostic a caller reads.
   if (!all(vapply(carried, is_name_part, logical(1)))) {
-    abort_marginplyr_flat(not_a_column_message)
+    abort_not_a_grouping_column(helper, args)
   }
 
   vars <- vapply(carried, as.character, character(1))
   if (anyDuplicated(vars)) {
-    abort_marginplyr_flat(
-      sprintf("`%s()` does not accept duplicate columns.", helper)
-    )
+    abort_marginplyr("{.fun {helper}} does not accept duplicate columns.")
   }
   if (identical(helper, "grouping_id") && length(vars) > 31L) {
-    abort_marginplyr_flat(
-      "`grouping_id()` supports at most 31 columns."
-    )
+    abort_marginplyr("{.fun grouping_id} supports at most 31 columns.")
   }
   allowed <- unique(c(plan$by, plan$dimensions))
   unknown <- setdiff(vars, allowed)
   if (length(unknown) > 0L) {
-    abort_marginplyr_flat(
-      sprintf(
-        "Column%s %s %s not part of `.by` or `.grouping`.",
-        if (length(unknown) == 1L) "" else "s",
-        paste0("`", unknown, "`", collapse = ", "),
-        if (length(unknown) == 1L) "is" else "are"
-      )
-    )
+    # The columns arrive alone in an `i` bullet, per ADR 0023's surviving line
+    # condition: how many of them there are is the caller's decision.
+    #
+    # The refusal left behind inflects both its noun and its verb, which is the
+    # one site ADR 0023's `{?}` rule describes that way. `cli::qty()` is what
+    # carries the count across the split: both markers would otherwise read the
+    # vector, and the split is what took it out of the line they sit in.
+    abort_marginplyr(c(
+      paste0(
+        "{cli::qty(length(unknown))}Column{?s} {?is/are} not part of ",
+        "{.arg .by} or {.arg .grouping}:"
+      ),
+      i = "{.var {unknown}}."
+    ))
   }
 
   vars
+}
+
+# The one refusal both of the name checks above reach: an argument that is not a
+# bare column, whether it is R's empty argument or something else entirely.
+# Written as a function rather than as a message bound once and passed twice,
+# because the structural gate reads `abort_marginplyr()`'s own argument and
+# refuses a template bound elsewhere -- the reason `R/share.R`'s two
+# Parent-share refusals are written out twice.
+#
+# `injected_quosure_clause()` is a whole sentence assembled around a deparsed
+# caller expression, so it stays an interpolated value and gains no markup: ADR
+# 0023's injection rule is what makes a caller's braces inert, and it holds
+# because cli reads the template and not the value. It carries its own leading
+# space and is empty at a call that injected nothing, so it follows the refusal
+# in the same line rather than taking a bullet of its own, which would sometimes
+# be a bullet marker with nothing after it. That is also where the flat form put
+# it, so every pin reading it composes as it did.
+#
+# `call` is forwarded rather than left to its default, because
+# `abort_marginplyr()` blames its own caller: defaulted here it would name this
+# helper rather than the frame the checks above are in, which is the call the
+# flat form blamed.
+abort_not_a_grouping_column <- function(helper,
+                                        args,
+                                        call = rlang::caller_call()) {
+  abort_marginplyr(
+    paste0(
+      "{.fun {helper}} only accepts bare grouping ",
+      "columns.{injected_quosure_clause(args)}"
+    ),
+    call = call
+  )
 }
 
 grouping_sql_expr <- function(var, con) {

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -286,23 +286,22 @@ grouping_helper_vars <- function(args, helper, plan) {
 # refuses a template bound elsewhere -- the reason `R/share.R`'s two
 # Parent-share refusals are written out twice.
 #
-# `injected_quosure_clause()` is a whole sentence assembled around a deparsed
-# caller expression, so it stays an interpolated value and gains no markup: ADR
-# 0023's injection rule is what makes a caller's braces inert, and it holds
-# because cli reads the template and not the value. It carries its own leading
-# space and is empty at a call that injected nothing, so it follows the refusal
-# in the same line rather than taking a bullet of its own, which would sometimes
-# be a bullet marker with nothing after it. That is also where the flat form put
-# it, so every pin reading it composes as it did.
+# `injected_quosure_clause()` reaches the template as an interpolated value
+# carrying no markup, for the reasons `R/share.R` states above the other site
+# that appends it: cli reads the template and not the value, so the caller's
+# braces are inert, and the clause is empty at a call that injected nothing, so
+# it follows prose already in a line rather than taking a bullet that would
+# sometimes hold a marker and nothing after it. The line it follows here is the
+# refusal, this refusal having no bullet to follow instead -- which is where the
+# flat form put it too, so every pin reading it composes as it did.
 #
-# ADR 0023's surviving line condition does not move it either, and reading it as
-# though it did would cost the sentence its subject. What that condition governs
-# is a part whose *length* the caller decides -- a vector whose element count
-# they chose, which is why the plan-membership refusal above splits -- and this
-# is one clause about one expression, as `{.var {output}}` in `R/share.R` and
-# `{.code {label}}` in `R/grouping-plan.R` are single caller subjects standing
-# in a main line. The bullet it would move to is not available in any case: this
-# refusal offers no remedy to attach it to, and #223 forbids inventing one.
+# ADR 0023's surviving line condition does not move it, and reading it as though
+# it did would cost the sentence its subject. What that condition governs is a
+# part whose *length* the caller decides -- a vector whose element count they
+# chose, which is what splits the plan-membership refusal above. This is one
+# clause about one expression, the shape `{.code {label}}` already has in
+# `R/grouping-plan.R`'s nested-specification refusal, where an arbitrary
+# deparsed caller expression stands in a main line with two bullets beside it.
 #
 # `call` is forwarded rather than left to its default, because
 # `abort_marginplyr()` blames its own caller: defaulted here it would name this

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -106,19 +106,17 @@
 #'   .margin_label = NULL
 #' )
 grouping_bit <- function(x) {
-  abort_marginplyr(paste0(
-    "{.fun grouping_bit} can only be used inside ",
-    "{.fun summarize_with_margins}."
-  ))
+  abort_marginplyr(
+    "{.fun grouping_bit} can only be used inside {.fun summarize_with_margins}."
+  )
 }
 
 #' @rdname grouping_bit
 #' @export
 grouping_id <- function(...) {
-  abort_marginplyr(paste0(
-    "{.fun grouping_id} can only be used inside ",
-    "{.fun summarize_with_margins}."
-  ))
+  abort_marginplyr(
+    "{.fun grouping_id} can only be used inside {.fun summarize_with_margins}."
+  )
 }
 
 rewrite_grouping_dots <- function(dots,
@@ -296,6 +294,15 @@ grouping_helper_vars <- function(args, helper, plan) {
 # in the same line rather than taking a bullet of its own, which would sometimes
 # be a bullet marker with nothing after it. That is also where the flat form put
 # it, so every pin reading it composes as it did.
+#
+# ADR 0023's surviving line condition does not move it either, and reading it as
+# though it did would cost the sentence its subject. What that condition governs
+# is a part whose *length* the caller decides -- a vector whose element count
+# they chose, which is why the plan-membership refusal above splits -- and this
+# is one clause about one expression, as `{.var {output}}` in `R/share.R` and
+# `{.code {label}}` in `R/grouping-plan.R` are single caller subjects standing
+# in a main line. The bullet it would move to is not available in any case: this
+# refusal offers no remedy to attach it to, and #223 forbids inventing one.
 #
 # `call` is forwarded rather than left to its default, because
 # `abort_marginplyr()` blames its own caller: defaulted here it would name this

--- a/tests/testthat/_snaps/diagnostic-authoring.md
+++ b/tests/testthat/_snaps/diagnostic-authoring.md
@@ -16,9 +16,6 @@
       check_summary_context_helpers(): 1
       check_summary_group_overwrite(): 1
       execute_margin_nest(): 1
-      grouping_bit(): 1
-      grouping_helper_vars(): 7
-      grouping_id(): 1
       match_margin_choice(): 1
       nest_margin_pipeline(): 2
       normalize_margin_id(): 1

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -285,7 +285,10 @@ test_that("the grouping helper refusal pluralizes its noun and its verb", {
   ))
   expect_identical(
     conditionMessage(singular),
-    "Column `nowhere` is not part of `.by` or `.grouping`."
+    paste0(
+      "Column is not part of `.by` or `.grouping`:\n",
+      "i `nowhere`."
+    )
   )
 
   plural <- expect_error(summarize_with_margins(
@@ -295,7 +298,10 @@ test_that("the grouping helper refusal pluralizes its noun and its verb", {
   ))
   expect_identical(
     conditionMessage(plural),
-    "Columns `nowhere`, `nor` are not part of `.by` or `.grouping`."
+    paste0(
+      "Columns are not part of `.by` or `.grouping`:\n",
+      "i `nowhere` and `nor`."
+    )
   )
 })
 

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -750,7 +750,7 @@ test_that("injection is transparent to the checks after the name test", {
   expect_s3_class(unknown, "marginplyr_error")
   expect_match(
     conditionMessage(unknown),
-    "Column `nowhere` is not part of `.by` or `.grouping`.",
+    "Column is not part of `.by` or `.grouping`:\ni `nowhere`.",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
#223's phase 3, fourth file: all 9 of `R/grouping-context.R`'s
`abort_marginplyr_flat()` sites become `abort_marginplyr()` templates authored
against ADR 0023. Every refusal says what its predecessor said, in the same
words. What moved is the inline style of each subject, one split into a refusal
plus an `i` bullet, and one pluralization that was two R branches.

`grouping_sql_expr()`'s bare `stop()` — the connection invariant — is outside
ADR 0023 and is untouched.

## The noun-and-verb refusal

The plan-membership refusal is the site ADR 0023's `{?}` rule describes as the
one that also inflects a verb, and both inflections survive as `{?s}` and
`{?is/are}`:

```r
abort_marginplyr(c(
  paste0(
    "{cli::qty(length(unknown))}Column{?s} {?is/are} not part of ",
    "{.arg .by} or {.arg .grouping}:"
  ),
  i = "{.var {unknown}}."
))
```

The columns move alone into an `i` bullet, per that ADR's surviving line
condition, which takes the vector out of the line the two markers sit in — so
`cli::qty()` is what carries the count across the split, the shape
`R/grouping-plan.R`'s duplicate-grouping-set refusal already has. The bullet
reads cli's serial `and`, as that file's two vector pins do.

```text
Column is not part of `.by` or `.grouping`:      Columns are not part of `.by` or `.grouping`:
i `nowhere`.                                     i `nowhere` and `nor`.
```

Worth a maintainer's eye: the singular main line is a verb whose subject moved
to the bullet. No word was added or dropped, and the line condition is what
forces it.

## The refusal both name checks reach

An argument that is not a bare column is refused by two checks, which shared one
assembled message. It becomes `abort_not_a_grouping_column()` rather than a
template bound once and passed twice, because the structural gate reads
`abort_marginplyr()`'s own argument and refuses a template bound elsewhere. It
forwards `call`, which is load-bearing at the raise site rather than decorative:
measured, the default names the new helper where the flat form named
`grouping_helper_vars()`. Its `injected_quosure_clause()` stays an interpolated
value with no markup, following the refusal in the same line, which is where the
flat form put it — the shape `R/share.R` gives the same clause.

## Pins, snapshot, site

Re-pinned in place, none moved to a snapshot: both arms of the plan-membership
refusal in `test-diagnostic-pluralization.R`, and its injected-name pin in
`test-static-expression-analysis.R`. The other pins on this file's messages read
bytes `{.fun}` renders unchanged, so they do not move. The
`abort_marginplyr_flat()` snapshot loses exactly 9 sites.

No `verify-site.R` marker quotes this file. `recipes.qmd`'s
`grouping-bit-in-filter` is the one `must_error` chunk raising one of these
refusals, its marker is the ``Error in `filter()` `` header, and the diagnostic
under it renders the bytes it rendered before. Checked against a rebuilt `docs/`
all the same.

## Checks

`lintr::lint_package()` clean, the full suite green with no new skips,
`verify-suite-coverage.R` (599 tests, every one in at least one configuration),
`verify-must-error.R` (8 fixtures), and `verify-site.R` (19 pages) against a
freshly rendered site.

## Review

Two rounds on both axes. Round 1 asked for the two context refusals as one
literal each — measured at 80 and 79 columns, inside `line_length_linter(80)` —
and read the injected-quosure clause on a main line as an undeclared departure
from the line condition. It is not one, and the comment now says why rather than
leaving it to be re-derived. Round 2 confirmed both, and its remaining points
are answered in `b86f0e2` or filed as #238, which asks for that reading to be
recorded in ADR 0023 rather than in the one file that needed it least.

A third round-2 observation — that `abort_nested_grouping_spec()` in
`R/grouping-plan.R` should forward `call` too — was checked and is not a defect:
it blames what the flat form blamed, one wrapper frame in either way.

Refs #223.