### PR TITLE
Print a specification whose kind is no name

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -834,12 +834,17 @@ grouping_kind_rules <- local({
   }
 })
 
+# Whether a kind read off an object is a name at all: one string, and not the
+# missing one. The lookup below needs this much before it can be made, and
+# answers `NULL` both for a kind that fails it and for a name it does not know,
+# so a caller that has to tell those apart asks this instead of reading that
+# answer.
+is_grouping_kind_name <- function(kind) {
+  is.character(kind) && length(kind) == 1L && !is.na(kind)
+}
+
 find_grouping_kind_rule <- function(kind) {
-  if (
-    !is.character(kind) ||
-      length(kind) != 1L ||
-      is.na(kind)
-  ) {
+  if (!is_grouping_kind_name(kind)) {
     return(NULL)
   }
   grouping_kind_rules()[[kind]]

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -205,13 +205,6 @@ new_grouping_spec <- function(type, args) {
 #' @exportS3Method
 #' @noRd
 print.margin_grouping_spec <- function(x, ...) {
-  # The kind stored on the object is internal; three of the five kinds are not
-  # the name of any function a caller can write. The kind rules already carry
-  # each kind's public constructor, so a new kind names itself correctly here
-  # without an edit. A kind with no rule is not constructible through the
-  # package, and printing one falls back to what it stores rather than
-  # reporting no name at all.
-  #
   # The kind is read through `grouping_spec_kind()`, the reader the two guards
   # that can be handed an unvalidated object share, because this site asks
   # their question of the same field: whether the object can be asked for a
@@ -221,30 +214,55 @@ print.margin_grouping_spec <- function(x, ...) {
   # this site, because a guard has a refusal to reach and a print method has
   # none, so the answer there was not available here.
   #
-  # What is printed instead is the line an object answering `NULL` already
-  # prints: the fallback below names nothing for a kind that is absent, and a
-  # read that raised is absent for this line's purposes, whatever raised it.
-  # Reporting which of the two it was would be a printed line saying what the
-  # object is, and that is the guards' sentence to say -- the same distinction
-  # `grouping_spec_kind()` itself declines to draw.
+  # What is printed for an object that cannot be asked is the line an object
+  # answering `NULL` already prints: the naming below answers nothing for a
+  # kind that is absent, and a read that raised is absent for this line's
+  # purposes, whatever raised it. Reporting which of the two it was would be a
+  # printed line saying what the object is, and that is the guards' sentence to
+  # say -- the same distinction `grouping_spec_kind()` itself declines to draw.
   #
-  # Binding the kind is what makes the read one, where the fallback below used
-  # to print the field by asking for it a second time. ADR 0008's printed-line
-  # amendment decides that count, and states what reading through a shared
-  # function costs as a property rather than as a list: the wording is
-  # unchanged for every object whose `$` is an ordinary field read, and it is a
-  # `$` doing something other than answer that can see the difference. The
-  # count is the part of that a test can hold to a number, and one counts it
-  # rather than describing it.
-  #
-  # What is decided here is the read and nothing after it. A field that answers
-  # with a value `cat()` refuses is not this fallback's case -- the read
-  # succeeded, and the value is what the line then cannot be finished from --
-  # so it is left where #264's scope left it, printing exactly what it printed
-  # before, and it is #268.
+  # Binding the kind is what makes the read one: what is named below is the
+  # value the read returned, not the field asked a second time. ADR 0008's
+  # amendment for a specification the printer could not read decides that
+  # count, and states what reading through a shared function costs.
   kind <- grouping_spec_kind(x)
-  rule <- find_grouping_kind_rule(kind)
-  name <- if (is.null(rule)) kind else rule$constructor
-  cat("<marginplyr grouping specification: ", name, ">\n", sep = "")
+  cat(
+    "<marginplyr grouping specification: ",
+    grouping_kind_printed_name(kind),
+    ">\n",
+    sep = ""
+  )
   invisible(x)
+}
+
+# The name a kind prints under, or the empty string where it has none. The
+# caller holds a kind some object answered with, or `NULL` where none could be
+# read; nothing about it has been established.
+#
+# The kind stored on a specification is internal, and three of the five are not
+# the name of any function a caller can write, so the rules' own constructor
+# names them: a new kind names itself correctly here without an edit. The three
+# answers are a kind a rule names, a kind that is one name no rule knows and so
+# names itself, and a kind that is no name at all. ADR 0008's amendment for a
+# kind that is no name decides the last, which falls here as the empty string
+# (#268).
+#
+# `is.na()` and `length()` are generic, so deciding which of the three a
+# character kind takes reaches methods of the value's own, and either can raise
+# instead of answering; a kind of another type is refused by `is.character()`,
+# which does not dispatch, before they are reached. That the catch is the
+# answer to that is the same amendment's. Its extent is what only this site
+# knows: the registry lookup is inside it, since its own guard asks those two
+# again, and the caller's `cat()` is outside, taking a character whichever
+# answer this returns.
+grouping_kind_printed_name <- function(kind) {
+  tryCatch(
+    if (!is_grouping_kind_name(kind)) {
+      ""
+    } else {
+      rule <- find_grouping_kind_rule(kind)
+      if (is.null(rule)) kind else rule$constructor
+    },
+    error = function(cnd) ""
+  )
 }

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -230,6 +230,99 @@ a condition is caught for what it says it is. Not catching it is the
 alternative that was rejected in #262, since an object that cannot answer for
 its kind is the case the reader exists for.
 
+## Amendment: the printed line for a kind that is no name
+
+The amendment above says which errors did not move, and #268 is that remainder:
+a field that answers with a value `cat()` cannot render. Deciding it moves two
+things, and only one of them is the constraint the amendments above move.
+
+**Condition classes.** The constraint holding error condition classes fixed is
+amended a fourth time, in the same direction as the amendment above and at the
+same site. A kind `cat()` refuses — a list, a closure, or an environment with
+something in it — raised `simpleError` from that call, and now raises nothing.
+It raised having already written the opening of the line, so what the reader
+was left with was an unterminated line as well.
+
+The same amendment covers the question between those two, which is asked of the
+same unvalidated value and can be answered the same way. Deciding whether a
+character kind is one name reaches the value's own `is.na()` and `length()`
+methods, both of which an object carrying the class can define, and either can
+raise instead of answering — before `cat()` is reached, so this half raised no
+partial line and was never visible as one. It is caught for the reason the read
+is, in a catch of the printer's own rather than the reader's, and that catch is
+narrow in what it decides and not in what it swallows, as
+`grouping_spec_kind()`'s is: a value no name can be got out of has none,
+whatever stopped it. It is `tryCatch(error = )` again, so the trade the
+amendment above records under *the handler the read is wrapped in* is made a
+second time on this line.
+
+With that, `print.margin_grouping_spec()` completes a line for every object
+carrying the class whose fields and methods either answer or raise an error.
+Three questions are asked of a value nothing has validated — the field is read,
+what the read produced is classified, and the classification is rendered — and
+the first two are caught, while the third cannot raise on what the second
+answers with: every branch of it answers with a character — the empty string, a
+constructor name the registry holds, or the kind itself, which
+`is.character()` has answered for.
+
+The qualification is the read's as much as this one's. `tryCatch(error = )`
+catches a condition for what it says it is, so a condition raised with `stop()`
+whose class does not inherit `error` is caught by neither and reaches the
+caller. Widening either to `condition` is the rewrite #268 rejects, since it
+would take a warning signalled on the way to answering for a failure to answer,
+and a test holds that direction. Under `options(warn = 2)` a warning is an
+error and is caught, which is R's semantics for the option rather than
+something decided here.
+
+A completed line is also not always one line. A kind that is one name and
+contains a newline prints across two, exactly as it did before this change: it
+reaches `cat()` through the fallback that names a kind the registry does not
+know, since no constructor this registry holds is spelled with one.
+
+The guards read the same field and reach the same methods, and this leaves them
+alone, in #280. What a guard does about a raising method is a change to the
+condition a call raises rather than to a printed line.
+
+**The printed line.** The claim the amendment above makes — the wording is
+unchanged for every object whose `$` is an ordinary field read — is what moves
+here, and it moves for exactly the three shapes #264 pinned against it: `1:3`
+printed `123`, `c("a", "b")` printed `ab`, and `NA_character_` printed `NA`.
+Each prints the empty name now: `is_grouping_kind_name()` is asked before the
+registry is — the predicate `find_grouping_kind_rule()` asks, so that what may
+be printed and what may be looked up remain one question — and a kind that is
+no name answers nothing without reaching the fallback at all.
+
+What those lines were evidence of goes with them. #264 pinned them because this
+printed line was where a reader narrowed to a character scalar could be seen —
+the shared reader answering with what the field held rather than with a name —
+and the line no longer varies with that narrowing. No test distinguishes it
+now, since a guard refuses an object no rule answers for and is given no rule
+whichever way the reader answers. One behaviour still does, and it is the one
+#280 is filed for: a kind whose classification raises reaches a guard as an
+error rather than as a value. Until that ticket decides, the reader's contract
+is recorded here rather than observed.
+
+The line printed instead is not new: an object answering no kind prints it, an
+object whose kind cannot be read prints it per the amendment above, and a kind
+of no length printed it before this change — `character()` and an empty
+environment among them — `cat()` rendering anything of no length as nothing.
+Which of them a given object is goes unreported, for the reason the amendment
+above gives.
+
+Rendering the field rather than dropping it is the alternative, and it was
+rejected for what it would have to promise. A rendering that always works is
+one marginplyr chooses for objects it never builds: `deparse()` and `format()`
+are both unbounded in length, and `format()` dispatches, so a `format()` method
+of the value's own raises exactly where the rendering is supposed to save the
+line. Guarding the `cat()` call is not an alternative at all, since the opening
+of the line is written by the time it raises.
+
+Nothing a constructor builds is affected, here as in the amendment above: every
+kind one stores is one name, so the branch is not reached. The constraint on
+the number and timing of evaluations is not reached either — the kind is read
+once, as the amendment above left it, and the predicate reads the value that
+read returned rather than the field again.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -1122,9 +1122,9 @@ fix — #268.
 The ticket's "wording unchanged for every object that prints today" is
 qualified, and the qualification is load-bearing rather than cautious: reading
 through a shared function rather than in place is visible to a `$` that does
-something other than answer. ADR 0008's printed-line amendment is where that
-property is written, in place of a list of exceptions, and every object a
-constructor builds satisfies it.
+something other than answer. ADR 0008's amendment for a specification the
+printer could not read is where that property is written, in place of a list of
+exceptions, and every object a constructor builds satisfies it.
 
 *Evidence:* `test-grouping-interface.R` "a printed Grouping specification asks
 for a kind it may not have", which prints the class over an atomic vector, over
@@ -1137,6 +1137,12 @@ once", which counts the reads on both branches and asserts its counter through
 the helper the counts come from, since a second read leaves no other trace; and
 "a printed Grouping specification names the constructor called", which is what
 fails if the shared reader changes what a well-formed specification prints.
+
+One name in that evidence has moved: #268 renamed "renders a kind that is no
+name" to "omits a kind that is no name" when it decided what those shapes
+print, and gave the counting test named beside it a third branch to count. ADR
+0008's amendment for a kind that is no name records what became of the
+narrowing the renamed test held.
 
 **A specification stored as a function is read by tidyselect as a predicate,
 so #190's refusal never fires** (Spec). **Not fixed — open, #265.** A nested

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1141,6 +1141,25 @@ test_that("a printed Grouping specification names the constructor called", {
   )
 })
 
+# The line a specification with no name to print prints, and the invisible
+# return a print method makes whatever it printed. The three tests below assert
+# it of shapes that reach it for four different reasons -- a kind that is
+# absent, a kind that cannot be read, a kind that is no name, a kind that
+# raises on being classified -- and that one line covers them all is the
+# decision itself, so those tests ask
+# for it in one place. The counting test further down spells the line out
+# instead, having a read count to assert beside it. A shape that raises fails
+# here as an error, since the raise leaves `capture.output()` with nothing to
+# return and the comparison below is never made.
+expect_empty_name_line <- function(spec, info = NULL) {
+  expect_identical(
+    utils::capture.output(returned <- withVisible(print(spec))),
+    "<marginplyr grouping specification: >",
+    info = info
+  )
+  expect_identical(returned, list(value = spec, visible = FALSE), info = info)
+}
+
 # The last reader of a kind that can be handed an object nothing has validated,
 # and the one #262 left. A guard has a refusal to reach, so reading the kind
 # too early there answered a forged `.grouping` with the wrong error; `print()`
@@ -1161,10 +1180,7 @@ test_that("a printed Grouping specification asks for a kind it may not have", {
   # objects below join rather than change: one that cannot be asked names no
   # constructor for the same reason one that answers `NULL` names none.
   kindless <- structure(list(args = list()), class = "margin_grouping_spec")
-  expect_identical(
-    utils::capture.output(print(kindless)),
-    "<marginplyr grouping specification: >"
-  )
+  expect_empty_name_line(kindless)
 
   unreadable <- list(
     `an atomic vector` = structure(1:3, class = "margin_grouping_spec"),
@@ -1179,70 +1195,111 @@ test_that("a printed Grouping specification asks for a kind it may not have", {
     })
   )
   for (shape in names(unreadable)) {
-    spec <- unreadable[[shape]]
-    expect_identical(
-      utils::capture.output(returned <- withVisible(print(spec))),
-      "<marginplyr grouping specification: >",
-      info = shape
-    )
-    # A print method returns its argument invisibly whatever it printed, so an
-    # object it could not read is still the object the caller passed.
-    expect_identical(
-      returned,
-      list(value = spec, visible = FALSE),
+    expect_empty_name_line(unreadable[[shape]], info = shape)
+  }
+})
+
+# The other reason no rule answers, and the one the printed field came from.
+# `find_grouping_kind_rule()` refuses two different things: a kind that is one
+# name the registry does not know, which is pinned above and prints itself, and
+# a kind that is no name at all, which is every shape below. Nothing is named
+# for the second, and it is refused before the registry is asked, so the line
+# it prints is the line an object answering no kind prints (#268).
+#
+# The first three shapes are #264's pin, and this test is where the decision
+# that moved them is visible rather than in a line nothing asserts. ADR 0008's
+# amendment for a kind that is no name is where the decision lives.
+#
+# What the shapes vary is why the kind is no name -- its type, its length, its
+# missingness -- against a line that does not vary, which is why they are
+# asserted together rather than one by one. None of them reaches `cat()`:
+# `is_grouping_kind_name()` refuses each first -- four for their type, and the
+# three character ones for their length or their missingness.
+test_that("a printed Grouping specification omits a kind that is no name", {
+  no_name <- list(
+    `a longer vector` = 1:3,
+    `two names` = c("a", "b"),
+    `a missing name` = NA_character_,
+    `no name at all` = character(),
+    `a list` = list("a"),
+    `a closure` = function() 1,
+    `an environment` = rlang::new_environment(list(x = 1))
+  )
+
+  for (shape in names(no_name)) {
+    expect_empty_name_line(
+      new_grouping_spec(no_name[[shape]], list()),
       info = shape
     )
   }
 })
 
-# The other half of what the reading decides, and the half only this asserts:
-# routing the kind through `grouping_spec_kind()` put a new function in front
-# of a line whose wording #264 fixed for every object that printed before it.
-# A kind that is read and is not one name is where that could be lost, because
-# `find_grouping_kind_rule()` answers `NULL` for it and the fallback then
-# prints the kind itself -- so a reader narrowed to a character scalar, the
-# narrowing this most easily becomes, would print the empty name here and fail
-# nothing. The character kind no rule answers is pinned above; this is the kind
-# no rule answers for the other reason.
+# The last question this line asks of a value nothing has validated. Deciding
+# whether a kind is one name asks the value's own `is.na()` and `length()`,
+# both of which an object carrying the class can answer by raising, so the
+# printed line is at the mercy of a method of the object's the way it was of a
+# `$` of the object's until #264. Every shape here holds `set` underneath, so
+# a classification that answers names `grouping_set`: the empty name is what
+# says the catch fired, and the named line is what says it did not.
 #
-# `cat()` is what prints the fallback, so what these shapes pin is its
-# rendering and not a wording marginplyr chose. That is also the boundary the
-# fix reached: a kind `cat()` refuses raises from that call, having already
-# written the opening of the line, and belongs to #268 rather than to this
-# ticket -- the read succeeded there, and #264's scope reaches the read.
-test_that("a printed Grouping specification renders a kind that is no name", {
-  as_kind <- function(type) {
-    structure(list(type = type, args = list()), class = "margin_grouping_spec")
+# The guards read the same field and reach the same methods, and are left
+# alone: the amendment says why, and #280 is where they are filed.
+test_that("a printed Grouping specification classifies a kind that may raise", {
+  kind_answering <- function(generic, suffix, method) {
+    class_name <- paste0("marginplyr_kind_", suffix)
+    registerS3method(generic, class_name, method, envir = asNamespace("base"))
+    structure("set", class = class_name)
   }
 
-  expect_identical(
-    utils::capture.output(print(as_kind(1:3))),
-    "<marginplyr grouping specification: 123>"
+  raises <- function(x, ...) rlang::abort("classifying this kind raises")
+  for (generic in c("is.na", "length")) {
+    suffix <- paste0(sub(".", "_", generic, fixed = TRUE), "_raises")
+    expect_empty_name_line(
+      new_grouping_spec(kind_answering(generic, suffix, raises), list()),
+      info = generic
+    )
+  }
+
+  # An error is caught and nothing else is, which is a choice rather than the
+  # limit of one: a method may signal a warning on its way to answering, and a
+  # kind that warns is still a kind. Catching `condition` would take the
+  # warning for a failure to answer and name nothing, so this is what fails if
+  # the catch is ever widened to one. The warnings are read as a set because
+  # classifying asks the method more than once -- the predicate asks, and the
+  # registry lookup's own guard asks again -- and no decision fixes that count
+  # the way ADR 0008 fixes the count of field reads.
+  warns <- kind_answering("is.na", "is_na_warns", function(x, ...) {
+    warning("classifying this kind warns")
+    FALSE
+  })
+  raised <- character()
+  line <- withCallingHandlers(
+    utils::capture.output(print(new_grouping_spec(warns, list()))),
+    warning = function(cnd) {
+      raised <<- c(raised, conditionMessage(cnd))
+      invokeRestart("muffleWarning")
+    }
   )
-  expect_identical(
-    utils::capture.output(print(as_kind(c("a", "b")))),
-    "<marginplyr grouping specification: ab>"
-  )
-  expect_identical(
-    utils::capture.output(print(as_kind(NA_character_))),
-    "<marginplyr grouping specification: NA>"
-  )
+  expect_identical(line, "<marginplyr grouping specification: grouping_set>")
+  expect_setequal(raised, "classifying this kind warns")
 })
 
 # What the reading did not leave alone, in the part of it that can be held to a
-# number. ADR 0008's printed-line amendment states the rest as a property --
-# the wording is unchanged for every object whose `$` is an ordinary field read
-# -- and illustrates it with the ways a `$` doing something else can see the
-# difference. This is what holds the tree to the count: the field is read once
-# on both branches, where the fallback used to ask a second time to print what
-# it had already been given.
+# number. ADR 0008's amendment for a specification the printer could not read
+# states the rest as a property, which its amendment for a kind that is no name
+# then narrows -- for the three shapes "omits a kind that is no name" pins from
+# #264, and no others.
+# This is what holds the tree to the count: the field is read once on each of
+# the three branches, none of them asking again for what it has already been
+# given.
 #
 # Counting is the whole of the evidence, because a second read leaves no other
 # trace. Only an object whose `$` answers differently on successive reads could
 # see one, only on the branch that made it -- the fallback, per the amendment
-# -- and no object a constructor builds is such an object. Both branches are
+# -- and no object a constructor builds is such an object. Every branch is
 # counted even so, since what the amendment fixes is the count on each and not
-# the difference between them.
+# the difference between them. The third branch is #268's, and it reads once as
+# the two the amendment was written for do.
 test_that("a printed Grouping specification asks for its kind once", {
   count_reads <- function(kind, read = print) {
     reads <- 0L
@@ -1286,4 +1343,13 @@ test_that("a printed Grouping specification asks for its kind once", {
     "<marginplyr grouping specification: nonesuch>"
   )
   expect_identical(without_rule$reads, 1L)
+
+  # The branch that names nothing, which classifies the value it was given
+  # rather than asking for it again.
+  without_name <- count_reads(1:3)
+  expect_identical(
+    without_name$line,
+    "<marginplyr grouping specification: >"
+  )
+  expect_identical(without_name$reads, 1L)
 })


### PR DESCRIPTION
Closes #268.

`print.margin_grouping_spec()` handed the kind it read to `cat()` whatever that
kind turned out to be, so a field holding a value `cat()` cannot render raised
`simpleError` from that call — after the opening of the line had been written:

```r
print(structure(list(type = list("a")), class = "margin_grouping_spec"))
#> <marginplyr grouping specification: Error: argument 2 (type 'list') cannot be handled by 'cat'
```

The reader is left an unterminated line and an untyped base-R error naming
`cat`, which says nothing about a Grouping specification and does not name the
object it was raised about. #264 fixed the read at this site and left this:
there the read failed, here it succeeds and the value it produced is what the
line cannot be finished from.

## What is decided

`find_grouping_kind_rule()` answers `NULL` for two different things, and the
fallback printing the field could not tell them apart: a kind that is one name
the registry does not know, which names itself, and a kind that is no name at
all, which has nothing to name. Every line the ticket tabulates came from the
second — `123` for `1:3`, `ab` for `c("a", "b")`, `NA` for `NA_character_`, and
the raise for a list or a closure.

So whether there is a name is asked before the registry is, through
`is_grouping_kind_name()` — the predicate `find_grouping_kind_rule()` already
asks, so what may be printed and what may be looked up stay one question rather
than two copies of a condition. A kind that is no name prints the line an
object answering no kind already printed.

That line is not a wording chosen for these shapes: an object answering no kind
prints it, an object whose kind cannot be read prints it since #264, and a kind
of no length printed it before this change, `cat()` rendering anything of no
length as nothing.

## The half the ticket did not ask about

Asking whether a character kind is one name is itself a question the value can
answer by raising, since `is.na()` and `length()` are generic and an object
carrying the class can define either. That half raised before `cat()` was
reached, so it left no partial line and was invisible as a defect — and without
it the printer would still raise for an object it was asked to print. The
naming is therefore made inside a catch of its own, in
`grouping_kind_printed_name()`, with the registry lookup inside it.

## What the claim excludes

Stated as exclusions rather than as a totality, in ADR 0008's fourth amendment:

- a condition raised with `stop()` that does not inherit `error` reaches the
  caller here and at the read #264 added — widening either catch to `condition`
  would take a warning signalled on the way to answering for a failure to
  answer, and a test holds that direction;
- under `options(warn = 2)` a warning is an error and is caught, which is R's
  semantics for the option;
- a name containing a newline still prints across two lines, through the
  fallback that names a kind the registry does not know.

The guards read the same field and reach the same methods, and are left alone:
what a guard does about a raising method changes the condition a call raises
rather than a printed line. Filed as #280, with the reproduction through
`inspect_grouping()` and through a Margin verb.

## Tests

`test-grouping-interface.R`'s "renders a kind that is no name" becomes "omits a
kind that is no name", as #268 requires of a fix that narrows the fallback —
the pin is what makes the decision visible in the diff. It covers seven shapes,
varying type, length, and missingness. "classifies a kind that may raise"
covers the other half: a kind holding `set` under a class whose `is.na()` or
`length()` raises, so a classification that answers would name `grouping_set`
and the empty name is what says the catch fired; plus a kind whose `is.na()`
warns and then answers, which is what fails if the catch is widened to
`condition`. "asks for its kind once" gains the third branch.

Full suite green (`NOT_CRAN=true`), `lintr::lint_package()` clean,
`roxygen2::roxygenise()` no diff, `verify-suite-coverage.R` passes. No ledger
entry: this commit names the finding and both tests fail without the fix, which
is `design/review-dispositions.md`'s first exemption.