### PR TITLE
Refuse a nested name the input and a binding both claim

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,8 @@ returns is therefore refused there, in marginplyr's own words and with the
 binding that works, while the same call is accepted as `.grouping` itself. The
 position answers for its own argument and not for a part of one: a
 specification written inside a selection is the wrong kind of object where it
-sits, and the selection's own report is what says so.
+sits, and where the input has no column of that name the selection's own
+report is what says so.
 
 A bare name is the one argument both readings can claim, where the input has a
 column of that name and the caller's environment binds that name to a
@@ -44,7 +45,6 @@ binding is read, it is read once, because what kind a name is bound to cannot
 be learned any other way. Inside a selection no second reading arises at all:
 a selection takes the column, which is what a selection means by a name the
 data holds.
-
 _Avoid_: Nested grouping, nested slot
 
 **Grouping plan**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,14 +20,31 @@ An argument of a Grouping specification constructor, where a nested Grouping
 specification and a column selection are both allowed. Which one is meant is
 decided by how the argument is written: a call to a constructor, or a name
 bound to a specification, is a nested specification, and every other argument
-is a column selection. The position never evaluates an argument to find out,
-because a selection such as `starts_with("re")` has no meaning outside a
-selection context. A specification a caller's own function returns is
-therefore refused there, in marginplyr's own words and with the binding that
-works, while the same call is accepted as `.grouping` itself. The position
-answers for its own argument and not for a part of one: a specification
-written inside a selection is the wrong kind of object where it sits, and
-keeps the selection's own report.
+is a column selection. A spelling the position does not recognize is never
+evaluated to find out, because a selection such as `starts_with("re")` has no
+meaning outside a selection context. A specification a caller's own function
+returns is therefore refused there, in marginplyr's own words and with the
+binding that works, while the same call is accepted as `.grouping` itself. The
+position answers for its own argument and not for a part of one: a
+specification written inside a selection is the wrong kind of object where it
+sits, and the selection's own report is what says so.
+
+A bare name is the one argument both readings can claim, where the input has a
+column of that name and the caller's environment binds that name to a
+specification the position admits. Such a name is refused rather than
+resolved, naming both readings and the spelling that settles each —
+`all_of("s")` for the column, `!!s` for the specification — because either
+precedence would decide by the input what the spelling is supposed to decide,
+and would decide it silently. Which kinds a position admits is what makes the
+second reading available, and the input never is: `grouping_sets()` and
+`grouping_spec()` admit every kind, `rollup()` and `cube()` admit a
+`grouping_set()` composite dimension, and `grouping_set()` admits none, so a
+colliding name there is a column and its binding is never read. Where the
+binding is read, it is read once, because what kind a name is bound to cannot
+be learned any other way. Inside a selection no second reading arises at all:
+a selection takes the column, which is what a selection means by a name the
+data holds.
+
 _Avoid_: Nested grouping, nested slot
 
 **Grouping plan**:

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,11 @@
   specification. That refusal is now marginplyr's own diagnostic, naming the
   recognized forms and the binding that works — `s <- my_spec(region)`, then
   `grouping_sets(s, grade)` — rather than tidyselect reporting the
-  specification as an unusable column selection.
+  specification as an unusable column selection. A name both readings claim —
+  a column of your input that is also bound to a nested specification the
+  position accepts — is refused rather than resolved by whichever the data
+  happens to have, and the refusal names the spelling for each reading:
+  `all_of("s")` for the column, `!!s` for the specification.
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -313,6 +313,7 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   for (arg in grouping_spec$args) {
     nested <- grouping_arg_spec(arg, data_vars)
     if (is.null(nested)) {
+      check_ambiguous_nested_name(arg, grouping_spec, rule, data_vars)
       name_only <- name_only && is_name_only_selection(arg, data_vars)
       next
     }
@@ -323,6 +324,181 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   }
   list(spec = grouping_spec, name_only = name_only)
 }
+
+# The one argument that has two readings available: a bare name that is a
+# column of the input and is bound to a specification of a kind this position
+# admits. The gate above answers it as a selection, because a selection is what
+# tidyselect's own precedence makes of a name the data holds -- so the caller
+# who meant the binding they wrote gets a well-formed plan of the other reading,
+# and nothing says so (#255). Refusing is what keeps a nested position's reading
+# decided by the spelling rather than by the input, without deciding it the
+# other way and leaving the same silence behind (ADR 0026).
+#
+# Available, not disagreeing: whether the two readings would produce different
+# grouping sets cannot be known without resolving the specification against this
+# input, and deciding by the input is the defect. So a name whose two readings
+# happen to agree is refused with the rest.
+#
+# Reading the binding is what the answer costs, and there is no cheaper
+# question: which kind a name is bound to cannot be known without reading it.
+# So a colliding name in a position that admits any kind is read once, where it
+# was read not at all -- once for each argument it is written as, and whether or
+# not its reading then changes, since what the read decides is whether it
+# changes. No argument outside a collision is read any more often than it was,
+# and a position that admits no kind reads nothing.
+#
+# It sits in the preflight rather than in the gate because the preflight runs
+# once for a whole operation and is handed to both compilation passes, where
+# the gate runs again on each.
+#
+# More than the count moves. Where the refusal fires, the arguments written
+# after it are not read at all, and this refusal is reported in place of
+# whatever the call would have been rejected for further along -- which is
+# every diagnostic reachable past this point and not one of them: a missing
+# column, a duplicate grouping set, a `.by` overlap, each nesting-grammar
+# rejection, and #190's own refusal among them. Where that displaced rejection
+# was an External condition, a caller who was receiving tidyselect's class and
+# tidyselect's blamed call now receives a `marginplyr_error` blamed on the
+# Margin verb.
+#
+# ADR 0008's compatibility list holds all of that, and not on the same terms.
+# The number and timing of evaluations are held "without a separately accepted
+# decision", which is the decision ADR 0026 makes. Condition classes, complete
+# messages, public call contexts, and detection order are one bullet carrying
+# no such clause, and this moves every item in it, so ADR 0026 amends that
+# bullet whole rather than naming a part of it.
+#
+# What that costs a caller is the forcing itself, not only the count: a
+# specification bound to a wrapper's own lazy argument is forced here for a
+# call whose answer may not depend on it, so a warning or a message it raises
+# reaches the caller, and R's own `restarting interrupted promise evaluation`
+# does where such a binding raises and the name is written more than once. ADR
+# 0026 accepts that rather than hiding it, since the alternative to reading the
+# binding is deciding by the input, which is the defect.
+#
+# The two conditions on the name below are the two that made the gate answer
+# "selection" for a symbol, asked again here because the gate reports which
+# reading it took and not why. A name nothing binds has no second reading, and
+# a name the data does not hold is resolved by the gate itself.
+#
+# The kinds this position admits are asked before the binding is read, so a
+# position that admits none -- `grouping_set()`, which holds columns -- reads
+# nothing. Nothing there could make the name ambiguous, and reading a caller's
+# binding to establish that would force a promise for an answer that was
+# already known.
+#
+# The shape test comes before anything is bound to a local, and it is
+# `is_name_part()` rather than a bare symbol test. Both halves are the rule
+# `R/utils.R` states for every reader a walk asks first: `expr <- ...` would
+# bind R's empty argument and raise `missingArgError` on the next read of it,
+# and the empty argument is itself a symbol whose name is `""` (#168, #174,
+# #261).
+#
+# A binding that raises when it is read is not a specification, so the
+# selection reading stands where it raises. Both catches are narrow in what
+# they decide and not in what they swallow: everything they hide is a failure
+# to produce a specification of an admitted kind, which is a specification
+# reading that is not available.
+check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
+  if (!is_name_part(rlang::quo_get_expr(arg))) {
+    return(invisible(NULL))
+  }
+  name <- rlang::as_string(rlang::quo_get_expr(arg))
+  if (
+    !name %in% data_vars ||
+      !rlang::env_has(rlang::quo_get_env(arg), name, inherit = TRUE)
+  ) {
+    return(invisible(NULL))
+  }
+  admitted <- admitted_nested_kinds(parent, rule)
+  if (length(admitted) == 0L) {
+    return(invisible(NULL))
+  }
+
+  value <- tryCatch(rlang::eval_tidy(arg), error = function(cnd) NULL)
+  if (!inherits(value, "margin_grouping_spec")) {
+    return(invisible(NULL))
+  }
+  kind <- tryCatch(value$type, error = function(cnd) NULL)
+  if (
+    !is.character(kind) ||
+      length(kind) != 1L ||
+      !kind %in% admitted
+  ) {
+    return(invisible(NULL))
+  }
+  abort_ambiguous_nested_name(name)
+}
+
+# Which nested kinds this position admits: `grouping_set()` none, `rollup()`
+# and `cube()` a `grouping_set()`, `grouping_sets()` and `grouping_spec()` all
+# of them. It is the other half of "both readings are available", and the half
+# the input may not answer.
+#
+# The kind is where the line sits, and nothing further. A specification of an
+# admitted kind that is invalid on its own terms -- one with no arguments, one
+# holding a family its own constructor forbids -- makes the name ambiguous just
+# the same, because what is wrong with it is a property of what the caller
+# wrote and `!!` is what reports it. What the refusal's advice promises is the
+# reading, not that the reading succeeds: a caller who meant that specification
+# receives the diagnostic about it, which is what the silent column selection
+# withheld. Drawing the line further in would put arity and validity on the
+# same footing as the input, and one of those is not like the others.
+#
+# Derived by asking each kind's own parent rule rather than by a second list of
+# which kinds nest inside which (ADR 0008), so a sixth kind is admitted or
+# refused here by the rule that decides it everywhere else. The rule answers
+# about an instance, so it is asked about one that differs from a caller's only
+# where it must not decide here -- each kind is offered carrying one argument,
+# which is what keeps an empty `grouping_set()` binding from being read as a
+# kind `rollup()` does not admit.
+#
+# Asking costs a raised Package condition for every kind the parent refuses,
+# which is four of five under `rollup()` and `cube()` and every one of them
+# under `grouping_set()` -- a cli expansion and a backtrace apiece, for
+# conditions no caller sees. So the answer is kept, and the key is the parent's
+# kind. What that key rests on is that no rule reads anything of the parent but
+# its kind: of the three the five kinds share, two ignore the parent entirely
+# and the third reads its type, to name it in a message. It does not rest on
+# the nested side, where arity is read and where the stand-in above is what
+# fixes it -- a stand-in carrying no argument would answer `{}` for `rollup()`
+# and `cube()`, turning the refusal off in two of the five positions. A rule
+# reading more of a parent than its kind would need this key widened; the first
+# computation for a kind is made with the real parent, so no parent asked about
+# here is a specification that was not written.
+#
+# Memoized as `grouping_kind_rules()` is, and for the same reason: the table it
+# derives from is fixed for the session.
+admitted_nested_kinds <- local({
+  admitted <- list()
+
+  function(parent, rule) {
+    parent_kind <- parent$type
+    known <- admitted[[parent_kind]]
+    if (!is.null(known)) {
+      return(known)
+    }
+    kinds <- names(grouping_kind_rules())
+    accepted <- vapply(
+      kinds,
+      function(kind) {
+        tryCatch(
+          {
+            rule$validate_nested(
+              parent,
+              new_grouping_spec(kind, list(rlang::quo(NULL)))
+            )
+            TRUE
+          },
+          error = function(cnd) FALSE
+        )
+      },
+      logical(1)
+    )
+    admitted[[parent_kind]] <<- unname(kinds[accepted])
+    admitted[[parent_kind]]
+  }
+})
 
 # The one way to turn a Grouping specification into a plan: preflight the
 # specification, then compile what the preflight resolved. Every call site is
@@ -709,6 +885,12 @@ grouping_arg_spec <- function(arg, data_vars) {
   # selection context. What runs once the gate opens is whatever the name is
   # bound to, so a constructor is not a Contextual helper even though it is
   # read statically (ADR 0019).
+  #
+  # It is not the only thing that evaluates a nested argument any more.
+  # `check_ambiguous_nested_name()` reads only names this gate declined, and
+  # only those it declined because the data holds them, in a position admitting
+  # a nested kind (ADR 0026). So no name is read twice, and a reader auditing
+  # when a caller's nested quosure is forced has that read to count as well.
   is_constructor_call <-
     !is.null(static_spelling_name(expr, "grouping_constructor"))
 
@@ -770,6 +952,12 @@ resolve_grouping_selection <- function(arg, data_proxy) {
 # they have already made. Comparing the labels is what separates the two, and
 # both are written by `rlang::as_label()` from the same expression when the
 # argument as a whole is what was refused.
+#
+# Where a column shares the name, tidyselect refuses nothing and none of this
+# runs: `c(s, region)` selects the column `s`, which is the one reading a
+# selection has for a name the data holds. The ambiguity refusal does not reach
+# inside a selection either, and deliberately -- the caller wrote a selection,
+# so the specification reading was never available to that argument.
 is_grouping_spec_subscript <- function(cnd, label) {
   any(vapply(
     condition_chain(cnd),
@@ -778,6 +966,43 @@ is_grouping_spec_subscript <- function(cnd, label) {
         identical(condition$subscript_arg, label)
     },
     logical(1)
+  ))
+}
+
+# The name as a caller writes it in code, which is the name itself wherever R
+# parses it as one and a backtick-quoted spelling everywhere else.
+# `expr_deparse()` answers which of the two it is -- a syntactic name should
+# not pay backticks it does not need -- and `encodeString()` writes the quoted
+# form, because `expr_deparse()`'s own is `` `a`b` `` for a name holding a
+# backtick, which does not parse.
+quoted_name_spelling <- function(name) {
+  deparsed <- rlang::expr_deparse(rlang::sym(name), width = Inf)
+  if (identical(deparsed, name)) {
+    return(name)
+  }
+  encodeString(name, quote = "`")
+}
+
+# Both bullets are spellings the caller can run rather than descriptions of
+# one, so each is built as a value and interpolated as one: the quoting a
+# non-syntactic name needs is different inside `all_of()` and after `!!`, and
+# neither the name nor the template carries either.
+#
+# The two are read only from the cli template below, which codetools cannot
+# see.
+abort_ambiguous_nested_name <- function(name) {
+  # nolint start: object_usage_linter.
+  column <- paste0("all_of(", encodeString(name, quote = "\""), ")")
+  specification <- paste0("!!", quoted_name_spelling(name))
+  # nolint end
+  abort_marginplyr(c(
+    paste0(
+      "{.var {name}} is both a column of the input and a name bound to a ",
+      "grouping specification, so a nested position cannot tell which one ",
+      "you mean."
+    ),
+    i = "For the column, write {.code {column}}.",
+    i = "For the specification, write {.code {specification}}."
   ))
 }
 

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -395,10 +395,23 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # #261).
 #
 # A binding that raises when it is read is not a specification, so the
-# selection reading stands where it raises. Both catches are narrow in what
-# they decide and not in what they swallow: everything they hide is a failure
-# to produce a specification of an admitted kind, which is a specification
-# reading that is not available.
+# selection reading stands where it raises, and so does an object carrying the
+# class with no kind to read -- an atomic vector given the class answers `$`
+# with a condition of its own, and a list without the field answers `NULL`,
+# neither of which is a kind this position could admit. Both catches are narrow
+# in what they decide and not in what they swallow: everything they hide is a
+# failure to produce a specification of an admitted kind, which is a
+# specification reading that is not available. That is where the ADR-0015 line
+# falls too, because nothing here is deciding what such an object is -- a list
+# carrying the class and no kind, bound to a name nothing shadows, still
+# reaches `validate_grouping_spec_early()` and is refused in its own words.
+# Where that guard reads a field too early to reach its own refusal is #262,
+# which reproduces at top level and so is not this position's to answer.
+#
+# `rule` is the parent's own, which the caller already holds because it
+# validates nested arguments with it; deriving it again here would be the same
+# lookup twice. That it is the parent's own is also what makes the memo below
+# sound, since the key is the parent's kind and nothing reads the pair apart.
 check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
   if (!is_name_part(rlang::quo_get_expr(arg))) {
     return(invisible(NULL))
@@ -987,10 +1000,9 @@ quoted_name_spelling <- function(name) {
 # one, so each is built as a value and interpolated as one: the quoting a
 # non-syntactic name needs is different inside `all_of()` and after `!!`, and
 # neither the name nor the template carries either.
-#
-# The two are read only from the cli template below, which codetools cannot
-# see.
 abort_ambiguous_nested_name <- function(name) {
+  # Both are read only from the cli template below, which codetools cannot
+  # see.
   # nolint start: object_usage_linter.
   column <- paste0("all_of(", encodeString(name, quote = "\""), ")")
   specification <- paste0("!!", quoted_name_spelling(name))

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -348,7 +348,7 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # and a position that admits no kind reads nothing.
 #
 # It sits in the preflight rather than in the gate because the preflight runs
-# once for a whole operation and is handed to both compilation passes, where
+# once for a whole operation and is handed to the compilation passes, where
 # the gate runs again on each.
 #
 # More than the count moves. Where the refusal fires, the arguments written

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -138,11 +138,12 @@ prepare_grouping_plan <- function(.data,
       if (!is.null(validate_names)) {
         validate_names(data_vars)
       }
-      # Preflighted once and handed to both compilation passes. Preflight is
-      # not a free re-run: `grouping_arg_spec()` evaluates a symbol or a nested
-      # constructor argument, so preflighting per pass would evaluate a
-      # caller's quosure twice, and ADR-0008 holds the number and timing of
-      # evaluations fixed.
+      # Preflighted once and handed to every compilation pass -- both of them
+      # where the plan is settled by names alone, and the one below otherwise.
+      # Preflight is not a free re-run: `grouping_arg_spec()` evaluates a
+      # symbol or a nested constructor argument, so preflighting per pass would
+      # evaluate a caller's quosure once per pass rather than once, and
+      # ADR-0008 holds the number and timing of evaluations fixed.
       preflight <- preflight_grouping_spec(grouping_spec, data_vars)
       if (preflight$name_only) {
         # Reject name-only plan errors before acquiring typed metadata. The

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -368,12 +368,14 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # no such clause, and this moves every item in it, so ADR 0026 amends that
 # bullet whole rather than naming a part of it.
 #
-# What that costs a caller is the forcing itself, not only the count: a
-# specification bound to a wrapper's own lazy argument is forced here for a
-# call whose answer may not depend on it, so a warning or a message it raises
-# reaches the caller, and R's own `restarting interrupted promise evaluation`
-# does where such a binding raises and the name is written more than once. ADR
-# 0026 accepts that rather than hiding it, since the alternative to reading the
+# What that costs a caller is the forcing itself, not only the count, and it
+# reaches every colliding binding rather than the ones that turn out to be
+# specifications -- the read is what establishes which those are. So a
+# wrapper's own lazy argument is forced here, whatever it holds, for a call
+# whose answer may not depend on it: a warning or a message it raises reaches
+# the caller, and R's own `restarting interrupted promise evaluation` does
+# where such a binding raises and the name is written more than once. ADR 0026
+# accepts that rather than hiding it, since the alternative to reading the
 # binding is deciding by the input, which is the defect.
 #
 # The two conditions on the name below are the two that made the gate answer
@@ -389,10 +391,13 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 #
 # The shape test comes before anything is bound to a local, and it is
 # `is_name_part()` rather than a bare symbol test. Both halves are the rule
-# `R/utils.R` states for every reader a walk asks first: `expr <- ...` would
-# bind R's empty argument and raise `missingArgError` on the next read of it,
-# and the empty argument is itself a symbol whose name is `""` (#168, #174,
-# #261).
+# `R/utils.R` states for every reader a walk asks first: binding R's empty
+# argument raises `missingArgError` on the next read of it, and the empty
+# argument is itself a symbol whose name is `""` (#168, #174). No empty
+# argument reaches this function today, because `grouping_arg_spec()` binds
+# one a line earlier and raises there, which is #261; following the rule here
+# is what keeps this from becoming a second site of it once that one is
+# fixed.
 #
 # A binding that raises when it is read is not a specification, so the
 # selection reading stands where it raises, and so does an object carrying the

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -45,7 +45,20 @@
 #'   accepted as `.grouping` itself. Assign what it returns to a name and use
 #'   that name: `s <- my_spec(region)`, then `grouping_sets(s, grade)`. A
 #'   specification written inside a selection, as in `c(s, grade)`, is a
-#'   selection containing something it cannot select, and is refused as one.
+#'   selection containing something it cannot select, and is refused as one —
+#'   unless the input has a column named `s`, when the selection takes that
+#'   column, as any selection does with a name the data holds.
+#'
+#'   A name both readings claim is refused rather than guessed. Where the
+#'   input has a column named `s` and `s` is also bound to a nested Grouping
+#'   specification the position accepts, the call names both readings and the
+#'   spelling that settles each: `all_of("s")` selects the column whatever is
+#'   bound, and `!!s` uses the specification whatever columns the input has.
+#'   What a position accepts is what decides whether there are two readings,
+#'   so a colliding name is refused in [grouping_sets()] and [grouping_spec()]
+#'   whatever it is bound to, in [rollup()] and [cube()] only when it is bound
+#'   to a [grouping_set()], and never in [grouping_set()], which takes no
+#'   nested Grouping specification at all.
 #'
 #'   A dimension is a column of the input, so a selection cannot rename it:
 #'   `c(area = region)` is an error rather than a dimension named `area`.

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -56,9 +56,10 @@
 #'   bound, and `!!s` uses the specification whatever columns the input has.
 #'   What a position accepts is what decides whether there are two readings,
 #'   so a colliding name is refused in [grouping_sets()] and [grouping_spec()]
-#'   whatever it is bound to, in [rollup()] and [cube()] only when it is bound
-#'   to a [grouping_set()], and never in [grouping_set()], which takes no
-#'   nested Grouping specification at all.
+#'   whatever specification it is bound to, in [rollup()] and [cube()] only
+#'   when it is bound to a [grouping_set()], and never in [grouping_set()],
+#'   which takes no nested Grouping specification at all. A name bound to
+#'   anything that is not a specification is a column, as it always was.
 #'
 #'   A dimension is a column of the input, so a selection cannot rename it:
 #'   `c(area = region)` is an error rather than a dimension named `area`.

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -15,8 +15,9 @@
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
 #'   represents the empty grouping set. Any expression returning a
 #'   specification can be written here, while a specification nested inside
-#'   another must be a constructor call or a name bound to one; see
-#'   [grouping_set()].
+#'   another must be a constructor call or a name bound to one, and a nested
+#'   name the input also has a column for is refused rather than read either
+#'   way; see [grouping_set()].
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, and nothing
 #'   else, controlling duplicate grouping-set occurrences; see *Option
 #'   arguments*.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -22,8 +22,9 @@
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
 #'   represents one empty grouping set. Any expression returning a
 #'   specification can be written here, while a specification nested inside
-#'   another must be a constructor call or a name bound to one; see
-#'   [grouping_set()].
+#'   another must be a constructor call or a name bound to one, and a nested
+#'   name the input also has a column for is refused rather than read either
+#'   way; see [grouping_set()].
 #' @param .margin_label A display label for dimensions omitted from a grouping
 #'   set. An unnamed character scalar applies to every resolved Margin
 #'   dimension. A named character vector must name every resolved Margin

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -89,6 +89,33 @@ The implementation must not change:
   or
 - the Grouping plan representation or its consumers.
 
+## Amendment: one nested argument, whose reading the spelling does not settle
+
+Two of the constraints above are amended by ADR 0026, which refuses a bare name
+in a Nested specification position that is both a column of the input and bound
+to a specification of a kind the position admits. Everything else in the list
+stands, and the registry this ADR centralizes is what that refusal derives
+availability from: it asks the parent's own `validate_nested()` rule rather than
+carrying a second list of which kinds nest inside which.
+
+**Evaluations.** The third constraint holds the number and timing of
+evaluations "without a separately accepted decision", and ADR 0026 is that
+decision, for that one argument. Deciding whether the two readings differ is a
+property of the bound value, so the binding is read — once, in the structural
+preflight, where it was read not at all. No argument outside such a collision is
+read more often than before, quosure environments are unchanged, and a position
+admitting no nested kind reads nothing. Timing moves with the count: where the
+refusal fires, the arguments written after it are not read.
+
+**Conditions and detection order.** The second constraint carries no such
+clause, and the refusal moves every item in it, so ADR 0026 amends it whole
+rather than naming a part of it. The refusal is reported in place of whatever
+the call would have been rejected for further along — a missing column, a
+duplicate grouping set, a `.by` overlap, each nesting-grammar rejection above,
+and #190's refusal among them — and where that displaced rejection was an
+External condition, the caller now receives a `marginplyr_error` blamed on the
+Margin verb instead of tidyselect's class and tidyselect's blamed call.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:
@@ -145,3 +172,7 @@ evaluation of a nested specification argument. ADR 0019 registers every
 statically recognized spelling in one place and derives the constructor family
 from this table rather than restating it, and records why a constructor is not
 a Contextual helper even though its spelling is read before anything runs.
+
+ADR 0026 refuses the one nested argument whose reading a spelling does not
+settle, deriving which kinds each position admits from this registry's own
+nesting rules, and is what the amendment above was written for.

--- a/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
+++ b/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
@@ -1,0 +1,248 @@
+# Refuse a nested name two readings claim
+
+A Nested specification position decides what an argument means by how it is
+written. One argument defeats that rule: a bare name that is a column of the
+input *and* is bound in the caller's environment to a Grouping specification of
+a kind the position admits. Both readings are available, the spelling settles
+neither, and the position resolved it by asking the data — the one thing the
+rule says does not decide.
+
+That name is refused. The refusal is a Package condition naming both readings
+and a spelling that settles each:
+
+```r
+grouping_sets(all_of("s"))   # the column, whatever is bound
+grouping_sets(!!s)           # the specification, whatever columns exist
+```
+
+Neither spelling is new. Both worked before this decision and are what the
+refusal points at.
+
+## Why a caller is asked rather than served
+
+The reason this is worth a refusal rather than a documented precedence is that
+the wrong plan is **silent and well-formed**. `grouping_sets(s)` over an input
+with a column `s` produced a plan with the right shape, the right column type,
+and no missing values, so nothing downstream reported anything — and every
+value derived from the plan went with it: the grouping sets, `.id`,
+`grouping_bit()`, `grouping_id()`, and the parent a Parent share divides by
+(#255).
+
+Choosing either precedence keeps that property and only moves which reading is
+silently wrong. Preferring the binding makes the documented sentence true as
+written, and silently changes what an existing call returns for a caller who
+has a column and an unrelated binding of that name in scope. Preferring the
+column is what the position does today. Refusing is the only disposition that
+removes the silence in both directions, and it removes nothing else: a caller
+who meant either reading has a spelling for it, and had one before.
+
+It is also what this position already does with the other argument it cannot
+read. #190 could have been answered by evaluating every nested argument and
+accepting whatever turned out to be a specification; the position refused
+instead and named the spelling that works. ADR 0015's criterion for a Package
+condition — an error the caller can avoid by rewriting the call within the
+documented public interface — is satisfied twice over here, because both
+rewrites already existed.
+
+## What makes the second reading available
+
+There are two readings only where the specification reading is *available*, and
+availability is decided by the **kind** of the bound specification — never by
+the input, which is the rule this decision exists to keep:
+
+- `grouping_sets()` and `grouping_spec()` admit every kind, so any colliding
+  name bound to a specification is refused there.
+- `rollup()` and `cube()` admit a `grouping_set()` composite dimension, so a
+  colliding name bound to anything else keeps the column reading it has today.
+- `grouping_set()` admits no kind at all, so a colliding name there is always
+  the column, and the binding is never read.
+
+That is the ticket's second acceptance criterion read precisely: the behaviour
+is the same in every position *that takes a nested specification*, and where the
+position takes none there is nothing to be ambiguous about.
+
+Which kinds a position admits is derived by asking that position's own
+`validate_nested()` rule from the kind registry ADR 0008 centralized, so a sixth
+kind is admitted or refused here by the rule that decides it everywhere else and
+there is no second list of what nests inside what. The rule answers about an
+instance, so it is asked about a stand-in of each kind rather than about the
+caller's value, and the stand-in carries one argument: `rollup()` and `cube()`
+read a composite's arity as well as its kind, so a stand-in carrying none
+answers "nothing is admitted" for both and turns the refusal off in two of the
+five positions.
+
+**Availability, not disagreement.** Whether the two readings would produce
+different grouping sets cannot be known without resolving the specification
+against this input, and deciding by the input is the defect. A name whose two
+readings happen to agree is therefore refused with the rest.
+
+**The kind, and nothing further.** A specification of an admitted kind that is
+invalid on its own terms — one with no arguments, one holding a family its own
+constructor forbids, a composite that is empty once its selection has run —
+makes the name ambiguous just the same, because what is wrong with it is a
+property of what the caller wrote. What the advice promises is the reading, not
+that the reading succeeds: `!!s` gives a plan where the specification is valid
+and the diagnostic about it where it is not, which is exactly what the silent
+column selection withheld. Drawing the line further in would put arity and
+validity on the same footing as the input, and only one of those is the
+caller's spelling — a composite that empties only after its selection runs
+cannot be judged at all without resolving that selection against the data,
+which is deciding by the input.
+
+## Where the decision is made
+
+In the structural preflight, on the branch where the spelling gate answered
+"selection", and not in the gate itself. The preflight runs once for a whole
+operation and is handed to both compilation passes, where the gate runs again on
+each. Deciding in the gate would read a colliding binding three times instead of
+once and make three of whatever forcing it does visible to the caller.
+
+The derivation is not recursive. Asking the preflight about the bound
+specification would let an ambiguity inside it swallow the refusal outside it —
+a binding that raises is a binding that is not a specification, so #255 would be
+reachable again one level further in — as well as costing time exponential in
+depth and answering a cyclic binding by the parity of its depth.
+
+The answer per parent kind is kept for the session, because asking costs a
+raised Package condition for every kind the parent refuses — four of five under
+`rollup()` and `cube()`, all five under `grouping_set()` — with a cli expansion
+and a backtrace apiece, for conditions no caller sees. The key is the parent's
+kind, which rests on no rule reading anything of a parent but its kind: of the
+three rules the five kinds share, two ignore the parent entirely and the third
+reads its type to name it in a message. A rule reading more of a parent than
+its kind would need that key widened.
+
+The refusal fires before `grouping_selection_proxy()`, so no backend metadata is
+acquired first (ADR 0005), and a lazy input is not read (ADR 0020).
+
+## Considered options
+
+**Honour the rule.** Prefer the bound specification over a same-named column,
+making `CONTEXT.md`'s sentence true as written. Rejected: it keeps the silence
+and swaps which reading is silently wrong. A caller who meant the column, with
+an unrelated specification bound to that name, would get the specification's
+plan with no condition raised — the same defect from the other side, and
+arriving in working code that has no reason to expect it.
+
+**Record the exception.** State the column-wins precedence in `CONTEXT.md` and
+on the reference page and pin it with a test. Rejected: it is the cheapest
+disposition and the only one that changes no behaviour, and what it writes down
+is that this position decides by the data. Every other rule about the position
+is a rule about the spelling, and a caller reading only the sentence still gets
+the plan they did not write.
+
+**Decide in the spelling gate.** Rejected above on the evaluation count, which
+is not a performance argument: the count is what a caller can observe when the
+binding is a wrapper's own lazy argument.
+
+**Refuse by comparing the two plans and accepting where they agree.** Rejected:
+resolving the specification against this input is what deciding by the input
+means, and a name would then be refused or accepted according to the columns the
+data happens to have — which is the defect, arriving through the refusal that
+was meant to remove it.
+
+## What this changes, and the ADR 0008 amendment
+
+ADR 0008's compatibility constraints hold this position's evaluation behaviour,
+and two of its bullets are amended here.
+
+**"quosure environments or the number and timing of evaluations without a
+separately accepted decision."** This is that decision, for one argument.
+Deciding whether the two readings differ is a property of the bound value, so
+the binding has to be read, and there is no cheaper question: which kind a name
+is bound to cannot be known without reading it. Measured, a colliding name in a
+position that admits any kind goes from 0 reads to 1, once for each argument it
+is written as, and whether or not its reading then changes — deciding whether it
+changes is what the read is for. No argument outside a collision is read more
+often than before, and a `grouping_set()` position reads nothing. Quosure
+environments are unchanged.
+
+Timing moves with the count. Where the refusal fires, the arguments written
+after it are not read at all.
+
+**"error condition classes, complete messages, public call contexts, or
+detection order."** This bullet carries no "separately accepted decision"
+clause, and this decision moves every item in it, so it is amended whole rather
+than in part. Detection order moves by position and by depth:
+`grouping_sets(s, rollup())` now reports the ambiguity where it reported the
+grammar error, while `grouping_sets(rollup(), s)` still reports the grammar
+error. What is displaced is every diagnostic reachable past the refusal and not
+one of them — a missing column, a duplicate grouping set, a `.by` overlap, each
+nesting-grammar rejection, and #190's own refusal among them. Where the
+displaced rejection was an External condition, a caller who was receiving
+tidyselect's class and tidyselect's blamed call now receives a
+`marginplyr_error` blamed on the Margin verb.
+
+Everything else in that list is untouched: exported functions and their
+arguments, specification classes, grouping-set membership and order, duplicate
+handling, Grouping identifiers, backend behaviour, metadata acquisition counts,
+laziness, and the Grouping plan representation.
+
+**The cost accepted.** What the read costs a caller is the forcing itself and
+not only the count. A specification bound to a wrapper's own lazy argument is
+forced here for a call whose answer may not depend on it, so a warning or a
+message it raises reaches that wrapper's caller, and R's own `restarting
+interrupted promise evaluation` does where such a binding raises and the name is
+written more than once. This decision accepts that rather than hiding it, since
+the alternative to reading the binding is deciding by the input, which is the
+defect.
+
+## Documentation consequences
+
+`CONTEXT.md`'s *Nested specification position* states the refusal and the
+narrowing by kind, and two of its sentences stop being true as written: that the
+position never evaluates an argument to find out, and that a specification
+written inside a selection keeps the selection's own report. The second was
+never true where a column shares the name — `grouping_sets(c(s, grade))` selects
+the column and raises nothing — and the same sentence stood in `?grouping_set`,
+`design/architecture.md`, and two code comments.
+
+`?grouping_set` carries the same rule in a caller's terms, with both spellings,
+and the `.grouping` parameter documentation points at it. Inside a selection the
+column is the only admissible reading, and that is now said where it is claimed
+rather than left to the collision-free case.
+
+## Test strategy
+
+The behavioural half runs through the compiler and one Margin verb, per the
+seam ADR 0013 established: the refusal in every position, derived from the kind
+registry rather than listed, asserting the complete message; the narrowing,
+where an inadmissible binding still selects the column; and the readings that do
+not change — a bound name with no colliding column, a column with nothing bound,
+a constructor call, a caller's own function, a specification inside a selection,
+and top-level `.grouping`, which has no column-selection reading at all and so
+cannot be ambiguous.
+
+Two contracts are asserted below the public seam because nothing above it can
+see them.
+
+The **admitted set per parent kind**, because an empty answer reads as a
+position that admits nothing rather than as a derivation that stopped working,
+and those two are the same silence. The `rollup()` and `cube()` entries are what
+pin the stand-in's arity.
+
+The **number of reads**, counted through an active binding, which reports every
+read of a name where a promise reports only the first. The counter is asserted
+to work before any zero is concluded from it, for the reason ADR 0025's
+absorption gate asserts its own mechanism: a count of zero from a mechanism that
+stopped counting reads exactly like a read that did not happen.
+
+Both printed spellings are executed and asserted to produce the reading they
+name, and they are read back out of the diagnostic that printed them, over a
+syntactic name and two non-syntactic ones. A name holding a backtick is what
+makes the quoting load-bearing: `rlang::expr_deparse()` writes `` `a`b` `` for
+it, which does not parse, so the quoted form comes from `encodeString()`
+instead.
+
+No test here requires a member of `optional_backends()`.
+
+## Related decisions
+
+ADR 0008 owns the kind registry this derives availability from, and is amended
+above. ADR 0019 registers the constructor spellings the gate reads, and is
+untouched: what this adds is read after the gate has answered, and only for a
+name the gate declined. ADR 0015 is the boundary the refusal is placed against,
+and ADR 0023 and ADR 0024 are the idiom and the spelling rule it is authored in
+— the caller's own name, quoted as R would parse it. ADR 0005 and
+ADR 0020 order the refusal before any metadata read and any read of a lazy
+input. ADR 0013 is the seam the behavioural half is asserted through.

--- a/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
+++ b/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
@@ -218,19 +218,20 @@ a constructor call, a caller's own function, a specification inside a selection,
 and top-level `.grouping`, which has no column-selection reading at all and so
 cannot be ambiguous.
 
-Two contracts are asserted below the public seam because nothing above it can
-see them.
+Two contracts need more than the public seam gives, and in different ways.
 
-The **admitted set per parent kind**, because an empty answer reads as a
-position that admits nothing rather than as a derivation that stopped working,
-and those two are the same silence. The `rollup()` and `cube()` entries are what
-pin the stand-in's arity.
+The **admitted set per parent kind** is asserted below it, against the
+derivation directly, because an empty answer reads as a position that admits
+nothing rather than as a derivation that stopped working, and those two are the
+same silence. The `rollup()` and `cube()` entries are what pin the stand-in's
+arity.
 
-The **number of reads**, counted through an active binding, which reports every
-read of a name where a promise reports only the first. The counter is asserted
-to work before any zero is concluded from it, for the reason ADR 0025's
-absorption gate asserts its own mechanism: a count of zero from a mechanism that
-stopped counting reads exactly like a read that did not happen.
+The **number of reads** is asserted through the seam like everything else; what
+sits below it is the observation. An active binding reports every read of a
+name where a promise reports only the first. The counter is asserted to work
+before any zero is concluded from it, for the reason ADR 0025's absorption gate
+asserts its own mechanism: a count of zero from a mechanism that stopped
+counting reads exactly like a read that did not happen.
 
 Both printed spellings are executed and asserted to produce the reading they
 name, and they are read back out of the diagnostic that printed them, over a

--- a/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
+++ b/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
@@ -93,9 +93,12 @@ which is deciding by the input.
 
 In the structural preflight, on the branch where the spelling gate answered
 "selection", and not in the gate itself. The preflight runs once for a whole
-operation and is handed to both compilation passes, where the gate runs again on
-each. Deciding in the gate would read a colliding binding three times instead of
-once and make three of whatever forcing it does visible to the caller.
+operation and is handed to the compilation passes, where the gate runs again on
+each. Deciding in the gate would read a colliding binding once per pass instead
+of once in all — three times where the plan is settled by names alone, since
+such a plan is compiled against the names first so that a plan error need not
+wait for a backend read, and twice where it is not — and make that many of
+whatever forcing it does visible to the caller.
 
 The derivation is not recursive. Asking the preflight about the bound
 specification would let an ambiguity inside it swallow the refusal outside it —
@@ -179,9 +182,11 @@ handling, Grouping identifiers, backend behaviour, metadata acquisition counts,
 laziness, and the Grouping plan representation.
 
 **The cost accepted.** What the read costs a caller is the forcing itself and
-not only the count. A specification bound to a wrapper's own lazy argument is
-forced here for a call whose answer may not depend on it, so a warning or a
-message it raises reaches that wrapper's caller, and R's own `restarting
+not only the count, and it is not confined to the bindings that turn out to be
+specifications: the read is what establishes which those are, so a wrapper's own
+lazy argument is forced here whenever its name collides, whatever it holds. That
+is for a call whose answer may not depend on it, so a warning or a message the
+argument raises reaches that wrapper's caller, and R's own `restarting
 interrupted promise evaluation` does where such a binding raises and the name is
 written more than once. This decision accepts that rather than hiding it, since
 the alternative to reading the binding is deciding by the input, which is the

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -101,12 +101,29 @@ that works. Being marginplyr's own report about a position of its own, it is
 parentless, as a share selection naming something ineligible is. The refused
 value is read from the condition rather than by evaluating the argument a
 second time to identify it, which is what keeps the number and timing of
-caller-quosure evaluations fixed. The replacement covers the argument the
-position owns and not a part of one: a specification written inside a
-selection keeps tidyselect's report, which names the sub-selection and is
-accurate about it. Every other selection failure is re-raised as it arrived,
-so an External condition still reaches the caller with its own class,
-diagnostic, and cause.
+caller-quosure evaluations fixed for every argument whose reading it does not
+decide. The replacement covers the argument the position owns and not a part
+of one: a specification written inside a selection keeps tidyselect's report,
+which names the sub-selection and is accurate about it — and where the input
+has a column of that name, tidyselect refuses nothing at all, because the
+column is what a selection means by a name the data holds. Every other
+selection failure is re-raised as it arrived, so an External condition still
+reaches the caller with its own class, diagnostic, and cause.
+
+One argument has both readings available, and it is decided in the structural
+preflight rather than by the spelling gate: a bare name that is a column of
+the input and is bound to a specification of a kind the position admits. It is
+refused, naming both readings and the spelling that settles each, because
+either precedence would decide by the input what the spelling decides
+everywhere else, and would decide it silently
+([ADR 0026](adr/0026-refuse-a-nested-name-two-readings-claim.md)). Which kinds
+a position admits is derived by asking that position's own rule from the kind
+registry, so there is no second list of what nests inside what, and it is
+asked before the binding is read: a position admitting no kind reads nothing.
+Where the binding is read it is read once, in the preflight, which runs once
+for an operation and is handed to both compilation passes — the one place from
+which the answer is not recomputed per pass. That read is the one caller
+evaluation this position adds, and ADR 0026 records what it costs.
 
 ### Margin label (`R/margin-label.R`)
 
@@ -604,6 +621,11 @@ The test suite divides supporting contracts as follows:
 - `test-grouping-plan.R` covers the backend-independent Grouping
   specification compiler directly, including the complete kind-nesting
   grammar, phase-sensitive empty rules, error precedence, and expansion order.
+  Two of its contracts are asserted below the public seam because nothing
+  above it can see them: the nested kinds each parent kind admits, since a
+  derivation that stopped working and a position that admits nothing answer
+  the same empty set, and the number of times a colliding name's binding is
+  read, which is counted through an active binding.
 - `test-documentation.R` covers the reference documentation's own contracts:
   that an italicised section cross-reference resolves in the topic it
   promises, that every user-facing topic offers related-topic links, and that

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -121,7 +121,7 @@ a position admits is derived by asking that position's own rule from the kind
 registry, so there is no second list of what nests inside what, and it is
 asked before the binding is read: a position admitting no kind reads nothing.
 Where the binding is read it is read once, in the preflight, which runs once
-for an operation and is handed to both compilation passes — the one place from
+for an operation and is handed to the compilation passes — the one place from
 which the answer is not recomputed per pass. That read is the one caller
 evaluation this position adds, and ADR 0026 records what it costs.
 
@@ -621,11 +621,12 @@ The test suite divides supporting contracts as follows:
 - `test-grouping-plan.R` covers the backend-independent Grouping
   specification compiler directly, including the complete kind-nesting
   grammar, phase-sensitive empty rules, error precedence, and expansion order.
-  Two of its contracts are asserted below the public seam because nothing
-  above it can see them: the nested kinds each parent kind admits, since a
-  derivation that stopped working and a position that admits nothing answer
-  the same empty set, and the number of times a colliding name's binding is
-  read, which is counted through an active binding.
+  One of its contracts is asserted below the public seam because nothing above
+  it can see them: the nested kinds each parent kind admits, since a derivation
+  that stopped working and a position that admits nothing answer the same empty
+  set. A second is asserted through the seam with an observation from below it
+  — the number of times a colliding name's binding is read, counted through an
+  active binding, which reports every read where a promise reports the first.
 - `test-documentation.R` covers the reference documentation's own contracts:
   that an italicised section cross-reference resolves in the topic it
   promises, that every user-facing topic offers related-topic links, and that

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -829,6 +829,74 @@ adapter used to.
 
 ---
 
+## 10. The repository-wide review (produced #254 and #255)
+
+A review of the whole tree, run after the ticket work of §8 had landed. Both
+findings below were reproduced from a clean session before they were filed, and
+each ticket carries the evidence; what is dispositioned here is the outcome.
+Both are behavioural defects rather than evidence-layer ones, which is what
+separates this section from §8: each changed what a caller receives, and each
+was answered with an accepted decision rather than with a documentation fix.
+
+**A Margin summary over an in-memory Arrow input surfaces an upstream internal
+failure as its answer** (Spec). **Fixed — #254, PR #258.** A summary expression
+Arrow cannot translate reached `arrow:::try_arrow_dplyr()`, whose call recovery
+finds `base::call` by inheriting lookup when it is reached through a
+`...`-forwarding wrapper, and aborted with `object of type 'special' is not
+subsettable` — carrying `notSubsettableError/error/condition`, naming nothing
+the caller wrote and offering no rewrite. The disposition recorded on the ticket
+is **refuse**: such a summary is now a `marginplyr_error` naming the argument as
+the caller spelled it and both rewrites, raised before any row is read. ADR 0025
+records why refusing cannot be justified by ADR 0020's cost reasoning — an input
+that absorbs is by class already in this process's memory — and rests it on ADR
+0020's other half instead. ADR 0020's own claim that an in-memory Arrow table
+cannot be told from a dataset in object storage is withdrawn in that ADR's
+second amendment, since it was what the predicate's exactness was argued from.
+*Evidence:* `test-grouping-backends.R` "Arrow refuses a summary it would
+otherwise absorb", "Arrow still absorbs the expressions the refusal is asserted
+over" — the two halves that fail in opposite directions — "an Arrow Dataset
+keeps Arrow's own refusal", "an Arrow summary Arrow can evaluate is unchanged
+and stays lazy", and "the branch guard refuses an absorbed summary the handler
+missed"; `test-query-policy.R` "no Arrow read happens while a Margin verb runs".
+
+**A nested Grouping specification position reads a bound specification as a
+column selection when a column shares its name** (Spec). **Fixed — #255.** The
+position is documented to decide what an argument means by how it is written,
+and decided it by what columns the input happened to have: a bare name bound to
+a specification became a selection of the same-named column, with no condition
+raised and a well-formed plan, so `.id`, `grouping_bit()`, `grouping_id()`, and
+the parent a Parent share divides by all followed it. The disposition recorded
+on the ticket is **refuse the ambiguity**, and ADR 0026 records it together with
+the two rejected alternatives: *Honour the rule* and *Record the exception* both
+keep the silence and only move which reading is silently wrong. Availability of
+the second reading is decided by the kind of the bound specification and never
+by the input, so `grouping_set()` — which admits no nested kind — keeps the
+column reading and does not read the binding at all. ADR 0008's compatibility
+list is amended there in two bullets: the evaluation count, which its own text
+admits a separately accepted decision for, and the condition-and-detection-order
+bullet, which carries no such clause and which the refusal moves whole.
+*Evidence:* `test-grouping-plan.R` "a nested name the input and a binding both
+claim is refused", which derives its cells from the kind registry and covers the
+narrowing as well as the refusal; "a nested position admits nested kinds by its
+own parent rule", which pins the admitted set per parent kind because no
+behavioural test can tell an empty answer from a derivation that stopped
+working; "a colliding nested name is read once, in the preflight", which asserts
+its counter before concluding a count; "the ambiguity refusal names a spelling
+that works for each reading", which executes both spellings read back out of the
+diagnostic; "a nested name only one reading claims keeps that reading"; and "a
+Margin verb refuses an ambiguous nested name".
+
+Two of the ticket's own premises were measured false and are corrected on it
+rather than carried into the work: top-level `.grouping` has no column-selection
+reading at all, so the symmetry its fifth acceptance criterion asks for was
+already true and needed nothing; and a specification written inside a selection
+does *not* keep tidyselect's report where a column shares the name — the
+selection takes the column and raises nothing. That second sentence stood in
+five places, and correcting them is part of this entry rather than a separate
+finding.
+
+---
+
 ## Status
 
 Every observation from every recorded review is dispositioned above. The

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -881,8 +881,8 @@ narrowing as well as the refusal; "a nested position admits nested kinds by its
 own parent rule", which pins the admitted set per parent kind because no
 behavioural test can tell an empty answer from a derivation that stopped
 working; "a colliding nested name is read once, in the preflight", which asserts
-its counter before concluding a count; "the ambiguity refusal names a spelling
-that works for each reading", which executes both spellings read back out of the
+its counter before concluding a count; "the ambiguity refusal names a working
+spelling for each reading", which executes both spellings read back out of the
 diagnostic; "a nested name only one reading claims keeps that reading"; and "a
 Margin verb refuses an ambiguous nested name".
 

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -30,8 +30,9 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
-another must be a constructor call or a name bound to one; see
-\code{\link[=grouping_set]{grouping_set()}}.}
+another must be a constructor call or a name bound to one, and a nested
+name the input also has a column for is refused rather than read either
+way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -40,7 +40,20 @@ returns a specification is refused where it is nested even though it is
 accepted as \code{.grouping} itself. Assign what it returns to a name and use
 that name: \code{s <- my_spec(region)}, then \code{grouping_sets(s, grade)}. A
 specification written inside a selection, as in \code{c(s, grade)}, is a
-selection containing something it cannot select, and is refused as one.
+selection containing something it cannot select, and is refused as one —
+unless the input has a column named \code{s}, when the selection takes that
+column, as any selection does with a name the data holds.
+
+A name both readings claim is refused rather than guessed. Where the
+input has a column named \code{s} and \code{s} is also bound to a nested Grouping
+specification the position accepts, the call names both readings and the
+spelling that settles each: \code{all_of("s")} selects the column whatever is
+bound, and \code{!!s} uses the specification whatever columns the input has.
+What a position accepts is what decides whether there are two readings,
+so a colliding name is refused in \code{\link[=grouping_sets]{grouping_sets()}} and \code{\link[=grouping_spec]{grouping_spec()}}
+whatever it is bound to, in \code{\link[=rollup]{rollup()}} and \code{\link[=cube]{cube()}} only when it is bound
+to a \code{\link[=grouping_set]{grouping_set()}}, and never in \code{\link[=grouping_set]{grouping_set()}}, which takes no
+nested Grouping specification at all.
 
 A dimension is a column of the input, so a selection cannot rename it:
 \code{c(area = region)} is an error rather than a dimension named \code{area}.

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -51,9 +51,10 @@ spelling that settles each: \code{all_of("s")} selects the column whatever is
 bound, and \code{!!s} uses the specification whatever columns the input has.
 What a position accepts is what decides whether there are two readings,
 so a colliding name is refused in \code{\link[=grouping_sets]{grouping_sets()}} and \code{\link[=grouping_spec]{grouping_spec()}}
-whatever it is bound to, in \code{\link[=rollup]{rollup()}} and \code{\link[=cube]{cube()}} only when it is bound
-to a \code{\link[=grouping_set]{grouping_set()}}, and never in \code{\link[=grouping_set]{grouping_set()}}, which takes no
-nested Grouping specification at all.
+whatever specification it is bound to, in \code{\link[=rollup]{rollup()}} and \code{\link[=cube]{cube()}} only
+when it is bound to a \code{\link[=grouping_set]{grouping_set()}}, and never in \code{\link[=grouping_set]{grouping_set()}},
+which takes no nested Grouping specification at all. A name bound to
+anything that is not a specification is a column, as it always was.
 
 A dimension is a column of the input, so a selection cannot rename it:
 \code{c(area = region)} is an error rather than a dimension named \code{area}.

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -26,8 +26,9 @@ fixed key named \code{area}. Rename the result afterwards with
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents the empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
-another must be a constructor call or a name bound to one; see
-\code{\link[=grouping_set]{grouping_set()}}.}
+another must be a constructor call or a name bound to one, and a nested
+name the input also has a column for is refused rather than read either
+way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, and nothing
 else, controlling duplicate grouping-set occurrences; see \emph{Option

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -33,8 +33,9 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
-another must be a constructor call or a name bound to one; see
-\code{\link[=grouping_set]{grouping_set()}}.}
+another must be a constructor call or a name bound to one, and a nested
+name the input also has a column for is refused rather than read either
+way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -33,8 +33,9 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
-another must be a constructor call or a name bound to one; see
-\code{\link[=grouping_set]{grouping_set()}}.}
+another must be a constructor call or a name bound to one, and a nested
+name the input also has a column for is refused rather than read either
+way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -51,8 +51,9 @@ named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{d
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
-another must be a constructor call or a name bound to one; see
-\code{\link[=grouping_set]{grouping_set()}}.}
+another must be a constructor call or a name bound to one, and a nested
+name the input also has a column for is refused rather than read either
+way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -322,14 +322,30 @@ test_that("a nested position admits nested kinds by its own parent rule", {
   expect_identical(asked, length(kinds))
 })
 
+# The refusal a colliding `s` receives, asserted in full wherever it is
+# asserted: the compiler tests below and the Margin verb one, which is the same
+# diagnostic reaching a caller by the route they meet it on.
+ambiguous_s_message <- paste0(
+  "`s` is both a column of the input and a name bound to a grouping ",
+  "specification, so a nested position cannot tell which one you mean.\n",
+  "i For the column, write `all_of(\"s\")`.\n",
+  "i For the specification, write `!!s`."
+)
+
+# One compilation, so that a test varying the specification varies nothing
+# else. `.duplicates = "keep"` is what keeps a union of agreeing readings from
+# being rejected for the agreement.
+compile_against <- function(spec, data_vars) {
+  compile_grouping_spec(
+    spec,
+    data_vars,
+    .duplicates = "keep",
+    duplicates_choices = margin_duplicates_choices
+  )
+}
+
 test_that("a nested name the input and a binding both claim is refused", {
   data_vars <- c("s", "grade", "value")
-  ambiguous_message <- paste0(
-    "`s` is both a column of the input and a name bound to a grouping ",
-    "specification, so a nested position cannot tell which one you mean.\n",
-    "i For the column, write `all_of(\"s\")`.\n",
-    "i For the specification, write `!!s`."
-  )
   # Derived from the kind table, so a sixth kind arrives here as a cell rather
   # than as a case nothing covers.
   bindings <- list(
@@ -356,12 +372,7 @@ test_that("a nested name the input and a binding both claim is refused", {
       ),
       envir = env
     )
-    compile_grouping_spec(
-      spec,
-      data_vars,
-      .duplicates = "keep",
-      duplicates_choices = margin_duplicates_choices
-    )
+    compile_against(spec, data_vars)
   }
 
   for (parent in names(bindings)) {
@@ -369,7 +380,7 @@ test_that("a nested name the input and a binding both claim is refused", {
       if (child %in% admitted[[parent]]) {
         error <- expect_error(compile_bound(parent, bindings[[child]]))
         expect_s3_class(error, "marginplyr_error")
-        expect_identical(conditionMessage(error), ambiguous_message)
+        expect_identical(conditionMessage(error), ambiguous_s_message)
         next
       }
 
@@ -390,13 +401,13 @@ test_that("a nested name the input and a binding both claim is refused", {
     for (binding in invalid) {
       error <- expect_error(compile_bound(parent, binding))
       expect_s3_class(error, "marginplyr_error")
-      expect_identical(conditionMessage(error), ambiguous_message)
+      expect_identical(conditionMessage(error), ambiguous_s_message)
     }
   }
   for (parent in c("rollup", "cube")) {
     empty_composite <- expect_error(compile_bound(parent, grouping_set()))
     expect_s3_class(empty_composite, "marginplyr_error")
-    expect_identical(conditionMessage(empty_composite), ambiguous_message)
+    expect_identical(conditionMessage(empty_composite), ambiguous_s_message)
   }
 
   # Availability is derived from the parent's own rule and from nothing
@@ -462,14 +473,7 @@ test_that("the ambiguity refusal names a working spelling for each reading", {
 
 test_that("a nested name only one reading claims keeps that reading", {
   data_vars <- c("s", "grade", "value")
-  compile <- function(spec) {
-    compile_grouping_spec(
-      spec,
-      data_vars,
-      .duplicates = "keep",
-      duplicates_choices = margin_duplicates_choices
-    )
-  }
+  compile <- function(spec) compile_against(spec, data_vars)
 
   # The two readings the position has always had, neither of them touched: a
   # binding the input has no column for, and a column nothing binds.
@@ -488,10 +492,26 @@ test_that("a nested name only one reading claims keeps that reading", {
     list("value", character())
   )
 
-  # A colliding name whose binding is not a specification, and one whose
-  # binding raises when it is read: neither has a second reading available, so
-  # the column reading stands. Both catches are narrow in what they decide and
-  # not in what they swallow.
+  # A caller's own function is neither of the two recognized spellings, and a
+  # call is never a bare name, so a column sharing the function's name reaches
+  # nothing: #190's refusal is still what the position reports.
+  spec_from_caller <- rlang::env(rlang::current_env())
+  spec_from_caller$grade <- function(...) rollup(...)
+  from_caller <- expect_error(
+    compile(eval(quote(grouping_sets(grade(value))), envir = spec_from_caller))
+  )
+  expect_s3_class(from_caller, "marginplyr_error")
+  expect_match(
+    conditionMessage(from_caller),
+    "is a grouping specification, but a nested position",
+    fixed = TRUE
+  )
+
+  # A colliding name whose binding is not a specification, one whose binding
+  # raises when it is read, and one carrying the class with no kind to read:
+  # none of the three has a second reading available, so the column reading
+  # stands. All three catches are narrow in what they decide and not in what
+  # they swallow.
   not_a_spec <- rlang::env(rlang::current_env(), s = 1)
   expect_identical(
     compile(eval(quote(grouping_sets(s)), envir = not_a_spec))$sets,
@@ -505,6 +525,14 @@ test_that("a nested name only one reading claims keeps that reading", {
   )
   from_raising <- eval(quote(grouping_sets(s)), envir = raising)
   expect_identical(suppressWarnings(compile(from_raising))$sets, list("s"))
+  kindless <- rlang::env(
+    rlang::current_env(),
+    s = structure(list(args = list()), class = "margin_grouping_spec")
+  )
+  expect_identical(
+    compile(eval(quote(grouping_sets(s)), envir = kindless))$sets,
+    list("s")
+  )
 
   # Top-level `.grouping` is evaluated in the caller's environment with no
   # data mask, so it has no column-selection reading to be ambiguous with and
@@ -593,14 +621,30 @@ test_that("a colliding nested name is read once, in the preflight", {
 
   # Outside a collision nothing moves: a bound name the input holds no column
   # for is read in the preflight and once per compilation pass, as it was
-  # before this refusal existed.
-  unchanged <- count_reads(
+  # before this refusal existed. Both counts are here because the number of
+  # passes is what differs -- a plan settled by name alone is compiled against
+  # the names first, so that a plan error need not wait for a backend read.
+  name_only <- count_reads(
     "t",
     rollup(value),
     quote(inspect_grouping(data, .grouping = grouping_sets(t)))
   )
-  expect_identical(unchanged$reads, 3L)
-  expect_identical(unchanged$result$included, c("(value)", "()"))
+  expect_identical(name_only$reads, 3L)
+  expect_identical(name_only$result$included, c("(value)", "()"))
+  with_predicate <- count_reads(
+    "t",
+    rollup(value),
+    quote(inspect_grouping(
+      data,
+      .grouping = grouping_sets(t, tidyselect::where(is.character)),
+      .duplicates = "keep"
+    ))
+  )
+  expect_identical(with_predicate$reads, 2L)
+  expect_identical(
+    with_predicate$result$included,
+    c("(value)", "()", "(s, grade)")
+  )
 })
 
 test_that("a Margin verb refuses an ambiguous nested name", {
@@ -618,15 +662,7 @@ test_that("a Margin verb refuses an ambiguous nested name", {
     envir = colliding
   ))
   expect_s3_class(error, "marginplyr_error")
-  expect_identical(
-    conditionMessage(error),
-    paste0(
-      "`s` is both a column of the input and a name bound to a grouping ",
-      "specification, so a nested position cannot tell which one you mean.\n",
-      "i For the column, write `all_of(\"s\")`.\n",
-      "i For the specification, write `!!s`."
-    )
-  )
+  expect_identical(conditionMessage(error), ambiguous_s_message)
 
   bound <- eval(
     quote(summarize_with_margins(
@@ -639,6 +675,9 @@ test_that("a Margin verb refuses an ambiguous nested name", {
   expect_identical(names(bound), c("value", "n"))
   expect_identical(nrow(bound), 3L)
 
+  # Namespace-qualified here only because a test file is linted as package
+  # code; the bare spelling the diagnostic prints is the one executed above,
+  # where it is read back out of the message.
   column <- eval(
     quote(summarize_with_margins(
       data,

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -250,9 +250,10 @@ test_that("a nested column selection is unaffected by the specification rule", {
   # position does not speak for a part of an argument it did not refuse: a
   # specification really is the wrong kind of object where `c()` puts it, and a
   # caller who bound it to a name has already done what this rule would ask.
-  # tidyselect deprecates the bare external vector these three write, and it is
-  # not what they are here to show, so its warning is suppressed rather than
-  # asserted.
+  # That is what a selection makes of a name the data does not hold; the other
+  # half is below. tidyselect deprecates the bare external vector these three
+  # write, and it is not what they are here to show, so its warning is
+  # suppressed rather than asserted.
   bound <- rollup(region)
   embedded <- expect_error(
     suppressWarnings(compile(grouping_sets(c(bound, grade), region)))
@@ -264,6 +265,390 @@ test_that("a nested column selection is unaffected by the specification rule", {
     embedded_error <- expect_error(suppressWarnings(compile(spec)))
     expect_false(inherits(embedded_error, "marginplyr_error"))
   }
+
+  # Where a column shares the name, tidyselect refuses nothing at all and the
+  # column is what a selection means by it. The ambiguity refusal does not
+  # reach inside a selection either (ADR 0026): the caller wrote a selection,
+  # so the specification reading was never available to that argument.
+  colliding <- rlang::env(rlang::current_env(), region = rollup(value))
+  inside <- eval(quote(grouping_sets(c(region, grade))), envir = colliding)
+  expect_equal(compile(inside)$sets, list(c("region", "grade")))
+})
+
+test_that("a nested position admits nested kinds by its own parent rule", {
+  # The half of "both readings are available" that the input may not answer,
+  # and the one thing no behavioural test reaches: an empty answer reads as a
+  # position that admits nothing rather than as a derivation that stopped
+  # working, and the two are the same silence.
+  kinds <- names(grouping_kind_rules())
+  expect_identical(kinds, c("set", "sets", "rollup", "cube", "product"))
+
+  # `rollup` and `cube` are what pin the stand-in's arity. Both read a
+  # composite's arity as well as its kind, so a stand-in carrying no argument
+  # answers `character()` for them and turns the refusal off in two of the
+  # five positions.
+  admitted <- list(
+    set = character(),
+    sets = kinds,
+    rollup = "set",
+    cube = "set",
+    product = kinds
+  )
+  for (kind in kinds) {
+    expect_identical(
+      admitted_nested_kinds(
+        new_grouping_spec(kind, list(rlang::quo(NULL))),
+        find_grouping_kind_rule(kind)
+      ),
+      admitted[[kind]]
+    )
+  }
+
+  # The answer is kept rather than recomputed, because asking costs a raised
+  # Package condition for every kind the parent refuses. A memo that stopped
+  # working reports nothing, so the derivation is counted directly, through a
+  # rule that admits everything and a parent kind no session has asked about.
+  asked <- 0L
+  probe_rule <- list(
+    validate_nested = function(parent, nested) {
+      asked <<- asked + 1L
+      invisible(NULL)
+    }
+  )
+  probe_parent <- list(type = basename(tempfile("probe-kind-")))
+  expect_identical(admitted_nested_kinds(probe_parent, probe_rule), kinds)
+  expect_identical(asked, length(kinds))
+  expect_identical(admitted_nested_kinds(probe_parent, probe_rule), kinds)
+  expect_identical(asked, length(kinds))
+})
+
+test_that("a nested name the input and a binding both claim is refused", {
+  data_vars <- c("s", "grade", "value")
+  ambiguous_message <- paste0(
+    "`s` is both a column of the input and a name bound to a grouping ",
+    "specification, so a nested position cannot tell which one you mean.\n",
+    "i For the column, write `all_of(\"s\")`.\n",
+    "i For the specification, write `!!s`."
+  )
+  # Derived from the kind table, so a sixth kind arrives here as a cell rather
+  # than as a case nothing covers.
+  bindings <- list(
+    set = grouping_set(value),
+    sets = grouping_sets(value),
+    rollup = rollup(value),
+    cube = cube(value),
+    product = grouping_spec(value)
+  )
+  expect_identical(names(bindings), names(grouping_kind_rules()))
+  admitted <- list(
+    set = character(),
+    sets = names(bindings),
+    rollup = "set",
+    cube = "set",
+    product = names(bindings)
+  )
+  compile_bound <- function(parent, binding) {
+    env <- rlang::env(rlang::caller_env(), s = binding)
+    spec <- eval(
+      rlang::call2(
+        grouping_kind_rules()[[parent]]$constructor,
+        rlang::sym("s")
+      ),
+      envir = env
+    )
+    compile_grouping_spec(
+      spec,
+      data_vars,
+      .duplicates = "keep",
+      duplicates_choices = margin_duplicates_choices
+    )
+  }
+
+  for (parent in names(bindings)) {
+    for (child in names(bindings)) {
+      if (child %in% admitted[[parent]]) {
+        error <- expect_error(compile_bound(parent, bindings[[child]]))
+        expect_s3_class(error, "marginplyr_error")
+        expect_identical(conditionMessage(error), ambiguous_message)
+        next
+      }
+
+      # The narrowing, which is the half a later reader is likeliest to
+      # "fix": where the position takes no nested specification of that kind,
+      # there is nothing to be ambiguous about and the column reading stands.
+      expect_identical(compile_bound(parent, bindings[[child]])$sets[[1L]], "s")
+    }
+  }
+
+  # The line is the kind and nothing further. A specification of an admitted
+  # kind that is invalid on its own terms is still what the caller wrote, so
+  # the name is ambiguous just the same and `!!` is what reports what is wrong
+  # with it. Reading arity or validity here would put them on the same footing
+  # as the input, and only one of those is the caller's spelling.
+  invalid <- list(grouping_sets(), rollup(), cube())
+  for (parent in c("sets", "product")) {
+    for (binding in invalid) {
+      error <- expect_error(compile_bound(parent, binding))
+      expect_s3_class(error, "marginplyr_error")
+      expect_identical(conditionMessage(error), ambiguous_message)
+    }
+  }
+  for (parent in c("rollup", "cube")) {
+    empty_composite <- expect_error(compile_bound(parent, grouping_set()))
+    expect_s3_class(empty_composite, "marginplyr_error")
+    expect_identical(conditionMessage(empty_composite), ambiguous_message)
+  }
+
+  # Availability is derived from the parent's own rule and from nothing
+  # recursive. Preflighting the bound specification instead would let an
+  # ambiguity inside it swallow the refusal outside it -- a binding that
+  # raises is a binding that is not a specification -- and #255 would be
+  # reachable again one level further in.
+  nested <- rlang::env(rlang::current_env(), inner = rollup(value))
+  nested$outer <- eval(quote(grouping_sets(inner)), envir = nested)
+  swallowed <- expect_error(compile_grouping_spec(
+    eval(quote(grouping_sets(outer)), envir = nested),
+    c("inner", "outer", "value"),
+    .duplicates = "keep",
+    duplicates_choices = margin_duplicates_choices
+  ))
+  expect_s3_class(swallowed, "marginplyr_error")
+  expect_match(
+    conditionMessage(swallowed),
+    "`outer` is both a column of the input",
+    fixed = TRUE
+  )
+})
+
+test_that("the ambiguity refusal names a working spelling for each reading", {
+  # Both spellings are executed rather than described, and they are read back
+  # out of the diagnostic that printed them, so an advice line that stopped
+  # parsing fails here. The non-syntactic names are what execute the quoting:
+  # `rlang::expr_deparse()` alone writes `` `a`b` `` for the last of them,
+  # which does not parse.
+  spelled <- function(line) {
+    gsub("^`+ ?| ?`+$", "", sub("\\.$", "", sub("^i [^,]+, write ", "", line)))
+  }
+  for (name in c("s", "a b", "a`b")) {
+    data_vars <- c(name, "value")
+    compile <- function(spec) {
+      compile_grouping_spec(
+        spec,
+        data_vars,
+        .duplicates = "keep",
+        duplicates_choices = margin_duplicates_choices
+      )
+    }
+    env <- rlang::env(rlang::current_env())
+    rlang::env_bind(env, !!name := rollup(value))
+    nested_call <- function(spelling) {
+      eval(
+        rlang::call2("grouping_sets", rlang::parse_expr(spelling)),
+        envir = env
+      )
+    }
+
+    refused <- expect_error(compile(nested_call(quoted_name_spelling(name))))
+    expect_s3_class(refused, "marginplyr_error")
+    lines <- strsplit(conditionMessage(refused), "\n", fixed = TRUE)[[1L]]
+    expect_length(lines, 3L)
+
+    column <- compile(nested_call(spelled(lines[[2L]])))
+    expect_identical(column$sets, list(name))
+    specification <- compile(nested_call(spelled(lines[[3L]])))
+    expect_identical(specification$sets, list("value", character()))
+  }
+})
+
+test_that("a nested name only one reading claims keeps that reading", {
+  data_vars <- c("s", "grade", "value")
+  compile <- function(spec) {
+    compile_grouping_spec(
+      spec,
+      data_vars,
+      .duplicates = "keep",
+      duplicates_choices = margin_duplicates_choices
+    )
+  }
+
+  # The two readings the position has always had, neither of them touched: a
+  # binding the input has no column for, and a column nothing binds.
+  bound_elsewhere <- rollup(value)
+  expect_identical(
+    compile(grouping_sets(bound_elsewhere))$sets,
+    list("value", character())
+  )
+  expect_identical(compile(grouping_sets(s))$sets, list("s"))
+
+  # A constructor call is read by its spelling and never by what a name is
+  # bound to, so a column of that name changes nothing.
+  colliding <- rlang::env(rlang::current_env(), s = rollup(value))
+  expect_identical(
+    compile(eval(quote(grouping_sets(rollup(value))), envir = colliding))$sets,
+    list("value", character())
+  )
+
+  # A colliding name whose binding is not a specification, and one whose
+  # binding raises when it is read: neither has a second reading available, so
+  # the column reading stands. Both catches are narrow in what they decide and
+  # not in what they swallow.
+  not_a_spec <- rlang::env(rlang::current_env(), s = 1)
+  expect_identical(
+    compile(eval(quote(grouping_sets(s)), envir = not_a_spec))$sets,
+    list("s")
+  )
+  raising <- rlang::env(rlang::current_env())
+  delayedAssign(
+    "s",
+    stop("this binding is not a specification"),
+    assign.env = raising
+  )
+  from_raising <- eval(quote(grouping_sets(s)), envir = raising)
+  expect_identical(suppressWarnings(compile(from_raising))$sets, list("s"))
+
+  # Top-level `.grouping` is evaluated in the caller's environment with no
+  # data mask, so it has no column-selection reading to be ambiguous with and
+  # a colliding column changes nothing there.
+  data <- data.frame(s = c("x", "y"), value = c(1, 2))
+  top_level <- eval(
+    quote(inspect_grouping(data, .grouping = s)),
+    envir = colliding
+  )
+  expect_identical(top_level$included, c("(value)", "()"))
+})
+
+test_that("a colliding nested name is read once, in the preflight", {
+  data <- data.frame(
+    s = c("x", "y"),
+    grade = c("a", "b"),
+    value = c(1, 2)
+  )
+  reads <- 0L
+  count_reads <- function(name, value, expr) {
+    reads <<- 0L
+    env <- rlang::env(rlang::caller_env())
+    makeActiveBinding(
+      name,
+      function() {
+        reads <<- reads + 1L
+        value
+      },
+      env
+    )
+    result <- tryCatch(eval(expr, envir = env), error = function(cnd) cnd)
+    list(reads = reads, result = result)
+  }
+
+  # The counter first: an active binding reports every read of the name, so a
+  # zero below is a read that did not happen rather than a mechanism that
+  # stopped counting.
+  probe <- count_reads("s", 1, quote(s))
+  expect_identical(probe$result, 1)
+  expect_identical(probe$reads, 1L)
+
+  # Reading the binding is what deciding costs, and there is no cheaper
+  # question: which kind a name is bound to cannot be known without reading
+  # it.
+  refused <- count_reads(
+    "s",
+    rollup(value),
+    quote(inspect_grouping(data, .grouping = grouping_sets(s)))
+  )
+  expect_s3_class(refused$result, "marginplyr_error")
+  expect_identical(refused$reads, 1L)
+
+  # The kinds a position admits are asked before the binding is read, so
+  # `grouping_set()`, which admits none, reads nothing.
+  in_set <- count_reads(
+    "s",
+    rollup(value),
+    quote(inspect_grouping(data, .grouping = grouping_set(s)))
+  )
+  expect_identical(in_set$reads, 0L)
+  expect_identical(in_set$result$included, "(s)")
+
+  # The check sits in the preflight, which runs once for an operation and is
+  # handed to both compilation passes, where the gate runs again on each.
+  # Moving it into the gate would read this binding three times instead of
+  # once, and make three of whatever forcing it does visible to the caller.
+  not_a_spec <- count_reads(
+    "s",
+    1,
+    quote(inspect_grouping(data, .grouping = grouping_sets(s)))
+  )
+  expect_identical(not_a_spec$reads, 1L)
+  expect_identical(not_a_spec$result$included, "(s)")
+
+  # Once for each argument the name is written as.
+  twice <- count_reads(
+    "s",
+    1,
+    quote(inspect_grouping(
+      data,
+      .grouping = grouping_sets(s, s),
+      .duplicates = "keep"
+    ))
+  )
+  expect_identical(twice$reads, 2L)
+
+  # Outside a collision nothing moves: a bound name the input holds no column
+  # for is read in the preflight and once per compilation pass, as it was
+  # before this refusal existed.
+  unchanged <- count_reads(
+    "t",
+    rollup(value),
+    quote(inspect_grouping(data, .grouping = grouping_sets(t)))
+  )
+  expect_identical(unchanged$reads, 3L)
+  expect_identical(unchanged$result$included, c("(value)", "()"))
+})
+
+test_that("a Margin verb refuses an ambiguous nested name", {
+  # What a caller sees is a result with the wrong grouping columns rather than
+  # a plan object, so the defect as it was reported gets one verb case.
+  data <- data.frame(s = c("x", "y"), value = c(1, 2))
+  colliding <- rlang::env(rlang::current_env(), s = rollup(value))
+
+  error <- expect_error(eval(
+    quote(summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = grouping_sets(s)
+    )),
+    envir = colliding
+  ))
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(
+    conditionMessage(error),
+    paste0(
+      "`s` is both a column of the input and a name bound to a grouping ",
+      "specification, so a nested position cannot tell which one you mean.\n",
+      "i For the column, write `all_of(\"s\")`.\n",
+      "i For the specification, write `!!s`."
+    )
+  )
+
+  bound <- eval(
+    quote(summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = grouping_sets(!!s)
+    )),
+    envir = colliding
+  )
+  expect_identical(names(bound), c("value", "n"))
+  expect_identical(nrow(bound), 3L)
+
+  column <- eval(
+    quote(summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = grouping_sets(tidyselect::all_of("s"))
+    )),
+    envir = colliding
+  )
+  expect_identical(names(column), c("s", "n"))
+  expect_identical(nrow(column), 2L)
 })
 
 test_that("recognizing a nested specification adds no caller evaluation", {

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -1,3 +1,41 @@
+# The refusal a colliding `s` receives, asserted in full wherever it is
+# asserted: the compiler tests below and the Margin verb one, which is the same
+# diagnostic reaching a caller by the route they meet it on.
+ambiguous_s_message <- paste0(
+  "`s` is both a column of the input and a name bound to a grouping ",
+  "specification, so a nested position cannot tell which one you mean.\n",
+  "i For the column, write `all_of(\"s\")`.\n",
+  "i For the specification, write `!!s`."
+)
+
+# One compilation, so that a test varying the specification varies nothing
+# else. `.duplicates = "keep"` is what keeps a union of agreeing readings from
+# being rejected for the agreement.
+compile_against <- function(spec, data_vars) {
+  compile_grouping_spec(
+    spec,
+    data_vars,
+    .duplicates = "keep",
+    duplicates_choices = margin_duplicates_choices
+  )
+}
+
+# The nested kinds each parent kind admits, written out rather than derived, so
+# that the derivation has something to be wrong against. Two tests read it for
+# different purposes -- one against the derivation itself, one against the
+# behaviour that follows from it -- and a wrong table fails the first, which is
+# what makes sharing it safe.
+admitted_nested_kinds_table <- function() {
+  kinds <- names(grouping_kind_rules())
+  list(
+    set = character(),
+    sets = kinds,
+    rollup = "set",
+    cube = "set",
+    product = kinds
+  )
+}
+
 test_that("rollup and cube compile to concrete grouping sets", {
   rollup_plan <- compile_grouping_spec(
     rollup(a, b, c),
@@ -287,13 +325,7 @@ test_that("a nested position admits nested kinds by its own parent rule", {
   # composite's arity as well as its kind, so a stand-in carrying no argument
   # answers `character()` for them and turns the refusal off in two of the
   # five positions.
-  admitted <- list(
-    set = character(),
-    sets = kinds,
-    rollup = "set",
-    cube = "set",
-    product = kinds
-  )
+  admitted <- admitted_nested_kinds_table()
   for (kind in kinds) {
     expect_identical(
       admitted_nested_kinds(
@@ -322,28 +354,6 @@ test_that("a nested position admits nested kinds by its own parent rule", {
   expect_identical(asked, length(kinds))
 })
 
-# The refusal a colliding `s` receives, asserted in full wherever it is
-# asserted: the compiler tests below and the Margin verb one, which is the same
-# diagnostic reaching a caller by the route they meet it on.
-ambiguous_s_message <- paste0(
-  "`s` is both a column of the input and a name bound to a grouping ",
-  "specification, so a nested position cannot tell which one you mean.\n",
-  "i For the column, write `all_of(\"s\")`.\n",
-  "i For the specification, write `!!s`."
-)
-
-# One compilation, so that a test varying the specification varies nothing
-# else. `.duplicates = "keep"` is what keeps a union of agreeing readings from
-# being rejected for the agreement.
-compile_against <- function(spec, data_vars) {
-  compile_grouping_spec(
-    spec,
-    data_vars,
-    .duplicates = "keep",
-    duplicates_choices = margin_duplicates_choices
-  )
-}
-
 test_that("a nested name the input and a binding both claim is refused", {
   data_vars <- c("s", "grade", "value")
   # Derived from the kind table, so a sixth kind arrives here as a cell rather
@@ -356,13 +366,7 @@ test_that("a nested name the input and a binding both claim is refused", {
     product = grouping_spec(value)
   )
   expect_identical(names(bindings), names(grouping_kind_rules()))
-  admitted <- list(
-    set = character(),
-    sets = names(bindings),
-    rollup = "set",
-    cube = "set",
-    product = names(bindings)
-  )
+  admitted <- admitted_nested_kinds_table()
   compile_bound <- function(parent, binding) {
     env <- rlang::env(rlang::caller_env(), s = binding)
     spec <- eval(
@@ -417,11 +421,9 @@ test_that("a nested name the input and a binding both claim is refused", {
   # reachable again one level further in.
   nested <- rlang::env(rlang::current_env(), inner = rollup(value))
   nested$outer <- eval(quote(grouping_sets(inner)), envir = nested)
-  swallowed <- expect_error(compile_grouping_spec(
+  swallowed <- expect_error(compile_against(
     eval(quote(grouping_sets(outer)), envir = nested),
-    c("inner", "outer", "value"),
-    .duplicates = "keep",
-    duplicates_choices = margin_duplicates_choices
+    c("inner", "outer", "value")
   ))
   expect_s3_class(swallowed, "marginplyr_error")
   expect_match(
@@ -442,14 +444,7 @@ test_that("the ambiguity refusal names a working spelling for each reading", {
   }
   for (name in c("s", "a b", "a`b")) {
     data_vars <- c(name, "value")
-    compile <- function(spec) {
-      compile_grouping_spec(
-        spec,
-        data_vars,
-        .duplicates = "keep",
-        duplicates_choices = margin_duplicates_choices
-      )
-    }
+    compile <- function(spec) compile_against(spec, data_vars)
     env <- rlang::env(rlang::current_env())
     rlang::env_bind(env, !!name := rollup(value))
     nested_call <- function(spelling) {
@@ -596,9 +591,11 @@ test_that("a colliding nested name is read once, in the preflight", {
   expect_identical(in_set$result$included, "(s)")
 
   # The check sits in the preflight, which runs once for an operation and is
-  # handed to both compilation passes, where the gate runs again on each.
-  # Moving it into the gate would read this binding three times instead of
-  # once, and make three of whatever forcing it does visible to the caller.
+  # handed to the compilation passes, where the gate runs again on each.
+  # Moving it into the gate would read this binding once per pass instead of
+  # once in all -- three times here, by the count the last assertion in this
+  # test pins -- and make that many of whatever forcing it does visible to the
+  # caller.
   not_a_spec <- count_reads(
     "s",
     1,

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -528,6 +528,19 @@ test_that("a nested name only one reading claims keeps that reading", {
     compile(eval(quote(grouping_sets(s)), envir = kindless))$sets,
     list("s")
   )
+  # The other shape a kind cannot be read from, and the one that raises rather
+  # than answering `NULL`: `$` is invalid for an atomic vector, so reading the
+  # kind is guarded as reading the binding is. Without that guard this call
+  # raises `$ operator is invalid for atomic vectors`, which is #262 arriving
+  # one position lower.
+  atomic <- rlang::env(
+    rlang::current_env(),
+    s = structure(1L, class = "margin_grouping_spec")
+  )
+  expect_identical(
+    compile(eval(quote(grouping_sets(s)), envir = atomic))$sets,
+    list("s")
+  )
 
   # Top-level `.grouping` is evaluated in the caller's environment with no
   # data mask, so it has no column-selection reading to be ambiguous with and


### PR DESCRIPTION
Closes #255.

A bare name in a Nested specification position was read as a column selection
whenever the input held a column of that name, so a name bound to a
specification — which `CONTEXT.md`, `?grouping_set` and `NEWS.md` all say is a
nested specification — silently became the other reading. The plan it produced
was well-formed and no condition was raised, and every value derived from the
plan went with it: the grouping sets, `.id`, `grouping_bit()`, `grouping_id()`,
and the parent a Parent share divides by.

## What it does

The disposition recorded on the ticket is **refuse the ambiguity**. Such a name
now raises a `marginplyr_error` naming both readings and the spelling that
settles each:

```r
grouping_sets(all_of("s"))   # the column, whatever is bound
grouping_sets(!!s)           # the specification, whatever columns exist
```

Both spellings already worked; neither is new. Refusing is what removes the
silence in both directions — preferring either reading only moves which one is
silently wrong, which is what rules out *Honour the rule* and *Record the
exception*.

## Availability is decided by kind, never by the input

That is the rule this refusal exists to keep, so the second reading has to be
available for a name to be ambiguous, and what decides availability is the
**kind** of the bound specification:

- `grouping_sets()` and `grouping_spec()` admit every kind, so any colliding
  name bound to a specification is refused there.
- `rollup()` and `cube()` admit a `grouping_set()` composite dimension, so a
  colliding name bound to anything else keeps the column reading it has today.
- `grouping_set()` admits no kind at all, so a colliding name there is always
  the column, and the binding is never read.

The admitted set is derived by asking each position's own `validate_nested()`
rule from ADR 0008's registry — no second list of what nests inside what, and
no recursion, since preflighting the bound specification would let an ambiguity
inside it swallow the refusal outside it. The line is the kind and nothing
further: a specification of an admitted kind that is invalid on its own terms
makes the name ambiguous just the same, because what is wrong with it is a
property of what the caller wrote, and `!!` is what reports it.

## Where it sits, and what it costs

In the structural preflight, which runs once for an operation, not in the
spelling gate, which runs again on each compilation pass. A colliding name in a
position admitting any kind goes from 0 reads to 1; no argument outside a
collision is read more often than before; a `grouping_set()` position reads
nothing. The refusal fires before `grouping_selection_proxy()`, so no backend
metadata is acquired and a lazy input is not read — measured at 0 queries on a
lazy DuckDB input.

**ADR 0026** records the decision, the two rejected dispositions, and the cost
accepted: the read is what establishes which bindings are specifications, so a
wrapper's own lazy argument is forced whenever its name collides, whatever it
holds. **ADR 0008**'s compatibility list is amended in two bullets — the
evaluation count, which its own text admits a separately accepted decision for,
and the condition-and-detection-order bullet, which carries no such clause and
which this moves whole.

## A claim five documents made that was false

`CONTEXT.md`, `?grouping_set`, `design/architecture.md` and two code comments
said a specification written inside a selection keeps tidyselect's own report.
Where a column shares the name it does not: the selection takes the column and
raises nothing. All five now say so, and the case has a test.

## Tests

Seven invariants are pinned, each verified to fail when the code is mutated to
break it: the admitted set per parent kind (which no behavioural test reaches,
since an empty answer and a stopped derivation are the same silence), the memo
behind it, the stand-in's arity, the check's placement in the preflight, the
non-recursive derivation, the guarded kind read, and the quoted spelling —
`rlang::expr_deparse()` alone writes the unparseable `` `a`b` `` for a name
holding a backtick. Both printed spellings are executed after being read back
out of the diagnostic that printed them, over one syntactic and two
non-syntactic names.

No test requires a member of `optional_backends()`.

## Verification

`lintr::lint_package()` 0 lints · full suite 5040 pass / 0 fail / 0 skip / 0
warn · `roxygen2::roxygenise()` no diff · `spelling::spell_check_package()`
clean · `verify-suite-coverage.R` all 619 tests covered.

## Filed separately

**#262** — a `margin_grouping_spec` class over an atomic vector makes
`validate_grouping_spec_early()` read `$type` two lines above the branch
written to refuse exactly that shape, so it raises an untyped
`$ operator is invalid for atomic vectors`. It reproduces at top level, where
none of this branch's code runs, so it is not this ticket's to answer.