### PR TITLE
Cite ADR 0026 at the site, and leave it the argument

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -361,69 +361,21 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   list(spec = grouping_spec, name_only = name_only)
 }
 
-# The one argument that has two readings available: a bare name that is a
-# column of the input and is bound to a specification of a kind this position
-# admits. The gate above answers it as a selection, because a selection is what
-# tidyselect's own precedence makes of a name the data holds -- so the caller
-# who meant the binding they wrote gets a well-formed plan of the other reading,
-# and nothing says so (#255). Refusing is what keeps a nested position's reading
-# decided by the spelling rather than by the input, without deciding it the
-# other way and leaving the same silence behind (ADR 0026).
-#
-# Available, not disagreeing: whether the two readings would produce different
-# grouping sets cannot be known without resolving the specification against this
-# input, and deciding by the input is the defect. So a name whose two readings
-# happen to agree is refused with the rest.
-#
-# Reading the binding is what the answer costs, and there is no cheaper
-# question: which kind a name is bound to cannot be known without reading it.
-# So a colliding name in a position that admits any kind is read once, where it
-# was read not at all -- once for each argument it is written as, and whether or
-# not its reading then changes, since what the read decides is whether it
-# changes. No argument outside a collision is read any more often than it was,
-# and a position that admits no kind reads nothing.
-#
-# It sits in the preflight rather than in the gate because the preflight runs
-# once for a whole operation and is handed to the compilation passes, where
-# the gate runs again on each.
-#
-# More than the count moves. Where the refusal fires, the arguments written
-# after it are not read at all, and this refusal is reported in place of
-# whatever the call would have been rejected for further along -- which is
-# every diagnostic reachable past this point and not one of them: a missing
-# column, a duplicate grouping set, a `.by` overlap, each nesting-grammar
-# rejection, and #190's own refusal among them. Where that displaced rejection
-# was an External condition, a caller who was receiving tidyselect's class and
-# tidyselect's blamed call now receives a `marginplyr_error` blamed on the
-# Margin verb.
-#
-# ADR 0008's compatibility list holds all of that, and not on the same terms.
-# The number and timing of evaluations are held "without a separately accepted
-# decision", which is the decision ADR 0026 makes. Condition classes, complete
-# messages, public call contexts, and detection order are one bullet carrying
-# no such clause, and this moves every item in it, so ADR 0026 amends that
-# bullet whole rather than naming a part of it.
-#
-# What that costs a caller is the forcing itself, not only the count, and it
-# reaches every colliding binding rather than the ones that turn out to be
-# specifications -- the read is what establishes which those are. So a
-# wrapper's own lazy argument is forced here, whatever it holds, for a call
-# whose answer may not depend on it: a warning or a message it raises reaches
-# the caller, and R's own `restarting interrupted promise evaluation` does
-# where such a binding raises and the name is written more than once. ADR 0026
-# accepts that rather than hiding it, since the alternative to reading the
-# binding is deciding by the input, which is the defect.
+# Refuses the one argument both readings claim: a bare name that is a column of
+# the input and is bound to a specification of a kind this position admits.
+# ADR 0026 holds that decision -- why such a name is refused rather than
+# resolved either way, what makes the second reading available, and what
+# reading the binding costs a caller. This is the site it names: the preflight,
+# on the branch where the gate above answered "selection".
 #
 # The two conditions on the name below are the two that made the gate answer
 # "selection" for a symbol, asked again here because the gate reports which
 # reading it took and not why. A name nothing binds has no second reading, and
 # a name the data does not hold is resolved by the gate itself.
 #
-# The kinds this position admits are asked before the binding is read, so a
-# position that admits none -- `grouping_set()`, which holds columns -- reads
-# nothing. Nothing there could make the name ambiguous, and reading a caller's
-# binding to establish that would force a promise for an answer that was
-# already known.
+# The kinds this position admits are asked before the binding is read: where a
+# position admits none, the answer is already known, and reading a caller's
+# binding to establish it would force a promise for nothing.
 #
 # The shape test comes before anything is bound to a local, and it is
 # `is_name_part()` rather than a bare symbol test. Both halves are the rule
@@ -455,8 +407,8 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 #
 # `rule` is the parent's own, which the caller already holds because it
 # validates nested arguments with it; deriving it again here would be the same
-# lookup twice. That it is the parent's own is also what makes the memo below
-# sound, since the key is the parent's kind and nothing reads the pair apart.
+# lookup twice. It is derived from the parent's kind, so the pair handed to the
+# memo below carries nothing that memo's key does not.
 check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
   if (!is_name_part(rlang::quo_get_expr(arg))) {
     return(invisible(NULL))

--- a/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
+++ b/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
@@ -32,9 +32,11 @@ Choosing either precedence keeps that property and only moves which reading is
 silently wrong. Preferring the binding makes the documented sentence true as
 written, and silently changes what an existing call returns for a caller who
 has a column and an unrelated binding of that name in scope. Preferring the
-column is what the position does today. Refusing is the only disposition that
-removes the silence in both directions, and it removes nothing else: a caller
-who meant either reading has a spelling for it, and had one before.
+column is what the position does today, because a selection is what
+tidyselect's own precedence makes of a name the data holds. Refusing is the
+only disposition that removes the silence in both directions, and it removes
+nothing else: a caller who meant either reading has a spelling for it, and had
+one before.
 
 It is also what this position already does with the other argument it cannot
 read. #190 could have been answered by evaluating every nested argument and


### PR DESCRIPTION
The header above `check_ambiguous_nested_name()` ran 96 lines over a body of
about 30, and seven of its twelve paragraphs were ADR 0026's argument written
out again in different words: why the refusal exists rather than a precedence,
"Available, not disagreeing", what reading a binding costs, why the preflight
and not the gate, "More than the count moves", which of ADR 0008's bullets the
decision amends, and what the forcing costs a caller. Verbatim overlap across
the block is 17%, so no copy-detector reaches it; what makes it the shape
`AGENTS.md`'s *Code comments* section names is that an amendment to ADR 0026
leaves those paragraphs standing and wrong, and nothing compares the two.

## What replaces them

Six lines: what this function refuses, ADR 0026 as where that decision lives,
and which way this site falls under it — the preflight, on the branch where the
gate above answered "selection". `R/margin-label.R:56` is the shape.

Every deleted sentence was checked against the ADR rather than assumed to be
there. One was not: that the gate answers "selection" because a selection is
what tidyselect's own precedence makes of a name the data holds. The ADR said
only that preferring the column is what the position does today, so it gains
the clause in *Why a caller is asked rather than served*.

## What stays

What the ADR does not hold, and that is the whole of what remains: the two
conditions the gate already answered and why they are asked again, the ordering
that keeps an admitted-kinds test in front of a promise and what moving it would
force, the `is_name_part()` rule and the #261 empty-argument path, the #262
catch and what it decides, and `rule` being the parent's own.

Two of those were trimmed to what only this site knows. The kinds paragraph kept
the ordering constraint and dropped its naming of `grouping_set()` as the
position admitting none, which ADR 0026 holds and the kind registry decides. The
`rule` paragraph now says what the memo key rests on *here* — that `rule` is
derived from the parent's kind, so the pair handed to the memo carries nothing
its key does not — where it used to restate why no rule reads more of a parent
than its kind, which is ADR 0026's argument and is also made in the memo's own
header below.

## The acceptance criterion that needed no edit

The ticket asked ADR 0026's *Documentation consequences* to name one fewer code
comment. #271 had already brought that count to one, by finding that of the two
it left unnamed, the second was `R/conditions.R`'s chain-walk header on a
different subject. The one it names, the header of
`is_grouping_spec_subscript()`, carries the corrected sentence about a
specification inside a selection and is unrelated to this block. Nothing is left
undone by leaving the section as it stands.

## Filed, not fixed here

#276 — `admitted_nested_kinds()`'s 39-line header, 30 lines below this one,
restates three of ADR 0026's sections the same way. It is out of this ticket's
scope and is what makes one file currently answer the admitted-kinds question
two ways.

## Verification

No behaviour changes; comments and prose only. Full suite green under
`pkgload::load_all()` — FAIL 0, WARN 0, SKIP 0, PASS 5084 — and
`lintr::lint_package()` clean. `design/adr/` is `.Rbuildignore`d and no roxygen
comment moved, so `man/`, `NAMESPACE`, and `README.md` are untouched.

Closes #272.
