### PR TITLE
Cite ADR 0026 above the memo, and leave it the argument

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -440,40 +440,17 @@ check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
   abort_ambiguous_nested_name(name)
 }
 
-# Which nested kinds this position admits: `grouping_set()` none, `rollup()`
-# and `cube()` a `grouping_set()`, `grouping_sets()` and `grouping_spec()` all
-# of them. It is the other half of "both readings are available", and the half
-# the input may not answer.
+# Which kinds a nested position under `parent` admits. `rule` is `parent`'s own
+# kind rule, which the caller holds. What this answer decides and how it is
+# derived is ADR 0026's; the registry the kinds are enumerated from is
+# ADR 0008's.
 #
-# The kind is where the line sits, and nothing further. A specification of an
-# admitted kind that is invalid on its own terms -- one with no arguments, one
-# holding a family its own constructor forbids -- makes the name ambiguous just
-# the same, because what is wrong with it is a property of what the caller
-# wrote and `!!` is what reports it. What the refusal's advice promises is the
-# reading, not that the reading succeeds: a caller who meant that specification
-# receives the diagnostic about it, which is what the silent column selection
-# withheld. Drawing the line further in would put arity and validity on the
-# same footing as the input, and one of those is not like the others.
+# Two things that derivation needs are the code below's to carry. `rule` is put
+# to a stand-in of each kind, and the stand-in is built with one argument --
+# `list(rlang::quo(NULL))`, not an empty list -- which is the arity the ADR
+# requires. And the memo's key is `parent$type`, the field a kind is read off.
 #
-# Derived by asking each kind's own parent rule rather than by a second list of
-# which kinds nest inside which (ADR 0008), so a sixth kind is admitted or
-# refused here by the rule that decides it everywhere else. The rule answers
-# about an instance, so it is asked about one that differs from a caller's only
-# where it must not decide here -- each kind is offered carrying one argument,
-# which is what keeps an empty `grouping_set()` binding from being read as a
-# kind `rollup()` does not admit.
-#
-# Asking costs a raised Package condition for every kind the parent refuses,
-# which is four of five under `rollup()` and `cube()` and every one of them
-# under `grouping_set()` -- a cli expansion and a backtrace apiece, for
-# conditions no caller sees. So the answer is kept, and the key is the parent's
-# kind. What that key rests on is that no rule reads anything of the parent but
-# its kind: of the three the five kinds share, two ignore the parent entirely
-# and the third reads its type, to name it in a message. It does not rest on
-# the nested side, where arity is read and where the stand-in above is what
-# fixes it -- a stand-in carrying no argument would answer `{}` for `rollup()`
-# and `cube()`, turning the refusal off in two of the five positions. A rule
-# reading more of a parent than its kind would need this key widened; the first
+# The invariant that is this memo's own rather than the ADR's: the first
 # computation for a kind is made with the real parent, so no parent asked about
 # here is a specification that was not written.
 #


### PR DESCRIPTION
The header above `admitted_nested_kinds()` ran 39 lines over a body of about 20,
and three of its four paragraphs were ADR 0026's argument written out again in
different words: the five-way admitted-kinds list, "the kind is where the line
sits, and nothing further", and what the memo's key rests on. What makes that
the shape `AGENTS.md`'s *Code comments* section names is that an amendment to
ADR 0026 leaves them standing and wrong, and nothing compares the two.

#277 removed the same duplication from `check_ambiguous_nested_name()`'s header,
30 lines above this one, and dropped that block's naming of `grouping_set()` as
the position admitting none — while the full five-way list stood here. This is
the second half of that, and what stops one file answering the admitted-kinds
question two ways.

## What replaces them

Four lines: what this function answers, what its caller holds, and ADR 0026 and
ADR 0008 as where the decision and the registry live. `R/margin-label.R:56` and
`check_ambiguous_nested_name()`'s header after #277 are the shape.

Every deleted sentence was checked against the ADR rather than assumed to be
there, and each is in it rather than merely near it — including "`!!` is what
reports it", which ADR 0026 carries in *The kind, and nothing further*. Unlike
#272, the ADR was thinner nowhere, so it gains no sentence here.

## What stays

What the ADR does not hold, and what only this site can say about what it does:

- `rule` is the parent's own kind rule, which the caller holds.
- The stand-in below carries one argument — `list(rlang::quo(NULL))`, not an
  empty list. ADR 0026 holds why that arity is required; the header's job is to
  say that this is where the code carries it.
- The memo's key is `parent$type`, the field a kind is read off. Why the key can
  be the parent's kind alone is the ADR's; which field that is, is here.
- The invariant that is this memo's own: the first computation for a kind is
  made with the real parent, so no parent asked about here is a specification
  that was not written.
- Memoized as `grouping_kind_rules()` is, and for the same reason — a fact about
  a sibling in this file.

## A drift the review caught

The first pass replaced paragraph 3 with a four-clause paraphrase of the ADR's
derivation instead of a citation, and the paraphrase was already wrong: it said
availability is asked of "each kind's own `validate_nested()` rule", where the
code asks the **parent's** rule about a stand-in of each kind. Implementing the
literal reading would invert the answer for `rollup()` and `cube()` and reopen
#255. That is the failure mode the ticket describes, arriving on the first
attempt to fix it, so the paragraph is now a citation and not a summary.

## Verification

No behaviour changes; comments only. Full suite green under
`pkgload::load_all()` — FAIL 0, WARN 0, SKIP 0, PASS 5084 — and
`lintr::lint_package()` clean. No roxygen comment moved, so `man/`, `NAMESPACE`,
and `README.md` are untouched.

Closes #276.