### PR TITLE
Print a specification that cannot be asked for its kind

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -48,13 +48,14 @@ abort_invalid_grouping_spec <- function() {
 # look equivalent and are not: `is.list()` refuses an environment whose fields
 # read, and `[[` with `exact = FALSE` bypasses a `$` method the object defines.
 #
-# The two readers that can be handed an object nothing has validated share
-# this one, because they ask the same question of the same field, and the
-# colliding and the non-colliding spelling answering that question differently
-# is the asymmetry #262 was found through. Every other reader of a kind in this
-# file sits behind the guard above, which is what establishes there is one to
-# read. The one reader anywhere that does not is
-# `print.margin_grouping_spec()`, in `R/grouping-spec.R`, and it is #264.
+# Every reader that can be handed an object nothing has validated shares this
+# one, because they ask the same question of the same field, and the colliding
+# and the non-colliding spelling answering that question differently is the
+# asymmetry #262 was found through. Every other reader of a kind in this file
+# sits behind the guard above, which is what establishes there is one to read.
+# The third sharer is `print.margin_grouping_spec()`, in `R/grouping-spec.R`,
+# which sits behind no guard because a print method has none to sit behind: it
+# joined the two this comment was written for in #264.
 #
 # The catch is narrow in what it decides and not in what it swallows, exactly
 # as the evaluation catch in `check_ambiguous_nested_name()` is: an object that

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -211,8 +211,40 @@ print.margin_grouping_spec <- function(x, ...) {
   # without an edit. A kind with no rule is not constructible through the
   # package, and printing one falls back to what it stores rather than
   # reporting no name at all.
-  rule <- find_grouping_kind_rule(x$type)
-  name <- if (is.null(rule)) x$type else rule$constructor
+  #
+  # The kind is read through `grouping_spec_kind()`, the reader the two guards
+  # that can be handed an unvalidated object share, because this site asks
+  # their question of the same field: whether the object can be asked for a
+  # kind at all. It is not every object a class can sit on that answers, and
+  # reading `$` before establishing that much printed no line at all -- base
+  # R's own error from this line instead (#264). #262 fixed the guards and left
+  # this site, because a guard has a refusal to reach and a print method has
+  # none, so the answer there was not available here.
+  #
+  # What is printed instead is the line an object answering `NULL` already
+  # prints: the fallback below names nothing for a kind that is absent, and a
+  # read that raised is absent for this line's purposes, whatever raised it.
+  # Reporting which of the two it was would be a printed line saying what the
+  # object is, and that is the guards' sentence to say -- the same distinction
+  # `grouping_spec_kind()` itself declines to draw.
+  #
+  # Binding the kind is what makes the read one, where the fallback below used
+  # to print the field by asking for it a second time. ADR 0008's printed-line
+  # amendment decides that count, and states what reading through a shared
+  # function costs as a property rather than as a list: the wording is
+  # unchanged for every object whose `$` is an ordinary field read, and it is a
+  # `$` doing something other than answer that can see the difference. The
+  # count is the part of that a test can hold to a number, and one counts it
+  # rather than describing it.
+  #
+  # What is decided here is the read and nothing after it. A field that answers
+  # with a value `cat()` refuses is not this fallback's case -- the read
+  # succeeded, and the value is what the line then cannot be finished from --
+  # so it is left where #264's scope left it, printing exactly what it printed
+  # before, and it is #268.
+  kind <- grouping_spec_kind(x)
+  rule <- find_grouping_kind_rule(kind)
+  name <- if (is.null(rule)) kind else rule$constructor
   cat("<marginplyr grouping specification: ", name, ">\n", sep = "")
   invisible(x)
 }

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -147,6 +147,89 @@ never for how it is stored. The constraint on the number and timing of
 evaluations is not reached, since no field is read any earlier or later for a
 well-formed specification.
 
+"No specification that compiled stops compiling" is a claim about what the
+object says, and reading through a shared function has a cost of its own that
+the amendment below states as a property. It is the same reader, so the same
+cost is paid here: a `$` doing something other than answer can be refused where
+it compiled. The property is written out once, below.
+
+## Amendment: the printed line for a specification the printer could not read
+
+The constraint holding error condition classes fixed is amended again by #264 —
+a third time, after ADR 0026 moved it whole and #262 moved it for the guard —
+at the site the amendment above does not reach. That one is scoped to
+"a field the guard reads", and `print.margin_grouping_spec()` is not a guard.
+It read the kind having established only the class, so an object carrying
+`margin_grouping_spec` over something `$` cannot be asked raised from that line
+— `simpleError` for an atomic vector, `notSubsettableError` for a closure —
+with no refusal below it to reach. What such a call raises therefore moves to
+raising nothing at all: the object prints, on the line an object answering no
+kind already printed.
+
+The move is over the read and not over the whole line. A field that answers
+with a value `cat()` cannot render still raises from that call, having written
+the opening of the line first, so this method is not one that never raises;
+what it no longer does is raise for an object it could not ask. That remainder
+is #268, and it is named here because a decision record saying a class of
+errors moved should say which errors did not.
+
+The direction differs from the amendment above and the reason it is admissible
+is the same. There, the guard's own refusal was being kept from arriving; here
+there is no refusal to arrive, because a print method has none, and a print
+method that raises for an object it was asked to print is the defect rather
+than the diagnostic. Nothing else in this constraint moves with it: every
+object that printed before reaches the same line, with the same wording, at the
+same point, for every object whose `$` is an ordinary field read — one that
+answers from the object and the same way each time it is asked, returns rather
+than signalling, does nothing else while answering, and does not consult the
+call stack. That is every object a constructor builds, since one builds a list
+with base R's `$`.
+
+The qualification is written as a property rather than as a list of exceptions
+because what falls outside it is a class of behaviours and not a fixed number
+of them: reading through a shared function rather than in place is visible to
+any `$` that does something other than answer. Three are known and are recorded
+below, the last two of which are `grouping_spec_kind()`'s rather than this
+site's — chosen by #262 for the two guards, and inherited here rather than
+decided again. None of the three is a property of a specification.
+
+**Evaluations.** The constraint holding the number and timing of evaluations
+does so "without a separately accepted decision", and this is that decision,
+for one branch of one line. Where no rule answered the kind, the field was read
+twice — once to ask the registry, once to print the field itself — and it is
+read once now. The branch a rule answers read once before and reads once now,
+so no well-formed specification is affected: no kind a constructor produces
+takes the other branch. For an object whose `$` does not answer the same way
+twice, the count decides which answer is printed — the answer that chose the
+branch, rather than a second one asked for after it — and, where the second
+answer would have raised, whether a line is printed at all. For one whose `$`
+does something while answering, it decides how many times that is done, whether
+or not the line changes.
+
+**The frame the read is made on.** The read moved behind
+`grouping_spec_kind()`, which reads inside a `tryCatch()`, so a `$` method that
+answers from the call stack rather than from the object answers differently:
+`sys.nframe()` and the bindings of `parent.frame()` are not what they were.
+The frame is deeper as well as different, which is a fact about the answer such
+a method gives and not about what the printer can do: the depth at which a
+printed specification exhausts `getOption("expressions")` was measured
+unchanged, and the shared reader was measured never to answer `NULL` for a
+well-formed specification at any depth below it. This is not a constraint the
+list above holds, and it is recorded here because the qualification above
+excludes it and would otherwise read as an omission. Preserving it would mean
+choosing a call depth as a public contract, which nothing in this package
+promises and no specification depends on.
+
+**The handler the read is wrapped in.** `tryCatch(error = )` is an exiting
+handler, so a `$` that signals a condition inheriting `error` without stopping
+— returning an answer afterwards, as `signalCondition()` allows — is now
+unwound where it used to resume, and a calling handler the caller established
+for that class no longer runs. This is the same trade `grouping_spec_kind()`
+already made at both guards, and it is what catching by class costs anywhere:
+a condition is caught for what it says it is. Not catching it is the
+alternative that was rejected in #262, since an object that cannot answer for
+its kind is the case the reader exists for.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -936,20 +936,53 @@ reachable from, and "a specification is read for what it says, not how it is
 stored", which fails if the reading narrows to `is.list()` — the narrowing a
 rewrite most easily becomes, and the one an environment separates from `$`.
 
-Two more findings came from #262's own review. Neither is this ticket's to
-answer and both are filed, so they are dispositioned here as §8 dispositions an
-open ticket, by naming the reproduction rather than a test that does not exist
-yet.
+Two more findings came from #262's own review. Neither was this ticket's to
+answer and both were filed. The first below has since been answered by the
+ticket it was filed as, and is dispositioned as any fixed finding is; the
+second is still open, and is dispositioned as §8 dispositions an open ticket,
+by naming the reproduction rather than a test that does not exist yet.
 
 **`print.margin_grouping_spec()` reads the kind off an object that may have
-none** (Standards). **Not fixed — open, #264.** The same too-early read as
-above, at the other site that reads a kind, and the only reader of one that
-does not sit behind `validate_grouping_spec_early()`. #262's scope was the
-guard, which has a refusal to reach; a print method has none, so the answer is
-not the same one and is that ticket's to choose. *Evidence:*
-`print(structure(1:3, class = "margin_grouping_spec"))` raises
-`$ operator is invalid for atomic vectors`, of class
-`simpleError/error/condition`.
+none** (Standards). **Fixed — #264.** The same too-early read as above, at the
+third site that can be handed an object nothing has validated, and the one that
+did not share the reader the other two were given. It sits behind no guard
+because a print method has none to sit behind, which is why #262's answer was
+not available here: a guard has a refusal to reach and a print method has only
+a line to print. What it prints for an object it cannot ask is the line an
+object answering with no kind already printed, naming no constructor, rather
+than a new line reporting the object unreadable. The fallback that covered an
+absent kind covers one that cannot be read, and telling the two apart would be a
+printed line saying what the object is — the guard's sentence to say, and the
+distinction `grouping_spec_kind()` already declines to draw. That reader is
+what the kind is now read through, so all three readers that can be handed an
+unvalidated object share one. ADR 0008's condition-class bullet is amended
+again for it — a third time, after ADR 0026 and #262 — because the amendment
+#262 made is scoped to a field the guard reads and this site is not a guard:
+what a forged object raised there moves to raising nothing, which is the
+direction a print method's version of this defect has. What the fix does not
+reach is a field that answers with a value `cat()` refuses, which raises from
+that call having already written the opening of the line: the read succeeded
+there, so it is not this finding, and it printed the same way before the
+fix — #268.
+
+The ticket's "wording unchanged for every object that prints today" is
+qualified, and the qualification is load-bearing rather than cautious: reading
+through a shared function rather than in place is visible to a `$` that does
+something other than answer. ADR 0008's printed-line amendment is where that
+property is written, in place of a list of exceptions, and every object a
+constructor builds satisfies it.
+
+*Evidence:* `test-grouping-interface.R` "a printed Grouping specification asks
+for a kind it may not have", which prints the class over an atomic vector, over
+a closure, and over an environment whose `type` raises on being read, and pins
+the unchanged line against the object that answers with no kind; "a printed
+Grouping specification renders a kind that is no name", which is what fails if
+the new reader narrows to a character scalar and takes the wording of a
+printing object with it; "a printed Grouping specification asks for its kind
+once", which counts the reads on both branches and asserts its counter through
+the helper the counts come from, since a second read leaves no other trace; and
+"a printed Grouping specification names the constructor called", which is what
+fails if the shared reader changes what a well-formed specification prints.
 
 **A specification stored as a function is read by tidyselect as a predicate,
 so #190's refusal never fires** (Spec). **Not fixed — open, #265.** A nested
@@ -988,7 +1021,8 @@ withholding, and a gate fails the workflow if it stops doing so. #40 stays open
 until #65 closes, and no submission is made before then. #266 is of that
 evidence layer too, and bears on the gate the same way: it changes no result
 marginplyr returns, and it is a review whose outcome this file cannot yet be
-read for. §11's other two open findings are not of that layer — #264 and #265
-each change what a caller receives, and each reproduces today. Whether a gate
-written for #40's review reaches findings from a later one is that ticket's to
-decide; what this file records is that they are open and behavioural.
+read for. §11's one other open finding is not of that layer — #265 changes what
+a caller receives, and reproduces today; #264 was of that kind too, and is
+fixed above. Whether a gate written for #40's review reaches findings from a
+later one is that ticket's to decide; what this file records is that one is
+open and behavioural.

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1140,3 +1140,150 @@ test_that("a printed Grouping specification names the constructor called", {
     "<marginplyr grouping specification: nonesuch>"
   )
 })
+
+# The last reader of a kind that can be handed an object nothing has validated,
+# and the one #262 left. A guard has a refusal to reach, so reading the kind
+# too early there answered a forged `.grouping` with the wrong error; `print()`
+# has no refusal at all, so the same too-early read answered it with no printed
+# line (#264).
+#
+# Three shapes, because what stops the read differs and the printed line does
+# not: `$` is invalid for an atomic vector, a closure is not subsettable, and a
+# field can raise on being read rather than being absent. The third is written
+# with an active binding because it is the shape where one field raises while
+# the object answers for another, and nothing produces that without a binding
+# or a `$` method of the object's own -- an S4 class defining no `$` method
+# refuses every field, which is the first shape again. None of the three is a
+# shape a caller is expected to build; what they pin is that the line comes
+# from what the object could say.
+test_that("a printed Grouping specification asks for a kind it may not have", {
+  # The line an object that answers with no kind prints today, which the
+  # objects below join rather than change: one that cannot be asked names no
+  # constructor for the same reason one that answers `NULL` names none.
+  kindless <- structure(list(args = list()), class = "margin_grouping_spec")
+  expect_identical(
+    utils::capture.output(print(kindless)),
+    "<marginplyr grouping specification: >"
+  )
+
+  unreadable <- list(
+    `an atomic vector` = structure(1:3, class = "margin_grouping_spec"),
+    `a closure` = structure(function() 1, class = "margin_grouping_spec"),
+    `a raising field` = local({
+      spec <- rlang::new_environment(list(args = list()))
+      raise <- function() {
+        rlang::abort("reading type raises", class = "grouping_spec_field_error")
+      }
+      makeActiveBinding("type", raise, spec)
+      structure(spec, class = "margin_grouping_spec")
+    })
+  )
+  for (shape in names(unreadable)) {
+    spec <- unreadable[[shape]]
+    expect_identical(
+      utils::capture.output(returned <- withVisible(print(spec))),
+      "<marginplyr grouping specification: >",
+      info = shape
+    )
+    # A print method returns its argument invisibly whatever it printed, so an
+    # object it could not read is still the object the caller passed.
+    expect_identical(
+      returned,
+      list(value = spec, visible = FALSE),
+      info = shape
+    )
+  }
+})
+
+# The other half of what the reading decides, and the half only this asserts:
+# routing the kind through `grouping_spec_kind()` put a new function in front
+# of a line whose wording #264 fixed for every object that printed before it.
+# A kind that is read and is not one name is where that could be lost, because
+# `find_grouping_kind_rule()` answers `NULL` for it and the fallback then
+# prints the kind itself -- so a reader narrowed to a character scalar, the
+# narrowing this most easily becomes, would print the empty name here and fail
+# nothing. The character kind no rule answers is pinned above; this is the kind
+# no rule answers for the other reason.
+#
+# `cat()` is what prints the fallback, so what these shapes pin is its
+# rendering and not a wording marginplyr chose. That is also the boundary the
+# fix reached: a kind `cat()` refuses raises from that call, having already
+# written the opening of the line, and belongs to #268 rather than to this
+# ticket -- the read succeeded there, and #264's scope reaches the read.
+test_that("a printed Grouping specification renders a kind that is no name", {
+  as_kind <- function(type) {
+    structure(list(type = type, args = list()), class = "margin_grouping_spec")
+  }
+
+  expect_identical(
+    utils::capture.output(print(as_kind(1:3))),
+    "<marginplyr grouping specification: 123>"
+  )
+  expect_identical(
+    utils::capture.output(print(as_kind(c("a", "b")))),
+    "<marginplyr grouping specification: ab>"
+  )
+  expect_identical(
+    utils::capture.output(print(as_kind(NA_character_))),
+    "<marginplyr grouping specification: NA>"
+  )
+})
+
+# What the reading did not leave alone, in the part of it that can be held to a
+# number. ADR 0008's printed-line amendment states the rest as a property --
+# the wording is unchanged for every object whose `$` is an ordinary field read
+# -- and illustrates it with the ways a `$` doing something else can see the
+# difference. This is what holds the tree to the count: the field is read once
+# on both branches, where the fallback used to ask a second time to print what
+# it had already been given.
+#
+# Counting is the whole of the evidence, because a second read leaves no other
+# trace. Only an object whose `$` answers differently on successive reads could
+# see one, only on the branch that made it -- the fallback, per the amendment
+# -- and no object a constructor builds is such an object. Both branches are
+# counted even so, since what the amendment fixes is the count on each and not
+# the difference between them.
+test_that("a printed Grouping specification asks for its kind once", {
+  count_reads <- function(kind, read = print) {
+    reads <- 0L
+    spec <- rlang::new_environment(list(args = list()))
+    makeActiveBinding(
+      "type",
+      function() {
+        reads <<- reads + 1L
+        kind
+      },
+      spec
+    )
+    line <- utils::capture.output(
+      read(structure(spec, class = "margin_grouping_spec"))
+    )
+    list(reads = reads, line = line)
+  }
+
+  # The counter first, through the helper the counts below come from rather
+  # than a copy of it: a reader that asks twice reports two. A one below is
+  # then a second read that did not happen, and not a counter that cannot
+  # report more than one -- which is the failure a zero would not reveal,
+  # since a counter that stopped entirely reports zero and the assertions
+  # below already refuse that.
+  twice <- count_reads("set", read = function(x) cat(x$type, x$type, "\n"))
+  expect_identical(twice$line, "set set ")
+  expect_identical(twice$reads, 2L)
+
+  # The branch a rule answers, which read once before and reads once now.
+  with_rule <- count_reads("set")
+  expect_identical(
+    with_rule$line,
+    "<marginplyr grouping specification: grouping_set>"
+  )
+  expect_identical(with_rule$reads, 1L)
+
+  # The branch that printed the field, which is where the second read was.
+  without_rule <- count_reads("nonesuch")
+  expect_identical(
+    without_rule$line,
+    "<marginplyr grouping specification: nonesuch>"
+  )
+  expect_identical(without_rule$reads, 1L)
+})


### PR DESCRIPTION
Closes #264.

## What was wrong

`print.margin_grouping_spec()` read `x$type` having established only the
class, so an object carrying that class over something `$` cannot be asked
raised base R's own error from that line instead of printing — `simpleError`
for an atomic vector, `notSubsettableError` for a closure. A print method has
no refusal to reach, so what the too-early read cost here was the printed line
itself, not the class of an error. #262 fixed the two guards that read the same
field and left this site, because the answer it chose there was a refusal and
this method has none to make.

## What this does

The kind is read through `grouping_spec_kind()`, the reader those guards
share, so every reader that can be handed an unvalidated object asks the
question the same way. That is the first of the two answers #264 left open.
An object that cannot be asked prints the line an object answering `NULL`
already printed, naming no constructor, rather than a new line reporting the
object unreadable: the fallback that covered an absent kind covers a read that
raised, and reporting which of the two it was would be a printed line saying
what the object is — the guards' sentence to say, and the distinction the
shared reader itself declines to draw.

## ADR 0008

The condition-class bullet is amended for this site, a third time after ADR
0026 and #262. #262's amendment is scoped to a field *the guard* reads, and a
print method is not a guard; the direction differs too, since what a forged
object raised moves to raising nothing rather than to a refusal of marginplyr's
own.

The amendment also states what reading through a shared function costs, as a
property rather than as a list of exceptions: the wording is unchanged for
every object whose `$` is an ordinary field read, which is every object a
constructor builds. Three differences a `$` doing something else can see are
recorded there as illustrations — the kind is read once where the fallback
asked a second time, the frame the read is made on is deeper, and an
error-classed condition signalled during the read is now caught. The last two
are `grouping_spec_kind()`'s and were #262's to decide.

## Evidence

`test-grouping-interface.R` gains three tests, because the reading is where
each of those claims could be lost and none of them leaves another trace:

- **"a printed Grouping specification asks for a kind it may not have"** — the
  class over an atomic vector, over a closure, and over an environment whose
  `type` raises on being read, pinned against the object that answers with no
  kind.
- **"a printed Grouping specification renders a kind that is no name"** — the
  wording for the kinds no rule answers for the *other* reason, which a reader
  narrowed to a character scalar would take with it.
- **"a printed Grouping specification asks for its kind once"** — counts the
  reads on both branches, asserting its counter through the helper the counts
  come from rather than a copy of it.

Each was mutation-tested: reverting the read, narrowing the reader to a
character scalar, and restoring the second read each fail exactly the test
written for it.

## Boundary

A kind `cat()` refuses still raises from that call, having already written the
opening of the line. The read succeeded there, so #264's scope does not reach
it, and it prints exactly as it did before this branch. That is #268, and the
amendment names it, since a decision record saying a class of errors moved
should say which errors did not.

## Checks run locally

`lintr::lint_package()`, `spelling::spell_check_package()`,
`roxygen2::roxygenise()` (no diff), the full test suite with and without
`NOT_CRAN`, `verify-suite-coverage.R` (623 tests, all executed in at least one
backend configuration), `verify-must-error.R`, and `R CMD check` on the built
tarball. The one NOTE is `.git` being shipped, which is an artifact of building
from a git worktree — `R CMD build` excludes a `.git` directory but not the
`.git` *file* a worktree has, confirmed by measurement — and does not occur in
a normal checkout.