### PR TITLE
Keep a comment to what it claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -576,6 +576,16 @@ review found, which round answered it, and what a test elsewhere now covers are
 things the code does not hold — the ledger, the commit message, and the test
 are where each of those is read.
 
+Every sentence a comment carries is a claim, so its length is a liability and
+not thoroughness: a paragraph nobody needed is a paragraph a later reader has
+to measure, and one that measures false is a comment asserting something the
+code does not do. Write what the site needs and stop, and delete a claim found
+false rather than restate it — a restatement is a new claim about the same
+thing and the next reading has it to measure too, which is how a fix's prose
+grows past the fix. Neither reaches a sentence carrying what this file requires
+to be written down, a header's contract here or the reason a `# nolint` in R
+code names under *Linting*: that one is kept, and corrected where it is wrong.
+
 No scan enforces any of this, and that is a decision rather than a gap. What
 makes a comment wrong is that a paragraph re-derives an argument another file
 owns, which is a semantic property: a scan over `R/` either fires on comments


### PR DESCRIPTION
Closes #282.

One paragraph in `AGENTS.md`'s *Code comments*, +10 lines. That section decides
what a comment may not carry — a second copy of an argument another file owns —
and says nothing about how much it may claim, which is the half #282 is filed
for.

## What lands

> Every sentence a comment carries is a claim, so its length is a liability and
> not thoroughness […] Write what the site needs and stop, and delete a claim
> found false rather than restate it — a restatement is a new claim about the
> same thing and the next reading has it to measure too, which is how a fix's
> prose grows past the fix. Neither reaches a sentence carrying what this file
> requires to be written down, a header's contract here or the reason a
> `# nolint` in R code names under *Linting*: that one is kept, and corrected
> where it is wrong.

The exception is scoped to both rules deliberately. Attached to the deletion
rule alone, "write what the site needs and stop" would read as licence to trim
a header's "what its caller holds before calling it" as surplus, which
*Code comments* requires two paragraphs above.

## What does not land, and why

#282 records two further rules that were drafted for `design/architecture.md`
and withdrawn — a termination condition for *Answering a review*, and a
placement criterion for *Repository placement* — with the table of formulations
and what falsified each. `design/architecture.md` is unchanged here, identical
to `main`.

The short of it: this repository's homes for a rule are historical rather than
derived, so a criterion over them would be invented and not recorded, and a
contributor applying an invented one would move what is already placed. The
issue keeps the evidence for a later look rather than this PR carrying a rule
its own repository contradicts.

## Review

Five rounds against the repository's own files. Fifteen findings, eleven of
them a claim measured false; every one was answered by deleting or correcting
the claim, never by adding a defence, which is the rule this PR adds applied to
itself. Two paragraphs were withdrawn entirely on that basis, and the change
went from +34 lines to +10.

No ledger entry: nothing here is executable, and the fix is its own diff under
`design/review-dispositions.md`'s prose exemption.