### PR TITLE
Define the pluralization baseline by coverage, not provenance

### DIFF
--- a/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
+++ b/design/adr/0023-author-diagnostics-in-the-cli-idiom.md
@@ -201,8 +201,17 @@ of its three columns — and #223's phase 3 moves the rest of it, since #235
 dissolved `abort_selection_rename()`'s noun pair into `{?s}`. Nothing reads the
 sentence, so nothing failed either time. It is struck rather than recounted,
 because the rule is deliberately stated over the construction and a recount
-would be stale again by the next file. Whether anything should count these
-sites is left open in [#236](https://github.com/sayuks/marginplyr/issues/236).
+would be stale again by the next file.
+
+[#236](https://github.com/sayuks/marginplyr/issues/236) settled what that left
+open, and the answer is that nothing counts these sites: what is counted
+instead is whether each one is *covered*.
+`test-diagnostic-pluralization.R` derives every pluralizing site from the
+namespace — a `{?}` in an `abort_marginplyr()` template, the one
+`cli::pluralize()` sentence, and the `if` a bare `stop()` invariant spells a
+plural with — and fails any the file's coverage table does not say is pinned at
+both arms. A census is a number someone maintains and nobody reads, which is how
+the inventory above drifted twice; a derivation is neither.
 
 The cost is the one those two precedents already pay, doubled, because the
 subject and the collision kind are two branches rather than one: four arms,

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -413,6 +413,18 @@ re-authoring `R/` file by file, so the transitional sibling that let a
 not-yet-re-authored site hand an assembled string across as a value is gone,
 and with it the snapshot that counted what was left.
 
+`test-diagnostic-pluralization.R` gates the other half of the plural rule, and
+it is a coverage question rather than an authoring one: every diagnostic this
+package pluralizes has both arms reached by a test, with the inflected span
+asserted in each. The set is derived from the namespace rather than listed —
+a `{?}` in an `abort_marginplyr()` template, the one `cli::pluralize()`
+sentence `report_branch_warnings()` writes, and the `if` a bare `stop()`
+invariant spells a plural with, ADR 0023 excluding those from the idiom — and
+the file's coverage table says where each one is pinned. Both directions fail:
+a derived site the table does not name, and a table entry naming no site. It
+replaced a hand-authored census that had drifted twice without failing
+anything (#236). Neither gate runs a diagnostic; the pins beside them do.
+
 It also owns the one reading of a condition another package raised.
 `condition_chain()` answers the conditions a `parent` chain holds, outermost
 first, and decides nothing about them. tidyselect wraps a failure raised inside

--- a/tests/testthat/helper-diagnostic-sites.R
+++ b/tests/testthat/helper-diagnostic-sites.R
@@ -1,0 +1,191 @@
+# The readers two gates share, over the source `R/` does not ship: the
+# structural gate in `test-diagnostic-authoring.R`, which asks whether every
+# `abort_marginplyr()` template is authored in the source, and the coverage
+# gate in `test-diagnostic-pluralization.R`, which asks whether every diagnostic
+# this package pluralizes has both of its arms pinned.
+#
+# They live here rather than in either file because testthat gives each test
+# file its own environment, so the second gate could not see a walker the first
+# one defined -- and a copy is the thing that drifts. `helper-` is where
+# testthat looks before it runs anything, which is also what lets both gates be
+# read against a package loaded with `pkgload::load_all()` or an installed dev
+# build.
+
+# Every call to `name` below `expr`, as the expression each passed as its
+# message argument -- the first argument, or `message =` where a site names it.
+#
+# The recursion goes through `lapply()` and never a bare `for` over a call's
+# elements, for the reason `test-query-policy.R` records: a parsed call can hold
+# the missing-argument placeholder as one of its own elements, and a `for`
+# loop's assignment preserves the internal missing flag, so reading it raises
+# "argument is missing, with no default" the moment the loop variable is looked
+# up.
+diagnostic_message_arguments <- function(expr, name) {
+  found <- list()
+  walk <- function(e) {
+    if (!is.call(e)) {
+      return(invisible(NULL))
+    }
+    head <- e[[1]]
+    if (is.name(head) && identical(as.character(head), name)) {
+      args <- as.list(e)[-1]
+      arg_names <- names(args)
+      # R's own matching for `abort_marginplyr(message, ..., class, call)`:
+      # `message =` by name, otherwise the first argument supplied without one.
+      # Reading `args[[1]]` instead would take `class` for the message at a
+      # site that named every argument it passed, and report that site clean
+      # because a class is a literal too.
+      positional <- if (is.null(arg_names)) args else args[!nzchar(arg_names)]
+      message <- if (!is.null(arg_names) && "message" %in% arg_names) {
+        args[["message"]]
+      } else if (length(positional) > 0L) {
+        positional[[1]]
+      } else {
+        NULL
+      }
+      # `c()` rather than `found[[length(found) + 1L]] <-`, which deletes
+      # instead of appending when the value is `NULL`. A call written with no
+      # message at all -- `abort_marginplyr(class = "x")` -- is exactly the
+      # site the gate must report, and that spelling would drop it.
+      found <<- c(found, list(message))
+    }
+    lapply(as.list(e)[-1], walk)
+    invisible(NULL)
+  }
+  walk(expr)
+  found
+}
+
+# Every function bound in the namespace, which is where the call sites are:
+# `R/` is not installed, so a scan of the shipped package would find no source
+# to read.
+marginplyr_namespace_functions <- function(ns = asNamespace("marginplyr")) {
+  Filter(
+    function(binding) is.function(get(binding, envir = ns)),
+    ls(ns, all.names = TRUE)
+  )
+}
+
+marginplyr_diagnostic_sites <- function(name, ns = asNamespace("marginplyr")) {
+  sites <- lapply(marginplyr_namespace_functions(ns), function(binding) {
+    diagnostic_message_arguments(body(get(binding, envir = ns)), name)
+  })
+  stats::setNames(sites, marginplyr_namespace_functions(ns))
+}
+
+# Whether a call is to `name`, however the source spells the head: bare, or
+# qualified with `::`. `cli::pluralize()` is written qualified and
+# `abort_marginplyr()` is not, and a reader that recognized only one of the two
+# spellings would answer a clean corpus for whichever it could not see.
+is_call_to <- function(expr, name) {
+  if (!is.call(expr)) {
+    return(FALSE)
+  }
+  head <- expr[[1]]
+  if (is.name(head)) {
+    return(identical(as.character(head), name))
+  }
+  is.call(head) &&
+    is.name(head[[1]]) &&
+    as.character(head[[1]]) %in% c("::", ":::") &&
+    identical(as.character(head[[3]]), name)
+}
+
+# Whether any part of this expression is an `if` choosing between two string
+# literals. That is how a diagnostic outside ADR 0023 spells a plural: the two
+# bare `stop()` invariants that suffix a noun write
+# `if (length(x) == 1L) " " else "s "`, and nothing else in the namespace has
+# the shape. It is deliberately not a test for the word `s`, because what makes
+# a branch a pluralization is that the two arms are fixed text the count picks
+# between, which is the same property ADR 0023's `{?}` rule is stated over.
+has_literal_branch <- function(expr) {
+  if (!is.call(expr)) {
+    return(FALSE)
+  }
+  chosen <- is_call_to(expr, "if") &&
+    length(expr) == 4L &&
+    is.character(expr[[3]]) &&
+    is.character(expr[[4]])
+  chosen ||
+    any(vapply(as.list(expr)[-1], has_literal_branch, logical(1)))
+}
+
+# Whether a template pluralizes through cli, which is `{?}` wherever it sits --
+# `{?s}`, `{?is/are}`, and `{?a/b}` alike, and behind a `cli::qty()` or not.
+# Read off the deparsed expression rather than off a literal, because a
+# re-authored template is a `paste()` or `paste0()` of literals split at a space
+# (ADR 0023's second amendment) and the `{?}` can fall either side of the split.
+has_cli_plural <- function(expr) {
+  if (is.null(expr)) {
+    return(FALSE)
+  }
+  any(grepl("{?", paste(deparse(expr), collapse = " "), fixed = TRUE))
+}
+
+# Every diagnostic this package pluralizes, as a count per namespace binding.
+#
+# Two constructions reach it and both are derived rather than listed. A Package
+# condition pluralizes through cli, so it is an `abort_marginplyr()` template
+# holding `{?}`; `report_branch_warnings()` writes the one sentence that
+# pluralizes outside a Package condition, through `cli::pluralize()` inside
+# `rlang::format_error_bullets()`, and is found by the same read of a different
+# call. An invariant pluralizes with an `if`, ADR 0023 excluding a bare
+# `stop()` from the idiom, and is found by `has_literal_branch()` above.
+#
+# A count rather than a set of names, because one binding can hold more than
+# one: `compile_grouping_spec_impl()` raises the duplicate-grouping-set refusal
+# and the unknown-`.by` invariant, which are pinned in different places, and
+# the two label-collision constructors hold two arms each.
+marginplyr_pluralizing_sites <- function(ns = asNamespace("marginplyr")) {
+  counts <- vapply(
+    marginplyr_namespace_functions(ns),
+    function(binding) {
+      expr <- body(get(binding, envir = ns))
+      templates <- c(
+        diagnostic_message_arguments(expr, "abort_marginplyr"),
+        pluralize_templates(expr)
+      )
+      cli_sites <- sum(vapply(templates, has_cli_plural, logical(1)))
+      cli_sites + invariant_plural_sites(expr)
+    },
+    integer(1)
+  )
+  counts[counts > 0L]
+}
+
+# The templates handed to `cli::pluralize()`, which takes its first argument
+# positionally at the one site that calls it.
+pluralize_templates <- function(expr) {
+  found <- list()
+  walk <- function(e) {
+    if (!is.call(e)) {
+      return(invisible(NULL))
+    }
+    if (is_call_to(e, "pluralize") && length(e) > 1L) {
+      found <<- c(found, list(e[[2]]))
+    }
+    lapply(as.list(e)[-1], walk)
+    invisible(NULL)
+  }
+  walk(expr)
+  found
+}
+
+# How many bare `stop()` calls below this expression spell a plural with an
+# `if`. Counted at the `stop()` rather than at the `if`, so that a diagnostic
+# inflecting a noun and a verb in one message is one site and not two.
+invariant_plural_sites <- function(expr) {
+  found <- 0L
+  walk <- function(e) {
+    if (!is.call(e)) {
+      return(invisible(NULL))
+    }
+    if (is_call_to(e, "stop") && has_literal_branch(e)) {
+      found <<- found + 1L
+    }
+    lapply(as.list(e)[-1], walk)
+    invisible(NULL)
+  }
+  walk(expr)
+  found
+}

--- a/tests/testthat/test-diagnostic-authoring.R
+++ b/tests/testthat/test-diagnostic-authoring.R
@@ -20,51 +20,10 @@
 # the property is about every call site rather than about any one file, so it is
 # asserted over the loaded namespace rather than described in prose. It needs
 # the package loaded through `pkgload::load_all()` or an installed dev build.
-
-# Every call to `name` below `expr`, as the expression each passed as its
-# message argument -- the first argument, or `message =` where a site names it.
 #
-# The recursion goes through `lapply()` and never a bare `for` over a call's
-# elements, for the reason `test-query-policy.R` records: a parsed call can hold
-# the missing-argument placeholder as one of its own elements, and a `for`
-# loop's assignment preserves the internal missing flag, so reading it raises
-# "argument is missing, with no default" the moment the loop variable is looked
-# up.
-diagnostic_message_arguments <- function(expr, name) {
-  found <- list()
-  walk <- function(e) {
-    if (!is.call(e)) {
-      return(invisible(NULL))
-    }
-    head <- e[[1]]
-    if (is.name(head) && identical(as.character(head), name)) {
-      args <- as.list(e)[-1]
-      arg_names <- names(args)
-      # R's own matching for `abort_marginplyr(message, ..., class, call)`:
-      # `message =` by name, otherwise the first argument supplied without one.
-      # Reading `args[[1]]` instead would take `class` for the message at a
-      # site that named every argument it passed, and report that site clean
-      # because a class is a literal too.
-      positional <- if (is.null(arg_names)) args else args[!nzchar(arg_names)]
-      message <- if (!is.null(arg_names) && "message" %in% arg_names) {
-        args[["message"]]
-      } else if (length(positional) > 0L) {
-        positional[[1]]
-      } else {
-        NULL
-      }
-      # `c()` rather than `found[[length(found) + 1L]] <-`, which deletes
-      # instead of appending when the value is `NULL`. A call written with no
-      # message at all -- `abort_marginplyr(class = "x")` -- is exactly the
-      # site the gate must report, and that spelling would drop it.
-      found <<- c(found, list(message))
-    }
-    lapply(as.list(e)[-1], walk)
-    invisible(NULL)
-  }
-  walk(expr)
-  found
-}
+# The namespace walk itself is in `helper-diagnostic-sites.R`, which
+# `test-diagnostic-pluralization.R`'s coverage gate reads too. Only the
+# predicate below is this gate's own.
 
 # Whether every string a message argument contributes is written in the source.
 #
@@ -112,20 +71,6 @@ authored_template <- function(expr) {
     return(all(vapply(as.list(expr)[-1], authored_template, logical(1))))
   }
   FALSE
-}
-
-# Every function bound in the namespace, which is where the call sites are:
-# `R/` is not installed, so a scan of the shipped package would find no source
-# to read.
-marginplyr_diagnostic_sites <- function(name, ns = asNamespace("marginplyr")) {
-  functions <- Filter(
-    function(binding) is.function(get(binding, envir = ns)),
-    ls(ns, all.names = TRUE)
-  )
-  sites <- lapply(functions, function(binding) {
-    diagnostic_message_arguments(body(get(binding, envir = ns)), name)
-  })
-  stats::setNames(sites, functions)
 }
 
 # The reading, driven over source `R/` does not contain. Both halves of it are

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -1,31 +1,38 @@
-# The byte-exact record of the eight diagnostics that pluralize a noun by
-# suffixing it, both arms of each. It is one file rather than an addition to
-# each site's own test file because these pins are one artifact with one
-# purpose: #223 re-authors these messages in the cli idiom file by file, and
-# each of those PRs diffs against this baseline. Spread across the five files
-# that raise them, a dropped arm would read as an ordinary deletion; here the
-# set is visible at once, and a file-by-file re-authoring edits a contiguous
-# block of it (#224).
+# The byte-exact record of eight diagnostics that pluralize a noun, both arms
+# of each, and the gate that says which diagnostics have to be recorded
+# somewhere. It is one file rather than an addition to each site's own test
+# file because these pins are one artifact with one purpose: #223 re-authored
+# these messages in the cli idiom file by file, and each of those PRs diffed
+# against this baseline. Spread across the five files that raise them, a
+# dropped arm would read as an ordinary deletion; here the set is visible at
+# once, and a file-by-file re-authoring edited a contiguous block of it (#224).
 #
-# Suffixing is what chose the eight, and two diagnostics were left out of them.
-# One is still out for the reason it was: the duplicate-grouping-set refusal
-# switches a whole phrase rather than suffixing one; both of its arms are
-# pinned in `test-grouping-plan.R`, the plural one separately from this file
-# because it needs a specification shape none of these eight do (#225).
+# The rule deciding what belongs is about coverage and not about how this set
+# came to be (#236):
 #
-# The other no longer has the construction it was described by. The
-# renaming-selection refusal -- one caller mistake, written out once for
-# `.grouping` and once for `.by` -- picked between a singular and a plural noun
-# held in a labels list, and #223 dissolved that pair into `{?s}` when it
-# re-authored `R/grouping-plan.R`, so it suffixes now as these eight do. Its
-# reason for being out is untouched by that: all four of its messages are
-# already pinned exactly in `test-grouping-plan.R`, so recording them again
-# would buy nothing. That is a thinner reason than the one the paragraph below
-# gives for recording three of these eight at both sites, and it is #224's to
-# revisit: re-authoring how a diagnostic is spelled is not where the question
-# of which diagnostics this baseline covers gets decided. Suffixing is
-# therefore where this set came from rather than a test a ninth diagnostic is
-# admitted by.
+#   Every diagnostic this package pluralizes has both arms reached by a test,
+#   and the inflected span asserted in each.
+#
+# Three things follow that the rule it replaces could not say. It is stated
+# over the property rather than over a construction, so `{?s}`, `{?is/are}`,
+# `{?a/b}`, and the `if` a bare `stop()` invariant spells a plural with are all
+# inside it -- what the baseline is for is that a re-wording of an inflection is
+# visible, and the construction the inflection is written in does not change
+# that. It does not require a byte-exact identity: the eight below achieve it
+# that way and keep it, but `report_branch_warnings()` cannot, its message being
+# a dplyr-rendered warning that carries the caller's own diagnostic, so an
+# identity there would pin dplyr's aggregation text. And it says nothing about
+# which file a pin lives in, which is the whole of why eight of the sixteen
+# sites are here and the rest are pinned where they are raised.
+#
+# The rule it replaces read "suffixing is where this set came from rather than
+# a test a ninth diagnostic is admitted by", which was right to refuse the
+# question and wrong to leave it unanswered: it turned away the `cur_group*()`
+# refusal in #246 and #223's own Definition of done in the same breath. The
+# census beside it -- eight diagnostics, and a named list of two left out --
+# is deleted rather than corrected, because under a coverage rule this file
+# does not have to say what it omits. `pluralizing_coverage()` below says where
+# each one went, and is checked against the corpus in both directions.
 #
 # The pins already beside each site stay where they are. Most match a phrase
 # rather than a whole message, which is enough to assert that a caller reaches
@@ -56,6 +63,123 @@
 # Plain expectations rather than snapshots: snapshots are skipped under CRAN
 # semantics, and these hold there too. Nothing here needs an optional backend,
 # so every configuration of the release matrix executes all of it.
+
+# Where both arms of each pluralizing diagnostic are pinned, keyed by the
+# namespace binding that raises it, with one entry per site that binding holds.
+#
+# This is a table and not a list, which is the distinction `.github/scripts/
+# verify-site.R` draws about its markers and `AGENTS.md` explains there: the
+# set of things that must be covered is derived, and the table only says where
+# each one went, so a table that fell behind fails rather than shrinking the
+# question. What it cannot check is that a line reference still points at the
+# assertion it names -- that is review surface, as a marker's text is.
+#
+# A binding holding more than one is why the value is a vector. The plan
+# compiler's implementation, named as a key below, raises the
+# duplicate-grouping-set refusal and the unknown-`.by` invariant, which are
+# pinned in different places; the two label-collision constructors hold two
+# arms each, all four pinned in the one block below.
+#
+# That name is written without its parentheses, here and in the key, because
+# `test-grouping-plan.R` fails any test file whose source spells it as a call
+# -- the scan behind "the only caller of the plan compiler" is deliberately
+# blunt, and a key in a table is not a call.
+pluralizing_coverage <- function() {
+  list(
+    abort_by_rename = "test-grouping-plan.R:604 and :645",
+    abort_declared_label_collision = rep("this file, the collision block", 2L),
+    abort_grouping_rename = "test-grouping-plan.R:493 and :543",
+    abort_observed_label_collision = rep("this file, the collision block", 2L),
+    check_summary_context_helpers = "test-contextual-helpers.R:696 and :728",
+    check_summary_group_overwrite = "this file, the summary-overwrite block",
+    compile_grouping_spec_impl = c(
+      "test-grouping-plan.R:915 and :768",
+      "this file, the unknown `.by` invariant block"
+    ),
+    grouping_helper_vars = "this file, the grouping-helper block",
+    proxy_columns = "this file, the selection proxy invariant block",
+    # The one sentence that pluralizes outside a Package condition, and the one
+    # covered by a fragment rather than an identity. ADR 0023's *Caller text is
+    # a value* puts it in scope, phase 2b moved it to `cli::pluralize()`, and
+    # #223's Definition of done asked for its arms here. They stay where they
+    # are: what the fragments assert is the inflected noun and the count in
+    # each arm, which is what the rule asks for, and an identity would pin the
+    # aggregation dplyr rendered around it (#236).
+    report_branch_warnings = "test-execution-conditions.R:332 and :291",
+    validate_margin_label = "this file, the NA-level block",
+    validate_margin_label_names = c(
+      "this file, the fixed `.by` label block",
+      "this file, the unknown label dimension block"
+    )
+  )
+}
+
+# The two readings the gate rests on, driven over source `R/` does not contain,
+# for the reason `test-diagnostic-authoring.R` gives about its own fixtures:
+# every site in the corpus satisfies the rule, so nothing but a fixture
+# executes a refusing branch, and a predicate that stopped refusing anything
+# reports the verdict a covered corpus reports.
+#
+# The corpus does execute both accepting branches -- twelve bindings between
+# them -- so what these add is the refusals, and the two shapes each reader has
+# to keep apart from the one it recognizes.
+test_that("the readings behind the coverage gate", {
+  cli_plural <- function() {
+    abort_marginplyr("{cli::qty(n)}column{?s}:")
+    abort_marginplyr(paste0("Can't rename ", "dimension{?s}:"))
+    abort_marginplyr("A refusal naming no count.")
+  }
+  found <- diagnostic_message_arguments(body(cli_plural), "abort_marginplyr")
+  # The third is the one a `{?}` test must not claim, and the second is the
+  # one it would lose by reading a literal instead of the expression: a
+  # re-authored template is split at a space, so the `{?}` can sit in either
+  # half (ADR 0023's second amendment).
+  expect_identical(
+    vapply(found, has_cli_plural, logical(1)),
+    c(TRUE, TRUE, FALSE)
+  )
+
+  invariants <- function(n) {
+    stop("column", if (n == 1L) " " else "s ", call. = FALSE)
+    stop("a flat invariant naming no count.", call. = FALSE)
+    warning("column", if (n == 1L) " " else "s ")
+  }
+  # One `stop()` of the three, so a plain invariant is not claimed and neither
+  # is a call that is not `stop()` at all.
+  expect_identical(invariant_plural_sites(body(invariants)), 1L)
+
+  # `cli::pluralize()` is written qualified and `abort_marginplyr()` is not, so
+  # the head reader has to answer both spellings and refuse the wrong name.
+  expect_true(is_call_to(quote(cli::pluralize("x")), "pluralize"))
+  expect_true(is_call_to(quote(pluralize("x")), "pluralize"))
+  expect_false(is_call_to(quote(cli::format_inline("x")), "pluralize"))
+})
+
+# The gate. A seventeenth pluralizing site fails until it is pinned and named
+# here, and a site that stops pluralizing fails until its entry goes -- neither
+# of which is a number anyone maintains, which is what the census this replaced
+# turned out to be.
+#
+# Both directions are asserted because each catches what the other cannot: a
+# derived site the table does not name is a diagnostic nothing may be asserting
+# at all, and a table entry naming no derived site is a pin pointing at a
+# message that no longer exists.
+test_that("every pluralizing diagnostic is covered somewhere", {
+  sites <- marginplyr_pluralizing_sites()
+  declared <- pluralizing_coverage()
+
+  # That the namespace was read at all, in the shape `test-diagnostic-
+  # authoring.R` uses for the same reason: a scan that found no site reports
+  # exactly what a corpus with nothing left to cover reports.
+  expect_gt(sum(sites), 0L)
+
+  expect_identical(setdiff(names(sites), names(declared)), character())
+  expect_identical(setdiff(names(declared), names(sites)), character())
+  expect_identical(
+    lengths(declared[names(sites)]),
+    sites
+  )
+})
 
 test_that("the selection proxy invariant pluralizes its column noun", {
   data <- data.frame(region = "East", units = 1)


### PR DESCRIPTION
Closes #236. **Stacked on #247** — it shares `test-diagnostic-authoring.R`, so
this targets that branch rather than `main`. Retarget to `main` once #247 lands.

## The measurement that shapes the work

I scanned the loaded namespace for every template this package pluralizes:
each `abort_marginplyr()` message holding `{?}`, the one `cli::pluralize()`
site, and each bare `stop()` invariant that spells a plural with an `if`.
**16 sites across 12 bindings** — and every one of them already has both arms
pinned.

So this closes no gap in what is asserted. What it closes is that nothing said
the corpus was covered, and nothing would have noticed a seventeenth site
arriving unpinned. That is the same defect as the census ADR 0023 struck, one
level up: a fact maintained by hand and read by nobody.

## The rule

`test-diagnostic-pluralization.R`'s selection rule was provenance:

> Suffixing is therefore where this set came from rather than a test a ninth
> diagnostic is admitted by.

Right to refuse the question, wrong to leave it unanswered — it turned away the
`cur_group*()` refusal in #246 and #223's Definition of done bullet 4 in the
same breath. Replaced by:

> Every diagnostic this package pluralizes has both arms reached by a test, and
> the inflected span asserted in each.

Three things follow that the old rule could not say, each of which had been
decided ad hoc until now:

- **Stated over the property, not a construction.** `{?s}`, `{?is/are}`,
  `{?a/b}`, and the `if` a bare `stop()` invariant uses are all in scope. What
  the baseline is for is that a re-wording of an inflection is visible, and
  which construction the inflection is written in does not change that.
- **No byte-exact identity required.** The eight blocks here achieve it that
  way and keep it. `report_branch_warnings()` cannot — its message is a
  dplyr-rendered warning carrying the caller's own diagnostic, so an identity
  would pin dplyr's aggregation text. Its two fragments assert exactly the
  inflected noun and the count.
- **Silent about which file a pin lives in.** That is the confusion behind
  bullet 4, which read this file as the place a diagnostic must be pinned when
  it is a collection of eight and the rule is about the corpus.

## The gate

Derived, not listed — the shape `verify-site.R` uses for its markers, and for
the reason `AGENTS.md` gives there. A namespace scan finds every pluralizing
site; a table says where each is pinned; both directions are asserted, so a
derived site the table does not name fails, and a table entry naming no site
fails. Neither is a number anyone maintains.

The walker moves to `helper-diagnostic-sites.R`, testthat giving each test file
its own environment, so the authoring gate and the coverage gate read one
reader rather than the second growing a copy.

Both readings get fixtures, for the reason the authoring gate's own fixtures
exist: every site in the corpus satisfies the rule, so nothing but a fixture
executes a refusing branch. The fixtures cover the `{?}` that falls either side
of a `paste0()` split, a template with no count, a plain invariant, a
non-`stop()` call holding the same `if`, and `cli::pluralize()`'s qualified head
against an unqualified one.

## Answering #223's bullet 4

`report_branch_warnings()`'s arms are **not** moved into this file. Under the
rule they do not need to be, and the table now says where they are. That is the
"strike the bullet" form of the two #223 named.

## Notes

`design/architecture.md`'s Conditions chapter states the gate. ADR 0023's third
amendment stops leaving the census question open.

One thing worth knowing for anyone editing this file: `test-grouping-plan.R`
fails any test file whose source spells the plan compiler's implementation as a
call, and the coverage table has to name that binding as a key. The name is
written without parentheses for that reason, and the comment says so.

Lint clean, 4801 passed / 0 failed / 0 skipped, `verify-suite-coverage.R` green
at 600 tests. No `R/` change, so the rendered site is untouched.