### PR TITLE
Give the two call-argument gates one scan and two predicates

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -168,28 +168,33 @@ is_call_arguments <- function(expr, locals) {
     (is.symbol(expr) && as.character(expr) %in% locals)
 }
 
-# The scan both gates below are, once the predicate is taken out of it: the
-# names of the namespace's functions whose body matches, named rather than
-# counted so a failure says which walk to rewrite. It reads the enumeration
-# through `namespace_functions()` like every other structural gate, and takes
-# the already-enumerated set so a gate can assert its witness against exactly
-# the set the scan iterated over.
+# The scan both gates below are, once the predicate is taken out of it: of the
+# functions a namespace binds, the names of those whose body the predicate
+# matches. Every predicate handed to it here matches a walk, which is what the
+# name says; what it returns is a set of names, named rather than counted so a
+# failure says which walk to rewrite.
 #
-# The predicate is the only thing it takes, and the two things it deliberately
-# does not take are the witness and the message. Each gate's witness is chosen
-# for what that gate reads -- `static_call_args` for the `for` scan,
+# The predicate is the only thing it takes for itself. The two it deliberately
+# does not take are the witness and the message: each gate's witness names what
+# that gate reads -- `static_call_args` for the `for` scan,
 # `parse_across_arguments` for the `<-` scan -- and each remedy is written for
-# its own spelling, so an argument for either would exist only to be different
+# its own spelling, so an argument for either would exist only to be different,
 # and would make the two look interchangeable. They stay in the `test_that()`
 # block that means them.
 #
-# It is local to this source rather than in `helper-namespace-walk.R`, because
-# that file exists for readings two test files need and testthat gives each file
-# its own environment. Both gates are here, so a shared home would be a home
-# nothing needed.
-walks_matching <- function(predicate,
-                           functions = namespace_functions(ns),
-                           ns = asNamespace("marginplyr")) {
+# The enumeration and the namespace come from the caller rather than from
+# defaults here. A gate then asserts its witness against the very set this
+# iterates, the two arguments cannot come to describe different namespaces, and
+# `namespace_functions()` keeps being passed the namespace its caller reads
+# bodies from -- which is what that function's own default is written around.
+#
+# Local to this source rather than in `helper-namespace-walk.R`: that file
+# exists because testthat gives each test file its own environment, so one
+# file's gate cannot see a reader another defined, and both gates here are in
+# one file. The other scan of this shape, in `test-grouping-plan.R`, decides by
+# deparsing rather than by walking and says so where it stands, so a shared home
+# would be a home for one caller.
+walks_matching <- function(predicate, functions, ns) {
   matched <- vapply(
     functions,
     function(name) predicate(body(get(name, envir = ns))),
@@ -216,14 +221,15 @@ binds_call_parts_with_for <- function(expr) {
 }
 
 test_that("no walk binds a call's parts with `for`", {
-  functions <- namespace_functions()
+  ns <- asNamespace("marginplyr")
+  functions <- namespace_functions(ns)
   # The scan iterates over this set, so a set that arrived empty is a set that
   # passes. `static_call_args()` itself is the cheapest witness that the
   # namespace was read.
   expect_true("static_call_args" %in% functions)
 
   expect_equal(
-    walks_matching(binds_call_parts_with_for, functions),
+    walks_matching(binds_call_parts_with_for, functions, ns),
     character(),
     info = paste(
       "Read the parts by subscript instead --",
@@ -329,11 +335,12 @@ binds_call_parts_by_assign <- function(expr) {
 }
 
 test_that("no walk binds a call's parts with `<-`", {
-  functions <- namespace_functions()
+  ns <- asNamespace("marginplyr")
+  functions <- namespace_functions(ns)
   expect_true("parse_across_arguments" %in% functions)
 
   expect_equal(
-    walks_matching(binds_call_parts_by_assign, functions),
+    walks_matching(binds_call_parts_by_assign, functions, ns),
     character(),
     info = paste(
       "Read the argument at the point of use --",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -168,6 +168,36 @@ is_call_arguments <- function(expr, locals) {
     (is.symbol(expr) && as.character(expr) %in% locals)
 }
 
+# The scan both gates below are, once the predicate is taken out of it: the
+# names of the namespace's functions whose body matches, named rather than
+# counted so a failure says which walk to rewrite. It reads the enumeration
+# through `namespace_functions()` like every other structural gate, and takes
+# the already-enumerated set so a gate can assert its witness against exactly
+# the set the scan iterated over.
+#
+# The predicate is the only thing it takes, and the two things it deliberately
+# does not take are the witness and the message. Each gate's witness is chosen
+# for what that gate reads -- `static_call_args` for the `for` scan,
+# `parse_across_arguments` for the `<-` scan -- and each remedy is written for
+# its own spelling, so an argument for either would exist only to be different
+# and would make the two look interchangeable. They stay in the `test_that()`
+# block that means them.
+#
+# It is local to this source rather than in `helper-namespace-walk.R`, because
+# that file exists for readings two test files need and testthat gives each file
+# its own environment. Both gates are here, so a shared home would be a home
+# nothing needed.
+walks_matching <- function(predicate,
+                           functions = namespace_functions(ns),
+                           ns = asNamespace("marginplyr")) {
+  matched <- vapply(
+    functions,
+    function(name) predicate(body(get(name, envir = ns))),
+    logical(1)
+  )
+  functions[matched]
+}
+
 # By subscript throughout, since the code being scanned is exactly the code that
 # may hold an empty argument.
 binds_call_parts_with_for <- function(expr) {
@@ -186,22 +216,14 @@ binds_call_parts_with_for <- function(expr) {
 }
 
 test_that("no walk binds a call's parts with `for`", {
-  ns <- asNamespace("marginplyr")
-  functions <- namespace_functions(ns)
+  functions <- namespace_functions()
   # The scan iterates over this set, so a set that arrived empty is a set that
   # passes. `static_call_args()` itself is the cheapest witness that the
   # namespace was read.
   expect_true("static_call_args" %in% functions)
 
-  offenders <- vapply(
-    functions,
-    function(name) binds_call_parts_with_for(body(get(name, envir = ns))),
-    logical(1)
-  )
-
-  # Named rather than counted, so the failure says which walk to rewrite.
   expect_equal(
-    functions[offenders],
+    walks_matching(binds_call_parts_with_for, functions),
     character(),
     info = paste(
       "Read the parts by subscript instead --",
@@ -307,18 +329,11 @@ binds_call_parts_by_assign <- function(expr) {
 }
 
 test_that("no walk binds a call's parts with `<-`", {
-  ns <- asNamespace("marginplyr")
-  functions <- namespace_functions(ns)
+  functions <- namespace_functions()
   expect_true("parse_across_arguments" %in% functions)
 
-  offenders <- vapply(
-    functions,
-    function(name) binds_call_parts_by_assign(body(get(name, envir = ns))),
-    logical(1)
-  )
-
   expect_equal(
-    functions[offenders],
+    walks_matching(binds_call_parts_by_assign, functions),
     character(),
     info = paste(
       "Read the argument at the point of use --",


### PR DESCRIPTION
Closes #250.

`test-utils.R`'s two gates over the call-argument-binding hazard held the same
eight lines: enumerate the namespace, assert one witness is in it, apply the
block's predicate to every body with `vapply()`, assert the matching names are
`character()`. `walks_matching()` is that scan with the predicate taken out of
it, local to the source holding both gates.

## What it does not take

The predicate is the only thing it takes for itself. The witness and the
message stay in the `test_that()` block that means them, which is the decision
recorded on the issue rather than a shape arrived at here: each gate's witness
names what that gate reads -- `static_call_args` for the `for` scan,
`parse_across_arguments` for the `<-` scan -- and each remedy is written for its
own spelling, so an argument for either would exist only to be different and
would make the two look interchangeable. A comment at the helper says so, since
re-adding them is the edit the next reader would otherwise make.

## The enumeration and the namespace come from the caller

The first version defaulted both. Review found the pair was dead -- both gates
pass the enumeration they asserted their witness against, and neither passed a
namespace -- and that what it bought was a way for the two to come to describe
different namespaces, names enumerated from one and bodies `get()`d from the
other, plus a default reading a parameter declared after it.

Passing both is also what keeps `namespace_functions()`'s own header true. It
says every caller passes the package's namespace explicitly, needing it again
for the `get()` that follows; a bare call here made that sentence false without
touching the file that states it, which the issue freezes.

The helper's comment says which other scan of this shape was left where it
stands -- `test-grouping-plan.R`'s, which decides by deparsing rather than by
walking and says so -- rather than claiming none exists. Routing that one
through a shared reader was considered and rejected during triage.

## Verification

Only `tests/testthat/test-utils.R` changes. The two self-witness tests, both
predicates, `reads_call_arguments()`, `call_argument_locals()`,
`is_call_arguments()`, and `helper-namespace-walk.R` are untouched, and no
assertion is added.

- `pkgload::load_all("."); testthat::test_local()` -- all files green
- `pkgload::load_all("."); lintr::lint_package()` -- no lints found
- *The namespace enumeration is written in one place* still passes: the helper
  re-spells neither `all.names` nor `is.function`.
- The refactor cannot have gone silently blind. `walks_matching()` was run over
  a synthetic namespace holding one offender per spelling and named each; run
  with a predicate matching everything, it returns all 353 of the enumeration.