### PR TITLE
Leave the glossary the term, and ADR 0026 the decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,29 +22,12 @@ decided by how the argument is written: a call to a constructor, or a name
 bound to a specification, is a nested specification, and every other argument
 is a column selection. A spelling the position does not recognize is never
 evaluated to find out, because a selection such as `starts_with("re")` has no
-meaning outside a selection context. A specification a caller's own function
-returns is therefore refused there, in marginplyr's own words and with the
-binding that works, while the same call is accepted as `.grouping` itself. The
-position answers for its own argument and not for a part of one: a
-specification written inside a selection is the wrong kind of object where it
-sits, and where the input has no column of that name the selection's own
-report is what says so.
-
-A bare name is the one argument both readings can claim, where the input has a
-column of that name and the caller's environment binds that name to a
-specification the position admits. Such a name is refused rather than
-resolved, naming both readings and the spelling that settles each —
-`all_of("s")` for the column, `!!s` for the specification — because either
-precedence would decide by the input what the spelling is supposed to decide,
-and would decide it silently. Which kinds a position admits is what makes the
-second reading available, and the input never is: `grouping_sets()` and
-`grouping_spec()` admit every kind, `rollup()` and `cube()` admit a
-`grouping_set()` composite dimension, and `grouping_set()` admits none, so a
-colliding name there is a column and its binding is never read. Where the
-binding is read, it is read once, because what kind a name is bound to cannot
-be learned any other way. Inside a selection no second reading arises at all:
-a selection takes the column, which is what a selection means by a name the
-data holds.
+meaning outside a selection context. Both readings claim one argument at once:
+a bare name that is a column of the input and is also bound, in the caller's
+environment, to a specification of a kind the position admits — which kinds
+those are varies by constructor. How that name is written settles neither
+reading, so it is refused rather than resolved. ADR 0026 decides that, and
+holds the admitted kinds and what the read costs a caller.
 _Avoid_: Nested grouping, nested slot
 
 **Grouping plan**:

--- a/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
+++ b/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
@@ -194,13 +194,19 @@ defect.
 
 ## Documentation consequences
 
-`CONTEXT.md`'s *Nested specification position* states the refusal and the
-narrowing by kind, and two of its sentences stop being true as written: that the
-position never evaluates an argument to find out, and that a specification
-written inside a selection keeps the selection's own report. The second was
-never true where a column shares the name — `grouping_sets(c(s, grade))` selects
-the column and raises nothing — and the same sentence stood in `?grouping_set`,
-`design/architecture.md`, and two code comments.
+`CONTEXT.md`'s *Nested specification position* defines the term and names the
+refusal as the one argument its spelling rule does not settle; the admitted
+kinds and what the read costs are cited to this ADR rather than restated there
+(#271). This decision narrowed one sentence it keeps: what is never evaluated
+to find out is a spelling the position does not recognize, where the entry
+once said the position never evaluates an argument at all.
+
+A second sentence stopped being true outright — that a specification written
+inside a selection keeps the selection's own report. It was never true where a
+column shares the name — `grouping_sets(c(s, grade))` selects the column and
+raises nothing — and the same sentence stood in `?grouping_set`,
+`design/architecture.md`, and the header of `is_grouping_spec_subscript()`.
+The glossary no longer carries it at all.
 
 `?grouping_set` carries the same rule in a caller's terms, with both spellings,
 and the `.grouping` parameter documentation points at it. Inside a selection the


### PR DESCRIPTION
`design/agents/domain.md` makes `CONTEXT.md` the home for this repository's
domain vocabulary — "short canonical definitions, relationships, and avoided
terms". *Nested specification position* ran 33 lines, and most of them were not
vocabulary: which kinds each constructor admits, that the gate answers before
the preflight decides, and that a colliding binding is read once. ADR 0026
holds every one of those as the decision it is, so the entry was the shape
`AGENTS.md`'s *Code comments* section names — a meaning with a home, restated
where nothing compares the two, which an amendment to ADR 0026 would leave
standing and wrong.

## What the entry keeps

What the term names: the two readings, that the spelling decides which is
meant, and that one bare name is claimed by both and is refused rather than
resolved. The last is kept rather than dropped because without it "a name bound
to a specification is a nested specification" reads as a complete rule that the
collision case contradicts — the glossary would be shorter and false.

Which kinds a position admits is named as varying by constructor, which is the
borderline the ticket delegates; the five-way table is not restated, ADR 0026
and the kind registry both holding it.

What the citation points at is the **read's** cost and not the refusal's: the
read is what establishes which bindings are specifications, so a colliding name
of an inadmissible kind pays it without being refused (ADR 0026, *The cost
accepted*).

## ADR 0026

*Documentation consequences* names one fewer copy: `CONTEXT.md` now cites it
instead of restating it.

What that section still tracks by hand is the sentence about a specification
written inside a selection, and it named two code comments as carrying it where
one did — `R/conditions.R`'s chain-walk header is about the depth a refused
subscript sits at, which is a different subject, and
`resolve_grouping_selection()`'s header is byte-identical before and after the
correction, so it neither carried it nor was corrected. Verified at `372eb5f^`,
before the code landed. It names the one header instead, since a name can be
grepped and a count cannot. That correction is pre-existing on `main` rather
than this ticket's, but the sentence is being rewritten here and re-endorsing a
measured-false count is the option worth avoiding.

## Verification

- Full suite green, twice — no failures, no skips.
- No generated file moves: the diff is `CONTEXT.md` and the ADR only, and both
  are `.Rbuildignore`d. Nothing in `tests/` or `.github/` reads the glossary's
  text.
- `?grouping_set` is untouched, per the ticket's scope boundary: a caller needs
  the rule in a caller's terms, which is a different reader.
- No other `CONTEXT.md` entry is touched.

Reviewed on both the Standards and Spec axes, to exhaustion — four rounds, the
last two clean.

Closes #271.