### PR TITLE
Give the namespace walk one home and a gate that keeps it there

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -619,13 +619,14 @@ asserting one of these is a *structural gate*: it reads the package's own
 expressions instead of its results, so a violation fails it wherever it is
 written, including in code no test executes.
 
-A gate reads the loaded namespace rather than the sources under `R/`, because
-`R/` is not installed beside the tests — under `R CMD check` the sources sit
-outside the `.Rcheck` directory, and in a CRAN-style installed copy they are
-gone. That is why every gate needs the package loaded through
-`pkgload::load_all()` or an installed dev build, and it is also what keeps a
+Such a gate reads the loaded namespace rather than the sources under `R/`,
+because `R/` is not installed beside the tests — under `R CMD check` the
+sources sit outside the `.Rcheck` directory, and in a CRAN-style installed copy
+they are gone. That is why a gate reading it needs the package loaded through
+`pkgload::load_all()` or an installed dev build, and it is also what keeps the
 gate free of a `skip_if()` that `verify-backend.R` would read as a job skipping
-for a reason other than a withheld backend.
+for a reason other than a withheld backend. A gate whose subject is the test
+sources rather than the package reads those instead, and needs neither.
 
 Reading a namespace that way is two operations — enumerating the functions it
 binds, and recursing over one parsed body — and both live in
@@ -634,13 +635,17 @@ recursion is shared rather than rewritten because it has a hazard in it: a
 parsed call can hold the missing-argument placeholder as one of its own
 elements, and a walk that binds an element to a name raises "argument is
 missing, with no default" on a body as ordinary as `sum(value[])` (#168, #174).
-Written three times, it answered that hazard three different ways, one of them
-with a guard the shape it was written in never needed (#229).
+Written in three spellings across four sources, it answered that hazard three
+different ways, one of them with a guard the shape it was written in never
+needed (#229).
 
 `test-namespace-walk.R` is what holds that state: it scans the test sources and
-fails unless the enumeration appears in the shared helper alone. It does not
-enumerate the gates, and neither does this section — the gate derives that set,
-and a list of walks is a list the next walk is not on.
+fails unless the enumeration appears in the shared helper alone. The
+enumeration and not the recursion, because the enumeration has one spelling and
+a recursion has any number — and a gate that enumerates is a gate that will
+walk, so the one it can see is enough to put every walker in front of the
+shared visitor. Which sources those are is derived there and listed neither
+here nor anywhere else: a list of walks is a list the next walk is not on.
 
 ### Release gates
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -612,13 +612,12 @@ byte-for-byte SQL formatting.
 ### Structural gates
 
 Some properties this package holds itself to are properties of every call site
-rather than of any one call, so no run of the verbs can observe them: that no
-function unquotes inside the `.data` pronoun, that only
-`compile_grouping_spec()` reaches the plan compiler, that every walk over a
-call's arguments reads them by subscript. A test asserting one of these is a
-*structural gate*: it reads the package's own expressions instead of its
-results, so a violation fails it wherever it is written, including in code no
-test executes.
+rather than of any one call, so no run of the verbs can observe them: that a
+hazardous shape is written nowhere in the package, that a shape which must have
+one home has exactly one, that everything of a kind is covered. A test
+asserting one of these is a *structural gate*: it reads the package's own
+expressions instead of its results, so a violation fails it wherever it is
+written, including in code no test executes.
 
 A gate reads the loaded namespace rather than the sources under `R/`, because
 `R/` is not installed beside the tests — under `R CMD check` the sources sit
@@ -635,7 +634,8 @@ recursion is shared rather than rewritten because it has a hazard in it: a
 parsed call can hold the missing-argument placeholder as one of its own
 elements, and a walk that binds an element to a name raises "argument is
 missing, with no default" on a body as ordinary as `sum(value[])` (#168, #174).
-Written three times, it was defended three different ways.
+Written three times, it answered that hazard three different ways, one of them
+with a guard the shape it was written in never needed (#229).
 
 `test-namespace-walk.R` is what holds that state: it scans the test sources and
 fails unless the enumeration appears in the shared helper alone. It does not

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -609,6 +609,39 @@ Backend tests may instrument a backend seam or inspect semantic query shape,
 but should not couple to the Margin operation representation or require
 byte-for-byte SQL formatting.
 
+### Structural gates
+
+Some properties this package holds itself to are properties of every call site
+rather than of any one call, so no run of the verbs can observe them: that no
+function unquotes inside the `.data` pronoun, that only
+`compile_grouping_spec()` reaches the plan compiler, that every walk over a
+call's arguments reads them by subscript. A test asserting one of these is a
+*structural gate*: it reads the package's own expressions instead of its
+results, so a violation fails it wherever it is written, including in code no
+test executes.
+
+A gate reads the loaded namespace rather than the sources under `R/`, because
+`R/` is not installed beside the tests — under `R CMD check` the sources sit
+outside the `.Rcheck` directory, and in a CRAN-style installed copy they are
+gone. That is why every gate needs the package loaded through
+`pkgload::load_all()` or an installed dev build, and it is also what keeps a
+gate free of a `skip_if()` that `verify-backend.R` would read as a job skipping
+for a reason other than a withheld backend.
+
+Reading a namespace that way is two operations — enumerating the functions it
+binds, and recursing over one parsed body — and both live in
+`tests/testthat/helper-namespace-walk.R`, which every gate takes them from. The
+recursion is shared rather than rewritten because it has a hazard in it: a
+parsed call can hold the missing-argument placeholder as one of its own
+elements, and a walk that binds an element to a name raises "argument is
+missing, with no default" on a body as ordinary as `sum(value[])` (#168, #174).
+Written three times, it was defended three different ways.
+
+`test-namespace-walk.R` is what holds that state: it scans the test sources and
+fails unless the enumeration appears in the shared helper alone. It does not
+enumerate the gates, and neither does this section — the gate derives that set,
+and a list of walks is a list the next walk is not on.
+
 ### Release gates
 
 One property of this suite is not observable from any single run of it: an

--- a/tests/testthat/helper-diagnostic-sites.R
+++ b/tests/testthat/helper-diagnostic-sites.R
@@ -1,8 +1,8 @@
-# The readers two gates share, over the source `R/` does not ship: the
-# structural gate in `test-diagnostic-authoring.R`, which asks whether every
-# `abort_marginplyr()` template is authored in the source, and the coverage
-# gate in `test-diagnostic-pluralization.R`, which asks whether every diagnostic
-# this package pluralizes has both of its arms pinned.
+# The diagnostics-specific readers two gates share, over the source `R/` does
+# not ship: the structural gate in `test-diagnostic-authoring.R`, which asks
+# whether every `abort_marginplyr()` template is authored in the source, and the
+# coverage gate in `test-diagnostic-pluralization.R`, which asks whether every
+# diagnostic this package pluralizes has both of its arms pinned.
 #
 # They live here rather than in either file because testthat gives each test
 # file its own environment, so the second gate could not see a walker the first
@@ -10,67 +10,50 @@
 # testthat looks before it runs anything, which is also what lets both gates be
 # read against a package loaded with `pkgload::load_all()` or an installed dev
 # build.
+#
+# What the readers below have in common with every other structural gate -- the
+# enumeration of the namespace's functions, and the recursion over one parsed
+# body -- comes from `helper-namespace-walk.R` and is not repeated here.
 
 # Every call to `name` below `expr`, as the expression each passed as its
 # message argument -- the first argument, or `message =` where a site names it.
-#
-# The recursion goes through `lapply()` and never a bare `for` over a call's
-# elements, for the reason `test-query-policy.R` records: a parsed call can hold
-# the missing-argument placeholder as one of its own elements, and a `for`
-# loop's assignment preserves the internal missing flag, so reading it raises
-# "argument is missing, with no default" the moment the loop variable is looked
-# up.
 diagnostic_message_arguments <- function(expr, name) {
   found <- list()
-  walk <- function(e) {
-    if (!is.call(e)) {
+  visit_calls(expr, function(node) {
+    head <- node[[1]]
+    if (!is.name(head) || !identical(as.character(head), name)) {
       return(invisible(NULL))
     }
-    head <- e[[1]]
-    if (is.name(head) && identical(as.character(head), name)) {
-      args <- as.list(e)[-1]
-      arg_names <- names(args)
-      # R's own matching for `abort_marginplyr(message, ..., class, call)`:
-      # `message =` by name, otherwise the first argument supplied without one.
-      # Reading `args[[1]]` instead would take `class` for the message at a
-      # site that named every argument it passed, and report that site clean
-      # because a class is a literal too.
-      positional <- if (is.null(arg_names)) args else args[!nzchar(arg_names)]
-      message <- if (!is.null(arg_names) && "message" %in% arg_names) {
-        args[["message"]]
-      } else if (length(positional) > 0L) {
-        positional[[1]]
-      } else {
-        NULL
-      }
-      # `c()` rather than `found[[length(found) + 1L]] <-`, which deletes
-      # instead of appending when the value is `NULL`. A call written with no
-      # message at all -- `abort_marginplyr(class = "x")` -- is exactly the
-      # site the gate must report, and that spelling would drop it.
-      found <<- c(found, list(message))
+    args <- as.list(node)[-1]
+    arg_names <- names(args)
+    # R's own matching for `abort_marginplyr(message, ..., class, call)`:
+    # `message =` by name, otherwise the first argument supplied without one.
+    # Reading `args[[1]]` instead would take `class` for the message at a
+    # site that named every argument it passed, and report that site clean
+    # because a class is a literal too.
+    positional <- if (is.null(arg_names)) args else args[!nzchar(arg_names)]
+    message <- if (!is.null(arg_names) && "message" %in% arg_names) {
+      args[["message"]]
+    } else if (length(positional) > 0L) {
+      positional[[1]]
+    } else {
+      NULL
     }
-    lapply(as.list(e)[-1], walk)
-    invisible(NULL)
-  }
-  walk(expr)
+    # `c()` rather than `found[[length(found) + 1L]] <-`, which deletes
+    # instead of appending when the value is `NULL`. A call written with no
+    # message at all -- `abort_marginplyr(class = "x")` -- is exactly the
+    # site the gate must report, and that spelling would drop it.
+    found <<- c(found, list(message))
+  })
   found
 }
 
-# Every function bound in the namespace, which is where the call sites are:
-# `R/` is not installed, so a scan of the shipped package would find no source
-# to read.
-marginplyr_namespace_functions <- function(ns = asNamespace("marginplyr")) {
-  Filter(
-    function(binding) is.function(get(binding, envir = ns)),
-    ls(ns, all.names = TRUE)
-  )
-}
-
 marginplyr_diagnostic_sites <- function(name, ns = asNamespace("marginplyr")) {
-  sites <- lapply(marginplyr_namespace_functions(ns), function(binding) {
+  bindings <- namespace_functions(ns)
+  sites <- lapply(bindings, function(binding) {
     diagnostic_message_arguments(body(get(binding, envir = ns)), name)
   })
-  stats::setNames(sites, marginplyr_namespace_functions(ns))
+  stats::setNames(sites, bindings)
 }
 
 # Whether a call is to `name`, however the source spells the head: bare, or
@@ -99,15 +82,17 @@ is_call_to <- function(expr, name) {
 # a branch a pluralization is that the two arms are fixed text the count picks
 # between, which is the same property ADR 0023's `{?}` rule is stated over.
 has_literal_branch <- function(expr) {
-  if (!is.call(expr)) {
-    return(FALSE)
-  }
-  chosen <- is_call_to(expr, "if") &&
-    length(expr) == 4L &&
-    is.character(expr[[3]]) &&
-    is.character(expr[[4]])
-  chosen ||
-    any(vapply(as.list(expr)[-1], has_literal_branch, logical(1)))
+  found <- FALSE
+  visit_calls(expr, function(node) {
+    chosen <- is_call_to(node, "if") &&
+      length(node) == 4L &&
+      is.character(node[[3]]) &&
+      is.character(node[[4]])
+    if (chosen) {
+      found <<- TRUE
+    }
+  })
+  found
 }
 
 # Whether a template pluralizes through cli, which is `{?}` wherever it sits --
@@ -138,7 +123,7 @@ has_cli_plural <- function(expr) {
 # the two label-collision constructors hold two arms each.
 marginplyr_pluralizing_sites <- function(ns = asNamespace("marginplyr")) {
   counts <- vapply(
-    marginplyr_namespace_functions(ns),
+    namespace_functions(ns),
     function(binding) {
       expr <- body(get(binding, envir = ns))
       templates <- c(
@@ -157,17 +142,11 @@ marginplyr_pluralizing_sites <- function(ns = asNamespace("marginplyr")) {
 # positionally at the one site that calls it.
 pluralize_templates <- function(expr) {
   found <- list()
-  walk <- function(e) {
-    if (!is.call(e)) {
-      return(invisible(NULL))
+  visit_calls(expr, function(node) {
+    if (is_call_to(node, "pluralize") && length(node) > 1L) {
+      found <<- c(found, list(node[[2]]))
     }
-    if (is_call_to(e, "pluralize") && length(e) > 1L) {
-      found <<- c(found, list(e[[2]]))
-    }
-    lapply(as.list(e)[-1], walk)
-    invisible(NULL)
-  }
-  walk(expr)
+  })
   found
 }
 
@@ -176,16 +155,10 @@ pluralize_templates <- function(expr) {
 # inflecting a noun and a verb in one message is one site and not two.
 invariant_plural_sites <- function(expr) {
   found <- 0L
-  walk <- function(e) {
-    if (!is.call(e)) {
-      return(invisible(NULL))
-    }
-    if (is_call_to(e, "stop") && has_literal_branch(e)) {
+  visit_calls(expr, function(node) {
+    if (is_call_to(node, "stop") && has_literal_branch(node)) {
       found <<- found + 1L
     }
-    lapply(as.list(e)[-1], walk)
-    invisible(NULL)
-  }
-  walk(expr)
+  })
   found
 }

--- a/tests/testthat/helper-namespace-walk.R
+++ b/tests/testthat/helper-namespace-walk.R
@@ -1,0 +1,57 @@
+# The two readings every structural gate in this suite is built out of: the
+# names of the functions a namespace binds, and the recursion over one parsed
+# body.
+#
+# A structural gate asserts a property of every call site rather than of any one
+# call -- that no function unquotes inside the `.data` pronoun, that only
+# `compile_grouping_spec()` reaches the plan compiler, that every
+# `abort_marginplyr()` template is authored in the source, that every walk over
+# a call's arguments reads them by subscript, that every pluralizing diagnostic
+# is pinned. Each of those reads the loaded namespace, because `R/` is not
+# installed beside the tests and a scan of the shipped package would find no
+# source to read; each therefore needs the package loaded through
+# `pkgload::load_all()` or an installed dev build. Why a gate reads the
+# namespace at all is the gate's own to state, and each of them states it.
+#
+# They live here rather than in whichever gate was written first because
+# testthat gives each test file its own environment: a second gate cannot see a
+# reader the first one defined, so the only two options were a helper or a copy.
+# `test-namespace-walk.R` is what keeps the copy from coming back.
+
+# The names of every function bound in a namespace.
+#
+# Names rather than the functions themselves, because `body()` is all a gate
+# reads and `get()` is one call away, while two shapes would be two things to
+# keep in step. The default is the package's own namespace; a gate proving its
+# matcher works passes a synthetic one instead.
+namespace_functions <- function(ns = asNamespace("marginplyr")) {
+  Filter(
+    function(binding) is.function(get(binding, envir = ns)),
+    ls(ns, all.names = TRUE)
+  )
+}
+
+# `fn` applied to every call below `expr`, including `expr` itself and including
+# each call's head -- a head that is not a symbol is a call like any other, and
+# a gate reading call targets has to see it.
+#
+# A parsed call can hold the missing-argument placeholder as one of its own
+# elements: a `switch()` fallthrough branch such as `switch(x, a = , b = f())`
+# and a subsetting call such as `x[i, ]` both produce one. Reading that
+# placeholder through an ordinary `for` loop raises "argument is missing, with
+# no default" the moment the loop variable is looked up, even though nothing
+# about the walk is actually missing an argument: a `for` loop's own assignment
+# preserves the internal missing flag, and normal symbol lookup checks for it.
+# Passing the same element as a function argument does not carry the flag
+# forward, which is why the recursion goes through `lapply()` and binds no
+# element of a call to a name. Reading an element by subscript is safe too, so
+# `fn` may take one apart however it needs to; it is the binding that is the
+# hazard, and this is the one place the recursion has to avoid it.
+visit_calls <- function(expr, fn) {
+  if (!is.call(expr)) {
+    return(invisible(NULL))
+  }
+  fn(expr)
+  lapply(as.list(expr), visit_calls, fn = fn)
+  invisible(NULL)
+}

--- a/tests/testthat/helper-namespace-walk.R
+++ b/tests/testthat/helper-namespace-walk.R
@@ -35,8 +35,12 @@
 #
 # Names rather than the functions themselves, because `body()` is all a gate
 # reads and `get()` is one call away, while two shapes would be two things to
-# keep in step. The default is the package's own namespace; a gate proving its
-# matcher works passes a synthetic one instead.
+# keep in step.
+#
+# Parameterized rather than fixed on marginplyr's namespace, because
+# `test-data-pronoun.R`'s self-witness runs its matcher over a synthetic one.
+# Every other caller passes the package's own explicitly, needing it again for
+# the `get()` that follows, so the default names what none of them leaves out.
 namespace_functions <- function(ns = asNamespace("marginplyr")) {
   Filter(
     function(binding) is.function(get(binding, envir = ns)),

--- a/tests/testthat/helper-namespace-walk.R
+++ b/tests/testthat/helper-namespace-walk.R
@@ -3,15 +3,28 @@
 # body.
 #
 # A structural gate asserts a property of every call site rather than of any one
-# call -- that no function unquotes inside the `.data` pronoun, that only
-# `compile_grouping_spec()` reaches the plan compiler, that every
-# `abort_marginplyr()` template is authored in the source, that every walk over
-# a call's arguments reads them by subscript, that every pluralizing diagnostic
-# is pinned. Each of those reads the loaded namespace, because `R/` is not
-# installed beside the tests and a scan of the shipped package would find no
-# source to read; each therefore needs the package loaded through
-# `pkgload::load_all()` or an installed dev build. Why a gate reads the
-# namespace at all is the gate's own to state, and each of them states it.
+# call, so it reads the loaded namespace: `R/` is not installed beside the
+# tests, and a scan of the shipped package would find no source to read. Every
+# such gate therefore needs the package loaded through `pkgload::load_all()` or
+# an installed dev build. Why a gate reads the namespace at all is the gate's
+# own to state, and each of them states it.
+#
+# The gates reading this file, which is what a header here can say and
+# `design/architecture.md`'s *Structural gates* section deliberately does not:
+#
+# - `test-data-pronoun.R`, that no function unquotes inside `.data`;
+# - `test-grouping-plan.R`, that only `compile_grouping_spec()` reaches the
+#   plan compiler -- the one that decides by deparsing, so it takes the
+#   enumeration and not the visitor;
+# - `test-query-policy.R`, ADR 0020's rule about which functions reach an
+#   execution entry point, and the capability table read out of the source;
+# - `test-utils.R`, that no walk over a call's arguments binds one to a name,
+#   in either the `for` spelling or the `<-` spelling;
+# - `helper-diagnostic-sites.R`, for the two diagnostics gates it serves.
+#
+# That list is a courtesy and not the record: `test-namespace-walk.R` derives
+# the set from the sources, so a gate missing from here still cannot hold a
+# second copy of the enumeration.
 #
 # They live here rather than in whichever gate was written first because
 # testthat gives each test file its own environment: a second gate cannot see a

--- a/tests/testthat/test-data-pronoun.R
+++ b/tests/testthat/test-data-pronoun.R
@@ -151,40 +151,21 @@ test_that("a source column named `.data` does not reach the pronoun", {
 # code no test executes.
 unquoted_pronoun_sites <- function(ns) {
   hits <- character()
-  # The empty symbol is held inside a list. Binding it to a variable and
-  # reading that variable back raises "argument is missing", which is what
-  # any argument-less call in a scanned body would otherwise trigger.
-  empty <- list(quote(expr = ))
 
   is_unquote <- function(x) {
     is.call(x) && identical(x[[1]], quote(`!`)) && length(x) == 2L &&
       is.call(x[[2]]) && identical(x[[2]][[1]], quote(`!`))
   }
 
-  walk <- function(x, where) {
-    if (!is.call(x)) {
-      return(invisible(NULL))
-    }
-    is_pronoun_index <- identical(x[[1]], quote(`[[`)) &&
-      length(x) >= 3L &&
-      identical(x[[2]], quote(.data))
-    if (is_pronoun_index && is_unquote(x[[3]])) {
-      hits <<- c(hits, where)
-    }
-    parts <- as.list(x)
-    for (i in seq_along(parts)) {
-      if (!identical(parts[i], empty)) {
-        walk(parts[[i]], where)
+  for (nm in namespace_functions(ns)) {
+    visit_calls(body(get(nm, envir = ns)), function(node) {
+      is_pronoun_index <- identical(node[[1]], quote(`[[`)) &&
+        length(node) >= 3L &&
+        identical(node[[2]], quote(.data))
+      if (is_pronoun_index && is_unquote(node[[3]])) {
+        hits <<- c(hits, nm)
       }
-    }
-    invisible(NULL)
-  }
-
-  for (nm in ls(ns, all.names = TRUE)) {
-    obj <- tryCatch(get(nm, envir = ns), error = function(e) NULL)
-    if (is.function(obj)) {
-      walk(body(obj), nm)
-    }
+    })
   }
   sort(unique(hits))
 }

--- a/tests/testthat/test-diagnostic-authoring.R
+++ b/tests/testthat/test-diagnostic-authoring.R
@@ -21,9 +21,10 @@
 # asserted over the loaded namespace rather than described in prose. It needs
 # the package loaded through `pkgload::load_all()` or an installed dev build.
 #
-# The namespace walk itself is in `helper-diagnostic-sites.R`, which
-# `test-diagnostic-pluralization.R`'s coverage gate reads too. Only the
-# predicate below is this gate's own.
+# The reading of the message arguments is in `helper-diagnostic-sites.R`, which
+# `test-diagnostic-pluralization.R`'s coverage gate reads too, over the
+# enumeration and the recursion in `helper-namespace-walk.R` that every
+# structural gate shares. Only the predicate below is this gate's own.
 
 # Whether every string a message argument contributes is written in the source.
 #

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -861,7 +861,7 @@ test_that("compile_grouping_spec() is the only caller of the plan compiler", {
     },
     logical(1)
   )
-  expect_identical(unname(objects[calls_impl]), "compile_grouping_spec")
+  expect_identical(objects[calls_impl], "compile_grouping_spec")
 
   # The namespace scan cannot see a test, and a test reaching the
   # implementation with `:::` is the half of #119 that was actually there. The

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -849,15 +849,15 @@ test_that("compile_grouping_spec() is the only caller of the plan compiler", {
   # report this file for holding the name it searches for.
   impl <- paste0("compile_grouping_spec", "_impl")
   ns <- asNamespace("marginplyr")
-  objects <- ls(ns, all.names = TRUE)
+  # Reads the loaded namespace rather than `R/`, which is not installed beside
+  # the tests. `namespace_functions()` is the enumeration every structural gate
+  # shares; this one decides by deparsing rather than by walking, so it is the
+  # one that takes nothing else from `helper-namespace-walk.R`.
+  objects <- namespace_functions(ns)
   calls_impl <- vapply(
     objects,
     function(name) {
-      object <- get(name, envir = ns)
-      if (!is.function(object)) {
-        return(FALSE)
-      }
-      any(grepl(impl, deparse(body(object)), fixed = TRUE))
+      any(grepl(impl, deparse(body(get(name, envir = ns))), fixed = TRUE))
     },
     logical(1)
   )

--- a/tests/testthat/test-namespace-walk.R
+++ b/tests/testthat/test-namespace-walk.R
@@ -1,9 +1,11 @@
 # `helper-namespace-walk.R` holds the two readings every structural gate in
 # this suite shares, and this file is what keeps them there. A gate that
 # enumerated the namespace itself would be a second copy of the reading, and
-# the copy is what drifts: the walk over a call's elements was independently
-# re-derived three times before it was shared, and two of the three carried
-# defensive code the third did not need.
+# the copy is what drifts: the recursion over a call's elements was
+# independently re-derived three times before it was shared, and the three
+# answered the missing-argument hazard three different ways -- two by
+# construction, and one with a guard against a placeholder it never had to
+# look at, beside a `tryCatch()` for a `get()` that fails on no binding.
 #
 # The enumeration is what is scanned for, rather than the recursion. It has one
 # spelling -- a function test over a listing that includes the hidden names --

--- a/tests/testthat/test-namespace-walk.R
+++ b/tests/testthat/test-namespace-walk.R
@@ -1,0 +1,76 @@
+# `helper-namespace-walk.R` holds the two readings every structural gate in
+# this suite shares, and this file is what keeps them there. A gate that
+# enumerated the namespace itself would be a second copy of the reading, and
+# the copy is what drifts: the walk over a call's elements was independently
+# re-derived three times before it was shared, and two of the three carried
+# defensive code the third did not need.
+#
+# The enumeration is what is scanned for, rather than the recursion. It has one
+# spelling -- a function test over a listing that includes the hidden names --
+# so a source holding it is visible from the outside, while a recursion can be
+# written any number of ways and is only recognizable once read, which is why
+# the markers below are named rather than quoted. A gate that enumerates is a
+# gate that will walk, so holding the enumeration in one place is what puts
+# every walker in front of the shared visitor.
+#
+# It reads the test sources rather than the loaded namespace, because a test
+# helper is not bound in it. Two things follow from that, and both have
+# precedent here. The markers are assembled rather than written out, as
+# `test-grouping-plan.R` assembles the plan compiler's name for its own source
+# scan, or this gate would report itself. And the self-witness below runs the
+# predicate over synthetic lines rather than over an offending file written
+# beside this one, which the gate would find and fail on.
+
+# Whether these lines hold the namespace enumeration: the function test and the
+# hidden-name listing that together name every function a namespace binds.
+# Both, because either alone is ordinary -- `test-optional-backends.R` asserts
+# a guard is a function, and `test-share-backends.R` lists a recorded-verdicts
+# environment -- and neither of those is walking a namespace.
+enumerates_namespace_functions <- function(lines) {
+  markers <- c(paste0("all", ".names"), paste0("is", ".function"))
+  all(vapply(
+    markers,
+    function(marker) any(grepl(marker, lines, fixed = TRUE)),
+    logical(1)
+  ))
+}
+
+sources_enumerating_functions <- function(sources) {
+  Filter(
+    function(path) enumerates_namespace_functions(readLines(path)),
+    sources
+  )
+}
+
+test_that("the namespace enumeration is written in one place", {
+  # The sources sit beside this file whenever the suite runs, so the scan needs
+  # no installed copy; the assertion refuses a scan that found nothing rather
+  # than passing on one, since every verdict below is a Filter over this set.
+  sources <- list.files(".", pattern = "^(test|helper)-.*\\.R$")
+  expect_gt(length(sources), 1L)
+
+  expect_identical(
+    sources_enumerating_functions(sources),
+    "helper-namespace-walk.R",
+    info = paste(
+      "Take the enumeration from `namespace_functions()` instead --",
+      "it is in `helper-namespace-walk.R`, beside the shared visitor."
+    )
+  )
+})
+
+test_that("the reuse scan detects the shape it is written to forbid", {
+  # Assembled for the reason the markers are: a copy of the enumeration written
+  # out here would be a copy of the enumeration in a test source, which is
+  # exactly what the gate above reports.
+  listing <- paste0("  ls(ns, all", ".names = TRUE)")
+  tested <- paste0("  function(binding) is", ".function(get(binding, ns)),")
+  offending <- c("  Filter(", tested, listing, "  )")
+
+  expect_true(enumerates_namespace_functions(offending))
+  # Either marker alone is not the enumeration, which is what keeps the two
+  # sources holding one of them correctly outside the gate.
+  expect_false(enumerates_namespace_functions(listing))
+  expect_false(enumerates_namespace_functions(tested))
+  expect_false(enumerates_namespace_functions(character()))
+})

--- a/tests/testthat/test-namespace-walk.R
+++ b/tests/testthat/test-namespace-walk.R
@@ -1,11 +1,11 @@
 # `helper-namespace-walk.R` holds the two readings every structural gate in
 # this suite shares, and this file is what keeps them there. A gate that
 # enumerated the namespace itself would be a second copy of the reading, and
-# the copy is what drifts: the recursion over a call's elements was
-# independently re-derived three times before it was shared, and the three
-# answered the missing-argument hazard three different ways -- two by
-# construction, and one with a guard against a placeholder it never had to
-# look at, beside a `tryCatch()` for a `get()` that fails on no binding.
+# the copy is what drifts: before it was shared, the recursion over a call's
+# elements stood in three spellings across four sources, answering the
+# missing-argument hazard three different ways -- two by construction, and one
+# with a guard against a placeholder it never had to look at, beside a
+# `tryCatch()` for a `get()` that fails on no binding.
 #
 # The enumeration is what is scanned for, rather than the recursion. It has one
 # spelling -- a function test over a listing that includes the hidden names --

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -42,6 +42,12 @@ call_targets <- function(expr) {
 # literal, so finding that assignment's right-hand side and evaluating it
 # reads the same table the package reads, rather than a copy of it kept here
 # by hand.
+#
+# The last such assignment in the body, since the visitor reaches every one of
+# them. A body assigning the name twice would be a body with two tables in it,
+# which is the state this reading exists to make impossible to have quietly:
+# the assertion below evaluates what it returns, so the wrong one of two would
+# show up as a changed snapshot rather than as a silent pass.
 find_local_assignment <- function(fn, var_name) {
   found <- NULL
   visit_calls(body(fn), function(node) {

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -43,11 +43,11 @@ call_targets <- function(expr) {
 # reads the same table the package reads, rather than a copy of it kept here
 # by hand.
 #
-# The last such assignment in the body, since the visitor reaches every one of
-# them. A body assigning the name twice would be a body with two tables in it,
-# which is the state this reading exists to make impossible to have quietly:
-# the assertion below evaluates what it returns, so the wrong one of two would
-# show up as a changed snapshot rather than as a silent pass.
+# Whichever such assignment the walk reaches last, the visitor stopping at
+# none of them. `backend_capabilities()` holds exactly one, and a body that
+# held two would be a body with two tables in it -- a state this reading does
+# not have to resolve, because the assertion below evaluates what it returns,
+# so the wrong one of two shows up as a changed snapshot and not as a pass.
 find_local_assignment <- function(fn, var_name) {
   found <- NULL
   visit_calls(body(fn), function(node) {

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -5,48 +5,34 @@
 # -- so this file asserts it structurally instead of describing it.
 #
 # `R/` is not installed, so scanning the shipped package would find nothing
-# to grep. The helpers below walk `body()` of every function bound in the
+# to grep. The readers below walk `body()` of every function bound in the
 # loaded marginplyr namespace instead, which is why every test here needs the
 # package loaded via `pkgload::load_all()` or an installed dev build, not a
-# CRAN-style installed copy of a release.
+# CRAN-style installed copy of a release. The enumeration of those functions
+# and the recursion over one body are shared with every other structural gate
+# and come from `helper-namespace-walk.R`.
 
-# A parsed call can hold the missing-argument placeholder as one of its own
-# elements -- a `switch()` fallthrough branch such as
-# `switch(x, a = , b = foo())`, or a subsetting call such as `x[i, ]` both
-# produce one. Reading that placeholder through an ordinary `for` loop raises
-# "argument is missing, with no default" the moment the loop variable is
-# looked up, even though nothing about the walk is actually missing an
-# argument: a `for` loop's own assignment preserves the internal missing flag,
-# and normal symbol lookup checks for it. Binding the same value through a
-# function argument does not carry the flag forward, which is why the
-# recursion below goes through `lapply()` and never through a bare `for` over
-# a call's elements.
+# The name each call below `expr` is to. A head that is not a symbol names no
+# target of its own, and the shared visitor reaches the call it holds anyway.
 call_targets <- function(expr) {
   targets <- character()
-  walk <- function(e) {
-    if (!is.call(e)) {
+  visit_calls(expr, function(node) {
+    head <- node[[1]]
+    if (!is.name(head)) {
       return(invisible(NULL))
     }
-    head <- e[[1]]
-    if (is.name(head)) {
-      head_chr <- as.character(head)
-      if (
-        (identical(head_chr, "::") || identical(head_chr, ":::")) &&
-          length(e) == 3
-      ) {
-        targets[[length(targets) + 1L]] <<- paste0(
-          as.character(e[[2]]), "::", as.character(e[[3]])
-        )
-      } else {
-        targets[[length(targets) + 1L]] <<- head_chr
-      }
+    head_chr <- as.character(head)
+    if (
+      (identical(head_chr, "::") || identical(head_chr, ":::")) &&
+        length(node) == 3
+    ) {
+      targets[[length(targets) + 1L]] <<- paste0(
+        as.character(node[[2]]), "::", as.character(node[[3]])
+      )
     } else {
-      walk(head)
+      targets[[length(targets) + 1L]] <<- head_chr
     }
-    lapply(as.list(e)[-1], walk)
-    invisible(NULL)
-  }
-  walk(expr)
+  })
   unique(targets)
 }
 
@@ -58,29 +44,17 @@ call_targets <- function(expr) {
 # by hand.
 find_local_assignment <- function(fn, var_name) {
   found <- NULL
-  walk <- function(e) {
-    if (!is.call(e)) {
-      return(invisible(NULL))
-    }
+  visit_calls(body(fn), function(node) {
     if (
-      identical(as.character(e[[1]]), "<-") &&
-        length(e) == 3 &&
-        is.symbol(e[[2]]) &&
-        identical(as.character(e[[2]]), var_name)
+      identical(as.character(node[[1]]), "<-") &&
+        length(node) == 3 &&
+        is.symbol(node[[2]]) &&
+        identical(as.character(node[[2]]), var_name)
     ) {
-      found <<- e[[3]]
-      return(invisible(NULL))
+      found <<- node[[3]]
     }
-    lapply(as.list(e), walk)
-    invisible(NULL)
-  }
-  walk(body(fn))
+  })
   found
-}
-
-marginplyr_internal_functions <- function(ns = asNamespace("marginplyr")) {
-  all_names <- ls(ns, all.names = TRUE)
-  Filter(function(name) is.function(get(name, envir = ns)), all_names)
 }
 
 # Enumerated rather than derived from a shape, exactly as ADR 0020 enumerates
@@ -130,7 +104,7 @@ test_that("the scanned entry-point set is the ADR 0020 execution catalog", {
 
 test_that("marginplyr functions reaching an execution entry point", {
   ns <- asNamespace("marginplyr")
-  internal_functions <- marginplyr_internal_functions(ns)
+  internal_functions <- namespace_functions(ns)
   call_graph <- stats::setNames(
     lapply(internal_functions, function(name) {
       call_targets(body(get(name, envir = ns)))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -201,7 +201,7 @@ test_that("no walk binds a call's parts with `for`", {
 
   # Named rather than counted, so the failure says which walk to rewrite.
   expect_equal(
-    unname(functions[offenders]),
+    functions[offenders],
     character(),
     info = paste(
       "Read the parts by subscript instead --",
@@ -318,7 +318,7 @@ test_that("no walk binds a call's parts with `<-`", {
   )
 
   expect_equal(
-    unname(functions[offenders]),
+    functions[offenders],
     character(),
     info = paste(
       "Read the argument at the point of use --",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -104,14 +104,9 @@ test_that("shared argument assertions use the package condition seam", {
 # than `R/`, so it holds under `R CMD check` too, where the sources sit beside
 # the `.Rcheck` directory rather than inside it -- and so it needs no
 # `skip_if()` that `verify-backend.R` would then read as a job skipping for a
-# reason other than a withheld backend.
-package_functions <- function() {
-  namespace <- asNamespace("marginplyr")
-  names <- ls(namespace, all.names = TRUE)
-  objects <- lapply(names, get, envir = namespace)
-  keep <- vapply(objects, is.function, logical(1))
-  stats::setNames(objects[keep], names[keep])
-}
+# reason other than a withheld backend. `namespace_functions()` and
+# `visit_calls()` are that reading, shared with every other structural gate from
+# `helper-namespace-walk.R`.
 
 # Where a list of a call's arguments comes from: the shared reader, the rlang
 # function it wraps, the reader that unwraps each of them through an injected
@@ -153,21 +148,18 @@ reads_call_arguments <- function(expr) {
 
 # The names a body binds to such a list, so that a loop over one, or a
 # subscript of one, is read as reaching the arguments themselves.
-call_argument_locals <- function(expr, found = character()) {
-  if (!is.call(expr)) {
-    return(found)
-  }
-  if (
-    identical(expr[[1L]], quote(`<-`)) &&
-      length(expr) == 3L &&
-      is.symbol(expr[[2L]]) &&
-      reads_call_arguments(expr[[3L]])
-  ) {
-    found <- unique(c(found, as.character(expr[[2L]])))
-  }
-  for (index in seq_along(expr)) {
-    found <- call_argument_locals(expr[[index]], found)
-  }
+call_argument_locals <- function(expr) {
+  found <- character()
+  visit_calls(expr, function(node) {
+    if (
+      identical(node[[1L]], quote(`<-`)) &&
+        length(node) == 3L &&
+        is.symbol(node[[2L]]) &&
+        reads_call_arguments(node[[3L]])
+    ) {
+      found <<- unique(c(found, as.character(node[[2L]])))
+    }
+  })
   found
 }
 
@@ -178,45 +170,38 @@ is_call_arguments <- function(expr, locals) {
 
 # By subscript throughout, since the code being scanned is exactly the code that
 # may hold an empty argument.
-binds_call_parts_with_for <- function(body) {
-  locals <- call_argument_locals(body)
-  scan <- function(expr) {
-    if (!is.call(expr)) {
-      return(FALSE)
-    }
+binds_call_parts_with_for <- function(expr) {
+  locals <- call_argument_locals(expr)
+  found <- FALSE
+  visit_calls(expr, function(node) {
     if (
-      identical(expr[[1L]], quote(`for`)) &&
-        length(expr) >= 3L &&
-        is_call_arguments(expr[[3L]], locals)
+      identical(node[[1L]], quote(`for`)) &&
+        length(node) >= 3L &&
+        is_call_arguments(node[[3L]], locals)
     ) {
-      return(TRUE)
+      found <<- TRUE
     }
-    for (index in seq_along(expr)) {
-      if (scan(expr[[index]])) {
-        return(TRUE)
-      }
-    }
-    FALSE
-  }
-  scan(body)
+  })
+  found
 }
 
 test_that("no walk binds a call's parts with `for`", {
-  functions <- package_functions()
+  ns <- asNamespace("marginplyr")
+  functions <- namespace_functions(ns)
   # The scan iterates over this set, so a set that arrived empty is a set that
   # passes. `static_call_args()` itself is the cheapest witness that the
   # namespace was read.
-  expect_true("static_call_args" %in% names(functions))
+  expect_true("static_call_args" %in% functions)
 
   offenders <- vapply(
     functions,
-    function(f) binds_call_parts_with_for(body(f)),
+    function(name) binds_call_parts_with_for(body(get(name, envir = ns))),
     logical(1)
   )
 
   # Named rather than counted, so the failure says which walk to rewrite.
   expect_equal(
-    names(functions)[offenders],
+    unname(functions[offenders]),
     character(),
     info = paste(
       "Read the parts by subscript instead --",
@@ -304,46 +289,36 @@ test_that("the walk scan detects the shape it is written to forbid", {
 # `x <- y[[i]]` in the package, most of which read an ordinary list. Those sites
 # are covered by behaviour instead, in `test-static-expression-analysis.R`,
 # where each shape is compared against what `dplyr::summarise()` does with it.
-binds_call_parts_by_assign <- function(body) {
-  locals <- call_argument_locals(body)
-  scan <- function(expr) {
-    if (!is.call(expr)) {
-      return(FALSE)
+binds_call_parts_by_assign <- function(expr) {
+  locals <- call_argument_locals(expr)
+  found <- FALSE
+  visit_calls(expr, function(node) {
+    assigns_element <- identical(node[[1L]], quote(`<-`)) &&
+      length(node) == 3L &&
+      is.symbol(node[[2L]]) &&
+      is.call(node[[3L]]) &&
+      identical(node[[3L]][[1L]], quote(`[[`)) &&
+      length(node[[3L]]) >= 2L
+    if (assigns_element && is_call_arguments(node[[3L]][[2L]], locals)) {
+      found <<- TRUE
     }
-    if (
-      identical(expr[[1L]], quote(`<-`)) &&
-        length(expr) == 3L &&
-        is.symbol(expr[[2L]]) &&
-        is.call(expr[[3L]]) &&
-        identical(expr[[3L]][[1L]], quote(`[[`)) &&
-        length(expr[[3L]]) >= 2L
-    ) {
-      if (is_call_arguments(expr[[3L]][[2L]], locals)) {
-        return(TRUE)
-      }
-    }
-    for (index in seq_along(expr)) {
-      if (scan(expr[[index]])) {
-        return(TRUE)
-      }
-    }
-    FALSE
-  }
-  scan(body)
+  })
+  found
 }
 
 test_that("no walk binds a call's parts with `<-`", {
-  functions <- package_functions()
-  expect_true("parse_across_arguments" %in% names(functions))
+  ns <- asNamespace("marginplyr")
+  functions <- namespace_functions(ns)
+  expect_true("parse_across_arguments" %in% functions)
 
   offenders <- vapply(
     functions,
-    function(f) binds_call_parts_by_assign(body(f)),
+    function(name) binds_call_parts_by_assign(body(get(name, envir = ns))),
     logical(1)
   )
 
   expect_equal(
-    names(functions)[offenders],
+    unname(functions[offenders]),
     character(),
     info = paste(
       "Read the argument at the point of use --",


### PR DESCRIPTION
Closes #229.

Five test sources each carried their own enumeration of the functions the
loaded namespace binds, and the recursion over a parsed body stood in three
spellings across four of them. All five enumerations returned the same 353
names and all three recursions were safe, but they answered the
missing-argument hazard three different ways — two by construction, and one
with a guard against a placeholder it never had to look at, beside a
`tryCatch()` for a `get()` that fails on no binding. That is what independent
re-derivation of one hazard produces.

## What moved

`tests/testthat/helper-namespace-walk.R` now holds both readings:

- `namespace_functions(ns = asNamespace("marginplyr"))`, returning the *names*
  of every function a namespace binds. Names rather than objects, because
  `body()` is all a gate reads and `get()` is one call away, and two shapes
  would be two things to keep in step.
- `visit_calls(expr, fn)`, applying `fn` to every call below `expr`, visiting
  each call's head, and binding no element of a call to a name.

Six sources take them from there. `test-grouping-plan.R` takes the enumeration
only — it decides by `deparse()` and `grepl()` and does not walk.

Each gate keeps its own account of what it asserts and why it asserts it over
the namespace. The only thing that left their headers is the mechanical
restatement of the hazard, which is now stated once beside the recursion that
answers it.

## What holds it

`tests/testthat/test-namespace-walk.R` scans the test sources and fails unless
the enumeration appears in the shared helper alone. Two properties follow from
its reading sources rather than the namespace, and both have precedent in this
suite: its markers are assembled rather than written out, so it does not report
itself, and its self-witness runs the predicate over synthetic lines rather
than over an offending file the gate would then find.

It was run red before the conversion and named all six sources then holding the
enumeration, including itself when a prose line in its own header still spelled
a marker out.

## Verification

Every converted reader was compared against its pre-conversion result across
all 353 namespace functions: the call graph, the diagnostic sites, the
pluralizing counts, the pronoun scan, the capability assignment, and both walk
verdicts are identical. No snapshot changed.

- Full suite green under `NOT_CRAN=true` with `pkgload::load_all()`.
- `lintr::lint_package()` clean after `load_all()`.
- `Rscript .github/scripts/verify-suite-coverage.R` passes — 602 tests, none
  executing in zero configurations.

## Documentation

`design/architecture.md`'s *Test seams* chapter gains a *Structural gates*
subsection saying what a structural gate is, why it reads the namespace rather
than `R/`, and that the shared walk has one home the reuse gate enforces. It
names no individual gate: the gate derives that set, and a list of walks is a
list the next walk is not on.

## Out of scope

#250 — the two call-argument-binding gates in `test-utils.R` are now one shape
written twice around two different predicates. Changing what an existing gate
asserts, or how it is framed, was out of scope here.

A `namespace_bodies()` collapsing `body(get(name, envir = ns))` at its seven
call sites was raised in review and declined: that is the second enumerator
shape #229 rules out, and the reason it gives — two shapes are two things to
keep in step — is why the repetition is worth paying for.