### PR TITLE
Reduce the element-count comment to a citation of ADR 0023

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -297,10 +297,10 @@ grouping_helper_vars <- function(args, helper, plan) {
 #
 # ADR 0023's surviving line condition does not move it, under the element-count
 # reading its first amendment records: this is one clause about one expression
-# and not a part whose count the caller decides. That is the shape
-# `{.code {label}}` already has in `R/grouping-plan.R`'s nested-specification
-# refusal, where an arbitrary deparsed caller expression stands in a main line
-# with two bullets beside it.
+# and not a part the caller decides the count of -- the shape `{.code {label}}`
+# already has in `R/grouping-plan.R`'s nested-specification refusal, where an
+# arbitrary deparsed caller expression stands in a main line with two `i`
+# bullets beside it.
 #
 # `call` is forwarded rather than left to its default, because
 # `abort_marginplyr()` blames its own caller: defaulted here it would name this

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -295,13 +295,12 @@ grouping_helper_vars <- function(args, helper, plan) {
 # refusal, this refusal having no bullet to follow instead -- which is where the
 # flat form put it too, so every pin reading it composes as it did.
 #
-# ADR 0023's surviving line condition does not move it, and reading it as though
-# it did would cost the sentence its subject. What that condition governs is a
-# part whose *length* the caller decides -- a vector whose element count they
-# chose, which is what splits the plan-membership refusal above. This is one
-# clause about one expression, the shape `{.code {label}}` already has in
-# `R/grouping-plan.R`'s nested-specification refusal, where an arbitrary
-# deparsed caller expression stands in a main line with two bullets beside it.
+# ADR 0023's surviving line condition does not move it, under the element-count
+# reading its first amendment records: this is one clause about one expression
+# and not a part whose count the caller decides. That is the shape
+# `{.code {label}}` already has in `R/grouping-plan.R`'s nested-specification
+# refusal, where an arbitrary deparsed caller expression stands in a main line
+# with two bullets beside it.
 #
 # `call` is forwarded rather than left to its default, because
 # `abort_marginplyr()` blames its own caller: defaulted here it would name this


### PR DESCRIPTION
Closes #240.

#238 recorded ADR 0023 condition 2's element-count reading in the ADR's first
amendment, beside the sentence saying which line conditions survived. That
left the reading stated twice: there, and in full in `R/grouping-context.R`'s
comment above `abort_not_a_grouping_column()`, which was its only home when it
was written. `AGENTS.md`'s stance is that a rule has one home, so the comment
now cites the amendment instead of deriving the reading again.

What it keeps is the part that is about this refusal rather than about the
condition: the clause is one clause about one expression, so the condition does
not move it out of the main line, and that is the shape `{.code {label}}`
already has in `R/grouping-plan.R`'s nested-specification refusal. The two
sibling comments state the reading nowhere and need no edit — `R/share.R`'s
above `validate_share_direct_syntax()`'s refusal, and `R/utils.R`'s
`injected_quosure_clause()`, which phase 3's last group re-authors.

The second commit answers the two-axis review: the reading is named in the
amendment's own words rather than paraphrased, the apposition joining the
clause to the shape it shares is restored, and the bullets beside the
`R/grouping-plan.R` refusal are named as the `i` bullets they are.

## Scope

Comment prose only — every changed line is a `#` comment. No diagnostic, test,
or snapshot moves, and nothing generated is regenerated.

## Checks

- `pkgload::load_all(".")` then `lintr::lint_package()` — no lints.
- `NOT_CRAN=true devtools::test()` — `FAIL 0 | WARN 0 | SKIP 0 | PASS 4791`.

## Out of scope

#242 records what the standards axis found and this ticket does not cover: six
comments in `R/` call condition 2 "ADR 0023's *surviving* line condition", where
the amendment left two survivors — condition 2 whole, and condition 3's second
sentence.