### PR TITLE
Point two citations at the precedents they describe

### DIFF
--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -283,8 +283,10 @@ grouping_helper_vars <- function(args, helper, plan) {
 # bare column, whether it is R's empty argument or something else entirely.
 # Written as a function rather than as a message bound once and passed twice,
 # because the structural gate reads `abort_marginplyr()`'s own argument and
-# refuses a template bound elsewhere -- the reason `R/share.R`'s two
-# Parent-share refusals are written out twice.
+# refuses a template bound elsewhere -- the shape `abort_ambiguous_parent()`
+# takes in `R/share.R`. What the gate rules out is the bound template; a
+# literal inside a helper it reads exactly as it reads one at each raising
+# site, which is what leaves the choice between one helper and two copies open.
 #
 # `injected_quosure_clause()` reaches the template as an interpolated value
 # carrying no markup, for the reasons `R/share.R` states above the other site

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -833,7 +833,9 @@ resolve_column_selection <- function(arg, data_proxy, on_rename) {
 # branch ADR 0023's `{?}` rule dissolves rather than relocates. Writing them
 # out also keeps both inside the structural gate, which reads
 # `abort_marginplyr()`'s own argument and refuses a template bound elsewhere --
-# the reason `R/share.R`'s two Parent-share refusals are written out twice.
+# the shape `abort_share_helper_position()` records in `R/share.R`, where what
+# two calls share is written out in each for that reason. ADR 0023's third
+# amendment names that refusal and this pair together.
 #
 # The pairs arrive alone in an `i` bullet, per ADR 0023's condition 2: how many
 # of them there are is the caller's decision.


### PR DESCRIPTION
Closes #245.

Two source comments cited "`R/share.R`'s two Parent-share refusals ... written
out twice" as the precedent for writing a refusal out rather than binding it
once. `R/share.R` holds no such pair: `abort_ambiguous_parent()` is one refusal
with two raising sites, deliberately a helper rather than two copies, and
`share_of_parent()`/`share_of_total()` refuse two different share kinds, each
written once. Nothing failed, because no gate reads a comment.

## The two paragraphs do not want the same precedent

#245 proposes `abort_share_helper_position()` for both. That holds for one of
them, because the two paragraphs resolve the structural gate's rule in opposite
directions:

- `abort_grouping_rename()` writes its refusal out beside `abort_by_rename()`.
  That is the written-out-twice shape, and it now cites
  `abort_share_helper_position()`, which records it. ADR 0023's third amendment
  already names that refusal and this pair together, so the comment says so.
- `abort_not_a_grouping_column()` does the other thing: one helper holding the
  literal, reached from two check sites, with `call` forwarded so the refusal
  blames the site. That is `abort_ambiguous_parent()`'s shape exactly, and that
  helper's own comment states why the gate permits it.

Cited the way the issue proposes, the second paragraph would have named a
written-out-twice precedent for a helper that shares nothing with a second
call, leaving a reader to conclude the gate forced a duplication this file
avoided -- the same defect class the issue exists to remove. The deviation and
the amended acceptance criterion are recorded on the issue.

The second citation also says what the gate *rules out* rather than what it
requires: the gate refuses the bound template and permits either resolution, so
choosing one helper over two copies is that file's call and not the gate's,
which is what `abort_ambiguous_parent()`'s comment records in saying nothing
required the sentence at both sites.

## Verification

Both edits are plain `#` comments, not roxygen, so nothing generated moves.

- `grep -rn "Parent-share refusals are written out twice" R/` -- no hits
- `git diff -- man NAMESPACE README.md` -- empty
- `pkgload::load_all("."); lintr::lint_package()` -- no lints found
- `devtools::test()` -- FAIL 0 | WARN 0 | SKIP 0 | PASS 4807

Every factual claim the new prose makes was checked against the code it names:
the shape `abort_share_helper_position()` records, the third `## Amendment`
heading in ADR 0023 and what it names, `abort_ambiguous_parent()`'s two raising
sites, and its `call` handling.
