### PR TITLE
Refuse a summary Arrow would read the input to compute

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -369,8 +369,13 @@ markers <- list(
     "Arrow and dtplyr are tested for the lazy",
     # The unconditional half of the absorbed-summary section. Its `must_error`
     # chunk is behind `has_arrow` like the two share refusals below it, so the
-    # prose introducing it is what a marker can reach.
-    "a summary Arrow's own engine cannot evaluate",
+    # prose introducing it is what a marker can reach. Chosen from a run of
+    # that prose holding no apostrophe: pandoc's `smart` extension renders one
+    # as U+2019 in prose, where the straight form survives only inside a code
+    # span, so a marker quoting one matches nothing. Every apostrophe-bearing
+    # marker in this file quotes a diagnostic, which reaches the page as a
+    # code span.
+    "refuses it before a row is read",
     # The one `must_error` chunk on this page that needs no optional Suggest:
     # nesting a SQL table, refused through the dbplyr simulator. The guide's
     # DuckDB, dtplyr, and Arrow refusals are behind availability guards, so

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -367,6 +367,10 @@ markers <- list(
     "DuckDB covers native SQL end to end",
     "dozen-plus fallback dialects",
     "Arrow and dtplyr are tested for the lazy",
+    # The unconditional half of the absorbed-summary section. Its `must_error`
+    # chunk is behind `has_arrow` like the two share refusals below it, so the
+    # prose introducing it is what a marker can reach.
+    "a summary Arrow's own engine cannot evaluate",
     # The one `must_error` chunk on this page that needs no optional Suggest:
     # nesting a SQL table, refused through the dbplyr simulator. The guide's
     # DuckDB, dtplyr, and Arrow refusals are behind availability guards, so

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,6 +132,25 @@ fact about one attempt rather than about the dialect, so nothing is recorded and
 the next share request asks again.
 _Avoid_: Coercing backend, lenient database, permissive SQL
 
+**Absorbing backend**:
+A backend that answers a summary expression its own engine cannot evaluate by
+reading the caller's input into R and evaluating it there, rather than
+refusing it. Its opposite is a *refusing* backend, which reports the
+expression as unsupported and leaves the input unread. Which of the two a
+backend is, is a property of the input's class and not of the expression: an
+Arrow table, an Arrow record batch, and a query over either absorb, while an
+Arrow dataset and a query over one refuse, and every SQL backend refuses at
+the caller's own execution. It is therefore finer-grained than a backend kind,
+one kind holding both, which is why it is established from the input rather
+than looked up. Which expressions it applies to cannot be read from the
+call — a composition of translatable operations is translatable however it is
+spelled and whoever wrote the function around it — and the boundary moves with
+the backend's own version, so it is described rather than enumerated. A Margin
+verb refuses on the caller's behalf wherever a backend would absorb, because
+absorbing reads every column of the input while a caller who is told can read
+fewer.
+_Avoid_: Pulling backend, fallback backend, collecting backend
+
 **Contextual helper**:
 A spelling whose meaning inside a Margin summary arises only through static
 rewriting, and which is therefore recognized by spelling and never resolved
@@ -183,10 +202,19 @@ _Avoid_: Package error, internal error, user-facing error
 
 **External condition**:
 A condition raised by a user summary expression, tidyselect, dplyr, or a
-backend, and propagated with its own class, its own diagnostic, and its own
-cause intact. Warnings and errors are alike External conditions. What a Margin
-verb may adjust is the Condition context; the condition itself is the caller's
-to receive unchanged.
+backend *as its answer to the question put to it*, and propagated with its own
+class, its own diagnostic, and its own cause intact. Warnings and errors are
+alike External conditions. What a Margin verb may adjust is the Condition
+context; the condition itself is the caller's to receive unchanged.
+
+An answer is what the qualification is for. A backend that reports an
+expression as unsupported has answered; a backend that violates one of its own
+invariants while working out what to answer has not, and the condition that
+escapes is neither its answer nor a defect the caller can act on. Passing one
+on unchanged satisfies every word of the first paragraph and still tells the
+caller nothing they can use, which is how such a condition reads as
+contract-abiding while being the shape ADR 0015 removes from marginplyr's own
+code.
 _Avoid_: Third-party error, foreign error
 
 **Condition context**:

--- a/NEWS.md
+++ b/NEWS.md
@@ -122,15 +122,22 @@
   versions, centralizes backend capabilities, and reports incompatible dbplyr
   query representations explicitly.
 * A summary Arrow's own engine cannot evaluate is now refused, before any row
-  is read, instead of failing with `object of type 'special' is not
-  subsettable`. Arrow answers such an expression by reading the whole input —
-  every column, not only the ones the summary names — and computing it in R;
-  the refusal names the argument you wrote and the two rewrites that compute
-  it, collecting first and selecting the columns you need before you collect.
+  is read. Arrow answers such an expression by reading the whole input — every
+  column, not only the ones the summary names — and computing it in R; the
+  refusal names the argument you wrote and the two rewrites that compute it,
+  collecting first and selecting the columns you need before you collect.
   Which expressions this reaches is Arrow's to decide and moves with its
   version; `?summarize_with_margins` describes the shapes. Ordinary numeric
   summaries, and arithmetic over them, are unaffected and stay lazy, and an
   Arrow dataset keeps raising Arrow's own error for the same expressions.
+
+  What this replaces depends on your Arrow. From arrow 17.0.0 such a call
+  aborted with `object of type 'special' is not subsettable`, an error carrying
+  no class of its own and naming nothing you wrote. Through arrow 16.0.0 it
+  returned the right answer,
+  having read the whole input to get it — so on those versions this is a
+  breaking change, and the rewrites the refusal names reproduce the old result
+  while letting you choose what is read.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/NEWS.md
+++ b/NEWS.md
@@ -128,11 +128,9 @@
   the refusal names the argument you wrote and the two rewrites that compute
   it, collecting first and selecting the columns you need before you collect.
   Which expressions this reaches is Arrow's to decide and moves with its
-  version, so no list is given: today it is a group collapsed into a single
-  value, an extraction that depends on row order, a subset inside an aggregate,
-  and a statistic over two columns at once. Ordinary numeric summaries, and
-  arithmetic over them, are unaffected and stay lazy, and an Arrow dataset
-  keeps raising Arrow's own error for the same expressions.
+  version; `?summarize_with_margins` describes the shapes. Ordinary numeric
+  summaries, and arithmetic over them, are unaffected and stay lazy, and an
+  Arrow dataset keeps raising Arrow's own error for the same expressions.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/NEWS.md
+++ b/NEWS.md
@@ -121,6 +121,18 @@
 * Backend detection now validates the documented Arrow and dtplyr minimum
   versions, centralizes backend capabilities, and reports incompatible dbplyr
   query representations explicitly.
+* A summary Arrow's own engine cannot evaluate is now refused, before any row
+  is read, instead of failing with `object of type 'special' is not
+  subsettable`. Arrow answers such an expression by reading the whole input —
+  every column, not only the ones the summary names — and computing it in R;
+  the refusal names the argument you wrote and the two rewrites that compute
+  it, collecting first and selecting the columns you need before you collect.
+  Which expressions this reaches is Arrow's to decide and moves with its
+  version, so no list is given: today it is a group collapsed into a single
+  value, an extraction that depends on row order, a subset inside an aggregate,
+  and a statistic over two columns at once. Ordinary numeric summaries, and
+  arithmetic over them, are unaffected and stay lazy, and an Arrow dataset
+  keeps raising Arrow's own error for the same expressions.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,10 +134,9 @@
   What this replaces depends on your Arrow. From arrow 17.0.0 such a call
   aborted with `object of type 'special' is not subsettable`, an error carrying
   no class of its own and naming nothing you wrote. Through arrow 16.0.0 it
-  returned the right answer,
-  having read the whole input to get it — so on those versions this is a
-  breaking change, and the rewrites the refusal names reproduce the old result
-  while letting you choose what is read.
+  returned the right answer, having read the whole input to get it — so on
+  those versions this is a breaking change, and the rewrites the refusal names
+  reproduce the old result while letting you choose what is read.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -284,7 +284,15 @@ summarize_margin_branch <- function(.data,
     }
   )
 
-  if (!is.data.frame(.data) && is.data.frame(result)) {
+  # Scoped as the handler is, and for the same reason: the refusal names Arrow,
+  # so an input Arrow does not hold must not reach it. A lazy input of another
+  # backend that answered with a local frame would be a defect in that backend
+  # or in this adapter, not an absorption, and misattributing it to Arrow is
+  # the one thing worse than not reporting it -- the shape ADR 0015 removes.
+  absorbed <- inherits(.data, arrow_input_classes()) &&
+    !is.data.frame(.data) &&
+    is.data.frame(result)
+  if (absorbed) {
     abort_absorbed_summary(caller_labels)
   }
   result

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -266,10 +266,13 @@ abort_absorbed_summary <- function(labels) {
 # bounded at one branch, because a Margin operation evaluates the caller's
 # expression once per grouping set and this stops at the first.
 #
-# The guard raises the refusal rather than an internal invariant (ADR 0015),
-# although what it reports is a defect. A caller reaching it can act on it, and
-# the action is the one the refusal already names; making them read a bug report
-# instead would move the cost of marginplyr's drift onto them. The maintainer's
+# Over an Arrow input the guard raises the refusal rather than an internal
+# invariant (ADR 0015), although what it reports is a defect. A caller reaching
+# it can act on it, and the action is the one the refusal already names; making
+# them read a bug report instead would move the cost of marginplyr's drift onto
+# them. It has a second arm, for every other lazy backend, where that reasoning
+# inverts and an invariant is what the caller should get; the comment on the
+# guard itself is where that sits, and ADR 0025 records both. The maintainer's
 # signal is `test-query-policy.R`, which fails when a read happens at all.
 summarize_margin_branch <- function(.data,
                                     ...,

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -171,12 +171,16 @@ absorbed_expression_label <- function(expr) {
 # through Arrow 16.0.0 named the offending expression inside a sentence rather
 # than on a line of its own, so every version below 17.0.0 takes the degradation
 # below rather than placing the blame on one argument.
+#
+# `[1L]` and not `[[1L]]`, which is what lets a message holding no lines at all
+# take that same route rather than a guard of its own: `character(0)[1L]` is
+# `NA_character_`, and the pattern matches that no better than it matches a
+# sentence. A guard would have been a branch nothing reaches, the handler being
+# unable to deliver an empty message -- it matches no marker -- and a branch
+# nothing executes is one nothing asserts.
 absorbing_warning_label <- function(cnd) {
-  lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
-  if (length(lines) == 0L) {
-    return(NA_character_)
-  }
-  matched <- regmatches(lines[[1L]], regexec("^In (.*): *$", lines[[1L]]))[[1L]]
+  first <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]][1L]
+  matched <- regmatches(first, regexec("^In (.*): *$", first))[[1L]]
   if (length(matched) == 2L) matched[[2L]] else NA_character_
 }
 

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -135,10 +135,10 @@ is_absorbing_backend_warning <- function(cnd, .data) {
   if (!inherits(.data, arrow_input_classes())) {
     return(FALSE)
   }
-  message <- conditionMessage(cnd)
-  is.character(message) &&
-    length(message) == 1L &&
-    grepl(absorbing_warning_marker(), message, ignore.case = TRUE)
+  text <- conditionMessage(cnd)
+  is.character(text) &&
+    length(text) == 1L &&
+    grepl(absorbing_warning_marker(), text, ignore.case = TRUE)
 }
 
 # The label Arrow writes an absorbed expression by, reproduced so that the
@@ -284,16 +284,28 @@ summarize_margin_branch <- function(.data,
     }
   )
 
-  # Scoped as the handler is, and for the same reason: the refusal names Arrow,
-  # so an input Arrow does not hold must not reach it. A lazy input of another
-  # backend that answered with a local frame would be a defect in that backend
-  # or in this adapter, not an absorption, and misattributing it to Arrow is
-  # the one thing worse than not reporting it -- the shape ADR 0015 removes.
-  absorbed <- inherits(.data, arrow_input_classes()) &&
-    !is.data.frame(.data) &&
-    is.data.frame(result)
-  if (absorbed) {
-    abort_absorbed_summary(caller_labels)
+  # A lazy input whose branch came back local was read, and both arms of this
+  # are that one fact. Which arm depends on who did the reading, because ADR
+  # 0015 sorts a condition by what the caller can do about it rather than by
+  # what happened: an Arrow input absorbing is something they can rewrite, and
+  # the refusal names the rewrites; any other backend answering a lazy input
+  # with a local frame is a defect here or there, which no rewrite of their
+  # call avoids. Attributing the second to Arrow would be worse than not
+  # reporting it -- a diagnostic that misdirects, over a defect.
+  #
+  # The second arm is also what catches a branch list that is part local and
+  # part lazy, which `combine_margin_branches()` does not: a lazy-first mix is
+  # accepted by `union_all()` and collects to the combined rows.
+  if (!is.data.frame(.data) && is.data.frame(result)) {
+    if (inherits(.data, arrow_input_classes())) {
+      abort_absorbed_summary(caller_labels)
+    }
+    stop(
+      "A lazy input produced a local summary branch, which no backend does.\n",
+      "Branch class: ",
+      toString(class(result)),
+      call. = FALSE
+    )
   }
   result
 }

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -122,7 +122,19 @@ absorbing_warning_marker <- function() {
   "pulling data into R"
 }
 
-is_absorbing_backend_warning <- function(cnd) {
+# `.data` decides as well as the text, because the text alone answers for a
+# warning marginplyr did not cause: a caller's own summary expression may spell
+# anything, and a refusal naming Arrow raised over a `dtplyr` input would be
+# wrong twice over. The class list is `R/grouping-backend.R`'s, so the two
+# readings cannot disagree about what an Arrow input is.
+#
+# `conditionMessage()` is checked for shape before it is matched: a condition
+# class of another package's may carry a message method returning anything, and
+# `grepl()` over a vector would answer for whichever element matched.
+is_absorbing_backend_warning <- function(cnd, .data) {
+  if (!inherits(.data, arrow_input_classes())) {
+    return(FALSE)
+  }
   message <- conditionMessage(cnd)
   is.character(message) &&
     length(message) == 1L &&
@@ -165,10 +177,20 @@ absorbing_warning_label <- function(cnd) {
 # from names one argument; a warning it cannot names them all, which is also
 # what the backstop below has to do, having no warning to read.
 absorbed_summary_labels <- function(cnd, dots, caller_labels) {
+  # The same invariant `branch_argument_map()` opens with, for the same reason
+  # (ADR-0015): the pair is parallel, and a misaligned one would quote one
+  # argument's expression under another argument's name -- which is the ADR
+  # 0024 failure this plumbing exists to prevent, arriving silently.
+  stopifnot(length(dots) == length(caller_labels))
+
   blamed <- absorbing_warning_label(cnd)
   if (is.na(blamed) || length(dots) == 0L) {
     return(caller_labels)
   }
+  # Not `summary_argument_labels()`, which spells `name = expr` with
+  # `rlang::as_label()`. What has to be recognised here is Arrow's spelling of
+  # the expression alone, and the two conventions disagree in exactly the
+  # places ADR 0022 records.
   labels <- vapply(
     dots,
     function(dot) {
@@ -254,7 +276,7 @@ summarize_margin_branch <- function(.data,
       .by = dplyr::all_of(.by)
     )),
     warning = function(cnd) {
-      if (is_absorbing_backend_warning(cnd)) {
+      if (is_absorbing_backend_warning(cnd, .data)) {
         abort_absorbed_summary(
           absorbed_summary_labels(cnd, dots, caller_labels)
         )

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -1,5 +1,9 @@
-# The `UNION ALL` composition every branch list ends in, and the one place the
-# package combines branches. `Reduce(dplyr::union_all, branches)` is
+# The portable adapter: the `UNION ALL` composition every branch list ends in,
+# the one place the package combines branches, and -- because it is also the one
+# place the caller's own summary expressions are handed to a backend once per
+# grouping set -- where a backend that would absorb one is refused (ADR 0025).
+#
+# `Reduce(dplyr::union_all, branches)` is
 # quadratic in the number of branches (#111): on an eager backend each step
 # re-copies the accumulated frame, and on a lazy one dbplyr re-aligns every
 # branch already folded in against the branch being added. The count is 2^n for
@@ -96,7 +100,17 @@ union_margin_branches <- function(branches) {
 # class of its own, no `$parent`, and no `$call` -- it is an `rlang_warning`
 # holding one rendered string -- so there is nothing else to key on.
 #
-# That is undocumented behaviour of another package, and it is depended on the
+# It is matched without regard to case, and that is a version range rather than
+# caution. `DESCRIPTION` admits `arrow (>= 13.0.0)`, and Arrow rewrote this
+# warning between 16.0.0 and 17.0.0: through 16.0.0 it was
+# `warning(msg, "; pulling data into R")`, and from 17.0.0 it is an rlang
+# warning whose body ends `"Pulling data into R"`. What survived the rewrite is
+# the phrase and not its capitalisation, so matching the capitalised spelling
+# alone left the refusal switched off for four of the versions this package
+# says it supports, where Arrow absorbs exactly as it does on the newest
+# (`investigation/what-arrow-does-with-an-untranslatable-summary.md`).
+#
+# This is undocumented behaviour of another package, and it is depended on the
 # way `AGENTS.md` depends on roxygen's treatment of a markdown table row: by
 # gating it. `test-grouping-backends.R` asserts that Arrow still absorbs the two
 # expressions the refusal is asserted over and still marks the absorption with
@@ -105,14 +119,14 @@ union_margin_branches <- function(branches) {
 # the marker the handler reads, and so that taking it away is how the backstop
 # below is reached in a test.
 absorbing_warning_marker <- function() {
-  "Pulling data into R"
+  "pulling data into R"
 }
 
 is_absorbing_backend_warning <- function(cnd) {
   message <- conditionMessage(cnd)
   is.character(message) &&
     length(message) == 1L &&
-    grepl(absorbing_warning_marker(), message, fixed = TRUE)
+    grepl(absorbing_warning_marker(), message, ignore.case = TRUE)
 }
 
 # The label Arrow writes an absorbed expression by, reproduced so that the
@@ -132,8 +146,12 @@ absorbed_expression_label <- function(expr) {
   if (length(lines) > 1L) paste0(lines[[1L]], "...") else lines[[1L]]
 }
 
-# The expression Arrow blamed, read off the line its warning opens with.
-absorbing_warning_expression <- function(cnd) {
+# The label Arrow blamed, read off the line its warning opens with. `NA` where
+# the warning does not open with one, which is not a hypothetical: the phrasing
+# through Arrow 16.0.0 named the offending expression inside a sentence rather
+# than on a line of its own, so every version below 17.0.0 takes the degradation
+# below rather than placing the blame on one argument.
+absorbing_warning_label <- function(cnd) {
   lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
   if (length(lines) == 0L) {
     return(NA_character_)
@@ -147,7 +165,7 @@ absorbing_warning_expression <- function(cnd) {
 # from names one argument; a warning it cannot names them all, which is also
 # what the backstop below has to do, having no warning to read.
 absorbed_summary_labels <- function(cnd, dots, caller_labels) {
-  blamed <- absorbing_warning_expression(cnd)
+  blamed <- absorbing_warning_label(cnd)
   if (is.na(blamed) || length(dots) == 0L) {
     return(caller_labels)
   }
@@ -169,12 +187,20 @@ absorbed_summary_labels <- function(cnd, dots, caller_labels) {
 # whole of what refusing buys the caller: an absorbed summary reads every
 # column of the input, including the ones it does not use, and a caller who is
 # told can read fewer. A caller who is not told cannot.
+#
+# The summaries arrive alone in an `i` bullet, per ADR 0023's condition 2: how
+# many of them there are is the caller's decision, since a warning Arrow's
+# older phrasing cannot be placed from names every summary argument rather than
+# one. `cli::qty()` is what carries the count across the split, the refusal
+# left behind inflecting both its noun and its pronoun with the vector gone
+# from the line they sit in -- the same shape as `grouping_helper_vars()`.
 abort_absorbed_summary <- function(labels) {
   abort_marginplyr(c(
     paste0(
-      "{.code {labels}} {?is/are} not {?a summary/summaries} Arrow can ",
-      "evaluate, so Arrow would read the whole input to compute {?it/them}."
+      "{cli::qty(length(labels))}Arrow cannot evaluate {?this summary/these ",
+      "summaries}, so Arrow would read the whole input to compute {?it/them}:"
     ),
+    i = "{.code {labels}}.",
     i = paste0(
       "Collect the Arrow input first, then call ",
       "{.fun summarize_with_margins}."
@@ -196,9 +222,9 @@ abort_absorbed_summary <- function(labels) {
 #
 # `caller_labels` is `new_summary_arguments()`'s, parallel to `dots`, and is
 # what makes the refusal name what the caller wrote rather than what the branch
-# rewrote. A direct call passing none is answered from the branch's own dots,
-# which is the same statement `summarize_margin_union()` makes by leaving the
-# blamed call alone when it has no verb to name.
+# rewrote. It is required rather than defaulted: the branch's own dots are the
+# rewritten ones, so a default computed from them would answer with a spelling
+# ADR 0024 forbids, silently, at whichever call site forgot to pass the labels.
 #
 # Two things can raise the refusal and they fail in opposite directions, which
 # is why both are here. The handler reads Arrow's warning, which is raised
@@ -218,13 +244,8 @@ abort_absorbed_summary <- function(labels) {
 summarize_margin_branch <- function(.data,
                                     ...,
                                     .by,
-                                    caller_labels = NULL) {
+                                    caller_labels) {
   dots <- rlang::enquos(...)
-  labels <- if (is.null(caller_labels)) {
-    summary_argument_labels(dots)
-  } else {
-    caller_labels
-  }
 
   result <- withCallingHandlers(
     rlang::inject(dplyr::summarize(
@@ -234,13 +255,15 @@ summarize_margin_branch <- function(.data,
     )),
     warning = function(cnd) {
       if (is_absorbing_backend_warning(cnd)) {
-        abort_absorbed_summary(absorbed_summary_labels(cnd, dots, labels))
+        abort_absorbed_summary(
+          absorbed_summary_labels(cnd, dots, caller_labels)
+        )
       }
     }
   )
 
   if (!is.data.frame(.data) && is.data.frame(result)) {
-    abort_absorbed_summary(labels)
+    abort_absorbed_summary(caller_labels)
   }
   result
 }

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -112,12 +112,20 @@ union_margin_branches <- function(branches) {
 #
 # This is undocumented behaviour of another package, and it is depended on the
 # way `AGENTS.md` depends on roxygen's treatment of a markdown table row: by
-# gating it. `test-grouping-backends.R` asserts that Arrow still absorbs the two
+# gating it. `test-grouping-backends.R` asserts that Arrow still absorbs the
 # expressions the refusal is asserted over and still marks the absorption with
 # this text, so a re-wording fails there rather than silently switching the
-# refusal off. It is a function rather than a constant so that the gate reads
-# the marker the handler reads, and so that taking it away is how the backstop
-# below is reached in a test.
+# refusal off. It is a function rather than a constant so that taking it away
+# is how the backstop below is reached in a test.
+#
+# The gate calls `is_absorbing_backend_warning()` rather than matching this
+# marker a second time of its own, and that is the difference between gating
+# the reading and gating a copy of it: a second match answers for its own
+# spelling, so it would go on reporting Arrow as marking the absorption after
+# the handler had stopped recognising it. Which leaves one thing the gate
+# cannot see, since it holds one Arrow and the case difference above spans two
+# -- so the reading is asserted on both phrasings beside it, over synthesised
+# warnings.
 absorbing_warning_marker <- function() {
   "pulling data into R"
 }

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -91,14 +91,158 @@ union_margin_branches <- function(branches) {
   branches[[1L]]
 }
 
+# The text an Absorbing backend marks an absorption with, which is the whole of
+# what a backend can be recognised as absorbing by. Arrow's warning carries no
+# class of its own, no `$parent`, and no `$call` -- it is an `rlang_warning`
+# holding one rendered string -- so there is nothing else to key on.
+#
+# That is undocumented behaviour of another package, and it is depended on the
+# way `AGENTS.md` depends on roxygen's treatment of a markdown table row: by
+# gating it. `test-grouping-backends.R` asserts that Arrow still absorbs the two
+# expressions the refusal is asserted over and still marks the absorption with
+# this text, so a re-wording fails there rather than silently switching the
+# refusal off. It is a function rather than a constant so that the gate reads
+# the marker the handler reads, and so that taking it away is how the backstop
+# below is reached in a test.
+absorbing_warning_marker <- function() {
+  "Pulling data into R"
+}
+
+is_absorbing_backend_warning <- function(cnd) {
+  message <- conditionMessage(cnd)
+  is.character(message) &&
+    length(message) == 1L &&
+    grepl(absorbing_warning_marker(), message, fixed = TRUE)
+}
+
+# The label Arrow writes an absorbed expression by, reproduced so that the
+# expression marginplyr handed it can be recognised in the warning it rendered.
+# Arrow deparses the expression, keeps the first line, and marks a longer one
+# with a trailing ellipsis -- which is neither `rlang::as_label()` nor a whole
+# `deparse()`.
+#
+# The convention is reproduced rather than the internal called, which is ADR
+# 0022's rule and its reason: an internal that changed would disagree silently,
+# while a convention that changed stops matching, and a label that matches
+# nothing is what sends the refusal to name every summary argument instead of
+# one. That degradation is the same one ADR 0022 accepts for a span it cannot
+# place.
+absorbed_expression_label <- function(expr) {
+  lines <- deparse(expr)
+  if (length(lines) > 1L) paste0(lines[[1L]], "...") else lines[[1L]]
+}
+
+# The expression Arrow blamed, read off the line its warning opens with.
+absorbing_warning_expression <- function(cnd) {
+  lines <- strsplit(conditionMessage(cnd), "\n", fixed = TRUE)[[1L]]
+  if (length(lines) == 0L) {
+    return(NA_character_)
+  }
+  matched <- regmatches(lines[[1L]], regexec("^In (.*): *$", lines[[1L]]))[[1L]]
+  if (length(matched) == 2L) matched[[2L]] else NA_character_
+}
+
+# Which summaries the refusal names, spelled as the caller spelled them (ADR
+# 0024). Arrow blames one expression at a time, so a warning it can be placed
+# from names one argument; a warning it cannot names them all, which is also
+# what the backstop below has to do, having no warning to read.
+absorbed_summary_labels <- function(cnd, dots, caller_labels) {
+  blamed <- absorbing_warning_expression(cnd)
+  if (is.na(blamed) || length(dots) == 0L) {
+    return(caller_labels)
+  }
+  labels <- vapply(
+    dots,
+    function(dot) {
+      expr <- if (rlang::is_quosure(dot)) rlang::quo_get_expr(dot) else dot
+      absorbed_expression_label(expr)
+    },
+    character(1),
+    USE.NAMES = FALSE
+  )
+  matched <- which(labels == blamed)
+  if (length(matched) == 1L) caller_labels[matched] else caller_labels
+}
+
+# The refusal an Absorbing backend earns, and the reason ADR 0025 chose it over
+# letting the backend absorb. Both rewrites are given because the second is the
+# whole of what refusing buys the caller: an absorbed summary reads every
+# column of the input, including the ones it does not use, and a caller who is
+# told can read fewer. A caller who is not told cannot.
+abort_absorbed_summary <- function(labels) {
+  abort_marginplyr(c(
+    paste0(
+      "{.code {labels}} {?is/are} not {?a summary/summaries} Arrow can ",
+      "evaluate, so Arrow would read the whole input to compute {?it/them}."
+    ),
+    i = paste0(
+      "Collect the Arrow input first, then call ",
+      "{.fun summarize_with_margins}."
+    ),
+    i = paste0(
+      "Select the columns you need before collecting. Arrow reads every ",
+      "column of the input, including the ones a summary does not use."
+    )
+  ))
+}
+
+# The caller's expressions are spliced into the `summarize()` call rather than
+# forwarded through `...`, which is the shape `grouping-adapter-native.R`
+# already uses. Arrow recovers the originating call from its own frame with
+# `match.call()`, and a `...`-forwarding wrapper is the one shape it cannot be
+# recovered from: the lookup falls through to `base::call`, and subsetting an
+# object of type `"special"` raises an untyped error where the backend's own
+# answer belonged (#254).
+#
+# `caller_labels` is `new_summary_arguments()`'s, parallel to `dots`, and is
+# what makes the refusal name what the caller wrote rather than what the branch
+# rewrote. A direct call passing none is answered from the branch's own dots,
+# which is the same statement `summarize_margin_union()` makes by leaving the
+# blamed call alone when it has no verb to name.
+#
+# Two things can raise the refusal and they fail in opposite directions, which
+# is why both are here. The handler reads Arrow's warning, which is raised
+# before the collect, so nothing is read; if the marker ever stops matching it
+# does not fire at all. The guard reads the result's class, which cannot stop
+# matching, but only after the branch has run. Between them the contract holds
+# whichever way Arrow moves: the handler is what keeps the read from happening,
+# and the guard is what keeps an absorbed result from ever being returned --
+# bounded at one branch, because a Margin operation evaluates the caller's
+# expression once per grouping set and this stops at the first.
+#
+# The guard raises the refusal rather than an internal invariant (ADR 0015),
+# although what it reports is a defect. A caller reaching it can act on it, and
+# the action is the one the refusal already names; making them read a bug report
+# instead would move the cost of marginplyr's drift onto them. The maintainer's
+# signal is `test-query-policy.R`, which fails when a read happens at all.
 summarize_margin_branch <- function(.data,
                                     ...,
-                                    .by) {
-  dplyr::summarize(
-    .data = .data,
-    ...,
-    .by = dplyr::all_of(.by)
+                                    .by,
+                                    caller_labels = NULL) {
+  dots <- rlang::enquos(...)
+  labels <- if (is.null(caller_labels)) {
+    summary_argument_labels(dots)
+  } else {
+    caller_labels
+  }
+
+  result <- withCallingHandlers(
+    rlang::inject(dplyr::summarize(
+      .data = .data,
+      !!!dots,
+      .by = dplyr::all_of(.by)
+    )),
+    warning = function(cnd) {
+      if (is_absorbing_backend_warning(cnd)) {
+        abort_absorbed_summary(absorbed_summary_labels(cnd, dots, labels))
+      }
+    }
   )
+
+  if (!is.data.frame(.data) && is.data.frame(result)) {
+    abort_absorbed_summary(labels)
+  }
+  result
 }
 
 # A literal recycles to whatever the branch holds, which is the whole of the
@@ -201,7 +345,8 @@ summarize_margin_union <- function(.data,
         summarize_margin_branch(
           .data = .data,
           !!!branch_dots,
-          .by = unname(key_names[grouping_set])
+          .by = unname(key_names[grouping_set]),
+          caller_labels = summaries$labels
         ),
         conditions = conditions,
         restatements = branch_argument_map(branch_dots, summaries$labels)

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -1,10 +1,16 @@
+# Named because two readings need it and a second copy of the vector is what
+# would drift: the kind below, and the branch summary's Absorbing-backend
+# handler, which has only `.data` to decide from and must not answer for a
+# warning some other backend raised (ADR 0025). `RecordBatchReader` is
+# deliberately absent, as it is from the kind: no verb accepts one.
+arrow_input_classes <- function() {
+  c("arrow_dplyr_query", "Table", "RecordBatch", "Dataset")
+}
+
 grouping_backend <- function(.data) {
   is_local <- is.data.frame(.data)
   is_dtplyr <- inherits(.data, "dtplyr_step")
-  is_arrow <- inherits(
-    .data,
-    c("arrow_dplyr_query", "Table", "RecordBatch", "Dataset")
-  )
+  is_arrow <- inherits(.data, arrow_input_classes())
   is_sql <- inherits(.data, "tbl_lazy") && !is_dtplyr && !is_arrow
 
   dialect <- if (is_sql) {

--- a/R/share.R
+++ b/R/share.R
@@ -390,8 +390,10 @@
 #' Margin-operation validation but before constructing a summary query. The
 #' reason belongs to the source summary they share, so it applies to both, and
 #' the diagnostic names whichever helpers the call used. Other Arrow Margin
-#' operations remain supported and lazy. Explicitly collect an Arrow input
-#' first when local share execution is appropriate.
+#' operations remain supported and lazy, apart from a summary Arrow's own
+#' engine cannot evaluate, which is refused for its own reason and before any
+#' row is read; see [summarize_with_margins()]. Explicitly collect an Arrow
+#' input first when local share execution is appropriate.
 #'
 #' A `dtplyr` step remains a native lazy query: no validation-only query is
 #' added and nothing is collected on your behalf. Its execution-time

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -109,6 +109,22 @@
 #' column in the result -- one summary, one fixed key, one grouping dimension,
 #' or `.id` -- ends the difference.
 #'
+#' One summary an Arrow table or record batch cannot carry is one Arrow's own
+#' engine cannot evaluate. Arrow answers such an expression by reading the
+#' whole input -- every column of it, not only the ones the summary names --
+#' and computing it in R. marginplyr refuses it instead, before a row is read,
+#' and names the two rewrites that compute it: collect the input first, and
+#' select the columns the summary needs before collecting, which is the
+#' narrowing Arrow's own route cannot do for you.
+#'
+#' Which expressions those are is Arrow's to decide and moves with its version,
+#' so they are not listed here. The shapes refused today are a group collapsed
+#' into a single value, such as pasting one, an extraction that depends on row
+#' order, a subset written inside an aggregate, and a statistic over two
+#' columns at once; ordinary numeric summaries, and arithmetic over them, are
+#' evaluated by Arrow and stay lazy. An Arrow dataset raises Arrow's own
+#' refusal for the same expressions, and is otherwise unaffected.
+#'
 #' @section Fixed columns and grouping dimensions:
 #' `.by` marks columns that are present in every grouping set, while
 #' `.grouping` describes dimensions that can be omitted to form margins.
@@ -393,8 +409,10 @@
 #'
 #' Arrow inputs reject both after expression planning and common
 #' Margin-operation validation but before constructing a summary query. Other
-#' Arrow Margin operations remain supported and lazy. Explicitly collect an
-#' Arrow input first when local share execution is appropriate.
+#' Arrow Margin operations remain supported and lazy, apart from a summary
+#' Arrow's own engine cannot evaluate, which is refused for its own reason and
+#' before any row is read. Explicitly collect an Arrow input first when local
+#' share execution is appropriate.
 #'
 #' A row that is its own denominator receives `1.0`. Missing numerators or
 #' denominators and zero denominators receive `NA_real_`; other finite ratios

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -110,22 +110,21 @@
 #' or `.id` -- ends the difference.
 #'
 #' One summary an Arrow table or record batch cannot carry -- or a query built
-#' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such
-#' an expression by reading the
-#' whole input -- every column of it, not only the ones the summary names --
-#' and computing it in R. marginplyr refuses it instead, before a row is read,
-#' and names the two rewrites that compute it: collect the input first, and
-#' select the columns the summary needs before collecting, which is the
-#' narrowing Arrow's own route cannot do for you.
+#' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an
+#' expression by reading the whole input -- every column of it, not only the
+#' ones the summary names -- and computing it in R. marginplyr refuses it
+#' instead, before a row is read, and names the two rewrites that compute it:
+#' collect the input first, and select the columns the summary needs before
+#' collecting, which is the narrowing Arrow's own route cannot do for you.
 #'
 #' Which expressions those are is Arrow's to decide and moves with its version,
-#' so they are not listed here. The shapes refused today are a group collapsed
-#' into a single value, such as pasting one, an extraction that depends on row
-#' order, a subset written inside an aggregate, and a statistic over two
-#' columns at once; ordinary numeric summaries, and arithmetic over them, are
-#' evaluated by Arrow and stay lazy. An Arrow dataset, and a query built on
-#' one, raise Arrow's own refusal for the same expressions instead, because a
-#' dataset never reads itself into R; they are otherwise unaffected.
+#' so they are not listed here. Among the shapes refused are a group collapsed
+#' into a single value, such as pasting one, a subset written inside an
+#' aggregate, and a statistic over two columns at once; ordinary numeric
+#' summaries, and arithmetic over them, are evaluated by Arrow and stay lazy.
+#' An Arrow dataset, and a query built on one, raise Arrow's own refusal for
+#' the same expressions instead, because a dataset never reads itself into R;
+#' they are otherwise unaffected.
 #'
 #' @section Fixed columns and grouping dimensions:
 #' `.by` marks columns that are present in every grouping set, while

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -109,8 +109,9 @@
 #' column in the result -- one summary, one fixed key, one grouping dimension,
 #' or `.id` -- ends the difference.
 #'
-#' One summary an Arrow table or record batch cannot carry is one Arrow's own
-#' engine cannot evaluate. Arrow answers such an expression by reading the
+#' One summary an Arrow table or record batch cannot carry -- or a query built
+#' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such
+#' an expression by reading the
 #' whole input -- every column of it, not only the ones the summary names --
 #' and computing it in R. marginplyr refuses it instead, before a row is read,
 #' and names the two rewrites that compute it: collect the input first, and
@@ -122,8 +123,9 @@
 #' into a single value, such as pasting one, an extraction that depends on row
 #' order, a subset written inside an aggregate, and a statistic over two
 #' columns at once; ordinary numeric summaries, and arithmetic over them, are
-#' evaluated by Arrow and stay lazy. An Arrow dataset raises Arrow's own
-#' refusal for the same expressions, and is otherwise unaffected.
+#' evaluated by Arrow and stay lazy. An Arrow dataset, and a query built on
+#' one, raise Arrow's own refusal for the same expressions instead, because a
+#' dataset never reads itself into R; they are otherwise unaffected.
 #'
 #' @section Fixed columns and grouping dimensions:
 #' `.by` marks columns that are present in every grouping set, while

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -46,11 +46,12 @@ justification covering both would be false of one of them:
    question could not be put here, and the share is refused.
 
 The predicate for "no external system is involved" is `is.data.frame(.data)`,
-and it is exact rather than an approximation of cheapness. Nothing
+and it is conservative rather than an approximation of cheapness. Nothing
 `grouping_backend()` reads distinguishes a local DuckDB file from a hosted
-DuckDB service, an in-memory Arrow table from a dataset in object storage, RDS
-PostgreSQL from Aurora Standard, or SQLite from BigQuery; the first of each
-pair charges nothing per query and the second may charge for every read.
+DuckDB service, RDS PostgreSQL from Aurora Standard, or SQLite from BigQuery;
+the first of each pair charges nothing per query and the second may charge for
+every read. It was written "exact" and given a fourth pair that does not hold;
+the amendment below corrects both.
 
 One rule sets every default: **a check that reads the caller's data is asked
 for, and a check that does not is not.**
@@ -99,6 +100,36 @@ A connection that *cannot be asked* — a `dbplyr::simulate_*()` one, which
 executes nothing — records nothing, precisely so that a live connection
 carrying the same dialect does not inherit it. A transient failure on a live
 connection belongs on that side of the line.
+
+## Amendment: the predicate is conservative, and one Arrow pair was wrong
+
+The rule, the exemptions, and the predicate are unchanged. What is withdrawn is
+a claim made in support of the predicate: that nothing `grouping_backend()`
+reads tells an in-memory Arrow table from a dataset in object storage. It does.
+`inherits()` already separates `Table` and `RecordBatch` from `Dataset` there,
+and Arrow's own reading of a query's source separates a query over one from a
+query over the other, so all five Arrow shapes are told apart from the object
+alone (#254). A `Table` is in this process's memory by definition, and there is
+no remote one for it to be confused with.
+
+The consequence is that "exact" was too strong for the predicate as a whole.
+`is.data.frame(.data)` is `FALSE` for an in-memory Arrow table, where no
+external system is involved, so it answers conservatively there rather than
+exactly. Conservative is the right direction and the predicate stands: the
+three pairs left above are genuinely indistinguishable, a rule that tracks four
+vendors' pricing pages is the option this ADR already rejected, and widening
+the predicate to admit a class as local would be a claim about a vendor's
+product made from an R class.
+
+What the correction costs is an argument, not a rule. ADR 0025 refuses a summary
+an Absorbing backend would read the caller's input to compute, and it cannot be
+justified by this ADR's cost reasoning, because the inputs that absorb are
+exactly the ones no external system is involved in. It rests on this ADR's other
+half instead — that when the caller's data is read is the caller's to decide —
+and on what absorbing takes from them: every column of the input, chosen by
+nobody. Leaving the sentence uncorrected would have made that argument look
+available when it is not, which is the whole reason a supporting claim is worth
+correcting on its own.
 
 ## Considered options
 
@@ -167,6 +198,8 @@ stands and only its cost justification is withdrawn. ADR 0012's factor contract
 is what exemption 1 protects. ADR 0014 selects the per-kind entry that reads
 the source, and is amended separately too: its two lookups stand, but the
 second no longer selects a sampler, because there is nothing left to sample.
+ADR 0025 applies this decision's other half to a read this package does not
+issue, and is what the amendment above was written for.
 
 Evidence: `investigation/query-cost-across-lazy-backends.md` and
 `investigation/share-source-eligibility-on-coercing-dialects.md`.

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -46,12 +46,16 @@ justification covering both would be false of one of them:
    question could not be put here, and the share is refused.
 
 The predicate for "no external system is involved" is `is.data.frame(.data)`,
-and it is conservative rather than an approximation of cheapness. Nothing
+and it is exact rather than an approximation of cheapness. Nothing
 `grouping_backend()` reads distinguishes a local DuckDB file from a hosted
-DuckDB service, RDS PostgreSQL from Aurora Standard, or SQLite from BigQuery;
-the first of each pair charges nothing per query and the second may charge for
-every read. It was written "exact" and given a fourth pair that does not hold;
-the amendment below corrects both.
+DuckDB service, an in-memory Arrow table from a dataset in object storage, RDS
+PostgreSQL from Aurora Standard, or SQLite from BigQuery; the first of each
+pair charges nothing per query and the second may charge for every read.
+
+*Two claims in that paragraph no longer describe the code: "exact", and the
+Arrow pair. The amendment* Two of the four pairs, and the word exact *below
+corrects them; the paragraph is left as it was written, as ADR 0014's amendment
+leaves the text it supersedes.*
 
 One rule sets every default: **a check that reads the caller's data is asked
 for, and a check that does not is not.**
@@ -101,11 +105,12 @@ executes nothing — records nothing, precisely so that a live connection
 carrying the same dialect does not inherit it. A transient failure on a live
 connection belongs on that side of the line.
 
-## Amendment: the predicate is conservative, and one Arrow pair was wrong
+## Amendment: two of the four pairs, and the word exact
 
 The rule, the exemptions, and the predicate are unchanged. What is withdrawn is
-a claim made in support of the predicate: that nothing `grouping_backend()`
-reads tells an in-memory Arrow table from a dataset in object storage. It does.
+a claim made in support of the predicate, in the paragraph above beginning "The
+predicate for": that nothing `grouping_backend()` reads tells an in-memory Arrow
+table from a dataset in object storage. It does.
 `inherits()` already separates `Table` and `RecordBatch` from `Dataset` there,
 and Arrow's own reading of a query's source separates a query over one from a
 query over the other, so all five Arrow shapes are told apart from the object

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -110,12 +110,17 @@ connection belongs on that side of the line.
 The rule, the exemptions, and the predicate are unchanged. What is withdrawn is
 a claim made in support of the predicate, in the paragraph above beginning "The
 predicate for": that nothing `grouping_backend()` reads tells an in-memory Arrow
-table from a dataset in object storage. It does.
-`inherits()` already separates `Table` and `RecordBatch` from `Dataset` there,
-and Arrow's own reading of a query's source separates a query over one from a
-query over the other, so all five Arrow shapes are told apart from the object
-alone (#254). A `Table` is in this process's memory by definition, and there is
-no remote one for it to be confused with.
+table from a dataset in object storage. It does — what it reads is the class
+attribute, and `Table` and `RecordBatch` are different values of it from
+`Dataset`. What that site does with them is a separate matter, and the reason
+this is a withdrawn claim rather than a changed line: `grouping_backend()`
+collapses all four into one `is_arrow`, because one backend kind is the right
+answer for the question it asks. The distinction is available to it and it
+declines to draw it, which is not the same as its being unavailable. Arrow's own
+reading of a query's source separates a query over a table from a query over a
+dataset, so all five Arrow shapes are told apart from the object alone (#254). A
+`Table` is in this process's memory by definition, and there is no remote one
+for it to be confused with.
 
 The consequence is that "exact" was too strong for the predicate as a whole.
 `is.data.frame(.data)` is `FALSE` for an in-memory Arrow table, where no

--- a/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
+++ b/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
@@ -115,9 +115,16 @@ the caller, who would be handed a bug report in place of a remedy they have.
 
 The pages that claim Arrow summaries are supported and lazy say what is refused
 and why, and say that which expressions are affected is decided by the backend's
-version. They do not enumerate them. A list would be a claim about one version of
-Arrow, and `DESCRIPTION` admits a range; the same reasoning keeps every other
-gate in `AGENTS.md` derived rather than listed.
+version.
+
+They do not name the functions. A list of those would be a claim about one
+version of Arrow, and `DESCRIPTION` admits a range; the same reasoning keeps
+every other gate in `AGENTS.md` derived rather than listed. What the reference
+does describe is the *shapes* refused, which is what a caller can recognise
+their own expression in, and every shape it names is covered by the gate above —
+a page that stopped being true fails a test rather than being re-read. The
+vignette and `NEWS.md` point at the reference rather than repeating the
+description, so an Arrow release that moves one shape is a one-page edit.
 
 `?marginplyr` is unchanged. Nothing a caller catches is new: an absorbed summary
 raises the promised `marginplyr_error`, and an Arrow dataset's refusal keeps
@@ -153,3 +160,9 @@ the route ruled out above. ADR 0021 governs what a condition raised once per
 grouping set reports, and is untouched: the refusal stops at the first branch, so
 there is nothing repeated to report. ADR 0022 and ADR 0024 are what the refusal
 spells its subject by, and ADR 0023 is the idiom it is authored in.
+
+Evidence: `investigation/what-arrow-does-with-an-untranslatable-summary.md`.
+Everything this decision asserts about Arrow was measured there, including the
+one fact the mechanism turns on that is not visible from the newest release:
+Arrow reworded the warning between 16.0.0 and 17.0.0, and `DESCRIPTION` admits
+both sides of that change.

--- a/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
+++ b/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
@@ -1,0 +1,155 @@
+# Refuse a summary a backend would absorb
+
+A Margin verb refuses a summary expression an Absorbing backend would evaluate
+by reading the caller's input into R, and refuses it before any row is read.
+The refusal is a Package condition naming the argument as the caller spelled it
+and the two rewrites that get the summary computed: collect the input first, and
+select the columns the summary needs before collecting.
+
+CONTEXT.md defines *Absorbing backend* and its opposite. Only Arrow absorbs
+today, and only some Arrow inputs do: an Arrow table, an Arrow record batch, and
+a query over either. An Arrow dataset and a query over one refuse on their own,
+and that refusal is Arrow's answer and propagates as an External condition
+unchanged.
+
+## Why a caller is asked rather than served
+
+Absorbing and refusing reach the same place — the input is materialized and the
+summary is computed in R — and they differ only in who asks for it. That is the
+whole of the decision, and ADR 0020's title is the answer to it.
+
+Two facts decide which side of that line this falls on, and neither is about the
+cost of a query:
+
+**A backend absorbs the whole input, not the part the summary uses.** Arrow
+collects the input as the verb received it, including every column the
+expression does not mention. A caller told to collect can `select()` first, and
+for a wide table that is the difference between materializing two columns and
+two hundred. Nothing about absorbing can be narrowed by the caller, because the
+caller is never consulted.
+
+**The alternative is not cheaper, only quieter.** A caller who collects pays one
+read, which is exactly what a correctly bounded absorption would cost. Refusing
+therefore takes nothing away except the silence.
+
+## What this does not rest on
+
+The obvious argument — that absorbing sends an unrequested query to an external
+system — is not available here, and recording that is the point of this section.
+An input that absorbs is, by class, already in this process's memory; an Arrow
+dataset is the shape that may sit in object storage, and Arrow refuses there
+without being asked to. So the fallback fires exactly where no external system
+is involved, and ADR 0020's cost reasoning reaches none of it. ADR 0020's own
+statement that this distinction cannot be computed is corrected in that ADR,
+because it is what its predicate's exactness was argued from.
+
+What survives is the other half of ADR 0020: a lazy input yields a lazy result,
+and when the caller's data is read is the caller's to decide.
+
+## Why the property is established and not looked up
+
+`grouping_backend()` returns one kind for every Arrow input, and absorbing splits
+that kind in two. So there is no entry in `backend_capabilities()` this could be,
+and adding one would mean a capability table that is wrong for half the inputs it
+covers. The property is read from the backend's own behaviour instead, at the
+moment it would matter.
+
+Nor can it be read from the caller's expression, which is what rules out ADR
+0019's route of deciding by spelling. `sum(v[v > 1])` is refused with `sum` at
+its head and `sum` translatable; a user-written function whose body composes
+translatable operations is itself translatable, so neither the head nor the
+author of a call answers the question. Only the backend can, and only by being
+asked to build the query.
+
+## Considered options
+
+**Let the backend absorb.** Rejected on the two facts above. It restores parity
+with a plain `dplyr::summarize()` on the same object, which is the strongest
+thing that can be said for it, and it is real: the same call on the same input
+answers where a Margin verb refuses. What it cannot restore is the caller's
+choice about what to read, since absorbing takes every column and asks nobody.
+
+**Collect once at admission and continue as a local operation.** Rejected, and
+recorded because it is the version of absorbing that is not wasteful — one read
+rather than one per grouping set. It fails on the same point, one step later: it
+still reads every column, and it still does not ask. It also turns
+`.check_margin_label`'s default from `FALSE` to `TRUE` behind the caller's back,
+that default being read from the input's class.
+
+**Record the limitation and wait for the backend.** Rejected. The condition a
+caller receives today is neither the backend's answer nor an actionable defect,
+and the read it was thought to prevent has already happened when it is raised.
+
+**Refuse by rebuilding the input as a dataset.** Rejected as the mechanism, not
+as the disposition: wrapping an Arrow table as a dataset makes Arrow refuse in
+its own words, which is exact and free, but it cannot be done for a query over a
+table without reading Arrow's internal structure, and getting that wrong turns a
+dataset's own refusal into marginplyr's.
+
+**Refuse after a zero-row probe.** Rejected for the same reason in a different
+place. Taking zero rows of a dataset yields a table, so a probe would have to tell
+absorbing and refusing inputs apart before probing, which is the introspection
+above. It also adds a query where the chosen mechanism adds none.
+
+## How the refusal is raised
+
+Two mechanisms, chosen so that they fail in opposite directions.
+
+The **handler** reads the warning an Absorbing backend marks the absorption
+with, which is raised before the read. Arrow's carries no class, no cause, and no
+call, so its text is the only thing to recognise it by. That is undocumented
+behaviour of another package, and it is gated rather than trusted: a test asserts
+that Arrow still absorbs the expressions the refusal is asserted over and still
+marks them with that text, so a re-wording fails there instead of switching the
+refusal off silently.
+
+The **guard** reads the branch result's class — a local data frame from an input
+that was not one — which cannot stop matching, but only answers after the branch
+has run. It bounds a missed absorption at one branch rather than one per grouping
+set, and it raises the same refusal rather than an internal invariant: a caller
+who reaches it can act on it, and the action is the one the refusal already
+names. ADR 0015's third category would be right about the defect and wrong about
+the caller, who would be handed a bug report in place of a remedy they have.
+
+## Documentation consequences
+
+The pages that claim Arrow summaries are supported and lazy say what is refused
+and why, and say that which expressions are affected is decided by the backend's
+version. They do not enumerate them. A list would be a claim about one version of
+Arrow, and `DESCRIPTION` admits a range; the same reasoning keeps every other
+gate in `AGENTS.md` derived rather than listed.
+
+`?marginplyr` is unchanged. Nothing a caller catches is new: an absorbed summary
+raises the promised `marginplyr_error`, and an Arrow dataset's refusal keeps
+propagating as any backend's does.
+
+## Test strategy
+
+The regression is in two parts, because a single one would fail without saying
+why. The first asserts that the backend still absorbs the expressions the second
+is written over; the second asserts the refusal. A release that translates one of
+them fails the first, which names the drift, rather than the second, which would
+read as marginplyr having stopped refusing.
+
+The expressions are chosen for how long they will keep being absorbed rather than
+for how the defect was found: a group collapsed to one string, and a subset inside
+an aggregate. `first()` and `last()` are absorbed too and deliberately unused,
+being the likeliest of that set to gain a kernel.
+
+Neither part may skip. `verify-backend.R` fails a job for a skip naming no
+withheld backend, so a test that stepped aside when the boundary moved would fail
+the job it was meant to keep green.
+
+`test-query-policy.R` carries the maintainer's half. Its other readings walk `R/`
+and so cannot see a read another package performs on marginplyr's behalf; this one
+counts the backend's own reads while a verb runs, over a summary the backend
+evaluates, an expansion that carries no caller expression, and the refusing path.
+
+## Related decisions
+
+ADR 0020 is the rule this serves and the one this corrects; its Arrow sentence is
+amended there. ADR 0015 is the boundary the guard is placed against. ADR 0019 is
+the route ruled out above. ADR 0021 governs what a condition raised once per
+grouping set reports, and is untouched: the refusal stops at the first branch, so
+there is nothing repeated to report. ADR 0022 and ADR 0024 are what the refusal
+spells its subject by, and ADR 0023 is the idiom it is authored in.

--- a/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
+++ b/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
@@ -106,10 +106,34 @@ refusal off silently.
 The **guard** reads the branch result's class — a local data frame from an input
 that was not one — which cannot stop matching, but only answers after the branch
 has run. It bounds a missed absorption at one branch rather than one per grouping
-set, and it raises the same refusal rather than an internal invariant: a caller
-who reaches it can act on it, and the action is the one the refusal already
-names. ADR 0015's third category would be right about the defect and wrong about
-the caller, who would be handed a bug report in place of a remedy they have.
+set.
+
+Over an Arrow input it raises the same refusal rather than an internal invariant:
+a caller who reaches it can act on it, and the action is the one the refusal
+already names. ADR 0015's third category would be right about the defect and
+wrong about the caller, who would be handed a bug report in place of a remedy
+they have.
+
+Over any other lazy input it raises an internal invariant, and this is where the
+decision departs from the wording #254 was accepted with — "raises **the same
+refusal**, not an internal-invariant error" — which reads the guard as having one
+arm. It has two, because ADR 0015 sorts a condition by what the caller can do
+about it and not by what happened. What the guard detects is one fact, that a
+lazy input's branch came back local; who did the reading decides the rest. An
+Arrow input absorbing is something the caller can rewrite. Any other backend
+answering a lazy input with a local frame is a defect here or there that no
+rewrite of their call avoids, and the refusal's remedies are Arrow's — so raising
+it there would name a backend that was not involved and offer a rewrite that
+does not apply. A diagnostic that misdirects is worse than the bug report ADR
+0015 asks for, which is the one case where that category is right about the
+caller too.
+
+The two arms differ in reach as well as in category. The first becomes reachable
+through a supported backend the day Arrow rewords its warning, which is the whole
+reason it exists, and `test-grouping-backends.R` reaches it by simulating that
+day. The second is reachable through no backend this package supports;
+`test-branch-union.R` reaches it through a fabricated one, which is what makes it
+an invariant rather than a refusal.
 
 ## Documentation consequences
 
@@ -135,8 +159,10 @@ propagating as any backend's does.
 The regression is in two parts, because a single one would fail without saying
 why. The first asserts that the backend still absorbs the expressions the second
 is written over; the second asserts the refusal. A release that translates one of
-them fails the first, which names the drift, rather than the second, which would
-read as marginplyr having stopped refusing.
+them fails the first, which names the drift, as well as the second, which on its
+own would read as marginplyr having stopped refusing. Both is the point rather
+than either: the second reports that a refusal stopped arriving, and only the
+first says why.
 
 The expressions are chosen for how long they will keep being absorbed rather than
 for how the defect was found: a group collapsed to one string, a subset inside an

--- a/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
+++ b/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
@@ -139,11 +139,15 @@ them fails the first, which names the drift, rather than the second, which would
 read as marginplyr having stopped refusing.
 
 The expressions are chosen for how long they will keep being absorbed rather than
-for how the defect was found: a group collapsed to one string, and a subset inside
-an aggregate. `first()` and `last()` are absorbed too and deliberately unused,
-being the likeliest of that set to gain a kernel — and the shipped pages name
-neither for the same reason, since a page and a test that both claim a shape have
-to move together.
+for how the defect was found: a group collapsed to one string, a subset inside an
+aggregate, and a statistic over two columns — the three shapes the reference
+names, so that a page and the gate move together. `first()` and `last()` are
+absorbed too and deliberately unused in both, being the likeliest of that set to
+gain a kernel.
+
+The refusal itself is asserted over the first two. The third is in the gate
+because the reference claims it, which is the point: what the gate covers is
+derived from what is claimed, not from what the refusal happens to use.
 
 Neither part may skip. `verify-backend.R` fails a job for a skip naming no
 withheld backend, so a test that stepped aside when the boundary moved would fail

--- a/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
+++ b/design/adr/0025-refuse-a-summary-a-backend-would-absorb.md
@@ -141,7 +141,9 @@ read as marginplyr having stopped refusing.
 The expressions are chosen for how long they will keep being absorbed rather than
 for how the defect was found: a group collapsed to one string, and a subset inside
 an aggregate. `first()` and `last()` are absorbed too and deliberately unused,
-being the likeliest of that set to gain a kernel.
+being the likeliest of that set to gain a kernel — and the shipped pages name
+neither for the same reason, since a page and a test that both claim a shape have
+to move together.
 
 Neither part may skip. `verify-backend.R` fails a job for a skip naming no
 withheld backend, so a test that stepped aside when the boundary moved would fail

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -468,6 +468,17 @@ per grouping set, it is also the one that owes a Condition context: it wraps
 the branch summary alone in `with_branch_conditions()`, so that the checks and
 builders around it keep raising their Package conditions unchanged.
 
+The same fact gives it a second responsibility, and ADR 0025 is where the
+decision behind it sits. An Absorbing backend answers an expression its own
+engine cannot evaluate by reading the caller's input into R, and the branch
+summary is where that would happen, so it is where the expression is refused
+instead. Two readings raise the refusal and they fail in opposite directions:
+a handler on the backend's own warning, which is raised before it reads, and a
+guard on the branch result's class, which cannot stop matching but answers only
+after the branch has run. Both are scoped by `arrow_input_classes()` from
+`R/grouping-backend.R`, Arrow being the only Absorbing backend and the refusal
+naming it.
+
 `combine_margin_branches()` is the one place the package combines a branch
 list, and the contextual-share module calls it for its denominator mappings
 rather than folding its own. It chooses its strategy from the branches, not
@@ -553,7 +564,11 @@ The test suite divides supporting contracts as follows:
   empty, and that each diagnostic names the helper the caller wrote.
 - `test-grouping-backends.R` covers Arrow and dtplyr metadata behavior,
   native and portable SQL strategy, lazy query composition, collision checks,
-  internal-name safety, and live DuckDB equivalence.
+  internal-name safety, and live DuckDB equivalence. It also carries the
+  Absorbing-backend contract of ADR 0025 in two parts, since one alone would
+  fail without saying why: that Arrow still absorbs the expressions the refusal
+  is asserted over, and that the refusal is raised for them across every Arrow
+  input class.
 - `test-share-backends.R` covers contextual-share adapter behavior for both
   denominators, including targeted pre-query Arrow rejection, dtplyr
   execution-time validation, lazy SQL composition, live SQLite portable

--- a/investigation/what-arrow-does-with-an-untranslatable-summary.md
+++ b/investigation/what-arrow-does-with-an-untranslatable-summary.md
@@ -1,0 +1,130 @@
+# What Arrow does with a summary it cannot evaluate
+
+Investigated: 2026-08-25
+
+Measured on R 4.6.1, arrow 25.0.1, dplyr 1.2.1, except where a version is
+named. Version history was read from `apache/arrow` at its release tags.
+
+## The failure
+
+`summarize_with_margins()` on an Arrow table, given a summary expression Arrow
+could not evaluate, aborted with `object of type 'special' is not subsettable`,
+class `notSubsettableError/error/condition`. `dplyr::summarize()` on the same
+table and the same expression returned the right answer.
+
+`arrow:::try_arrow_dplyr()` runs
+`try(evalq(call <- match.call(), parent), silent = TRUE)`. Reached through a
+wrapper that forwards the caller's expressions in `...`, `match.call()` raises
+`... used in a situation where it does not exist` — visible by setting
+`options(arrow.debug = TRUE)`, which unsilences the `try()` — so `call` is
+never bound. `arrow:::abandon_ship()` then reads it with
+`get("call", envir = env)`, whose inheriting lookup finds `base::call`, and
+`call$.data <- dplyr::collect(.data)` subsets an object of type `"special"`.
+
+Tracing `arrow:::collect.ArrowTabular` showed it is called before the error:
+R evaluates the right-hand side of the assignment first, so the whole input was
+read on the failing path as well.
+
+## What Arrow does instead of translating
+
+Arrow warns and evaluates the expression in R. Two properties were measured
+because the design turned on them.
+
+**It collects the input as the verb received it.** Traced on a table with three
+columns the summary did not mention, `collect.ArrowTabular` was called with
+`k,v,junk1,junk2,junk3`. `abandon_ship()` reads `.data` from the verb's frame,
+not the narrowed table `do_arrow_summarize()` built. The collect is not
+ALTREP-deferred: 8M rows by 3 columns collected in 0.063s with non-ALTREP
+columns.
+
+**It happens only where no external system is involved.**
+`arrow:::query_on_dataset()` answered `FALSE` for `Table`, `RecordBatch`, and an
+`arrow_dplyr_query` over either, and `TRUE` for `Dataset` and a query over one.
+The fallback fires on the `FALSE` set exactly; the `TRUE` set raises
+`arrow_not_supported` instead, carrying `$call` (the blamed expression) and
+`$body` ("Call collect() first to pull data into R.").
+
+## Which expressions are absorbed
+
+34 expressions were put to `dplyr::summarize()` on an Arrow table.
+
+Translated: `sum` `mean` `min` `max` `dplyr::n()` `n_distinct` `sd` `var`
+`median` `quantile` `any` `all` `sum(x, na.rm = TRUE)` `sum(x > 1)`,
+`max()` of a character or date column, `n_distinct()` of a factor column, and
+arithmetic composed on top of an aggregate — `sum(v)/dplyr::n()`,
+`max(v) - min(v)`, `round(mean(v), 2)`, `as.integer(sum(v))`,
+`mean(dplyr::if_else(...))`.
+
+Absorbed: `dplyr::first` `dplyr::last` `dplyr::nth`, `length(unique(v))`,
+`paste(collapse=)` `toString`, `sum(v[v > 1])` `mean(v[s == "a"])`,
+`stats::cor` `stats::weighted.mean`.
+
+Two findings bear on how the boundary can be described.
+
+`sum(v[v > 1])` is absorbed although `sum` is at its head and `sum` is
+translated; it is the `[` that fails. And a user-written closure is *not*
+automatically absorbed: `myfun <- function(x) sum(x)/length(x)` gave `myfun(v)`
+an `arrow_dplyr_query`, Arrow's mask evaluating the body symbolically. So
+neither the head of a call nor who wrote the function decides it. Only the
+composition of primitives does, and only Arrow can answer.
+
+Translatability did not vary with the grouping set: 18 expressions were put to
+each of `.by = character()`, one column, and two columns, with no expression
+differing across the three.
+
+## How an absorption can be recognised
+
+The warning carries nothing but its text: class `rlang_warning/warning/condition`
+with `$parent` `NULL`, `$call` `NULL`, and an empty `$footer`.
+
+Its wording changed inside the range `DESCRIPTION` admits. `arrow (>= 13.0.0)`
+is the floor, and at tags 13.0.0, 14.0.0, 15.0.0, and 16.0.0 `abandon_ship()`
+lived in `r/R/dplyr.R` and wrote
+
+```r
+warning(msg, "; pulling data into R", immediate. = TRUE, call. = FALSE)
+```
+
+while from 17.0.0 it lives in `r/R/dplyr-eval.R` and writes an rlang warning
+whose body ends `"Pulling data into R"`. What survived is the phrase and not its
+capitalisation, which is why the marker in `R/grouping-adapter-union.R` is
+matched case-insensitively.
+
+Two further differences follow from the same rewrite. Through 16.0.0
+`abandon_ship(call, .data, msg)` takes the originating call as an argument, so
+the `match.call()` defect above does not arise there at all — the untyped error
+is reachable only from 17.0.0. And the older wording names the offending
+expression inside a sentence rather than on an `In <expr>: ` line, so the label
+cannot be placed from it and the refusal names every summary argument.
+
+No option controls any of this: all 23 `arrow.*` options referenced in the
+arrow namespace were enumerated and none of them does, and arrow's `NEWS.md`
+carries no entry for the behaviour.
+
+## Refusing costs no read
+
+A calling handler that stops when the warning is raised refuses with zero calls
+to `collect.ArrowTabular`, in both the `...`-forwarding shape and one that
+splices the caller's expressions at the call site, because Arrow warns before it
+collects.
+
+A zero-row probe on `head(.data, 0L)` also identifies an absorbed expression —
+by the class of what `summarize()` returns rather than by any text — at a
+constant ~14 ms independent of input size, and one probe over all the summaries
+detects any absorbed one among them. It was not adopted: `head()` turns a
+`Dataset` into a `Table`, so it would have to tell absorbing and refusing inputs
+apart before probing, and for an `arrow_dplyr_query` that means reading Arrow's
+internal structure.
+
+The whole test suite was run twice against a rebuilt branch summary — once
+refusing, once absorbing — and reported 4807 passing, 0 failing, 0 skipped, and
+0 warnings both times. No test in the suite reaches Arrow's fallback, which is
+what let the defect ship.
+
+## What was decided from this
+
+ADR 0025 refuses a summary an Absorbing backend would read the input to compute.
+ADR 0020's amendment withdraws the claim that an in-memory Arrow table cannot be
+told from a dataset in object storage. `CONTEXT.md` defines *Absorbing backend*.
+Those are authoritative for the decision and for current state; this note is
+authoritative only for what was measured on the date above.

--- a/investigation/what-arrow-does-with-an-untranslatable-summary.md
+++ b/investigation/what-arrow-does-with-an-untranslatable-summary.md
@@ -97,6 +97,20 @@ is reachable only from 17.0.0. And the older wording names the offending
 expression inside a sentence rather than on an `In <expr>: ` line, so the label
 cannot be placed from it and the refusal names every summary argument.
 
+What did not change across the rewrite is the order, which is what a refusal
+raised from the warning depends on. At 13.0.0 through 16.0.0 the body reads
+
+```r
+warning(msg, "; pulling data into R", immediate. = TRUE, call. = FALSE)
+call$.data <- dplyr::collect(.data)
+```
+
+and from 17.0.0 the `rlang::warn()` call sits in the same position. The warning
+precedes the collect on every version `DESCRIPTION` admits, so stopping from a
+calling handler reads no rows on any of them. That was measured directly on
+25.0.1 and read from the source at the other tags, there being no way to install
+four Arrows in one session.
+
 No option controls any of this: all 23 `arrow.*` options referenced in the
 arrow namespace were enumerated and none of them does, and arrow's `NEWS.md`
 carries no entry for the behaviour.

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -410,8 +410,10 @@ Arrow inputs reject both helpers after expression planning and common
 Margin-operation validation but before constructing a summary query. The
 reason belongs to the source summary they share, so it applies to both, and
 the diagnostic names whichever helpers the call used. Other Arrow Margin
-operations remain supported and lazy. Explicitly collect an Arrow input
-first when local share execution is appropriate.
+operations remain supported and lazy, apart from a summary Arrow's own
+engine cannot evaluate, which is refused for its own reason and before any
+row is read; see \code{\link[=summarize_with_margins]{summarize_with_margins()}}. Explicitly collect an Arrow
+input first when local share execution is appropriate.
 
 A \code{dtplyr} step remains a native lazy query: no validation-only query is
 added and nothing is collected on your behalf. Its execution-time

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -154,6 +154,22 @@ collects to zero rows where a local data frame returns one, as
 \code{\link[dplyr:summarize]{dplyr::summarize()}} itself does for that lazy input. Anything that puts a
 column in the result -- one summary, one fixed key, one grouping dimension,
 or \code{.id} -- ends the difference.
+
+One summary an Arrow table or record batch cannot carry is one Arrow's own
+engine cannot evaluate. Arrow answers such an expression by reading the
+whole input -- every column of it, not only the ones the summary names --
+and computing it in R. marginplyr refuses it instead, before a row is read,
+and names the two rewrites that compute it: collect the input first, and
+select the columns the summary needs before collecting, which is the
+narrowing Arrow's own route cannot do for you.
+
+Which expressions those are is Arrow's to decide and moves with its version,
+so they are not listed here. The shapes refused today are a group collapsed
+into a single value, such as pasting one, an extraction that depends on row
+order, a subset written inside an aggregate, and a statistic over two
+columns at once; ordinary numeric summaries, and arithmetic over them, are
+evaluated by Arrow and stay lazy. An Arrow dataset raises Arrow's own
+refusal for the same expressions, and is otherwise unaffected.
 }
 \section{Fixed columns and grouping dimensions}{
 
@@ -450,8 +466,10 @@ the same values and are interchangeable.
 
 Arrow inputs reject both after expression planning and common
 Margin-operation validation but before constructing a summary query. Other
-Arrow Margin operations remain supported and lazy. Explicitly collect an
-Arrow input first when local share execution is appropriate.
+Arrow Margin operations remain supported and lazy, apart from a summary
+Arrow's own engine cannot evaluate, which is refused for its own reason and
+before any row is read. Explicitly collect an Arrow input first when local
+share execution is appropriate.
 
 A row that is its own denominator receives \code{1.0}. Missing numerators or
 denominators and zero denominators receive \code{NA_real_}; other finite ratios

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -155,8 +155,9 @@ collects to zero rows where a local data frame returns one, as
 column in the result -- one summary, one fixed key, one grouping dimension,
 or \code{.id} -- ends the difference.
 
-One summary an Arrow table or record batch cannot carry is one Arrow's own
-engine cannot evaluate. Arrow answers such an expression by reading the
+One summary an Arrow table or record batch cannot carry -- or a query built
+on either -- is one Arrow's own engine cannot evaluate. Arrow answers such
+an expression by reading the
 whole input -- every column of it, not only the ones the summary names --
 and computing it in R. marginplyr refuses it instead, before a row is read,
 and names the two rewrites that compute it: collect the input first, and
@@ -168,8 +169,9 @@ so they are not listed here. The shapes refused today are a group collapsed
 into a single value, such as pasting one, an extraction that depends on row
 order, a subset written inside an aggregate, and a statistic over two
 columns at once; ordinary numeric summaries, and arithmetic over them, are
-evaluated by Arrow and stay lazy. An Arrow dataset raises Arrow's own
-refusal for the same expressions, and is otherwise unaffected.
+evaluated by Arrow and stay lazy. An Arrow dataset, and a query built on
+one, raise Arrow's own refusal for the same expressions instead, because a
+dataset never reads itself into R; they are otherwise unaffected.
 }
 \section{Fixed columns and grouping dimensions}{
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -156,22 +156,21 @@ column in the result -- one summary, one fixed key, one grouping dimension,
 or \code{.id} -- ends the difference.
 
 One summary an Arrow table or record batch cannot carry -- or a query built
-on either -- is one Arrow's own engine cannot evaluate. Arrow answers such
-an expression by reading the
-whole input -- every column of it, not only the ones the summary names --
-and computing it in R. marginplyr refuses it instead, before a row is read,
-and names the two rewrites that compute it: collect the input first, and
-select the columns the summary needs before collecting, which is the
-narrowing Arrow's own route cannot do for you.
+on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an
+expression by reading the whole input -- every column of it, not only the
+ones the summary names -- and computing it in R. marginplyr refuses it
+instead, before a row is read, and names the two rewrites that compute it:
+collect the input first, and select the columns the summary needs before
+collecting, which is the narrowing Arrow's own route cannot do for you.
 
 Which expressions those are is Arrow's to decide and moves with its version,
-so they are not listed here. The shapes refused today are a group collapsed
-into a single value, such as pasting one, an extraction that depends on row
-order, a subset written inside an aggregate, and a statistic over two
-columns at once; ordinary numeric summaries, and arithmetic over them, are
-evaluated by Arrow and stay lazy. An Arrow dataset, and a query built on
-one, raise Arrow's own refusal for the same expressions instead, because a
-dataset never reads itself into R; they are otherwise unaffected.
+so they are not listed here. Among the shapes refused are a group collapsed
+into a single value, such as pasting one, a subset written inside an
+aggregate, and a statistic over two columns at once; ordinary numeric
+summaries, and arithmetic over them, are evaluated by Arrow and stay lazy.
+An Arrow dataset, and a query built on one, raise Arrow's own refusal for
+the same expressions instead, because a dataset never reads itself into R;
+they are otherwise unaffected.
 }
 \section{Fixed columns and grouping dimensions}{
 

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -380,3 +380,48 @@ test_that("Parent shares combine their denominator mappings the same way", {
     by_channel$total / unname(region_totals[by_channel$region])
   )
 })
+
+# The second arm of the branch guard ADR 0025 adds. Its first arm refuses an
+# Arrow input that absorbed a summary, which is a Package condition because the
+# caller can rewrite the call; this one covers every other lazy backend, where
+# a local branch from a lazy input is a defect no rewrite of theirs avoids and
+# is therefore an internal invariant (ADR 0015).
+#
+# It has no path through a public verb by construction -- that is what makes it
+# an invariant, and why the two invariants in `test-diagnostic-pluralization.R`
+# are called directly too. The backend below is fabricated for the same reason:
+# no backend marginplyr supports answers a lazy input with a local frame, and
+# one that started to is exactly what this reports. It is also what
+# `combine_margin_branches()` does not catch on its own -- a branch list that is
+# part lazy and part local is accepted in the lazy-first order and collects to
+# the combined rows.
+local_answering_summarise <- function(.data, ..., .by = NULL) {
+  data.frame(k = "E", out = 1)
+}
+
+test_that("a lazy input answering with a local branch is an invariant", {
+  registerS3method(
+    "summarise",
+    "marginplyr_test_local_answering",
+    local_answering_summarise,
+    envir = asNamespace("dplyr")
+  )
+  lazy <- structure(list(), class = "marginplyr_test_local_answering")
+
+  raised <- expect_error(
+    marginplyr:::summarize_margin_branch(
+      lazy,
+      out = 1,
+      .by = character(),
+      caller_labels = "out = 1"
+    ),
+    "A lazy input produced a local summary branch"
+  )
+
+  # Not a Package condition: the caller cannot rewrite their way out of it, and
+  # it must not be reported as the Arrow refusal, which names a remedy that
+  # would not apply.
+  expect_false(inherits(raised, "marginplyr_error"))
+  expect_no_match(conditionMessage(raised), "Arrow", fixed = TRUE)
+  expect_match(conditionMessage(raised), "data.frame", fixed = TRUE)
+})

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -409,7 +409,7 @@ test_that("a lazy input answering with a local branch is an invariant", {
   lazy <- structure(list(), class = "marginplyr_test_local_answering")
 
   raised <- expect_error(
-    marginplyr:::summarize_margin_branch(
+    summarize_margin_branch(
       lazy,
       out = 1,
       .by = character(),

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -91,7 +91,7 @@ pluralizing_coverage <- function() {
     # by whether Arrow's warning could be placed -- a property of the
     # behaviour, not of the wording. The plural arm is the backstop's, which
     # has no warning to read.
-    abort_absorbed_summary = "test-grouping-backends.R:197 and :536",
+    abort_absorbed_summary = "test-grouping-backends.R:197 and :540",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -91,7 +91,7 @@ pluralizing_coverage <- function() {
     # by whether Arrow's warning could be placed -- a property of the
     # behaviour, not of the wording. The plural arm is the backstop's, which
     # has no warning to read.
-    abort_absorbed_summary = "test-grouping-backends.R:192 and :386",
+    abort_absorbed_summary = "test-grouping-backends.R:197 and :414",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -91,7 +91,7 @@ pluralizing_coverage <- function() {
     # by whether Arrow's warning could be placed -- a property of the
     # behaviour, not of the wording. The plural arm is the backstop's, which
     # has no warning to read.
-    abort_absorbed_summary = "test-grouping-backends.R:189 and :308",
+    abort_absorbed_summary = "test-grouping-backends.R:191 and :346",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -91,7 +91,7 @@ pluralizing_coverage <- function() {
     # by whether Arrow's warning could be placed -- a property of the
     # behaviour, not of the wording. The plural arm is the backstop's, which
     # has no warning to read.
-    abort_absorbed_summary = "test-grouping-backends.R:192 and :391",
+    abort_absorbed_summary = "test-grouping-backends.R:192 and :386",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -91,7 +91,7 @@ pluralizing_coverage <- function() {
     # by whether Arrow's warning could be placed -- a property of the
     # behaviour, not of the wording. The plural arm is the backstop's, which
     # has no warning to read.
-    abort_absorbed_summary = "test-grouping-backends.R:197 and :414",
+    abort_absorbed_summary = "test-grouping-backends.R:197 and :536",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -91,7 +91,7 @@ pluralizing_coverage <- function() {
     # by whether Arrow's warning could be placed -- a property of the
     # behaviour, not of the wording. The plural arm is the backstop's, which
     # has no warning to read.
-    abort_absorbed_summary = "test-grouping-backends.R:191 and :346",
+    abort_absorbed_summary = "test-grouping-backends.R:192 and :391",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -86,6 +86,12 @@
 # blunt, and a key in a table is not a call.
 pluralizing_coverage <- function() {
   list(
+    # Both arms sit with the Arrow contracts rather than here, because what
+    # each asserts is which summaries the refusal names, and that is decided
+    # by whether Arrow's warning could be placed -- a property of the
+    # behaviour, not of the wording. The plural arm is the backstop's, which
+    # has no warning to read.
+    abort_absorbed_summary = "test-grouping-backends.R:189 and :308",
     abort_by_rename = "test-grouping-plan.R:604 and :645",
     abort_declared_label_collision = rep("this file, the collision block", 2L),
     abort_grouping_rename = "test-grouping-plan.R:493 and :543",

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -198,28 +198,13 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
   }
 })
 
-# The refusal names the summary Arrow blamed, which is only observable where
-# the call holds more than one. Only the naming is asserted through the verb:
-# *which* summaries are named is a function of how the installed Arrow phrases
-# its warning, and both phrasings are inside the range `DESCRIPTION` admits, so
-# the split is asserted at the reading instead, below.
-test_that("Arrow names the summary it absorbed", {
-  skip_if_suggest_absent("arrow")
-
-  raised <- expect_error(summarize_with_margins(
-    arrow::Table$create(absorbed_summary_data()),
-    total = sum(v),
-    joined = paste(s, collapse = ","),
-    .grouping = rollup(k)
-  ))
-
-  expect_match(
-    conditionMessage(raised),
-    "joined = paste(s, collapse = \",\")",
-    fixed = TRUE
-  )
-})
-
+# Which summaries the refusal names is a function of how the installed Arrow
+# phrases its warning, and both phrasings are inside the range `DESCRIPTION`
+# admits, so it is asserted at the reading rather than through a verb: a
+# verb-level assertion would either hold on one half of that range only, or --
+# by asserting the blamed summary appears, which it does on both halves --
+# pass whatever the reading answered.
+#
 # Both phrasings, over synthesised warnings, because no session holds both
 # Arrows at once and `verify-backend.R` fails a job for a skip naming no
 # withheld backend -- so a version-gated assertion is not available and would
@@ -325,19 +310,22 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
   table <- arrow::Table$create(absorbed_summary_data())
   marker <- absorbing_warning_marker()
   # One per shape the shipped pages describe, so a page that stops being true
-  # fails here. The refusal itself is asserted over the first two only; the
-  # other two are covered because they are claimed, not because they are used.
+  # fails here rather than being re-read. `first()` and `last()` are absorbed
+  # too and are in none of them: they are the likeliest of the absorbed set to
+  # gain an Arrow kernel, so a page naming them and a test asserting them would
+  # both be claims with a short life.
   absorbed <- list(
     collapsed = quote(paste(s, collapse = ",")),
     subset = quote(sum(v[v > 1])),
-    ordered = quote(dplyr::first(v)),
     two_column = quote(stats::weighted.mean(v, v))
   )
 
-  for (expression in absorbed) {
+  for (shape in names(absorbed)) {
     marked <- FALSE
     result <- withCallingHandlers(
-      rlang::inject(dplyr::summarize(table, out = !!expression, .by = k)),
+      rlang::inject(
+        dplyr::summarize(table, out = !!absorbed[[shape]], .by = k)
+      ),
       warning = function(cnd) {
         if (grepl(marker, conditionMessage(cnd), ignore.case = TRUE)) {
           marked <<- TRUE
@@ -346,10 +334,17 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
       }
     )
 
-    expect_true(marked)
+    # Labelled, because this is the assertion an Arrow release moving the
+    # boundary is meant to fail: it has to name which shape moved.
+    expect_true(marked, label = paste("Arrow marks the absorbed", shape))
     # Absorbed rather than translated: a local frame is what Arrow answers
-    # with once it has pulled the input into R.
-    expect_s3_class(result, "data.frame")
+    # with once it has pulled the input into R. `expect_true()` rather than
+    # `expect_s3_class()`, which takes no label, and a label is what tells a
+    # reader which shape moved.
+    expect_true(
+      inherits(result, "data.frame"),
+      label = paste("Arrow answers the absorbed", shape, "with a local frame")
+    )
   }
 
   # And the ordinary numeric summaries the same pages call unaffected.

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -145,10 +145,12 @@ absorbed_summary_data <- function() {
 # helpers readable by `object_usage_linter()`.
 absorbing_arrow_inputs <- function(data) {
   table <- arrow::Table$create(data)
+  batch <- arrow::record_batch(data)
   list(
     table = table,
-    record_batch = arrow::record_batch(data),
-    query = dplyr::select(table, dplyr::all_of(names(data)))
+    record_batch = batch,
+    table_query = dplyr::select(table, dplyr::all_of(names(data))),
+    batch_query = dplyr::select(batch, dplyr::all_of(names(data)))
   )
 }
 
@@ -183,15 +185,36 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
       "joined = paste(s, collapse = \",\")",
       fixed = TRUE
     )
-    # The singular arm of this diagnostic; the plural one is the guard block
-    # below, which names every summary argument because it has no warning to
-    # place one from.
-    expect_match(message, "is not a summary Arrow can evaluate", fixed = TRUE)
+    # The singular arm of this diagnostic, both inflections of it; the plural
+    # one is the guard block below, which names every summary argument because
+    # it has no warning to place one from.
+    expect_match(message, "Arrow cannot evaluate this summary", fixed = TRUE)
+    expect_match(message, "to compute it:", fixed = TRUE)
     # Both rewrites. The second is the whole reason refusing beats absorbing:
     # Arrow reads every column, and a caller who is told can read fewer.
     expect_match(message, "collect", fixed = TRUE)
     expect_match(message, "column", fixed = TRUE)
   }
+})
+
+# The refusal names the summary Arrow blamed rather than every summary in the
+# call, which is only observable where the call holds more than one. Without
+# this, a reading of Arrow's warning that always failed would still pass the
+# block above: the fallback there is to name them all, and there is only one.
+test_that("Arrow names the summary it absorbed and not its neighbours", {
+  skip_if_suggest_absent("arrow")
+
+  raised <- expect_error(summarize_with_margins(
+    arrow::Table$create(absorbed_summary_data()),
+    total = sum(v),
+    joined = paste(s, collapse = ","),
+    .grouping = rollup(k)
+  ))
+
+  message <- conditionMessage(raised)
+  expect_match(message, "joined = paste(s, collapse = \",\")", fixed = TRUE)
+  expect_false(grepl("total = sum(v)", message, fixed = TRUE))
+  expect_match(message, "Arrow cannot evaluate this summary", fixed = TRUE)
 })
 
 test_that("Arrow refuses a subset inside an aggregate", {
@@ -256,14 +279,22 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
   skip_if_suggest_absent("arrow")
   table <- arrow::Table$create(absorbed_summary_data())
   marker <- absorbing_warning_marker()
-  absorbed <- list(quote(paste(s, collapse = ",")), quote(sum(v[v > 1])))
+  # One per shape the shipped pages describe, so a page that stops being true
+  # fails here. The refusal itself is asserted over the first two only; the
+  # other two are covered because they are claimed, not because they are used.
+  absorbed <- list(
+    collapsed = quote(paste(s, collapse = ",")),
+    subset = quote(sum(v[v > 1])),
+    ordered = quote(dplyr::first(v)),
+    two_column = quote(stats::weighted.mean(v, v))
+  )
 
   for (expression in absorbed) {
     marked <- FALSE
     result <- withCallingHandlers(
       rlang::inject(dplyr::summarize(table, out = !!expression, .by = k)),
       warning = function(cnd) {
-        if (grepl(marker, conditionMessage(cnd), fixed = TRUE)) {
+        if (grepl(marker, conditionMessage(cnd), ignore.case = TRUE)) {
           marked <<- TRUE
         }
         invokeRestart("muffleWarning")
@@ -275,6 +306,12 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
     # with once it has pulled the input into R.
     expect_s3_class(result, "data.frame")
   }
+
+  # And the ordinary numeric summaries the same pages call unaffected.
+  translated <- suppressWarnings(
+    dplyr::summarize(table, out = sum(v) / dplyr::n(), .by = k)
+  )
+  expect_s3_class(translated, "arrow_dplyr_query")
 })
 
 # The backstop, reached by taking the marker away -- which is what an Arrow
@@ -305,7 +342,9 @@ test_that("the branch guard refuses an absorbed summary the handler missed", {
   message <- conditionMessage(raised)
   expect_match(message, "joined = paste(s, collapse = \",\")", fixed = TRUE)
   expect_match(message, "kept = sum(v[v > 1])", fixed = TRUE)
-  expect_match(message, "summaries Arrow can evaluate", fixed = TRUE)
+  # The plural arm, both inflections of it.
+  expect_match(message, "Arrow cannot evaluate these summaries", fixed = TRUE)
+  expect_match(message, "to compute them:", fixed = TRUE)
 })
 
 test_that("Arrow schema metadata supports predicates and computed queries", {

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -122,13 +122,14 @@ test_that("Arrow uses the normalized grouping contract", {
 # Both halves are asserted, because what the decision turns on is that the two
 # are told apart (#254).
 #
-# The two expressions are chosen for how long they will keep being absorbed
-# rather than for how the defect was found. A group collapsed to one string and
-# a subset inside an aggregate are the shapes least likely to gain an Arrow
-# kernel; `first()` and `last()` are absorbed today and deliberately unused
-# here, being the likeliest of the absorbed set to stop being so. The block
-# below asserts they are still absorbed, so an Arrow release that translates
-# one fails there, naming the drift, rather than here.
+# The expressions are chosen for how long they will keep being absorbed rather
+# than for how the defect was found. A group collapsed to one string, a subset
+# inside an aggregate, and a statistic over two columns are the shapes least
+# likely to gain an Arrow kernel, and are the three the reference names;
+# `first()` and `last()` are absorbed today and deliberately unused here and
+# there, being the likeliest of the absorbed set to stop being so. The block
+# below asserts all three are still absorbed, so an Arrow release that
+# translates one fails there, naming the drift, rather than here.
 absorbed_summary_data <- function() {
   data.frame(
     k = c("E", "E", "W"),
@@ -174,27 +175,33 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
       .grouping = rollup(k)
     ), label = shape)
 
-    expect_s3_class(raised, "marginplyr_error")
+    # Every expectation carries the shape, so a failure on one input class
+    # does not read as a failure on the three beside it.
+    expect_true(inherits(raised, "marginplyr_error"), label = shape)
     # The condition this ticket exists to remove, named so that a regression
     # to it fails as itself rather than as a missing class.
-    expect_false(inherits(raised, "notSubsettableError"))
-    message <- conditionMessage(raised)
+    expect_false(inherits(raised, "notSubsettableError"), label = shape)
+    text <- conditionMessage(raised)
     # The argument as the caller spelled it, not the expression Arrow blamed
     # inside it and not the internal key columns the branch grouped by.
     expect_match(
-      message,
+      text,
       "joined = paste(s, collapse = \",\")",
-      fixed = TRUE
+      fixed = TRUE,
+      info = shape
     )
     # The singular arm of this diagnostic, both inflections of it; the plural
     # one is the guard block below, which names every summary argument because
     # it has no warning to place one from.
-    expect_match(message, "Arrow cannot evaluate this summary", fixed = TRUE)
-    expect_match(message, "to compute it:", fixed = TRUE)
+    expect_match(
+      text, "Arrow cannot evaluate this summary",
+      fixed = TRUE, info = shape
+    )
+    expect_match(text, "to compute it:", fixed = TRUE, info = shape)
     # Both rewrites. The second is the whole reason refusing beats absorbing:
     # Arrow reads every column, and a caller who is told can read fewer.
-    expect_match(message, "collect", fixed = TRUE)
-    expect_match(message, "column", fixed = TRUE)
+    expect_match(text, "collect", fixed = TRUE, info = shape)
+    expect_match(text, "column", fixed = TRUE, info = shape)
   }
 })
 
@@ -272,12 +279,13 @@ test_that("an Arrow Dataset keeps Arrow's own refusal", {
     # marginplyr's only part in it is the context it carries. The diagnostic
     # is asserted as well as the class, since propagating one without the
     # other is what ADR 0015 forbids.
-    expect_s3_class(raised, "arrow_not_supported")
-    expect_false(inherits(raised, "marginplyr_error"))
+    expect_true(inherits(raised, "arrow_not_supported"), label = shape)
+    expect_false(inherits(raised, "marginplyr_error"), label = shape)
     expect_match(
       conditionMessage(raised),
       "Call collect() first",
-      fixed = TRUE
+      fixed = TRUE,
+      info = shape
     )
   }
 })
@@ -309,6 +317,7 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
   skip_if_suggest_absent("arrow")
   table <- arrow::Table$create(absorbed_summary_data())
   marker <- absorbing_warning_marker()
+  raised <- NULL
   # One per shape the shipped pages describe, so a page that stops being true
   # fails here rather than being re-read. `first()` and `last()` are absorbed
   # too and are in none of them: they are the likeliest of the absorbed set to
@@ -329,6 +338,7 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
       warning = function(cnd) {
         if (grepl(marker, conditionMessage(cnd), ignore.case = TRUE)) {
           marked <<- TRUE
+          raised <<- cnd
         }
         invokeRestart("muffleWarning")
       }
@@ -352,6 +362,24 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
     dplyr::summarize(table, out = sum(v) / dplyr::n(), .by = k)
   )
   expect_s3_class(translated, "arrow_dplyr_query")
+
+  # The second undocumented Arrow text the refusal reads: the `In <expr>: `
+  # header the blamed summary is placed from. Asserted against the warning the
+  # installed Arrow actually raised, because a rewording of it would silently
+  # degrade every refusal to naming all of a call's summaries, and the suite
+  # would stay green -- every other assertion here passes a single summary,
+  # where naming the blamed one and naming them all are the same answer.
+  #
+  # Two answers are correct and a third is not. From Arrow 17.0.0 the header is
+  # present and carries Arrow's own deparse of the expression; through 16.0.0
+  # there is no header and `NA` is right, that being the degradation the
+  # refusal is designed around. A header this reading half-recognises would
+  # return some other string, and that is what fails here.
+  placed <- absorbing_warning_label(raised)
+  expect_true(
+    is.na(placed) || identical(placed, "stats::weighted.mean(v, v)"),
+    label = paste0("the label placed from Arrow's warning (", placed, ")")
+  )
 })
 
 # The backstop, reached by taking the marker away -- which is what an Arrow

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -166,12 +166,13 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
   skip_if_suggest_absent("arrow")
   data <- absorbed_summary_data()
 
-  for (input in absorbing_arrow_inputs(data)) {
+  inputs <- absorbing_arrow_inputs(data)
+  for (shape in names(inputs)) {
     raised <- expect_error(summarize_with_margins(
-      input,
+      inputs[[shape]],
       joined = paste(s, collapse = ","),
       .grouping = rollup(k)
-    ))
+    ), label = shape)
 
     expect_s3_class(raised, "marginplyr_error")
     # The condition this ticket exists to remove, named so that a regression
@@ -197,11 +198,12 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
   }
 })
 
-# The refusal names the summary Arrow blamed rather than every summary in the
-# call, which is only observable where the call holds more than one. Without
-# this, a reading of Arrow's warning that always failed would still pass the
-# block above: the fallback there is to name them all, and there is only one.
-test_that("Arrow names the summary it absorbed and not its neighbours", {
+# The refusal names the summary Arrow blamed, which is only observable where
+# the call holds more than one. Only the naming is asserted through the verb:
+# *which* summaries are named is a function of how the installed Arrow phrases
+# its warning, and both phrasings are inside the range `DESCRIPTION` admits, so
+# the split is asserted at the reading instead, below.
+test_that("Arrow names the summary it absorbed", {
   skip_if_suggest_absent("arrow")
 
   raised <- expect_error(summarize_with_margins(
@@ -211,10 +213,45 @@ test_that("Arrow names the summary it absorbed and not its neighbours", {
     .grouping = rollup(k)
   ))
 
-  message <- conditionMessage(raised)
-  expect_match(message, "joined = paste(s, collapse = \",\")", fixed = TRUE)
-  expect_false(grepl("total = sum(v)", message, fixed = TRUE))
-  expect_match(message, "Arrow cannot evaluate this summary", fixed = TRUE)
+  expect_match(
+    conditionMessage(raised),
+    "joined = paste(s, collapse = \",\")",
+    fixed = TRUE
+  )
+})
+
+# Both phrasings, over synthesised warnings, because no session holds both
+# Arrows at once and `verify-backend.R` fails a job for a skip naming no
+# withheld backend -- so a version-gated assertion is not available and would
+# leave whichever half CI does not install unasserted.
+#
+# From Arrow 17.0.0 the warning opens `In <expr>: `, which places the blame on
+# one argument. Through 16.0.0 it names the expression inside a sentence, which
+# places it on none, and the refusal then names every summary argument rather
+# than guessing. Only the second is a claim about a version this package cannot
+# install here; both are claims about this reading.
+test_that("an absorbed summary is placed from the warning that carries it", {
+  dots <- rlang::quos(total = sum(v), joined = paste(s, collapse = ","))
+  labels <- c("total = sum(v)", "joined = paste(s, collapse = \",\")")
+  placed <- function(message) {
+    absorbed_summary_labels(
+      rlang::warning_cnd(message = message),
+      dots = dots,
+      caller_labels = labels
+    )
+  }
+
+  expect_identical(
+    placed("In paste(s, collapse = \",\"): \nPulling data into R"),
+    labels[[2L]]
+  )
+  expect_identical(
+    placed("object of type 'closure'; pulling data into R"),
+    labels
+  )
+  # An expression that matches no argument places nothing either, which is the
+  # degradation ADR 0022 accepts for a span it cannot recognise.
+  expect_identical(placed("In nothing_written_here(): \nx"), labels)
 })
 
 test_that("Arrow refuses a subset inside an aggregate", {
@@ -238,17 +275,25 @@ test_that("an Arrow Dataset keeps Arrow's own refusal", {
   skip_if_suggest_absent("arrow")
   data <- absorbed_summary_data()
 
-  for (input in refusing_arrow_inputs(data)) {
+  inputs <- refusing_arrow_inputs(data)
+  for (shape in names(inputs)) {
     raised <- expect_error(summarize_with_margins(
-      input,
+      inputs[[shape]],
       joined = paste(s, collapse = ","),
       .grouping = rollup(k)
-    ))
+    ), label = shape)
 
     # An External condition: Arrow's answer to the question put to it, and
-    # marginplyr's only part in it is the context it carries.
+    # marginplyr's only part in it is the context it carries. The diagnostic
+    # is asserted as well as the class, since propagating one without the
+    # other is what ADR 0015 forbids.
     expect_s3_class(raised, "arrow_not_supported")
     expect_false(inherits(raised, "marginplyr_error"))
+    expect_match(
+      conditionMessage(raised),
+      "Call collect() first",
+      fixed = TRUE
+    )
   }
 })
 

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -255,6 +255,10 @@ test_that("an absorbed summary is placed from the warning that carries it", {
   # An expression that matches no argument places nothing either, which is the
   # degradation ADR 0022 accepts for a span it cannot recognise.
   expect_identical(placed("In nothing_written_here(): \nx"), labels)
+  # And a message holding no lines at all takes that route rather than a guard
+  # of its own. The handler cannot deliver one, an empty message matching no
+  # marker, so the reading answers for it by indexing rather than by branching.
+  expect_identical(placed(""), labels)
 })
 
 # Arrow's convention for the label it blames, which the refusal reproduces

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -198,10 +198,21 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
       fixed = TRUE, info = shape
     )
     expect_match(text, "to compute it:", fixed = TRUE, info = shape)
-    # Both rewrites. The second is the whole reason refusing beats absorbing:
-    # Arrow reads every column, and a caller who is told can read fewer.
-    expect_match(text, "collect", fixed = TRUE, info = shape)
-    expect_match(text, "column", fixed = TRUE, info = shape)
+    # Both rewrites, each matched on a span the other does not carry. The
+    # second bullet holds the words `collect` and `column` between them, so a
+    # pair of assertions on those alone is satisfied by that bullet by itself
+    # and passes with the first rewrite deleted -- which is the half a caller
+    # who cannot narrow their input still needs.
+    expect_match(
+      text, "Collect the Arrow input first",
+      fixed = TRUE, info = shape
+    )
+    # The second is the whole reason refusing beats absorbing: Arrow reads
+    # every column, and a caller who is told can read fewer.
+    expect_match(
+      text, "Select the columns you need before collecting",
+      fixed = TRUE, info = shape
+    )
   }
 })
 
@@ -244,6 +255,112 @@ test_that("an absorbed summary is placed from the warning that carries it", {
   # An expression that matches no argument places nothing either, which is the
   # degradation ADR 0022 accepts for a span it cannot recognise.
   expect_identical(placed("In nothing_written_here(): \nx"), labels)
+})
+
+# Arrow's convention for the label it blames, which the refusal reproduces
+# rather than calling the internal that writes it (ADR 0022). What makes the
+# reproduction worth asserting on its own is that it agrees with both obvious
+# alternatives everywhere except one place: an expression that deparses to a
+# single line is spelled identically by `deparse()`, `rlang::as_label()`, and
+# Arrow. Every other expression in this file is one of those, so without the
+# long case here the convention could be swapped for `as_label()` and the whole
+# suite would stay green -- and the refusal would then place nothing on any
+# expression long enough to be worth reading, silently naming every summary
+# argument instead of the blamed one.
+#
+# Asserted as properties rather than against `arrow:::format_expr()`: an
+# assertion on another package's internal is the coupling ADR 0022 declines,
+# and it would make this reachable only where Arrow is installed, where its
+# siblings above run everywhere.
+test_that("an absorbed expression is labelled by Arrow's convention", {
+  short <- quote(paste(s, collapse = ","))
+  expect_length(deparse(short), 1L)
+  expect_identical(
+    absorbed_expression_label(short),
+    "paste(s, collapse = \",\")"
+  )
+
+  # Past the deparse width the three spellings part company: Arrow keeps the
+  # first line and marks the loss, while `as_label()` abbreviates the arguments
+  # away to `stats::weighted.mean(...)`, which matches no line Arrow writes.
+  long <- quote(stats::weighted.mean(
+    value_column_with_a_long_name,
+    weight_column_with_a_long_name,
+    na.rm = TRUE
+  ))
+  expect_gt(length(deparse(long)), 1L)
+
+  labelled <- absorbed_expression_label(long)
+  expect_length(labelled, 1L)
+  expect_true(startsWith(labelled, deparse(long)[[1L]]))
+  expect_true(endsWith(labelled, "..."))
+  expect_false(identical(labelled, rlang::as_label(long)))
+})
+
+# The other half of the handler's reading, asserted the same way and for the
+# same reason. Which text marks an absorption is a function of the installed
+# Arrow, both phrasings are inside the range `DESCRIPTION` admits, and no
+# session holds both -- so the live gate below sees whichever one CI installed
+# and cannot answer for the other. Left to that gate alone, capitalising the
+# marker and dropping `ignore.case` stays green on every Arrow this package can
+# be tested against while switching the refusal off for four versions it
+# claims, which is not hypothetical: that is the state this branch found the
+# handler in (#254).
+#
+# The inputs carry a class attribute rather than being Arrow objects, which is
+# the whole of what `inherits()` reads, so this runs wherever the suite does --
+# a claim about a reading, like its sibling above, and not about a backend.
+test_that("an absorption is recognised on every phrasing and only on Arrow", {
+  # Built with `structure()` for the reason `test-execution-conditions.R` gives
+  # about its own foreign condition: `warning_cnd()` cannot express the case.
+  # It collapses a vector `message` to one string, which is exactly the shape
+  # the reading guards against, so the guard could not be reached through it.
+  warned <- function(message) {
+    structure(
+      list(message = message, call = NULL),
+      class = c("warning", "condition")
+    )
+  }
+  # Every class the handler scopes itself by, not one of them. `Dataset` is in
+  # the vector and does not absorb; what the loop asserts is the scoping
+  # contract -- that the reading answers for an Arrow input and no other -- and
+  # deriving it is what makes the R-side claim that the two readings share one
+  # class list an assertion rather than a sentence.
+  for (cls in arrow_input_classes()) {
+    input <- structure(list(), class = cls)
+    marked <- function(message) {
+      is_absorbing_backend_warning(warned(message), input)
+    }
+
+    # From Arrow 17.0.0, and through 16.0.0, which differ in the case of the
+    # phrase and in nothing else the reading depends on. `info` rather than
+    # `label`, which would replace the expression and leave a reader knowing
+    # which class failed but not which of the four readings did.
+    expect_true(
+      marked("In paste(s, collapse = \",\"): \nPulling data into R"),
+      info = cls
+    )
+    expect_true(
+      marked("object of type 'closure'; pulling data into R"),
+      info = cls
+    )
+    expect_false(marked("Expression not supported in Arrow"), info = cls)
+
+    # A condition class of another package's may carry a message method
+    # answering with a vector, and `grepl()` over one answers for whichever
+    # element matched. Hence the shape check ahead of the match.
+    expect_false(marked(c("Pulling data into R", "x")), info = cls)
+  }
+
+  # `.data` decides as well as the text. A caller's own summary expression may
+  # spell anything, so the same text over an input that is not Arrow's is some
+  # other backend's warning, and a refusal naming Arrow would be wrong twice
+  # over.
+  not_arrow <- function(.data) {
+    is_absorbing_backend_warning(warned("Pulling data into R"), .data)
+  }
+  expect_false(not_arrow(data.frame(k = 1)))
+  expect_false(not_arrow(structure(list(), class = "dtplyr_step")))
 })
 
 test_that("Arrow refuses a subset inside an aggregate", {
@@ -313,10 +430,15 @@ test_that("an Arrow summary Arrow can evaluate is unchanged and stays lazy", {
 # `$call`, so its message is the only thing to recognise it by; that is
 # undocumented behaviour, and this is what keeps it honest, the way
 # `document.yaml` keeps the roxygen table-row exception honest.
+#
+# The absorption is recognised by calling the handler's own reading rather than
+# by matching the marker again here. A second match would answer for its own
+# spelling and not the handler's: it would report Arrow as still marking the
+# absorption while the handler had stopped recognising it, which is exactly the
+# drift this block exists to catch.
 test_that("Arrow still absorbs the expressions the refusal is asserted over", {
   skip_if_suggest_absent("arrow")
   table <- arrow::Table$create(absorbed_summary_data())
-  marker <- absorbing_warning_marker()
   raised <- NULL
   # One per shape the shipped pages describe, so a page that stops being true
   # fails here rather than being re-read. `first()` and `last()` are absorbed
@@ -336,7 +458,7 @@ test_that("Arrow still absorbs the expressions the refusal is asserted over", {
         dplyr::summarize(table, out = !!absorbed[[shape]], .by = k)
       ),
       warning = function(cnd) {
-        if (grepl(marker, conditionMessage(cnd), ignore.case = TRUE)) {
+        if (is_absorbing_backend_warning(cnd, table)) {
           marked <<- TRUE
           raised <<- cnd
         }

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -115,6 +115,199 @@ test_that("Arrow uses the normalized grouping contract", {
   expect_true("Total" %in% factor_result$a)
 })
 
+# CONTEXT.md's *Absorbing backend*, asserted at the seam ADR 0025 draws it at.
+# An Arrow `Table`, `RecordBatch`, or query over either answers an expression
+# its own engine cannot evaluate by reading the whole input into R; a `Dataset`
+# and a query over one refuse instead, and that refusal is Arrow's to raise.
+# Both halves are asserted, because what the decision turns on is that the two
+# are told apart (#254).
+#
+# The two expressions are chosen for how long they will keep being absorbed
+# rather than for how the defect was found. A group collapsed to one string and
+# a subset inside an aggregate are the shapes least likely to gain an Arrow
+# kernel; `first()` and `last()` are absorbed today and deliberately unused
+# here, being the likeliest of the absorbed set to stop being so. The block
+# below asserts they are still absorbed, so an Arrow release that translates
+# one fails there, naming the drift, rather than here.
+absorbed_summary_data <- function() {
+  data.frame(
+    k = c("E", "E", "W"),
+    v = c(1, 2, 3),
+    s = c("a", "b", "c"),
+    stringsAsFactors = FALSE
+  )
+}
+
+# A query rather than the object itself is the third shape, because
+# `arrow_dplyr_query` is the one class that appears on both sides of the
+# division: over a table it absorbs, over a dataset it refuses. `select()`
+# builds one without a data-masked column reference, which keeps these
+# helpers readable by `object_usage_linter()`.
+absorbing_arrow_inputs <- function(data) {
+  table <- arrow::Table$create(data)
+  list(
+    table = table,
+    record_batch = arrow::record_batch(data),
+    query = dplyr::select(table, dplyr::all_of(names(data)))
+  )
+}
+
+refusing_arrow_inputs <- function(data) {
+  dataset <- arrow::InMemoryDataset$create(arrow::Table$create(data))
+  list(
+    dataset = dataset,
+    query = dplyr::select(dataset, dplyr::all_of(names(data)))
+  )
+}
+
+test_that("Arrow refuses a summary it would otherwise absorb", {
+  skip_if_suggest_absent("arrow")
+  data <- absorbed_summary_data()
+
+  for (input in absorbing_arrow_inputs(data)) {
+    raised <- expect_error(summarize_with_margins(
+      input,
+      joined = paste(s, collapse = ","),
+      .grouping = rollup(k)
+    ))
+
+    expect_s3_class(raised, "marginplyr_error")
+    # The condition this ticket exists to remove, named so that a regression
+    # to it fails as itself rather than as a missing class.
+    expect_false(inherits(raised, "notSubsettableError"))
+    message <- conditionMessage(raised)
+    # The argument as the caller spelled it, not the expression Arrow blamed
+    # inside it and not the internal key columns the branch grouped by.
+    expect_match(
+      message,
+      "joined = paste(s, collapse = \",\")",
+      fixed = TRUE
+    )
+    # The singular arm of this diagnostic; the plural one is the guard block
+    # below, which names every summary argument because it has no warning to
+    # place one from.
+    expect_match(message, "is not a summary Arrow can evaluate", fixed = TRUE)
+    # Both rewrites. The second is the whole reason refusing beats absorbing:
+    # Arrow reads every column, and a caller who is told can read fewer.
+    expect_match(message, "collect", fixed = TRUE)
+    expect_match(message, "column", fixed = TRUE)
+  }
+})
+
+test_that("Arrow refuses a subset inside an aggregate", {
+  skip_if_suggest_absent("arrow")
+
+  raised <- expect_error(summarize_with_margins(
+    arrow::Table$create(absorbed_summary_data()),
+    kept = sum(v[v > 1]),
+    .grouping = rollup(k)
+  ))
+
+  expect_s3_class(raised, "marginplyr_error")
+  expect_match(
+    conditionMessage(raised),
+    "kept = sum(v[v > 1])",
+    fixed = TRUE
+  )
+})
+
+test_that("an Arrow Dataset keeps Arrow's own refusal", {
+  skip_if_suggest_absent("arrow")
+  data <- absorbed_summary_data()
+
+  for (input in refusing_arrow_inputs(data)) {
+    raised <- expect_error(summarize_with_margins(
+      input,
+      joined = paste(s, collapse = ","),
+      .grouping = rollup(k)
+    ))
+
+    # An External condition: Arrow's answer to the question put to it, and
+    # marginplyr's only part in it is the context it carries.
+    expect_s3_class(raised, "arrow_not_supported")
+    expect_false(inherits(raised, "marginplyr_error"))
+  }
+})
+
+test_that("an Arrow summary Arrow can evaluate is unchanged and stays lazy", {
+  skip_if_suggest_absent("arrow")
+
+  result <- summarize_with_margins(
+    arrow::Table$create(absorbed_summary_data()),
+    total = sum(v),
+    .grouping = rollup(k)
+  )
+
+  expect_s3_class(result, "arrow_dplyr_query")
+  expect_setequal(dplyr::collect(result)$total, c(3, 3, 6))
+})
+
+# Part one of the two-part regression. The refusal above asserts what
+# marginplyr does with an absorbed expression; this asserts that Arrow still
+# absorbs the two expressions it is asserted over, and that Arrow still marks
+# the absorption with the text the handler keys on.
+#
+# The text dependency is what makes this block load-bearing rather than
+# redundant. Arrow's fallback warning carries no class, no `$parent`, and no
+# `$call`, so its message is the only thing to recognise it by; that is
+# undocumented behaviour, and this is what keeps it honest, the way
+# `document.yaml` keeps the roxygen table-row exception honest.
+test_that("Arrow still absorbs the expressions the refusal is asserted over", {
+  skip_if_suggest_absent("arrow")
+  table <- arrow::Table$create(absorbed_summary_data())
+  marker <- absorbing_warning_marker()
+  absorbed <- list(quote(paste(s, collapse = ",")), quote(sum(v[v > 1])))
+
+  for (expression in absorbed) {
+    marked <- FALSE
+    result <- withCallingHandlers(
+      rlang::inject(dplyr::summarize(table, out = !!expression, .by = k)),
+      warning = function(cnd) {
+        if (grepl(marker, conditionMessage(cnd), fixed = TRUE)) {
+          marked <<- TRUE
+        }
+        invokeRestart("muffleWarning")
+      }
+    )
+
+    expect_true(marked)
+    # Absorbed rather than translated: a local frame is what Arrow answers
+    # with once it has pulled the input into R.
+    expect_s3_class(result, "data.frame")
+  }
+})
+
+# The backstop, reached by taking the marker away -- which is what an Arrow
+# release that rewords the warning would do. The handler then does not fire,
+# Arrow absorbs, and the branch result is a local frame the input was not: the
+# guard raises the same refusal, so the caller sees what they should have seen
+# and only the CI gate below records the drift.
+#
+# Two summaries rather than one, because the guard names every summary
+# argument where the handler names the one Arrow blamed. That is also the
+# plural arm of this diagnostic; the singular arm is the refusal above.
+test_that("the branch guard refuses an absorbed summary the handler missed", {
+  skip_if_suggest_absent("arrow")
+  testthat::local_mocked_bindings(
+    absorbing_warning_marker = function() {
+      "no Arrow warning is written with this text"
+    }
+  )
+
+  raised <- expect_error(suppressWarnings(summarize_with_margins(
+    arrow::Table$create(absorbed_summary_data()),
+    joined = paste(s, collapse = ","),
+    kept = sum(v[v > 1]),
+    .grouping = rollup(k)
+  )))
+
+  expect_s3_class(raised, "marginplyr_error")
+  message <- conditionMessage(raised)
+  expect_match(message, "joined = paste(s, collapse = \",\")", fixed = TRUE)
+  expect_match(message, "kept = sum(v[v > 1])", fixed = TRUE)
+  expect_match(message, "summaries Arrow can evaluate", fixed = TRUE)
+})
+
 test_that("Arrow schema metadata supports predicates and computed queries", {
   skip_if_suggest_absent("arrow")
 

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -134,43 +134,57 @@ test_that("marginplyr functions reaching an execution entry point", {
 # clean result throughout, which reads exactly like a package that causes no
 # such read, and is the failure mode this gate closes (#254).
 #
-# Tracing Arrow's own methods is what the question needs. Nothing marginplyr
-# holds afterwards says whether a row was read: an absorbed summary answers
-# with a local frame, and so does a summary the caller collected themselves.
-# The trace is installed around one expression and removed on exit, so a
-# failure here leaves nothing behind for the rest of the file.
-# Filtered against the namespace rather than assumed: `DESCRIPTION` admits
-# `arrow (>= 13.0.0)`, and `trace()` errors on a name a version does not bind,
-# which would fail this gate for a reason that is not a read. What matters is
-# that whichever of them the installed Arrow has are watched -- a version
-# missing one cannot reach it either.
-arrow_collect_methods <- function() {
-  candidates <- c(
-    "collect.ArrowTabular",
-    "collect.arrow_dplyr_query",
-    "collect.Dataset"
+# Watching the reads as they happen is what the question needs. Nothing
+# marginplyr holds afterwards says whether a row was read: an absorbed summary
+# answers with a local frame, and so does a summary the caller collected
+# themselves. The trace is installed around one expression and removed on exit,
+# so a failure here leaves nothing behind for the rest of the file.
+#
+# Derived from the catalog above rather than listed again, and traced at the
+# *generic* rather than at a backend's methods. `trace()` rewrites a namespace
+# binding, while S3 dispatch reaches the copy `registerS3method()` left in the
+# methods table, so tracing `arrow:::collect.ArrowTabular` sees only Arrow's own
+# by-name call and misses every `dplyr::collect()` a caller or `R/` makes --
+# which is the read this gate exists to see. Measured on arrow 25.0.1: a plain
+# `dplyr::collect()` of an Arrow table counted 0 that way and counts 1 this way.
+#
+# Only the qualified entries are traced. `as.data.frame` is a base generic that
+# unrelated code calls while any expression runs, so counting it would report a
+# read that never reached a backend; the `DBI::` entries are traced although no
+# Arrow input can reach one, because deriving the set is what keeps it in step
+# with the catalog and skipping them would be a second list.
+traced_execution_entry_points <- function() {
+  catalog <- lazy_execution_entry_points()
+  qualified <- catalog[grepl("::", catalog, fixed = TRUE)]
+  parts <- strsplit(qualified, "::", fixed = TRUE)
+  Filter(
+    function(entry) {
+      isNamespaceLoaded(entry$package) &&
+        exists(entry$name, envir = asNamespace(entry$package))
+    },
+    lapply(parts, function(part) list(package = part[[1L]], name = part[[2L]]))
   )
-  intersect(candidates, ls(asNamespace("arrow"), all.names = TRUE))
 }
 
 # A function tracer rather than `quote()`, which is the difference between
 # counting and silently counting nothing: an expression tracer is evaluated in
-# the traced function's own frame, so its `<<-` walks Arrow's namespace and
-# assigns into the global environment instead of into this counter.
-count_arrow_collects <- function(expr) {
+# the traced function's own frame, so its `<<-` walks the traced package's
+# namespace and assigns into the global environment instead of into this
+# counter.
+count_backend_reads <- function(expr) {
   count <- 0L
-  ns <- asNamespace("arrow")
-  for (method in arrow_collect_methods()) {
+  entries <- traced_execution_entry_points()
+  for (entry in entries) {
     suppressMessages(trace(
-      method,
-      where = ns,
+      entry$name,
+      where = asNamespace(entry$package),
       tracer = function() count <<- count + 1L,
       print = FALSE
     ))
   }
   on.exit(
-    for (method in arrow_collect_methods()) {
-      suppressMessages(untrace(method, where = ns))
+    for (entry in entries) {
+      suppressMessages(untrace(entry$name, where = asNamespace(entry$package)))
     },
     add = TRUE
   )
@@ -188,9 +202,16 @@ test_that("no Arrow read happens while a Margin verb runs", {
   )
   table <- arrow::Table$create(data)
 
+  # The mechanism, asserted before anything is concluded from it. Every
+  # expectation below is a zero, so a counter that counted nothing would report
+  # exactly what a package that reads nothing reports -- which is the shape
+  # `AGENTS.md` rules out for every derived gate, and the shape this counter
+  # had while it traced Arrow's methods.
+  expect_gt(count_backend_reads(dplyr::collect(table)), 0L)
+
   # A summary Arrow evaluates itself: the verb builds a query and returns it.
   expect_identical(
-    count_arrow_collects(summarize_with_margins(
+    count_backend_reads(summarize_with_margins(
       table,
       total = sum(v),
       .grouping = rollup(k)
@@ -202,7 +223,7 @@ test_that("no Arrow read happens while a Margin verb runs", {
   # absorbed one. Asserted rather than assumed, since that is a property of
   # the signature and signatures change.
   expect_identical(
-    count_arrow_collects(expand_with_margins(table, .grouping = rollup(k))),
+    count_backend_reads(expand_with_margins(table, .grouping = rollup(k))),
     0L
   )
 
@@ -210,7 +231,7 @@ test_that("no Arrow read happens while a Margin verb runs", {
   # disposition of #254 is held to. `try()` keeps the refusal from leaving
   # before the count is read.
   expect_identical(
-    count_arrow_collects(try(
+    count_backend_reads(try(
       summarize_with_margins(
         table,
         joined = paste(s, collapse = ","),

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -174,6 +174,18 @@ traced_execution_entry_points <- function() {
 count_backend_reads <- function(expr) {
   count <- 0L
   entries <- traced_execution_entry_points()
+  # Registered before the first trace is installed rather than after the last.
+  # `trace()` failing part-way through the loop would otherwise leave every
+  # trace already installed in place for the rest of the run -- a whole suite,
+  # not a file -- each one incrementing a counter in a frame that has gone.
+  # `untrace()` on a function that was never traced is a no-op, so removing
+  # more than was installed is safe and removing less is not.
+  on.exit(
+    for (entry in entries) {
+      suppressMessages(untrace(entry$name, where = asNamespace(entry$package)))
+    },
+    add = TRUE
+  )
   for (entry in entries) {
     suppressMessages(trace(
       entry$name,
@@ -182,12 +194,6 @@ count_backend_reads <- function(expr) {
       print = FALSE
     ))
   }
-  on.exit(
-    for (entry in entries) {
-      suppressMessages(untrace(entry$name, where = asNamespace(entry$package)))
-    },
-    add = TRUE
-  )
   force(expr)
   count
 }
@@ -228,19 +234,33 @@ test_that("no Arrow read happens while a Margin verb runs", {
   )
 
   # And the refusing path reads nothing, which is the criterion the refuse
-  # disposition of #254 is held to. `try()` keeps the refusal from leaving
-  # before the count is read.
-  expect_identical(
-    count_backend_reads(try(
-      summarize_with_margins(
-        table,
-        joined = paste(s, collapse = ","),
-        .grouping = rollup(k)
-      ),
-      silent = TRUE
-    )),
-    0L
+  # disposition of #254 is held to. Over every input class that absorbs rather
+  # than over the one: what raises the refusal before the read is a class check,
+  # so a class it stopped recognising would be read by Arrow and caught only
+  # afterwards by the guard -- a difference invisible in the condition the
+  # caller receives, both arms raising the same refusal, and visible only here.
+  # `try()` keeps the refusal from leaving before the count is read.
+  batch <- arrow::record_batch(data)
+  absorbing <- list(
+    table = table,
+    record_batch = batch,
+    table_query = dplyr::select(table, dplyr::all_of(names(data))),
+    batch_query = dplyr::select(batch, dplyr::all_of(names(data)))
   )
+  for (shape in names(absorbing)) {
+    expect_identical(
+      count_backend_reads(try(
+        summarize_with_margins(
+          absorbing[[shape]],
+          joined = paste(s, collapse = ","),
+          .grouping = rollup(k)
+        ),
+        silent = TRUE
+      )),
+      0L,
+      info = shape
+    )
+  }
 })
 
 test_that("backend kinds granted the collect_selection_proxy capability", {

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -139,8 +139,18 @@ test_that("marginplyr functions reaching an execution entry point", {
 # with a local frame, and so does a summary the caller collected themselves.
 # The trace is installed around one expression and removed on exit, so a
 # failure here leaves nothing behind for the rest of the file.
+# Filtered against the namespace rather than assumed: `DESCRIPTION` admits
+# `arrow (>= 13.0.0)`, and `trace()` errors on a name a version does not bind,
+# which would fail this gate for a reason that is not a read. What matters is
+# that whichever of them the installed Arrow has are watched -- a version
+# missing one cannot reach it either.
 arrow_collect_methods <- function() {
-  c("collect.ArrowTabular", "collect.arrow_dplyr_query", "collect.Dataset")
+  candidates <- c(
+    "collect.ArrowTabular",
+    "collect.arrow_dplyr_query",
+    "collect.Dataset"
+  )
+  intersect(candidates, ls(asNamespace("arrow"), all.names = TRUE))
 }
 
 # A function tracer rather than `quote()`, which is the difference between

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -126,6 +126,92 @@ test_that("marginplyr functions reaching an execution entry point", {
   expect_snapshot(reach)
 })
 
+# ADR 0020's subject is a read marginplyr *causes*, not one it issues. Every
+# reading above walks `R/`, so all of them are structurally blind to a read
+# another package performs on marginplyr's behalf -- and one such read exists:
+# an Arrow input absorbs an expression its own engine cannot evaluate by
+# collecting the whole input while the verb runs. The scans above reported a
+# clean result throughout, which reads exactly like a package that causes no
+# such read, and is the failure mode this gate closes (#254).
+#
+# Tracing Arrow's own methods is what the question needs. Nothing marginplyr
+# holds afterwards says whether a row was read: an absorbed summary answers
+# with a local frame, and so does a summary the caller collected themselves.
+# The trace is installed around one expression and removed on exit, so a
+# failure here leaves nothing behind for the rest of the file.
+arrow_collect_methods <- function() {
+  c("collect.ArrowTabular", "collect.arrow_dplyr_query", "collect.Dataset")
+}
+
+# A function tracer rather than `quote()`, which is the difference between
+# counting and silently counting nothing: an expression tracer is evaluated in
+# the traced function's own frame, so its `<<-` walks Arrow's namespace and
+# assigns into the global environment instead of into this counter.
+count_arrow_collects <- function(expr) {
+  count <- 0L
+  ns <- asNamespace("arrow")
+  for (method in arrow_collect_methods()) {
+    suppressMessages(trace(
+      method,
+      where = ns,
+      tracer = function() count <<- count + 1L,
+      print = FALSE
+    ))
+  }
+  on.exit(
+    for (method in arrow_collect_methods()) {
+      suppressMessages(untrace(method, where = ns))
+    },
+    add = TRUE
+  )
+  force(expr)
+  count
+}
+
+test_that("no Arrow read happens while a Margin verb runs", {
+  skip_if_suggest_absent("arrow")
+  data <- data.frame(
+    k = c("E", "E", "W"),
+    v = c(1, 2, 3),
+    s = c("a", "b", "c"),
+    stringsAsFactors = FALSE
+  )
+  table <- arrow::Table$create(data)
+
+  # A summary Arrow evaluates itself: the verb builds a query and returns it.
+  expect_identical(
+    count_arrow_collects(summarize_with_margins(
+      table,
+      total = sum(v),
+      .grouping = rollup(k)
+    )),
+    0L
+  )
+
+  # An expansion carries no caller expression at all, so it cannot reach an
+  # absorbed one. Asserted rather than assumed, since that is a property of
+  # the signature and signatures change.
+  expect_identical(
+    count_arrow_collects(expand_with_margins(table, .grouping = rollup(k))),
+    0L
+  )
+
+  # And the refusing path reads nothing, which is the criterion the refuse
+  # disposition of #254 is held to. `try()` keeps the refusal from leaving
+  # before the count is read.
+  expect_identical(
+    count_arrow_collects(try(
+      summarize_with_margins(
+        table,
+        joined = paste(s, collapse = ","),
+        .grouping = rollup(k)
+      ),
+      silent = TRUE
+    )),
+    0L
+  )
+})
+
 test_that("backend kinds granted the collect_selection_proxy capability", {
   ns <- asNamespace("marginplyr")
   enabled_expr <- find_local_assignment(

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -524,12 +524,11 @@ arrow::arrow_table(january_sales) |>
 Collecting first is one rewrite; selecting the columns the summary needs before
 collecting is the other, and it is the one Arrow's own route cannot take for
 you. Which expressions this reaches is Arrow's to decide and changes with its
-version, so this vignette does not list them. Today it is a group collapsed
-into a single value, an extraction that depends on row order, a subset written
-inside an aggregate, and a statistic over two columns at once; the ordinary
-numeric summaries, and arithmetic over them, stay lazy. An Arrow dataset
-answers the same expressions with Arrow's own error rather than this one,
-because a dataset never reads itself into R.
+version, so the shapes are described in one place rather than repeated here —
+see the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
+An Arrow dataset answers the same expressions with Arrow's own error rather
+than this one, because a dataset never reads itself into R.
 
 The second is contextual shares. `share_of_parent()` and `share_of_total()` are
 both rejected outright, before any Arrow query is constructed: the reason is the

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -500,10 +500,40 @@ january_sales |>
   collect()
 ```
 
-Arrow summaries and expansions are supported and lazy, but `share_of_parent()`
-and `share_of_total()` are both rejected outright, before any Arrow query is
-constructed: the reason is the source summary they share. Collect the Arrow
-table first when you need either.
+Arrow summaries and expansions are supported and lazy wherever Arrow can
+evaluate the summary itself. Two things are refused instead, for two unrelated
+reasons.
+
+The first is a summary Arrow's own engine cannot evaluate. Arrow answers one of
+those by reading the whole input — every column, not just the ones the summary
+names — and computing it in R, so marginplyr refuses it before a row is read
+and tells you the two ways to get it computed:
+
+```{r}
+#| label: arrow-absorbed-summary
+#| eval: !expr has_arrow
+#| must_error: marginplyr_error
+
+arrow::arrow_table(january_sales) |>
+  summarize_with_margins(
+    channels = paste(sort(unique(channel)), collapse = "/"),
+    .grouping = rollup(region, store)
+  )
+```
+
+Collecting first is one rewrite; selecting the columns the summary needs before
+collecting is the other, and it is the one Arrow's own route cannot take for
+you. Which expressions this reaches is Arrow's to decide and changes with its
+version, so this vignette does not list them. Today it is a group collapsed
+into a single value, an extraction that depends on row order, a subset written
+inside an aggregate, and a statistic over two columns at once; the ordinary
+numeric summaries, and arithmetic over them, stay lazy. An Arrow dataset
+answers the same expressions with Arrow's own error rather than this one,
+because a dataset never reads itself into R.
+
+The second is contextual shares. `share_of_parent()` and `share_of_total()` are
+both rejected outright, before any Arrow query is constructed: the reason is the
+source summary they share. Collect the Arrow table first when you need either.
 
 ```{r}
 #| label: arrow-parent-share


### PR DESCRIPTION
Closes #254.

A Margin summary over an in-memory Arrow input aborted with `object of type
'special' is not subsettable` whenever the caller's expression was one Arrow
cannot translate. The condition carried `notSubsettableError/error/condition`,
named nothing the caller wrote, and offered no rewrite — an upstream internal
failure surfacing as though it were the backend's answer, which is the shape
#100 removed from static expression analysis.

`arrow:::try_arrow_dplyr()` recovers the originating call with
`evalq(call <- match.call(), parent)`. Reached through a `...`-forwarding
wrapper that raises, `call` is never bound, and `abandon_ship()` then finds
`base::call` by inheriting lookup and subsets an object of type `"special"`.
`summarize_margin_branch()` was the only `...`-forwarding site in the package;
the native adapter already splices at the call site, so the shape that works
was already here.

## What it does

The disposition recorded on the ticket is **refuse**. A summary Arrow's own
engine cannot evaluate is now refused with a `marginplyr_error` naming the
argument as the caller spelled it and both rewrites — collect first, and select
the columns the summary needs before collecting. No row is read on that path.

Refusing rather than falling back is not a cost argument, and ADR 0025 records
why it cannot be: an input that absorbs is, by class, already in this process's
memory, so ADR 0020's billed-bytes reasoning reaches none of it. It rests on
ADR 0020's other half — when the caller's data is read is the caller's to
decide — and on what absorbing takes from them. Arrow collects the input as the
verb received it, every column, including the ones the expression never
mentions. A caller who is told can `select()` first; a caller who is never
consulted cannot.

## Two mechanisms, failing in opposite directions

The **handler** reads the warning Arrow marks an absorption with, which is
raised before it collects, so nothing is read. Arrow's carries no class, no
`$parent` and no `$call`, so its text is the only thing to key on — undocumented
behaviour of another package, gated rather than trusted.

The **guard** reads the branch result's class, which cannot stop matching but
only answers after the branch has run, bounding a missed absorption at one
branch rather than one per grouping set. It has two arms: over an Arrow input it
raises the same refusal, and over any other lazy input an internal invariant,
since the refusal's remedies are Arrow's and raising them elsewhere would name a
backend that was not involved. That second arm departs from the wording the
ticket was accepted with and is ratified on it.

## The version range is load-bearing

Every measurement was taken on arrow 25.0.1 while `DESCRIPTION` admits
`arrow (>= 13.0.0)`, and the range is not decorative. Arrow reworded the
fallback warning between 16.0.0 and 17.0.0: what survived is the phrase and not
its capitalisation, so the match is case-insensitive by necessity. Through
16.0.0 `abandon_ship()` took the call as an argument and there was no crash —
the call returned the right answer, having read the whole input to get it. On
those versions this is a breaking change, and `NEWS.md` says so.

## Documentation

The vignette and both reference pages narrow the Arrow claim to summaries Arrow
can translate, and describe the *shapes* refused rather than listing functions:
a list of those would be a claim about one version of Arrow. `CONTEXT.md` gains
*Absorbing backend* and sharpens *External condition* to a condition a backend
raises **as its answer to the question put to it** — as written, the old entry
admitted `notSubsettableError`, which is how this defect read as
contract-abiding. ADR 0020's Arrow sentence was factually wrong and load-bearing
for this decision, so it is amended rather than left standing.

## Gates

The regression is in two parts, because one alone would fail without saying why:
that Arrow still absorbs the expressions the refusal is asserted over, and that
the refusal is raised across every Arrow input class. `test-query-policy.R`
gains the maintainer's half — its other readings walk `R/` and so cannot see a
read another package performs on marginplyr's behalf — counting the backend's
own reads while a verb runs, over an evaluated summary, an expansion, and the
refusing path on all four absorbing shapes.

Every reading the refusal turns on is asserted where it can fail: both Arrow
phrasings of the marker, the `In <expr>: ` header the blamed summary is placed
from, the label convention past the deparse width where `deparse()` and
`rlang::as_label()` part company, and both rewrites on spans only each carries.

Full suite: 4905 pass, 0 fail, 0 skip, 0 warn. `lintr` and `spelling` clean,
`roxygen2` produces no diff, and `verify-suite-coverage.R` reports 613 tests
with none executing in zero configurations.
