### PR TITLE
Say what a comment holds, and where its argument lives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,6 +548,48 @@ in use across the backends dbplyr reaches, two of them appear under one
 `grouping_backend()` kind, and `is.data.frame()` is the only predicate that
 answers whether an external system is involved at all.
 
+### Code comments
+
+`R/` carries two kinds of comment, and they answer different questions.
+
+A **header** sits above a definition and documents it. An internal name has no
+roxygen, so its header is the only place its contract is written: for a
+function, what it answers and what its caller holds before calling it.
+
+An **inline** comment states what only that location knows — an invariant
+established upstream and not re-checked here, an ordering constraint and what
+breaks if the line moves, an R, dplyr, dbplyr, or backend behaviour the code
+cannot show, or the reason a `# nolint` names.
+
+Either may cite a decision, and a citation does one job: it names where the
+decision lives, which is what keeps the comment true after the ADR is amended.
+What a citation cannot say is which way *this* site falls under it — that this
+guard stays a bare `stop()` because no call rewrite avoids it (ADR 0015) — so
+say that, and stop there. Re-deriving the ADR's own argument beside the
+citation is the second copy: it reads as support for the citation while nothing
+compares the two, so an amendment leaves it standing and wrong. ADR 0023
+settled this once already, for a rule that governed one file while two others
+re-derived it.
+
+A comment describes the code it sits beside, in the present tense. What a
+review found, which round answered it, and what a test elsewhere now covers are
+things the code does not hold — the ledger, the commit message, and the test
+are where each of those is read.
+
+No scan enforces any of this, and that is a decision rather than a gap. What
+makes a comment wrong is that a paragraph re-derives an argument another file
+owns, which is a semantic property: a scan over `R/` either fires on comments
+that are correct or finds almost nothing, and a bound on a block's length is
+answered by one blank `#` line. A structural gate cannot reach it either: those
+gates read a loaded namespace, per *Structural gates* in
+`design/architecture.md`, and a comment is not in one the way a name and a body
+are. A `srcref` opens at `function(`, so no header is inside any of them, and
+an installed package carries no `srcref` at all, `keep.source.pkgs` being
+`FALSE`. Such a gate would have to skip where every existing one runs, and
+`verify-backend.R` fails a job for a skip naming no withheld backend. This is a
+hand audit for the reason *Dependency metadata* above is one: what defeats the
+scan is what a scanner can express, not missing configuration.
+
 ## Agent skills
 
 ### Issue tracker

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -760,7 +760,33 @@ source packages. Internal architecture is not duplicated into the README or
 vignettes.
 
 `review-dispositions.md` is the ledger that gives "review complete" an
-auditable meaning: every observation from a recorded review is listed there as
-fixed or rejected, with a test, command, or reproduction behind it. An ADR
-records what was decided; the ledger records what was reviewed and what
-happened to it.
+auditable meaning: an observation from a recorded review is listed there as
+fixed or rejected, with a test, command, or reproduction behind it, and that
+file states which observations reach it. An ADR records what was decided; the
+ledger records what was reviewed and what happened to it.
+
+An ADR is amended when its decision changed observably, and the amendment
+records what the decision now is and what moved with it. The argument for
+changing it is the ticket's, and the ticket is what the amendment cites: an
+amendment that makes the case again is a second copy of the ticket's, and it
+goes stale the way a comment re-deriving an ADR does — see *Code comments* in
+`AGENTS.md`.
+
+## Answering a review
+
+An answer lands with the thing that makes it checkable. A finding answered in
+code lands with the test that fails without it; a finding answered in prose
+lands with the citation, the command, or the reproduction the next reader runs.
+An answer that lands as prose alone is a claim the next round has to check, and
+that round is what `59bb476` is: it found that the previous answer's "now have
+a test" covered one of the two shapes it named, and that the uncovered one was
+reachable from the public interface.
+
+Each finding is dispositioned before it is answered — the code, a test, a
+workflow or verifier script, an ADR, another repository document, or a
+rejection with evidence. Naming which one is what the disposition does, and a
+comment is not among them: a finding a comment would answer is one of the
+others.
+
+Where code is misread without a comment, the finding is the naming or the
+decomposition that allowed the misreading, and it is reported as that.

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -1,16 +1,25 @@
 # Review disposition ledger
 
-Every observation from a recorded review of the 0.1.0 stabilization work is
-listed here as **fixed** or **rejected**, with a test name, command, or
-reproduction result behind it. This is what makes "review complete" mean
-something other than "the reviewer stopped talking": a suggestion that was not
-implemented has to say why, in a form the next reader can check.
+An observation from a recorded review of the 0.1.0 stabilization work is listed
+here as **fixed** or **rejected**, with a test name, command, or reproduction
+result behind it. This is what makes "review complete" mean something other
+than "the reviewer stopped talking": a suggestion that was not implemented has
+to say why, in a form the next reader can check.
 
 A recorded review is one whose findings were written down in the issue tracker
 — an issue comment, a pull-request body, or a commit message that names what
 review found. Findings raised and fixed inside one commit before it was pushed
 are not separately listed; they left no trace to reconcile and the commit is
 the record.
+
+An observation reaches this file when its disposition is not already readable
+from what the branch produced: every rejection, and every fix whose evidence is
+not named by the commit that made it. A fix whose commit names the finding and
+the test that now covers it has already left the record this file exists to
+make, and listing it again is the second copy. Rejections carry no such
+exemption, and that asymmetry is deliberate: a fix is held up by something that
+runs, where a rejection is held up only by the sentence explaining it, so the
+rejection is the one a reader cannot reconstruct.
 
 Rejecting an observation is a normal outcome. A review suggestion is a
 hypothesis about the code, and several of the ones below were disproved by
@@ -1002,6 +1011,11 @@ same position takes #190's refusal for an object of any other storage.
 Every observation from every recorded review is dispositioned above, but for
 the one §11 names: the review of #255's branch has entries here only for the
 finding that left the branch as a ticket, and #266 is what tracks the rest.
+The bar that sentence measures against narrowed when the scope rule at the top
+of this file was written down, so #266 is re-read against that rule rather than
+closed by it: which of its items are entries this file still owes is the
+question it now asks, and each is answered by looking at whether the commit
+that fixed it names the finding and the test.
 Until #266 closes, this file does not meet its own bar, and the release gate
 #23 sets is not met by this file even where it does: the gate also requires a
 fresh two-axis review and Docs & Tests audit with no unresolved findings, which


### PR DESCRIPTION
Code comments are the one artifact in this repository with no recorded rule.
`AGENTS.md` says nothing about them beyond the reason a `# nolint` carries, and
the authority split that `investigation/README.md`, `design/agents/domain.md`,
and `AGENTS.md` draw between ADRs, tests, and the ledger leaves them out. Every
other artifact has a gate; this one has neither a gate nor a sentence.

## What filled the gap

Measured at `04f093f`, reproducible from the commit body:

| | |
|---|---:|
| plain comment lines in `R/` | 2,989 |
| of those, sitting above a definition and documenting it | **2,050 (69%)** |
| inline, beside code | 939 (31%) |
| function definitions in `R/` | 384 |
| with a header block | 180 (47%) |

The 2,050 lines are not verbose explanation. An internal function has no
roxygen, so a header is the only place its contract is written — which is why a
bound on a block's length would have asked, of two thirds of the population,
whether that documentation may be deleted rather than whether the comment may
be shorter.

The defect is narrower and does not grep. The longest block, 96 lines above
`check_ambiguous_nested_name()`, spends about half its length re-deriving ADR
0026's own argument in different words; the other half records the `#261` and
`#262` paths, which ADR 0026 does not contain. Verbatim overlap is 17%, so a
copy-detector finds nothing, while an amendment to the ADR leaves the
re-derivation standing and wrong.

## What this adds

**`AGENTS.md` — *Code comments*.** Names the two kinds and what each answers,
and separates the three jobs around a citation: the citation says where the
decision lives, the comment says which way this site falls under it, and the
ADR keeps the argument. ADR 0023 settled this once already, for a rule that
stood in one code comment while two other files re-derived it, and `8fd4e89`
acted on it once by reducing an element-count comment to a citation. This is
that rule written where the next comment is authored.

**No gate, stated as a decision.** Four syntactic proxies were measured and
none landed between over- and under-firing; a length bound is answered by one
blank `#` line, since 352 blocks already hold 555 paragraphs; and a structural
gate cannot reach a comment at all — a `srcref` opens at `function(`, so no
header is inside one, and an installed package carries no `srcref` with
`keep.source.pkgs` false, so such a gate would skip where every existing one
runs and `verify-backend.R` would fail the job for the skip. That is the
*Dependency metadata* case: what defeats the scan is what a scanner can
express, not missing configuration.

**`design/architecture.md` — *Answering a review*.** Since 2026-08-01,
review-answering commits added 411 comment lines against 307 code lines — 2.4×
the ratio of the other 268 commits — while the same 21 commits added two lines
to the ledger. An answer now lands with the thing that makes it checkable,
because an answer that is prose alone is a claim the next round has to check.
`59bb476` is that round: it found the previous answer's "now have a test"
covered one of the two shapes it named, and the other was reachable from the
public interface.

**The ledger states its own scope.** Its bar was every observation from every
recorded review, and its *Status* section says it cannot meet that. A fix whose
commit names the finding and **a test that fails without the fix** has already
left the record. Rejections carry no exemption — a fix is held up by something
that runs, a rejection only by the sentence explaining it.

**ADR amendments get the comment rule.** 23 amendment sections hold 1,076
lines, 23% of the ADR corpus. An amendment records what the decision now is and
cites the ticket instead of making the ticket's case again.

## What #266 changed here

#266 framed this choice as its **option 2** — amend the exemption rather than
write the missing entries — and argued against it from `59bb476`. The argument
landed, and `e6b4484` is the answer.

The first draft exempted a fix whose commit "names the finding and the test
that now covers it". `def830e` is a commit that did exactly that and was wrong,
and mutating the guard it claimed covered left the whole suite green. Resting
the exemption on a *test that fails without the fix* is what `def830e` could
not have claimed, because reverting the fix is what checks it — and it is the
sentence `59bb476` wrote once it had found the gap. #266 stays open: which
entries remain owed is now a check that runs, and closing it is what decides.

## Rejected

- **A four- or eight-line cap.** Evaded by a blank `#` line, and wrong for a
  population that is 69% internal-function documentation.
- **A scan in `test-documentation.R`.** `R/` is not installed beside the tests,
  and the skip it would need fails `verify-backend.R`.
- **Ending a review round when `R/` code stops changing.** PR #205 never
  touches `R/`; `41463d7` in #202 is `R/` 0 / tests 83; `4d745e2` in #218 is
  `R/` 0 / ADR 0022 166. And it would have ended #263 before `59bb476`.
- **Capping a ledger entry at three lines.** A well-formed rejection runs 6–8,
  and every line is the test name a reader checks.
- **Immutable ADRs superseded by new ones.** 23 amendments become 23 ADRs,
  which is worse by the measure that opened the question.

## Verification

Full suite green under `pkgload::load_all()` — no failures, warnings, or skips.
All three files are `.Rbuildignore`d, so `document.yaml`, `R CMD check`, and
the site build are untouched. No test asserts the edited text.

## Follow-ups

Filed, and none is in this PR:

- #271 — `CONTEXT.md`'s *Nested specification position* carries evaluation
  order and execution counts.
- #272 — the 96-line header above `check_ambiguous_nested_name()`.
- #273 — the 37 paragraphs, 328 lines, that name an ADR and run past six.
