### PR TITLE
Author R/summary-selections.R's diagnostics in the cli idiom

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -296,11 +296,11 @@ markers <- list(
     # The `cur_group*()` refusal, quoted one sentence further in than it used
     # to be. #223's re-authoring moved the helper the caller wrote into an `i`
     # bullet of its own, so the opening phrase and the helper name are no
-    # longer one run of this page, and the bullets around the sentence below
-    # each carry something the call decides -- the helper, or the plural its
-    # count chooses. This sentence is the longest run of that refusal no data
-    # reaches, which is what ADR 0023's condition 3 asks a marker to be chosen
-    # from.
+    # longer one run of this page. The sentence below is the longest run of
+    # that refusal no data reaches, which is what ADR 0023's condition 3 asks
+    # a marker to be chosen from; the two bullets above it each carry
+    # something the call decides -- the helper, or the plural its count
+    # chooses.
     "These helpers describe one branch-local dplyr grouping or data mask",
     "Duplicate grouping sets were produced at",
     "Can't supply `.by` when `.data` is grouped",

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -293,7 +293,15 @@ markers <- list(
     # so all of them hold wherever the page is built.
     "Error in `summarize_with_margins()`",
     "Error in `nest_with_margins()`",
-    "does not support `cur_group_id()`",
+    # The `cur_group*()` refusal, quoted one sentence further in than it used
+    # to be. #223's re-authoring moved the helper the caller wrote into an `i`
+    # bullet of its own, so the opening phrase and the helper name are no
+    # longer one run of this page, and the bullets around the sentence below
+    # each carry something the call decides -- the helper, or the plural its
+    # count chooses. This sentence is the longest run of that refusal no data
+    # reaches, which is what ADR 0023's condition 3 asks a marker to be chosen
+    # from.
+    "These helpers describe one branch-local dplyr grouping or data mask",
     "Duplicate grouping sets were produced at",
     "Can't supply `.by` when `.data` is grouped",
     "Grouped input created with `.drop = FALSE` is not supported",

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -89,25 +89,46 @@ check_option_named_summaries <- function(dots) {
     # the option they were reaching for leaves them looking for a word that is
     # not in their code.
     if (matched %in% names(removed_summary_options)) {
-      opening <- if (identical(name, matched)) {
-        paste0("`summarize_with_margins()` has no `", matched, "` argument")
-      } else {
-        paste0(
-          "`", name, "` is not an argument of `summarize_with_margins()`, ",
-          "and neither is the `", matched, "` it resembles"
-        )
+      # Two calls rather than the one opening this branch used to bind and
+      # hand to a single call, because the structural gate reads
+      # `abort_marginplyr()`'s own argument and refuses a template bound
+      # elsewhere -- the reason `R/share.R`'s two Parent-share refusals are
+      # written out twice. What the branch chooses is a whole main line, which
+      # is the shape ADR 0023's third amendment admits; the cost is the `i`
+      # bullet the two arms share, written out in each.
+      #
+      # That bullet is the option's own guidance, which is written in the
+      # table above rather than beside either call, so it arrives interpolated
+      # as a value -- a template may not be bound elsewhere, and a value may.
+      # It names no subject, so it loses no markup by arriving that way, and
+      # the `;` the flat form joined it with is now the break between the
+      # refusal and its bullet.
+      if (identical(name, matched)) {
+        abort_marginplyr(c(
+          "{.fun summarize_with_margins} has no {.arg {matched}} argument.",
+          i = "{removed_summary_options[[matched]]}"
+        ))
       }
-      abort_marginplyr_flat(
-        paste0(opening, "; ", removed_summary_options[[matched]])
-      )
+      abort_marginplyr(c(
+        paste0(
+          "{.arg {name}} is not an argument of ",
+          "{.fun summarize_with_margins}, and neither is the ",
+          "{.arg {matched}} it resembles."
+        ),
+        i = "{removed_summary_options[[matched]]}"
+      ))
     }
-    abort_marginplyr_flat(
+    # The captured summary is a column the caller can see in the result, so it
+    # is `{.var}` where the name they meant to write is `{.arg}`. Both spell
+    # the same string, which is the point the two styles are separated over.
+    abort_marginplyr(c(
       paste0(
-        "`", name, "` is not an argument of `summarize_with_margins()`, so ",
-        "it was captured as a summary named `", name, "`. Did you mean `",
-        matched, "`? Rename the summary if the column is intended."
-      )
-    )
+        "{.arg {name}} is not an argument of {.fun summarize_with_margins}, ",
+        "so it was captured as a summary named {.var {name}}."
+      ),
+      i = "Did you mean {.arg {matched}}?",
+      i = "Rename the summary if the column is intended."
+    ))
   }
   invisible(NULL)
 }
@@ -126,28 +147,45 @@ check_summary_context_helpers <- function(dots) {
     return(invisible(NULL))
   }
 
-  # `does not support` opens the message deliberately. Six assertions match
-  # that phrase by regular expression rather than by condition class, and it is
-  # still what the message says; the sentence after it is the part #172 added,
-  # because a caller who had bound one of these names themselves was told only
-  # that the verb refused the helper and had no way to learn that their own
-  # function was never going to run (ADR 0019).
-  abort_marginplyr_flat(
-    paste0(
-      "`summarize_with_margins()` does not support ",
-      paste0("`", unsupported, "()`", collapse = ", "),
-      if (length(unsupported) == 1L) {
-        ". This spelling is reserved inside a Margin summary and is not "
-      } else {
-        ". These spellings are reserved inside a Margin summary and are not "
-      },
-      "resolved from the calling environment. These helpers describe one ",
-      "branch-local dplyr grouping or data mask, but a margin result ",
-      "combines multiple grouping sets. Use ",
-      "`grouping_bit()` or ",
-      "`grouping_id()` when identifying margin levels."
+  # `does not support` still opens the message deliberately, which is what ADR
+  # 0019 asks of it: six assertions match that phrase by regular expression
+  # rather than by condition class.
+  #
+  # What no longer follows it in the same line is the helpers, which arrive
+  # alone in an `i` bullet, per ADR 0023's condition 2: how many of them the
+  # caller wrote is the caller's decision. Five of those six read across the
+  # break unchanged -- four join the phrase to a helper name with `.*`, which
+  # spans a newline in R's default regular expressions, and one matches the
+  # phrase alone. Four assertions spelled the two as one run and could not, so
+  # each is re-pinned across the break where it sits: the sixth of that census,
+  # in `test-summarize-operation.R`; a `fixed = TRUE` match in
+  # `test-static-expression-analysis.R`; and the two in
+  # `test-contextual-helpers.R`, which is where the opening is asserted at the
+  # site the wording is decided.
+  #
+  # The sentence after the helpers is the part #172 added, because a caller who
+  # had bound one of these names themselves was told only that the verb refused
+  # the helper and had no way to learn that their own function was never going
+  # to run (ADR 0019). It inflects a demonstrative, a noun, and two verbs, and
+  # `cli::qty()` is what carries the count to all four: the vector deciding it
+  # is no longer in the line they sit in.
+  abort_marginplyr(c(
+    "{.fun summarize_with_margins} does not support:",
+    i = "{.fun {unsupported}}.",
+    i = paste0(
+      "{cli::qty(length(unsupported))}{?This/These} spelling{?s} {?is/are} ",
+      "reserved inside a Margin summary and {?is/are} not resolved from the ",
+      "calling environment."
+    ),
+    i = paste0(
+      "These helpers describe one branch-local dplyr grouping or data mask, ",
+      "but a margin result combines multiple grouping sets."
+    ),
+    i = paste0(
+      "Use {.fun grouping_bit} or {.fun grouping_id} when identifying margin ",
+      "levels."
     )
-  )
+  ))
 }
 
 check_summary_group_overwrite <- function(output_names, group_vars) {
@@ -156,14 +194,17 @@ check_summary_group_overwrite <- function(output_names, group_vars) {
     return(invisible(NULL))
   }
 
-  abort_marginplyr_flat(
+  # The columns arrive alone in an `i` bullet, per ADR 0023's condition 2: how
+  # many of them there are is the caller's decision. `cli::qty()` is what
+  # carries the count across that split, the noun it inflects no longer sitting
+  # beside the vector.
+  abort_marginplyr(c(
     paste0(
-      "Summary results cannot overwrite grouping column",
-      if (length(overwritten_groups) == 1L) " " else "s ",
-      paste0("`", overwritten_groups, "`", collapse = ", "),
-      "."
-    )
-  )
+      "{cli::qty(length(overwritten_groups))}Summary results cannot ",
+      "overwrite grouping column{?s}:"
+    ),
+    i = "{.var {overwritten_groups}}."
+  ))
 }
 
 # The three questions to ask of the names a summary really produced, which the
@@ -197,14 +238,18 @@ check_internal_summary_names <- function(output_names, internal_names) {
     return(invisible(NULL))
   }
 
-  abort_marginplyr_flat(
+  # The columns arrive alone in an `i` bullet, per ADR 0023's condition 2: how
+  # many of them there are is the caller's decision. The `:` the flat form
+  # already introduced them with is the break they arrive across, so the noun
+  # ahead of it needs no inflection -- it was written plural whatever arrived.
+  abort_marginplyr(c(
     paste0(
-      "Dynamically generated summary output names conflict with ",
-      "internal grouping columns: ",
-      paste0("`", conflicting_names, "`", collapse = ", "),
-      ". Use different summary output names."
-    )
-  )
+      "Dynamically generated summary output names conflict with internal ",
+      "grouping columns:"
+    ),
+    i = "{.var {conflicting_names}}.",
+    i = "Use different summary output names."
+  ))
 }
 
 # What execution carries for the caller's summary arguments: the dots to hand
@@ -697,14 +742,19 @@ check_across_name_count <- function(expanded, template, column) {
     return(expanded)
   }
 
-  abort_marginplyr_flat(
+  # The template and the column both stay in the main line, under ADR 0023's
+  # element-count reading of its condition 2: each is one caller subject rather
+  # than a part the caller decides the count of, however long a template
+  # renders. `{.code}` is what a spelling the caller typed takes, and the
+  # braces inside one are inert because it arrives interpolated as a value.
+  abort_marginplyr(c(
     paste0(
-      "The `across()` `.names` template `", template, "` must produce one ",
-      "name per column, but it produced ", length(expanded),
-      " for column `", column,
-      "`. Use a template that expands to a single name."
-    )
-  )
+      "The {.fun across} {.arg .names} template {.code {template}} must ",
+      "produce one name per column, but it produced {length(expanded)} for ",
+      "column {.var {column}}."
+    ),
+    i = "Use a template that expands to a single name."
+  ))
 }
 
 known_across_source_names <- function(expr, env, data_proxy) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -159,11 +159,13 @@ check_summary_context_helpers <- function(dots) {
   # break unchanged -- four join the phrase to a helper name with `.*`, which
   # spans a newline in R's default regular expressions, and one matches the
   # phrase alone. Four assertions spelled the two as one run and could not, so
-  # each is re-pinned across the break where it sits: the sixth of that census,
-  # in `test-summarize-operation.R`; a `fixed = TRUE` match in
-  # `test-static-expression-analysis.R`; and the two in
-  # `test-contextual-helpers.R`, which is where the opening is asserted at the
-  # site the wording is decided.
+  # each is re-pinned where it sits: the sixth of that census, in
+  # `test-summarize-operation.R`, and a `fixed = TRUE` match in
+  # `test-static-expression-analysis.R`, both now spelling the break; and the
+  # two in `test-contextual-helpers.R`, which is where the opening is asserted
+  # at the site the wording is decided, as byte-exact identities of each arm --
+  # one of them against the other, since what it asserts is that a
+  # parenthesized spelling reaches the same refusal.
   #
   # The sentence after the helpers is the part #172 added, because a caller who
   # had bound one of these names themselves was told only that the verb refused

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -92,10 +92,11 @@ check_option_named_summaries <- function(dots) {
       # Two calls rather than the one opening this branch used to bind and
       # hand to a single call, because the structural gate reads
       # `abort_marginplyr()`'s own argument and refuses a template bound
-      # elsewhere -- the reason `R/share.R`'s two Parent-share refusals are
-      # written out twice. What the branch chooses is a whole main line, which
-      # is the shape ADR 0023's third amendment admits; the cost is the `i`
-      # bullet the two arms share, written out in each.
+      # elsewhere -- the shape `abort_share_helper_position()` records in
+      # `R/share.R` and three further sites in that file cite. What the branch
+      # chooses is a whole main line, which is what ADR 0023's third amendment
+      # admits; the cost is the `i` bullet the two arms share, written out in
+      # each.
       #
       # That bullet is the option's own guidance, which is written in the
       # table above rather than beside either call, so it arrives interpolated
@@ -118,9 +119,10 @@ check_option_named_summaries <- function(dots) {
         i = "{removed_summary_options[[matched]]}"
       ))
     }
-    # The captured summary is a column the caller can see in the result, so it
-    # is `{.var}` where the name they meant to write is `{.arg}`. Both spell
-    # the same string, which is the point the two styles are separated over.
+    # One string under two styles: `{.arg}` where the caller wrote it as an
+    # argument name, `{.var}` for the column it became instead. The two render
+    # alike, which is the point the style table separates them over -- what
+    # the sentence is made of is what each one records.
     abort_marginplyr(c(
       paste0(
         "{.arg {name}} is not an argument of {.fun summarize_with_margins}, ",

--- a/tests/testthat/_snaps/diagnostic-authoring.md
+++ b/tests/testthat/_snaps/diagnostic-authoring.md
@@ -8,12 +8,7 @@
       assert_margin_input(): 1
       assert_nest_possible(): 1
       assert_string_scalar(): 1
-      check_across_name_count(): 1
-      check_internal_summary_names(): 1
       check_margin_id_collision(): 1
-      check_option_named_summaries(): 2
-      check_summary_context_helpers(): 1
-      check_summary_group_overwrite(): 1
       execute_margin_nest(): 1
       match_margin_choice(): 1
       nest_margin_pipeline(): 2

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -661,24 +661,42 @@ test_that("a nested constructor is gated however it is written", {
 
 test_that("the refusal names the helper and keeps its opening", {
   data <- contextual_probe_data()
-  # The opening phrase six other assertions match by regular expression. It is
-  # asserted here as well so that a rewording is caught where the wording is
-  # decided rather than only where it is relied on.
+  # Both arms byte-exactly, and #223's re-authoring is what they are worth
+  # writing out for. The sentence #172 added inflects a demonstrative, a noun,
+  # and two verbs, and all four now go through `{?}` behind one `cli::qty()`
+  # rather than through an `if` spelling each arm. What stood here before was
+  # a substring per arm, and neither covered its own arm whole: the singular's
+  # reached `is not resolved` but opened after `This spelling is`, and the
+  # plural's stopped at `These spellings are reserved`. Read together they
+  # covered every inflection once and no arm at all.
   #
-  # Anchored at both ends of the split #223 gave the refusal: the phrase closes
-  # the main line and the helper opens the bullet under it, so a re-wording
-  # that moved either back across the break fails here. The six read across it
+  # Here rather than in `test-diagnostic-pluralization.R`, whose header keeps
+  # that file to the eight diagnostics that pluralize by suffixing and says
+  # re-authoring a message is not where the question of which ones it covers
+  # gets decided. This refusal switches whole words instead, which is the same
+  # reason the duplicate-grouping-set refusal is pinned at its own site.
+  #
+  # Each identity also asserts the opening phrase six other assertions match
+  # by regular expression, so a rewording is caught where the wording is
+  # decided rather than only where it is relied on -- and it asserts both ends
+  # of the split #223 gave the refusal, the phrase closing the main line and
+  # the helper opening the bullet under it. The six read across that break
   # instead, matching the phrase alone or reaching the helper with `.*`.
-  expect_error(
-    summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region),
-    paste0(
-      "^`summarize_with_margins\\(\\)` does not support:\n",
-      "i `cur_group_id\\(\\)`\\."
-    )
+  singular <- expect_error(
+    summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region)
   )
-  expect_error(
-    summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region),
-    "reserved inside a Margin summary and is not resolved from the calling"
+  expect_identical(
+    conditionMessage(singular),
+    paste0(
+      "`summarize_with_margins()` does not support:\n",
+      "i `cur_group_id()`.\n",
+      "i This spelling is reserved inside a Margin summary and is not ",
+      "resolved from the calling environment.\n",
+      "i These helpers describe one branch-local dplyr grouping or data ",
+      "mask, but a margin result combines multiple grouping sets.\n",
+      "i Use `grouping_bit()` or `grouping_id()` when identifying margin ",
+      "levels."
+    )
   )
   # A caller who bound the name themselves is the reader that sentence was
   # added for, so it has to survive the shadow that motivates it.
@@ -689,15 +707,28 @@ test_that("the refusal names the helper and keeps its opening", {
     }),
     "is not resolved from the calling environment"
   )
-  # More than one refused spelling in one call reads as a list.
-  expect_error(
+  # More than one refused spelling in one call reads as a list, joined with
+  # cli's serial `and` since #223 adopted its vector defaults.
+  plural <- expect_error(
     summarize_with_margins(
       data,
       k = dplyr::cur_group_id(),
       j = list(dplyr::cur_group()),
       .by = region
-    ),
-    "These spellings are reserved"
+    )
+  )
+  expect_identical(
+    conditionMessage(plural),
+    paste0(
+      "`summarize_with_margins()` does not support:\n",
+      "i `cur_group_id()` and `cur_group()`.\n",
+      "i These spellings are reserved inside a Margin summary and are not ",
+      "resolved from the calling environment.\n",
+      "i These helpers describe one branch-local dplyr grouping or data ",
+      "mask, but a margin result combines multiple grouping sets.\n",
+      "i Use `grouping_bit()` or `grouping_id()` when identifying margin ",
+      "levels."
+    )
   )
   # A prohibited context is a Package condition, and parentheses do not turn it
   # into one of R's. Before #178 `(cur_group_id)()` reached the data mask and
@@ -706,11 +737,14 @@ test_that("the refusal names the helper and keeps its opening", {
   # reached the exported stub, which reports that the helper can only be used
   # inside the verb the caller is already inside.
   parenthesized <- expect_error(
-    summarize_with_margins(data, k = (cur_group_id)(), .by = region),
-    paste0(
-      "^`summarize_with_margins\\(\\)` does not support:\n",
-      "i `cur_group_id\\(\\)`\\."
-    )
+    summarize_with_margins(data, k = (cur_group_id)(), .by = region)
+  )
+  # Against the singular arm above rather than a pattern of its own, which is
+  # the whole of what this asserts: the parenthesized spelling reaches the same
+  # refusal, not merely one that opens alike.
+  expect_identical(
+    conditionMessage(parenthesized),
+    conditionMessage(singular)
   )
   expect_s3_class(parenthesized, "marginplyr_error")
   expect_identical(

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -670,18 +670,21 @@ test_that("the refusal names the helper and keeps its opening", {
   # plural's stopped at `These spellings are reserved`. Read together they
   # covered every inflection once and no arm at all.
   #
-  # Here rather than in `test-diagnostic-pluralization.R`, whose header keeps
-  # that file to the eight diagnostics that pluralize by suffixing and says
-  # re-authoring a message is not where the question of which ones it covers
-  # gets decided. This refusal switches whole words instead, which is the same
-  # reason the duplicate-grouping-set refusal is pinned at its own site.
+  # Here rather than in `test-diagnostic-pluralization.R`, on that file's own
+  # sentence that re-authoring a message is not where the question of which
+  # diagnostics its baseline covers gets decided. Not on its selection rule:
+  # this refusal does suffix a noun, so admitting it would be a defensible
+  # call -- it is just not this pull request's to make, any more than the
+  # duplicate-grouping-set refusal's exclusion was, which is pinned at its own
+  # site for a reason that file states and revisits.
   #
   # Each identity also asserts the opening phrase six other assertions match
   # by regular expression, so a rewording is caught where the wording is
   # decided rather than only where it is relied on -- and it asserts both ends
   # of the split #223 gave the refusal, the phrase closing the main line and
-  # the helper opening the bullet under it. The six read across that break
-  # instead, matching the phrase alone or reaching the helper with `.*`.
+  # the helper opening the bullet under it. Five of those six read across that
+  # break instead, matching the phrase alone or reaching the helper with `.*`;
+  # the sixth spells the break, having been re-pinned with these.
   singular <- expect_error(
     summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region)
   )

--- a/tests/testthat/test-contextual-helpers.R
+++ b/tests/testthat/test-contextual-helpers.R
@@ -664,9 +664,17 @@ test_that("the refusal names the helper and keeps its opening", {
   # The opening phrase six other assertions match by regular expression. It is
   # asserted here as well so that a rewording is caught where the wording is
   # decided rather than only where it is relied on.
+  #
+  # Anchored at both ends of the split #223 gave the refusal: the phrase closes
+  # the main line and the helper opens the bullet under it, so a re-wording
+  # that moved either back across the break fails here. The six read across it
+  # instead, matching the phrase alone or reaching the helper with `.*`.
   expect_error(
     summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region),
-    "^`summarize_with_margins\\(\\)` does not support `cur_group_id\\(\\)`\\."
+    paste0(
+      "^`summarize_with_margins\\(\\)` does not support:\n",
+      "i `cur_group_id\\(\\)`\\."
+    )
   )
   expect_error(
     summarize_with_margins(data, k = dplyr::cur_group_id(), .by = region),
@@ -699,7 +707,10 @@ test_that("the refusal names the helper and keeps its opening", {
   # inside the verb the caller is already inside.
   parenthesized <- expect_error(
     summarize_with_margins(data, k = (cur_group_id)(), .by = region),
-    "^`summarize_with_margins\\(\\)` does not support `cur_group_id\\(\\)`\\."
+    paste0(
+      "^`summarize_with_margins\\(\\)` does not support:\n",
+      "i `cur_group_id\\(\\)`\\."
+    )
   )
   expect_s3_class(parenthesized, "marginplyr_error")
   expect_identical(

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -342,7 +342,10 @@ test_that("the summary overwrite refusal pluralizes its column noun", {
   ))
   expect_identical(
     conditionMessage(singular),
-    "Summary results cannot overwrite grouping column `region`."
+    paste0(
+      "Summary results cannot overwrite grouping column:\n",
+      "i `region`."
+    )
   )
 
   plural <- expect_error(summarize_with_margins(
@@ -353,6 +356,9 @@ test_that("the summary overwrite refusal pluralizes its column noun", {
   ))
   expect_identical(
     conditionMessage(plural),
-    "Summary results cannot overwrite grouping columns `region`, `grade`."
+    paste0(
+      "Summary results cannot overwrite grouping columns:\n",
+      "i `region` and `grade`."
+    )
   )
 })

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -716,7 +716,10 @@ test_that("a Package condition raised while branches run is untouched", {
   expect_s3_class(error, "marginplyr_error")
   expect_identical(
     conditionMessage(error),
-    "Summary results cannot overwrite grouping column `region`."
+    paste0(
+      "Summary results cannot overwrite grouping column:\n",
+      "i `region`."
+    )
   )
   expect_identical(
     rlang::call_name(conditionCall(error)),

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -832,8 +832,8 @@ test_that("summary expressions reject the removed .groups argument", {
       .groups = "drop"
     ),
     paste0(
-      "`summarize_with_margins\\(\\)` has no `\\.groups` argument; ",
-      "Margin-summary results are always ungrouped\\."
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.\n",
+      "i Margin-summary results are always ungrouped\\."
     ),
     class = "marginplyr_error"
   )

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -3689,7 +3689,7 @@ test_that("evaluating a captured helper reaches the rule it always did", {
       .grouping = rollup(region),
       .margin_label = NULL
     ),
-    "does not support `cur_group_id()`",
+    "does not support:\ni `cur_group_id()`.",
     fixed = TRUE
   )
   expect_s3_class(context, "marginplyr_error")

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -283,7 +283,7 @@ test_that("summary selection errors use the package condition seam", {
         id = dplyr::cur_group_id(),
         .grouping = rollup(group)
       )),
-      message = "does not support `cur_group_id\\(\\)`"
+      message = "does not support:\ni `cur_group_id\\(\\)`\\."
     ),
     group_overwrite = list(
       expr = rlang::expr(summarize_with_margins(
@@ -291,7 +291,7 @@ test_that("summary selection errors use the package condition seam", {
         group = sum(value),
         .grouping = rollup(group)
       )),
-      message = "cannot overwrite grouping column `group`"
+      message = "cannot overwrite grouping column:\ni `group`\\."
     )
   )
 

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -27,7 +27,13 @@ test_that("every removed option answers its near misses the same way", {
   # caller who wrote `.groupss` never wrote `.groups`, and an error naming only
   # the option they were reaching for sends them looking for a word that is not
   # in their code.
-  guidance <- "Margin-summary results are always ungrouped\\."
+  #
+  # The `;` that joined the guidance to each refusal is the break between the
+  # main line and its `i` bullet since #223 re-authored this file, so both
+  # patterns below read across it. That is what keeps them assertions about one
+  # message rather than two: the guidance is asserted where the refusal that
+  # carries it is, not merely somewhere in the corpus.
+  guidance <- "\ni Margin-summary results are always ungrouped\\."
 
   expect_error(
     summarize_with_margins(
@@ -37,7 +43,7 @@ test_that("every removed option answers its near misses the same way", {
       .groups = "drop"
     ),
     paste0(
-      "`summarize_with_margins\\(\\)` has no `\\.groups` argument; ", guidance
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.", guidance
     ),
     class = "marginplyr_error"
   )
@@ -51,7 +57,7 @@ test_that("every removed option answers its near misses the same way", {
     ),
     paste0(
       "`\\.groupss` is not an argument.+neither is the `\\.groups` it ",
-      "resembles; ", guidance
+      "resembles\\.", guidance
     ),
     class = "marginplyr_error"
   )


### PR DESCRIPTION
#223's phase 3, fifth file: all 6 of `R/summary-selections.R`'s
`abort_marginplyr_flat()` sites become `abort_marginplyr()` templates authored
against ADR 0023. Every refusal says what its predecessor said, in the same
words. What moved is the inline style of each subject, four splits into a
refusal plus `i` bullets, and two pluralizations that were R branches.

The wording was verified by executing both trees over all seven rendered
messages and diffing them word by word. The only deltas are the four this phase
has already established: a `;` or a `: ` or a `. ` becoming the main-line/bullet
break, the `.`/capital a re-split gives a bullet, and cli's serial `and` where a
vector is joined.

## The site whose word order was load-bearing

`R/summary-selections.R:129` recorded that `does not support` opens the
`cur_group*()` refusal deliberately, because assertions match that phrase by
regular expression rather than by condition class — ADR 0019 says the same. ADR
0023's condition 2 moves the helpers out from behind it, into an `i` bullet of
their own: how many of them the caller wrote is the caller's decision.

```text
`summarize_with_margins()` does not support:
i `cur_group_id()`.
i This spelling is reserved inside a Margin summary and is not resolved from the calling environment.
i These helpers describe one branch-local dplyr grouping or data mask, but a margin result combines multiple grouping sets.
i Use `grouping_bit()` or `grouping_id()` when identifying margin levels.
```

The phrase still opens the message, so the census survives mostly intact.
Locating all of it first was the work:

- **Six match by regular expression** — `test-grouping-interface.R:1023`,
  `:1031`, `:1039`, `:1047`, `test-static-expression-analysis.R:807`, and
  `test-summarize-operation.R:286`. `investigation/contextual-helper-name-resolution.md`
  lists *seven* line references under the heading "Six assertions"; the
  seventh, `test-static-expression-analysis.R:3692`, is a `fixed = TRUE` match
  and not one of the six. That is where the discrepancy has always been.
- **Five of the six read across the break unchanged.** Four join the phrase to
  a helper name with `.*`, which spans a newline in R's default regular
  expressions — measured, not assumed — and one matches the phrase alone.
- **Four assertions spelled the two as one run** and are re-pinned: the sixth of
  that census, the `fixed = TRUE` match, and the two in
  `test-contextual-helpers.R`.

The source comment is rewritten to say that, and now names where each re-pin
went.

Worth a maintainer's eye: the refusal reads `This spelling is …` and then
`These helpers describe …` in adjacent bullets, which the flat paragraph made
less visible. Both spellings are shipped wording, so #223 forbids touching
either.

That sentence also inflects a demonstrative, a noun, and two verbs, all four
now through `{?}` behind one `cli::qty()`, since the vector deciding the count
is no longer in the line they sit in.

## The removed-option branch

`opening` was bound by an `if` and handed to one call. It becomes two calls,
because the structural gate refuses a template bound elsewhere; what the branch
chooses is a whole main line, which is what ADR 0023's third amendment admits.
The option's own guidance stays an interpolated value — it is written in the
table at the top of the file, and a value may be bound elsewhere where a
template may not — and the `;` that joined it is now the break before its
bullet.

The `across()` `.names` refusal keeps both the template and the column in its
main line, under the element-count reading of condition 2 that #240 recorded:
each is one caller subject, not a part the caller decides the count of.

## Pins, snapshot, site

Re-pinned in place, none moved to a snapshot: both arms of the summary-overwrite
refusal in `test-diagnostic-pluralization.R`, its identity in
`test-execution-conditions.R`, the removed-option pins in
`test-grouping-interface.R` and `test-verb-argument-admission.R` — where the
pattern got stronger, now anchoring the break — and the four context-helper
assertions above. Pins reading a phrase inside one element, or joining two with
`.*`, do not move. The `abort_marginplyr_flat()` snapshot loses exactly 6 sites.

`get_started.qmd`'s `cur-group-id-rejected` chunk renders this refusal, so
`verify-site.R`'s marker moves off the opening phrase — now interrupted by the
break — onto `These helpers describe one branch-local dplyr grouping or data
mask`, the longest run of the refusal no data reaches, per ADR 0023's condition
3. Checked against a freshly rendered `docs/`, where it renders unwrapped.

## What review added

Both axes ran twice. Six comment-accuracy findings across the two rounds, all
fixed, and one that was not about prose:

The `cur_group*()` refusal's two arms were pinned nowhere whole. A substring
per arm covered `is not resolved` in one and `These spellings are reserved` in
the other — between them every inflection once, and no arm at all. That was
tolerable while an `if` spelled each arm; it is not now that one template
carries four `{?}`. Both arms are byte-exact identities in
`test-contextual-helpers.R`, which subsume the anchored opening assertions they
replace, and the parenthesized spelling asserts an identity against the
singular arm rather than a pattern that only opens alike.

They are pinned there and not in `test-diagnostic-pluralization.R`, on that
file's own sentence that re-authoring a message is not where the question of
which diagnostics its baseline covers gets decided — **not** on its selection
rule, which this refusal would satisfy, since it does suffix a noun. Admitting
it is a defensible call; it is not this pull request's to make, and the comment
beside the pins says so. Related: #236.

#245 carries an out-of-scope finding — `R/grouping-plan.R` and
`R/grouping-context.R` both cite "`R/share.R`'s two Parent-share refusals are
written out twice", which `R/share.R` does not do. This file cites
`abort_share_helper_position()` instead.

## Verification

`lintr::lint_package()` clean, 4793 passed / 0 failed / 0 skipped,
`verify-site.R` against a freshly rendered `docs/`, `verify-must-error.R`, and
`verify-suite-coverage.R`.