### PR TITLE
Rest the ledger's exemption on a test that fails, not on a claim of one

### DIFF
--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -15,11 +15,22 @@ the record.
 An observation reaches this file when its disposition is not already readable
 from what the branch produced: every rejection, and every fix whose evidence is
 not named by the commit that made it. A fix whose commit names the finding and
-the test that now covers it has already left the record this file exists to
-make, and listing it again is the second copy. Rejections carry no such
-exemption, and that asymmetry is deliberate: a fix is held up by something that
-runs, where a rejection is held up only by the sentence explaining it, so the
-rejection is the one a reader cannot reconstruct.
+a test that fails without the fix has already left the record this file exists
+to make, and listing it again is the second copy.
+
+The test has to fail without the fix rather than merely exist, because a commit
+naming one that does not is how a fix escapes both records at once. `def830e`
+is that commit: it said two shapes a kind cannot be read from "now have a test"
+when only the list one did, and mutating the guard around the other read left
+the whole suite green. `59bb476` is what found that out, a round later. An
+exemption resting on a claim would have taken `def830e` at its word; one
+resting on a test that fails without the fix could not have been claimed there
+at all.
+
+Rejections carry no such exemption, and that asymmetry is deliberate: a fix is
+held up by something that runs, where a rejection is held up only by the
+sentence explaining it, so the rejection is the one a reader cannot
+reconstruct.
 
 Rejecting an observation is a normal outcome. A review suggestion is a
 hypothesis about the code, and several of the ones below were disproved by
@@ -1015,7 +1026,10 @@ The bar that sentence measures against narrowed when the scope rule at the top
 of this file was written down, so #266 is re-read against that rule rather than
 closed by it: which of its items are entries this file still owes is the
 question it now asks, and each is answered by looking at whether the commit
-that fixed it names the finding and the test.
+that fixed it names the finding and a test that fails without the fix. #266
+put that choice as its option 2 and argued against it from `59bb476`; the
+scope rule answers that argument rather than waiving it, and whether any
+entries remain owed is what closing #266 decides.
 Until #266 closes, this file does not meet its own bar, and the release gate
 #23 sets is not met by this file even where it does: the gate also requires a
 fresh two-axis review and Docs & Tests audit with no unresolved findings, which


### PR DESCRIPTION
#270 merged at `2388e1e` and this commit was pushed to that branch after the
merge, so it did not land. It is the answer to the one substantive objection
against what #270 did to the ledger, and #266 is where the objection is
written down.

## The objection

#266 framed the choice as two options — write the missing entries, or amend the
exemption — and argued against the second from `59bb476`:

> `59bb476` is the case that shows the difference — it records that `def830e`
> had over-claimed, saying two shapes "now have a test" when only one did.

#270 took the second option. Its rule exempted a fix whose commit "names the
finding and the test that now covers it", and `def830e` is a commit that did
exactly that and was wrong: it said two shapes a kind cannot be read from "now
have a test" when only the list one did, and mutating the guard around the
other read left the whole suite green. The exemption rested on a claim, so it
would have taken `def830e` at its word and left the over-claim in neither the
commit record nor the ledger. `59bb476` found it a round later, which is the
round the exemption would have made unnecessary to have.

## The change

The exemption now rests on a commit naming the finding **and a test that fails
without the fix**. Reverting the fix is what checks that, so it is not a claim
a commit can make falsely and have stand, and it is not one `def830e` could
have made at all. It is also the sentence `59bb476` itself wrote once it had
found the gap:

> It has a test now, and that test fails without the guard.

The *Status* section is updated to say which question #266 now asks rather than
answering it: whether any entries remain owed is that ticket's to close, and it
is now a check that runs rather than a judgement about the exemption's shape.

## Verification

`design/review-dispositions.md` only; it is `.Rbuildignore`d, so no generated
file moves and no test reads it. The full suite was green on this content
before #270 merged.
