### PR TITLE
Record condition 2's element-count reading in ADR 0023

### DIFF
--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -60,6 +60,35 @@ the second sentence of condition 3, that a marker is chosen from a run of
 uninterpolated prose, which was never about wrapping — a marker quoting an
 interpolated part varies with the data at any width.
 
+**The length condition 2 speaks of is an element count**, not a character
+count. Read literally, "a part whose length the caller decides" covers any
+caller-derived text, and on that reading a single caller subject — one column
+name, one deparsed expression — leaves every main line it appears in. The
+condition's own glosses say otherwise, and they are what settle it: the
+statement below explains the fixed-`.by` refusal by saying "its length is a
+function of how many columns the caller passed", and the paragraph above — as
+does ADR 0024's *Consequences*, restating the surviving condition — calls the
+bullet the only thing between a long vector and a very long line. All of them
+are about how many parts arrive, not how many characters one part has. So what
+takes a bullet is a part the caller decides the count of, and a single caller
+subject stays where the sentence needs it however long its text renders.
+
+Phase 3 of #223 had already decided it that way three times before it was
+written down here. `R/share.R`'s helper-position refusal and
+`R/grouping-context.R`'s not-a-bare-column refusal each append
+`injected_quosure_clause()` — a whole sentence built around a deparsed caller
+expression — to prose already in a line, and `R/grouping-plan.R`'s
+nested-specification refusal puts `{.code {label}}`, an arbitrary deparsed
+caller expression, in a main line with two `i` bullets beside it. All three are
+correct under this reading and none under the literal one, `R/utils.R`
+re-authors a fourth site appending that clause, and only one of them says so —
+in a code comment, where it governs one file and the others re-derive it. That
+is the whole reason this is a paragraph in the amendment rather than a comment:
+which parts a line may hold is a decision, and it holds for every file the
+re-authoring reaches. Nothing gates it, for the reason *Two rules are gated*
+gives about the line conditions generally — the distinction is between what a
+part *is* and what it measures, which no scan over the templates can see.
+
 **The paragraph in *Consequences* beginning "Wrapping is not the whole of what
 retrieval-time formatting costs"** recorded the collapsing and left the trade
 open in #230. It is settled: the collapsing is a defect, and ADR 0024 is the

--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -74,20 +74,19 @@ takes a bullet is a part the caller decides the count of, and a single caller
 subject stays where the sentence needs it however long its text renders.
 
 Phase 3 of #223 had already decided it that way three times before it was
-written down here. `R/share.R`'s helper-position refusal and
-`R/grouping-context.R`'s not-a-bare-column refusal each append
-`injected_quosure_clause()` — a whole sentence built around a deparsed caller
-expression — to prose already in a line, and `R/grouping-plan.R`'s
-nested-specification refusal puts `{.code {label}}`, an arbitrary deparsed
-caller expression, in a main line with two `i` bullets beside it. All three are
-correct under this reading and none under the literal one, `R/utils.R`
-re-authors a fourth site appending that clause, and only one of them says so —
-in a code comment, where it governs one file and the others re-derive it. That
-is the whole reason this is a paragraph in the amendment rather than a comment:
-which parts a line may hold is a decision, and it holds for every file the
-re-authoring reaches. Nothing gates it, for the reason *Two rules are gated*
-gives about the line conditions generally — the distinction is between what a
-part *is* and what it measures, which no scan over the templates can see.
+written down here. `R/share.R`'s refusal of a direct-syntax call carrying
+anything but one bare name appends `injected_quosure_clause()` — a whole
+sentence built around a deparsed caller expression — to the remedy inside its
+`i` bullet, and `R/grouping-context.R`'s not-a-bare-column refusal appends the
+same clause to its main line; `R/grouping-plan.R`'s nested-specification
+refusal puts `{.code {label}}`, an arbitrary deparsed caller expression, in a
+main line with two `i` bullets beside it. All three are correct under this
+reading and none under the literal one, and only one of them said so — in a
+code comment, where it governed one file while the other two re-derived it.
+`R/utils.R`, which composes that clause, is re-authored in phase 3's last
+group and would have to re-derive it a third time. That is why this is a
+paragraph in the amendment: which parts a line may hold is a decision, and it
+holds for every file the re-authoring reaches.
 
 **The paragraph in *Consequences* beginning "Wrapping is not the whole of what
 retrieval-time formatting costs"** recorded the collapsing and left the trade


### PR DESCRIPTION
Closes #238.

ADR 0023's surviving line condition says a part whose length the caller decides
goes alone in an `i` bullet. Read literally, "length" covers any caller-derived
text, and a re-authoring reading it that way sends a single caller subject out
of every main line it appears in. The ADR's own glosses say otherwise — "its
length is a function of how many columns the caller passed", and the amendment's
"the only thing between a long vector and a very long line", which ADR 0024's
*Consequences* restates — so what the condition governs is a part whose element
count the caller decides.

That reading is now a paragraph in the first amendment, beside the sentence
saying which line conditions survived. No code changes, and no test or snapshot
moves.

## Why the amendment and not a comment

#223's phase 3 had already decided it three times, each time correctly:
`R/share.R`'s direct-syntax refusal appends `injected_quosure_clause()` — a
whole sentence built around a deparsed caller expression — to the remedy inside
its `i` bullet; `R/grouping-context.R`'s not-a-bare-column refusal appends the
same clause to its main line; and `R/grouping-plan.R`'s nested-specification
refusal puts `{.code {label}}` in a main line with two `i` bullets beside it.
Only one of the three says so, in a code comment, and `R/utils.R` — which
composes that clause — is re-authored in phase 3's last group and would have to
derive it a third time. Which parts a line may hold is a decision that holds for
every file the re-authoring reaches, so it belongs where the other decisions
about those conditions are.

## Worth a maintainer's eye

The reading is now stated in two places: this paragraph, and
`R/grouping-context.R`'s comment, which still derives it in full. #238 confined
itself to the ADR, so reducing that comment to a citation — and the sibling
comments in `R/share.R` and the one `R/utils.R` will get — is filed as #240
rather than done here.

The paragraph makes no claim about gating. *Two rules are gated* declines a gate
on the line conditions because a width measured over the literal alone returns
clean for the line a long vector pushed past the margin, and that argument is
unchanged by which kind of length condition 2 means.

## Checks

`testthat::test_local()` passes with nothing failing or skipping, and
`lintr::lint_package()` after `pkgload::load_all()` reports no lints. Neither is
evidence about this change beyond confirming it touched no code: nothing in
`tests/` or `.github/scripts/` reads `design/adr/`, so this file has no gate and
review is what holds it up.