### PR TITLE
Establish the specification can be read before reading a field of it

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -9,8 +9,11 @@ validate_grouping_spec_early <- function(grouping_spec) {
     ))
   }
 
-  kind <- grouping_spec$type
-  args <- grouping_spec$args
+  kind <- grouping_spec_kind(grouping_spec)
+  # A catch of its own, because the two fields are not read together: an object
+  # can refuse one while answering the other, and this is the only reader of
+  # `args` before the guard below has run.
+  args <- tryCatch(grouping_spec$args, error = function(cnd) NULL)
   if (
     !is.character(kind) ||
       length(kind) != 1L ||
@@ -30,6 +33,37 @@ validate_grouping_spec_early <- function(grouping_spec) {
 
 abort_invalid_grouping_spec <- function() {
   abort_marginplyr("Invalid grouping specification.")
+}
+
+# The kind an object carrying the specification class says it is, or `NULL`
+# where it cannot be asked for one at all. Reading a field is a question not
+# every object a class can sit on answers: `$` is invalid for an atomic vector,
+# a closure is not subsettable, and an S4 class that defines no method for it
+# refuses it. Asking before establishing that much is what answered a forged
+# `.grouping` with base R's own untyped error, in place of the refusal the
+# guard above is written for (#262).
+#
+# The read is `$` itself and the catch is the whole of what is new, so nothing
+# here decides what a specification may be stored as. Two narrower readings
+# look equivalent and are not: `is.list()` refuses an environment whose fields
+# read, and `[[` with `exact = FALSE` bypasses a `$` method the object defines.
+#
+# The two readers that can be handed an object nothing has validated share
+# this one, because they ask the same question of the same field, and the
+# colliding and the non-colliding spelling answering that question differently
+# is the asymmetry #262 was found through. Every other reader of a kind in this
+# file sits behind the guard above, which is what establishes there is one to
+# read. The one reader anywhere that does not is
+# `print.margin_grouping_spec()`, in `R/grouping-spec.R`, and it is #264.
+#
+# The catch is narrow in what it decides and not in what it swallows, exactly
+# as the evaluation catch in `check_ambiguous_nested_name()` is: an object that
+# cannot produce a kind is not a specification of a readable one, whatever
+# stopped it producing one. Deciding that is not deciding what the object is,
+# which is where ADR 0015 puts the line -- the guard above says what it is, in
+# marginplyr's words.
+grouping_spec_kind <- function(spec) {
+  tryCatch(spec$type, error = function(cnd) NULL)
 }
 
 normalize_grouping_input <- function(.data, by_quo) {
@@ -402,17 +436,21 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 #
 # A binding that raises when it is read is not a specification, so the
 # selection reading stands where it raises, and so does an object carrying the
-# class with no kind to read -- an atomic vector given the class answers `$`
-# with a condition of its own, and a list without the field answers `NULL`,
-# neither of which is a kind this position could admit. Both catches are narrow
+# class with no kind to read -- an atomic vector given the class offers no
+# field to read at all, which `grouping_spec_kind()` answers with `NULL`, and
+# a list without the field answers `NULL` too, neither of which is a kind this
+# position could admit. That reading is the guard's own, so the two cannot
+# disagree about what a kind is readable off. Both catches are narrow
 # in what they decide and not in what they swallow: everything they hide is a
 # failure to produce a specification of an admitted kind, which is a
 # specification reading that is not available. That is where the ADR-0015 line
 # falls too, because nothing here is deciding what such an object is -- a list
 # carrying the class and no kind, bound to a name nothing shadows, still
 # reaches `validate_grouping_spec_early()` and is refused in its own words.
-# Where that guard reads a field too early to reach its own refusal is #262,
-# which reproduces at top level and so is not this position's to answer.
+# So does an atomic vector carrying it, since #262 stopped that guard reading
+# a field before it had established the object can be read: what a colliding
+# name withholds here is a Package condition in either shape, not an untyped
+# one.
 #
 # `rule` is the parent's own, which the caller already holds because it
 # validates nested arguments with it; deriving it again here would be the same
@@ -438,7 +476,7 @@ check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
   if (!inherits(value, "margin_grouping_spec")) {
     return(invisible(NULL))
   }
-  kind <- tryCatch(value$type, error = function(cnd) NULL)
+  kind <- grouping_spec_kind(value)
   if (
     !is.character(kind) ||
       length(kind) != 1L ||

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -98,8 +98,8 @@ stands, and the registry this ADR centralizes is what that refusal derives
 availability from: it asks the parent's own `validate_nested()` rule rather than
 carrying a second list of which kinds nest inside which.
 
-**Evaluations.** The third constraint holds the number and timing of
-evaluations "without a separately accepted decision", and ADR 0026 is that
+**Evaluations.** The constraint holding the number and timing of evaluations
+does so "without a separately accepted decision", and ADR 0026 is that
 decision, for that one argument. Deciding whether the two readings differ is a
 property of the bound value, so the binding is read — once, in the structural
 preflight, where it was read not at all. No argument outside such a collision is
@@ -107,14 +107,45 @@ read more often than before, quosure environments are unchanged, and a position
 admitting no nested kind reads nothing. Timing moves with the count: where the
 refusal fires, the arguments written after it are not read.
 
-**Conditions and detection order.** The second constraint carries no such
-clause, and the refusal moves every item in it, so ADR 0026 amends it whole
-rather than naming a part of it. The refusal is reported in place of whatever
-the call would have been rejected for further along — a missing column, a
-duplicate grouping set, a `.by` overlap, each nesting-grammar rejection above,
-and #190's refusal among them — and where that displaced rejection was an
-External condition, the caller now receives a `marginplyr_error` blamed on the
-Margin verb instead of tidyselect's class and tidyselect's blamed call.
+**Conditions and detection order.** The constraint holding error condition
+classes, complete messages, public call contexts, and detection order carries
+no such clause, and the refusal moves every item in it, so ADR 0026 amends it
+whole rather than naming a part of it. The refusal is reported in place of
+whatever the call would have been rejected for further along — a missing
+column, a duplicate grouping set, a `.by` overlap, each nesting-grammar
+rejection above, and #190's refusal among them — and where that displaced
+rejection was an External condition, the caller now receives a
+`marginplyr_error` blamed on the Margin verb instead of tidyselect's class and
+tidyselect's blamed call.
+
+## Amendment: the condition class of a specification the guard could not read
+
+The constraint holding error condition classes fixed is amended by #262, in one
+direction and for one thing: an object carrying `margin_grouping_spec` that
+cannot answer for a field the guard reads. `validate_grouping_spec_early()`
+read those fields having established only the class, so whatever the object
+raised when it was asked came out of that line rather than reaching
+`abort_invalid_grouping_spec()` below it. Some such objects cannot be asked at
+all — an atomic vector, a closure — and others can be asked and raise, per
+field: an object that answers for its kind and raises on its arguments is why
+the two fields are read through a catch each. The class such a call raises
+therefore moves to `marginplyr_error`, from whatever base R or the object
+itself raised — `simpleError` for an atomic vector, `notSubsettableError` for
+a closure, and a class of the object's own where the object is what raised.
+
+This is the guard's own answer arriving rather than a new one being chosen, and
+that is what separates it from ADR 0026's amendment above, which moves the same
+constraint by deciding something. ADR 0015 already assigns a malformed
+specification reaching this guard a Package condition, and the refusal that
+raises it was already written for an object whose fields do not read as a
+specification's; what reading one too early did was keep the object from
+getting there. Nothing else in the constraint moves with it: every object that
+reached the refusal reaches it with the same message, the same call context,
+and at the same point, and no specification that compiled stops compiling —
+the reading is `$` itself, so an object is refused for what it says it is and
+never for how it is stored. The constraint on the number and timing of
+evaluations is not reached, since no field is read any earlier or later for a
+well-formed specification.
 
 ## Test strategy
 
@@ -175,4 +206,6 @@ a Contextual helper even though its spelling is read before anything runs.
 
 ADR 0026 refuses the one nested argument whose reading a spelling does not
 settle, deriving which kinds each position admits from this registry's own
-nesting rules, and is what the amendment above was written for.
+nesting rules, and is what the amendment *one nested argument, whose reading
+the spelling does not settle* was written for. There are two amendments above
+as of #262, and this names the one it means.

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -897,17 +897,87 @@ finding.
 
 ---
 
+## 11. The review of #255's branch (produced #262)
+
+A two-axis review of the branch §10's second entry landed on, run in three
+rounds and answered on the branch in `def830e`, `8d074c2`, and `59bb476`, each
+of whose messages names the round it answers and what that round found. Those
+messages are what recorded the review, which is the header's definition of a
+recorded one, so the rest of what it raised is owed entries here and does not
+have them — the exemption above does not cover it, since the findings were
+answered in later commits and pushed rather than folded into the commit they
+were about. #266 is that gap, and the *Status* section below is qualified for
+it. This section dispositions the one finding that left the branch as a ticket
+of its own.
+
+**A malformed Grouping specification whose class sits on an atomic vector
+raises an untyped base-R error** (Standards). **Fixed — #262.**
+`validate_grouping_spec_early()` read `grouping_spec$type` having established
+only the class, so an object carrying `margin_grouping_spec` over something
+`$` cannot be asked raised base R's own error — `simpleError` for an atomic
+vector, `notSubsettableError` for a closure — from that line, instead of
+reaching the `Invalid grouping specification.` refusal below it, which was
+already written for an object whose fields do not read as a specification's.
+It reproduced through the public verbs at top level and in a nested position.
+The same held of `args`, which an object can raise on while answering for its
+kind, so the two fields are now read through a catch each. The kind is read
+through `grouping_spec_kind()`, which `check_ambiguous_nested_name()` reads
+through as well: one hazard, which only the colliding path had a catch for,
+and that asymmetry is what the finding was made from. The read is `$` itself,
+so no object is refused for how it is stored; `is.list()` and `[[` with
+`exact = FALSE` were both tried and both narrow, the first refusing an
+environment carrying the class with readable fields and the second bypassing a
+`$` method the object defines. ADR 0008's condition-class bullet is amended
+there, for these shapes and in the direction ADR 0015 had already chosen.
+*Evidence:*
+`test-grouping-plan.R` "a malformed grouping specification is refused by both
+guards", which writes each malformed object in both positions the guard is
+reachable from, and "a specification is read for what it says, not how it is
+stored", which fails if the reading narrows to `is.list()` — the narrowing a
+rewrite most easily becomes, and the one an environment separates from `$`.
+
+Two more findings came from #262's own review. Neither is this ticket's to
+answer and both are filed, so they are dispositioned here as §8 dispositions an
+open ticket, by naming the reproduction rather than a test that does not exist
+yet.
+
+**`print.margin_grouping_spec()` reads the kind off an object that may have
+none** (Standards). **Not fixed — open, #264.** The same too-early read as
+above, at the other site that reads a kind, and the only reader of one that
+does not sit behind `validate_grouping_spec_early()`. #262's scope was the
+guard, which has a refusal to reach; a print method has none, so the answer is
+not the same one and is that ticket's to choose. *Evidence:*
+`print(structure(1:3, class = "margin_grouping_spec"))` raises
+`$ operator is invalid for atomic vectors`, of class
+`simpleError/error/condition`.
+
+**A specification stored as a function is read by tidyselect as a predicate,
+so #190's refusal never fires** (Spec). **Not fixed — open, #265.** A nested
+position derives #190's diagnostic from tidyselect's own refusal of the
+subscript, and tidyselect does not refuse a function — it calls it. The caller
+is then told about a call they did not write, about an object carrying the
+class the position exists to recognize. *Evidence:* with
+`f <- function() structure(function() 1, class = "margin_grouping_spec")`,
+`inspect_grouping(d, .grouping = grouping_sets(f()))` raises
+`unused argument (X[[i]])`, of class `simpleError/error/condition`, where the
+same position takes #190's refusal for an object of any other storage.
+
+---
+
 ## Status
 
-Every observation from every recorded review is dispositioned above. The
-release gate #23 sets is not met by this file alone: it also requires a fresh
-two-axis review and Docs & Tests audit with no unresolved findings, which is
-#40. New findings from that review are dispositioned here as they arrive.
+Every observation from every recorded review is dispositioned above, but for
+the one §11 names: the review of #255's branch has entries here only for the
+finding that left the branch as a ticket, and #266 is what tracks the rest.
+Until #266 closes, this file does not meet its own bar, and the release gate
+#23 sets is not met by this file even where it does: the gate also requires a
+fresh two-axis review and Docs & Tests audit with no unresolved findings, which
+is #40. New findings from that review are dispositioned here as they arrive.
 
 **The gate is not met as of #40's review.** Local checks, the release matrix,
-and the two-axis review of package behaviour are clean, and no finding above
-changes a result marginplyr returns. What is not clean is the evidence layer
-the gate is written in terms of. One of its three tickets is still open:
+and the two-axis review of package behaviour are clean, and no finding of that
+review changes a result marginplyr returns. What is not clean is the evidence
+layer the gate is written in terms of. One of its three tickets is still open:
 `cran-comments.md` states counts the tree no longer produces (#65). Of the
 seven smaller standards and spec findings, six were #66 and are fixed above;
 the seventh, the skip-helper argument order, moved to #69, which took it
@@ -915,4 +985,10 @@ because the finding as written was factually wrong about why the gate passes
 and correcting it belongs with the list it names. The third ticket, #64, is
 fixed — the release matrix now withholds the optional backends it documents
 withholding, and a gate fails the workflow if it stops doing so. #40 stays open
-until #65 closes, and no submission is made before then.
+until #65 closes, and no submission is made before then. #266 is of that
+evidence layer too, and bears on the gate the same way: it changes no result
+marginplyr returns, and it is a review whose outcome this file cannot yet be
+read for. §11's other two open findings are not of that layer — #264 and #265
+each change what a caller receives, and each reproduces today. Whether a gate
+written for #40's review reaches findings from a later one is that ticket's to
+decide; what this file records is that they are open and behavioural.

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -870,14 +870,14 @@ test_that("invalid grouping input lists every supported constructor", {
 # specification's own fields and whether its kind names a rule, and answer with
 # the same sentence, so either one running alone would leave the other unrun
 # and report nothing about it.
+#
+# Every object is written in both positions a specification is reachable in,
+# because the guard is reached by a different route from each -- the top-level
+# object the caller passed as `.grouping`, and an argument of a well-formed
+# parent, which `grouping_arg_spec()` evaluates and the preflight recurses into.
+# #262 reproduced at both, and a fix holding at one and not the other would
+# read as a fix.
 test_that("a malformed grouping specification is refused by both guards", {
-  compile <- function(spec) {
-    compile_grouping_spec(
-      spec,
-      "a",
-      duplicates_choices = margin_duplicates_choices
-    )
-  }
   malformed <- list(
     # A `type` that is not one name, and `args` that are not a list: the two
     # halves of the first guard's condition, which no single object fails both
@@ -894,14 +894,67 @@ test_that("a malformed grouping specification is refused by both guards", {
     structure(
       list(type = "pivot", args = list()),
       class = "margin_grouping_spec"
-    )
+    ),
+    # The class over something with no field to read at all, which a guard
+    # reading `type` before establishing that much answered with base R's own
+    # untyped error from that line instead of the refusal below it (#262).
+    # Both, because what raises differs -- `$` is invalid for an atomic vector
+    # and a closure is not subsettable, one a `simpleError` and the other a
+    # `notSubsettableError` -- and the guard's answer does not.
+    structure(1:3, class = "margin_grouping_spec"),
+    structure(function() 1, class = "margin_grouping_spec"),
+    # An object that answers for one field and raises on the other, which is
+    # why the two are read through separate catches rather than one decision
+    # about whether the object can be read at all. An active binding is what
+    # writes it without a `$` method: nothing here is a shape a caller is
+    # expected to build, and what it pins is that the guard's answer comes from
+    # what the object could say, field by field.
+    local({
+      spec <- rlang::new_environment(list(type = "set"))
+      raise <- function() {
+        rlang::abort("reading args raises", class = "grouping_spec_field_error")
+      }
+      makeActiveBinding("args", raise, spec)
+      structure(spec, class = "margin_grouping_spec")
+    })
   )
 
+  # `identity` is the top-level position and `grouping_sets` the nested one.
+  positions <- list(identity, grouping_sets)
   for (spec in malformed) {
-    error <- expect_error(compile(spec))
-    expect_s3_class(error, "marginplyr_error")
-    expect_identical(conditionMessage(error), "Invalid grouping specification.")
+    for (position in positions) {
+      error <- expect_error(compile_against(position(spec), "a"))
+      expect_s3_class(error, "marginplyr_error")
+      expect_identical(
+        conditionMessage(error),
+        "Invalid grouping specification."
+      )
+    }
   }
+})
+
+# The other half of #262, and the half nothing above would report. Establishing
+# that a field can be read is not the same question as requiring a list, and
+# the narrower reading passes every test above: `new_grouping_spec()` builds a
+# list, so every specification a caller can construct is one, and the object
+# the reading would newly refuse is one no test had reason to write. It is
+# still a specification that says what it is when it is asked -- the guard
+# reads fields, and this object answers for both of them -- so refusing it
+# would be the guard deciding by storage what it is written to decide by
+# content, and a caller whose specification arrived from somewhere else would
+# be refused for how it got here.
+#
+# One storage form carries it, because `is.list()` is what a rewrite of that
+# reading most easily becomes and an environment is what separates it from `$`.
+# A pairlist would not: `is.list()` is already true of one.
+test_that("a specification is read for what it says, not how it is stored", {
+  fields <- list(type = "set", args = list(rlang::quo(a)))
+  as_spec <- function(x) structure(x, class = "margin_grouping_spec")
+
+  expect_identical(
+    compile_against(as_spec(rlang::new_environment(fields)), "a"),
+    compile_against(as_spec(fields), "a")
+  )
 })
 
 test_that("selectors and fixed .by columns are resolved once", {


### PR DESCRIPTION
Closes #262.

`validate_grouping_spec_early()` is the guard that turns a malformed Grouping
specification into a Package condition. It read `grouping_spec$type` having
established only the object's class, so whatever the object raised when it was
asked for a field came out of that line instead of reaching
`abort_invalid_grouping_spec()` below it — the refusal already written for an
object whose fields do not read as a specification's.

```r
d   <- data.frame(s = c("x", "y"), value = c(1, 2))
bad <- structure(1:3, class = "margin_grouping_spec")

inspect_grouping(d, .grouping = bad)
#> Error: $ operator is invalid for atomic vectors
#>   class: simpleError/error/condition
```

Both the top-level `.grouping` route and a nested position reached it.

## What it does

Both fields are read through a catch, so an object that cannot answer for one
has none, and the guard refuses it in marginplyr's own words. The kind is read
through `grouping_spec_kind()`, which `check_ambiguous_nested_name()` reads
through as well: the two were defending against one hazard and only the
colliding path had a catch for it, which is the asymmetry the finding was made
from.

```r
inspect_grouping(d, .grouping = bad)
#> Error: Invalid grouping specification.
#>   class: marginplyr_error/rlang_error/error/condition
```

Three shapes move, and only these three: an object that cannot be asked for a
field at all (an atomic vector, a closure, an S4 object with no `$` method),
one that raises on a field it is asked for, and the same in a nested position.

## The read is `$` itself

Nothing here decides what a specification may be *stored* as, and both narrower
readings were tried on the way and both narrow:

- `is.list()` refuses an environment carrying the class with both fields
  readable, which compiled before. No constructor in the package builds one, so
  no test would have reported it — "a specification is read for what it says,
  not how it is stored" now does.
- `[[` with `exact = FALSE` bypasses a `$` method the object defines, warns on a
  tibble, and cost an ADR 0026 ambiguity refusal.

A helper taking the field name is possible —
`eval(call("$", quote(spec), as.name(name)), list(spec = spec))` is faithful,
since the object reaches `$` as a binding and so is never evaluated — but it is
metaprogramming to share one line read twice with a literal field name. The
drift that mattered is two readers of a *kind*, and the helper closes that.

## ADR 0008

The compatibility constraint holding error condition classes fixed is amended
in that ADR. It is the guard's own answer arriving rather than a new one being
chosen: ADR 0015 already assigns these shapes a Package condition and the
refusal raising it already existed. Nothing else in the constraint moves —
every object that reached the refusal reaches it with the same message, call
context, and detection order, no specification that compiled stops compiling,
and no field is read any earlier or later for a well-formed one.

Adding a second amendment is what made the first one's two ordinals worth
correcting: "the third constraint" and "the second constraint" were the fourth
and the third of the list they count. Both now name the constraint by what it
holds.

## Ledger

`design/review-dispositions.md` gains §11, which this finding was owed: it came
from a recorded review of #255's branch and was filed rather than fixed there.
#264 and #265 are dispositioned there as §8 dispositions an open ticket, with
the reproduction rather than a test that does not exist yet. What §11 cannot
claim is that the review it came from is otherwise dispositioned — #266 is that
gap, and the *Status* section is qualified for it.

## Filed, not fixed here

- **#264** — `print.margin_grouping_spec()` has the same too-early read. It is
  the only reader of a kind anywhere that does not sit behind this guard.
- **#265** — a specification stored as a function in a nested position is
  called by tidyselect as a selection predicate, so #190's refusal never fires.
- **#266** — the rest of that review's findings are recorded in commit messages
  and dispositioned nowhere.

## Checks

`lintr::lint_package()`, `spelling::spell_check_package(".")`, and the full
suite (620 files, 5068 pass, 0 fail, 0 skip) are clean, as is
`.github/scripts/verify-suite-coverage.R`. No roxygen source changed, so
nothing is owed regeneration.