### PR TITLE
Name ADR 0023 condition 2 in source comments

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -260,8 +260,8 @@ grouping_helper_vars <- function(args, helper, plan) {
   allowed <- unique(c(plan$by, plan$dimensions))
   unknown <- setdiff(vars, allowed)
   if (length(unknown) > 0L) {
-    # The columns arrive alone in an `i` bullet, per ADR 0023's surviving line
-    # condition: how many of them there are is the caller's decision.
+    # The columns arrive alone in an `i` bullet, per ADR 0023's condition 2:
+    # how many of them there are is the caller's decision.
     #
     # The refusal left behind inflects both its noun and its verb, which is the
     # one site ADR 0023's `{?}` rule describes that way. `cli::qty()` is what
@@ -295,12 +295,12 @@ grouping_helper_vars <- function(args, helper, plan) {
 # refusal, this refusal having no bullet to follow instead -- which is where the
 # flat form put it too, so every pin reading it composes as it did.
 #
-# ADR 0023's surviving line condition does not move it, under the element-count
-# reading its first amendment records: this is one clause about one expression
-# and not a part the caller decides the count of -- the shape `{.code {label}}`
-# already has in `R/grouping-plan.R`'s nested-specification refusal, where an
-# arbitrary deparsed caller expression stands in a main line with two `i`
-# bullets beside it.
+# ADR 0023's condition 2 does not move it, under the element-count reading its
+# first amendment records: this is one clause about one expression and not a
+# part the caller decides the count of -- the shape `{.code {label}}` already
+# has in `R/grouping-plan.R`'s nested-specification refusal, where an arbitrary
+# deparsed caller expression stands in a main line with two `i` bullets beside
+# it.
 #
 # `call` is forwarded rather than left to its default, because
 # `abort_marginplyr()` blames its own caller: defaulted here it would name this

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -420,8 +420,8 @@ compile_grouping_spec_impl <- function(.grouping,
 
   overlap <- intersect(.by, dimensions)
   if (length(overlap) > 0L) {
-    # The columns arrive alone in an `i` bullet, per ADR 0023's surviving line
-    # condition: how many of them there are is the caller's decision.
+    # The columns arrive alone in an `i` bullet, per ADR 0023's condition 2:
+    # how many of them there are is the caller's decision.
     abort_marginplyr(c(
       "Columns cannot appear in both {.arg .by} and {.arg .grouping}:",
       i = "{.var {overlap}}."
@@ -835,8 +835,8 @@ resolve_column_selection <- function(arg, data_proxy, on_rename) {
 # `abort_marginplyr()`'s own argument and refuses a template bound elsewhere --
 # the reason `R/share.R`'s two Parent-share refusals are written out twice.
 #
-# The pairs arrive alone in an `i` bullet, per ADR 0023's surviving line
-# condition: how many of them there are is the caller's decision.
+# The pairs arrive alone in an `i` bullet, per ADR 0023's condition 2: how many
+# of them there are is the caller's decision.
 abort_grouping_rename <- function(selected_names, source_names) {
   abort_marginplyr(c(
     "Can't rename {cli::qty(length(selected_names))}grouping dimension{?s}:",

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -54,8 +54,8 @@ validate_margin_label_names <- function(.margin_label, dimensions, by) {
 
   label_names <- names(.margin_label)
   # Each refusal below names whichever names it is refusing, and each carries
-  # them in an `i` bullet rather than in its main line, per ADR 0023's
-  # surviving line condition: how many of them arrive is the caller's decision.
+  # them in an `i` bullet rather than in its main line, per
+  # ADR 0023's condition 2: how many of them arrive is the caller's decision.
   fixed_names <- intersect(label_names, by)
   if (length(fixed_names) > 0L) {
     abort_marginplyr(c(

--- a/R/share.R
+++ b/R/share.R
@@ -1359,9 +1359,8 @@ abort_share_source_type <- function(value,
         "source summary {.var {source_summary}} to be a plain integer or ",
         "double scalar."
       ),
-      # Alone in a bullet per ADR 0023's surviving line condition: a class
-      # vector is as long as the value's class chain, which the caller's data
-      # decides.
+      # Alone in a bullet per ADR 0023's condition 2: a class vector is as long
+      # as the value's class chain, which the caller's data decides.
       i = "Detected type {detected_type}.",
       i = "Convert it explicitly in the ordinary summary."
     ),
@@ -1701,8 +1700,8 @@ preflight_share_across_syntax <- function(expr, output_name) {
     ))
   }
   if (length(args$additional) > 0L) {
-    # The arguments arrive alone in an `i` bullet, per ADR 0023's surviving
-    # line condition: how many of them there are is the caller's decision.
+    # The arguments arrive alone in an `i` bullet, per ADR 0023's condition 2:
+    # how many of them there are is the caller's decision.
     abort_marginplyr(c(
       paste0(
         "{share_kind_modifier(kind)} {.fun across} does not accept ",


### PR DESCRIPTION
## Summary

- name ADR 0023's condition 2 directly in all seven affected source comments
- preserve each comment's local explanation while removing the ambiguous description
- keep executable code, diagnostics, tests, snapshots, ADRs, and gates unchanged

## Verification

- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); lintr::lint_package()'`
- `git diff --check`
- multiline-aware search confirms the old citation is absent

Closes #242
