### PR TITLE
Bound what a review may raise about prose, and what an agent loads before it starts

### DIFF
--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -1,0 +1,139 @@
+# Fails when the always-loaded agent context grows past the baseline below.
+#
+# `CLAUDE.md` is read before every task an agent runs here, and each `@path` in
+# it pulls that file in too, so the closure is loaded whether or not the task
+# reaches what it says. Nothing else in the repository fails when that closure
+# grows: prose costs no test and breaks no build, which is why it grew to 618
+# lines before anyone measured it. A budget is the only thing that makes an
+# addition cost something at the moment it is made.
+#
+# The baseline is a ratchet and not a target. It records what the closure
+# measured when it was last deliberately set, so an addition is paid for by a
+# deletion until someone decides otherwise and moves it in the same commit that
+# spends it. A number chosen for how much the closure ought to be would be
+# invented; this one is measured.
+#
+# The closure is derived from `CLAUDE.md` rather than listed, for the reason
+# every other gate here derives: a list would name what it named when it was
+# written, and a file added to the closure by a new `@path` would escape the
+# budget it was added to. A derivation that stopped working reports a closure of
+# one small file and passes, so the mechanism is asserted before the total is.
+
+source(".github/scripts/ci-helpers.R")
+
+# What the closure measured when it was last set, and the commit that set it.
+# Moving this means saying in the same commit what was added and what paid for
+# it.
+baseline_bytes <- 38396L
+baseline_note <- "this gate, its entry in AGENTS.md, and #283's paragraph"
+
+entry <- "CLAUDE.md"
+
+# Reads `@path` references the way the harness does: one per line, leading
+# whitespace allowed, the rest of the line taken as the path. A reference inside
+# a fenced block is still a reference for this purpose -- the budget is what the
+# file costs, and a reader that resolves it costs that whether the fence was
+# meant to quote it or not.
+references <- function(path) {
+  lines <- readLines(path, warn = FALSE)
+  found <- regmatches(lines, regexpr("^\\s*@\\S+", lines))
+  sub("^\\s*@", "", found)
+}
+
+closure <- function(root) {
+  seen <- character()
+  pending <- root
+  while (length(pending) > 0L) {
+    path <- pending[[1L]]
+    pending <- pending[-1L]
+    if (path %in% seen) {
+      next
+    }
+    if (!file.exists(path)) {
+      stop(call. = FALSE, sprintf(
+        paste0(
+          "%s names `@%s`, which no file answers. An agent reaches the ",
+          "closure through these references, so one that resolves to nothing ",
+          "is context the task was promised and did not get."
+        ),
+        entry, path
+      ))
+    }
+    seen <- c(seen, path)
+    pending <- c(pending, references(path))
+  }
+  seen
+}
+
+if (!file.exists(entry)) {
+  stop(call. = FALSE, sprintf(
+    "%s is absent, so nothing here can say what an agent loads before a task.",
+    entry
+  ))
+}
+
+files <- closure(entry)
+
+# The mechanism, before the total. `CLAUDE.md` is a pointer file -- it carries
+# one `@` line and no prose -- so a closure of itself alone is a reference
+# reader that stopped reading, not a repository that shrank.
+if (length(files) < 2L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "%s resolved to %d file(s), so no `@` reference was read. The budget ",
+      "below would pass on any repository. Fix the reference reader in this ",
+      "script before trusting what it reports."
+    ),
+    entry, length(files)
+  ))
+}
+
+sizes <- vapply(files, file.size, numeric(1))
+total <- sum(sizes)
+
+report <- sprintf("%8.0f  %s", sizes, files)
+
+# The remedy is part of the message, as `verify-suite-coverage.R`'s is: a gate
+# that only refuses invites the baseline to be raised instead of the argument
+# being moved.
+if (total > baseline_bytes) {
+  stop(call. = FALSE, paste(
+    c(
+      sprintf(
+        paste0(
+          "The always-loaded context is %.0f bytes against a baseline of %d ",
+          "(%s), over by %.0f."
+        ),
+        total, baseline_bytes, baseline_note, total - baseline_bytes
+      ),
+      "",
+      report,
+      "",
+      paste(
+        "An instruction belongs in this closure; the argument for it belongs",
+        "to the file that owns the decision -- an ADR, a workflow comment, a",
+        "verifier's header, or the ticket. Move the argument and cite it. If",
+        "the addition is an instruction that has to be loaded before the task",
+        "reaches it, move the baseline in this file in the same commit, and",
+        "say there what was added and what paid for it."
+      )
+    ),
+    collapse = "\n"
+  ))
+}
+
+write_step_summary(c(
+  "## Always-loaded agent context",
+  "",
+  sprintf(
+    "%.0f bytes of a %d-byte baseline (%s).",
+    total, baseline_bytes, baseline_note
+  ),
+  "",
+  as_summary_block(paste(report, collapse = "\n"))
+))
+
+cat(sprintf(
+  "Verified: the always-loaded context is %.0f bytes, within %d.\n",
+  total, baseline_bytes
+))

--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -30,10 +30,9 @@ baseline_note <- "this gate, its entry in AGENTS.md, and #283's paragraph"
 entry <- "CLAUDE.md"
 
 # Reads `@path` references the way the harness does: one per line, leading
-# whitespace allowed, the rest of the line taken as the path. A reference inside
-# a fenced block is still a reference for this purpose -- the budget is what the
-# file costs, and a reader that resolves it costs that whether the fence was
-# meant to quote it or not.
+# whitespace allowed. A reference inside a fenced block is still a reference for
+# this purpose -- the budget is what the file costs, and a reader that resolves
+# it costs that whether the fence was meant to quote it or not.
 references <- function(path) {
   lines <- readLines(path, warn = FALSE)
   found <- regmatches(lines, regexpr("^\\s*@\\S+", lines))

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Here rather than in a workflow of its own because it is repository hygiene
+  # on the same trigger, and beside `lint` rather than inside it because it
+  # needs no package installed: a byte count over `CLAUDE.md`'s closure runs on
+  # a bare R, so it reports before the dependency install that job waits on.
+  context-budget:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Verify the always-loaded context is within its baseline
+        run: Rscript .github/scripts/verify-context-budget.R
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -614,6 +614,10 @@ Triage uses the five standard roles: `needs-triage`, `needs-info`, `ready-for-ag
 
 This is a single-context repo. Read the root `CONTEXT.md` and relevant ADRs under `design/adr/`. See `design/agents/domain.md`.
 
+### Code review
+
+Reviews run through `mattpocock-skills:code-review`. See `design/agents/code-review.md`.
+
 ### Investigation notes
 
 `investigation/` holds dated research notes. A note records what was

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 ## Local checks
 
+### Always-loaded context
+
+`CLAUDE.md` and the files its `@` references pull in are read before every task,
+whether or not the task reaches what they say, so that closure carries a byte
+budget. Run it with `Rscript .github/scripts/verify-context-budget.R`; the
+script holds the baseline and `lint.yaml` fails when the closure passes it.
+When it fires, move the argument to the file that owns the decision and cite it
+from here. Move the baseline only in the commit that spends it, saying there
+what was added and what paid for it.
+
 ### Linting
 
 Load the package before linting, so the local run matches `.github/workflows/lint.yaml`:

--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -4,6 +4,8 @@ Reviews here run through that skill. It reviews the diff since a fixed point on 
 
 What may be a finding, and how one is answered, is not here. `design/architecture.md`'s *Answering a review* governs that, for this reviewer and for any other.
 
+That section binds a reviewer only if the reviewer is handed it. This skill composes its own sub-agent prompts (`SKILL.md`, step 4), so pass what a finding about prose may be alongside the standards sources, in the same call.
+
 ## What the skill looks for, and what is here
 
 | The skill looks for | Here |

--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -1,0 +1,21 @@
+# Code review: `mattpocock-skills:code-review`
+
+Reviews here run through that skill. It reviews the diff since a fixed point on two axes — Standards and Spec — as parallel sub-agents. This file maps what it expects onto what this repository has.
+
+What may be a finding, and how one is answered, is not here. `design/architecture.md`'s *Answering a review* governs that, for this reviewer and for any other.
+
+## What the skill looks for, and what is here
+
+| The skill looks for | Here |
+|---------------------|------|
+| `docs/agents/issue-tracker.md` | `design/agents/issue-tracker.md`. `docs/` is altdoc's generated site — gitignored, no tracked file — so do not run `/setup-matt-pocock-skills`: it would write into what the next site build deletes. |
+| `CODING_STANDARDS.md` or `CONTRIBUTING.md` | `AGENTS.md`. Pass the sections the diff reaches, not the file. |
+| a spec found by searching | Pass the issue number or a path as an argument. |
+| the Fowler smell baseline | Written for OO. This package is functional R with S3, so several of those smells have no site here. They arrive as judgement calls and are dispositioned as any finding is. |
+| standards that tooling already enforces | The `verify-*.R` scripts, `lint.yaml`, and `document.yaml`. `AGENTS.md` names what each fails on. |
+
+The diff also carries generated files — `man/`, `NAMESPACE`, and `README.md` — which `document.yaml` regenerates and checks against their sources. They are outside the review.
+
+## Running it a second time
+
+A second run reviews the diff since the same fixed point, so it reads the answers the first run produced. Verify a finding against the evidence its answer landed with instead, and run the skill again only over executable behaviour the first run did not see.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -545,103 +545,17 @@ rows, columns, types, grouping, errors, laziness, and SQL semantics through
 those interfaces. They must not assert the Margin operation class, fields,
 constructor shape, or internal helper order.
 
-The test suite divides supporting contracts as follows:
+The test suite divides supporting contracts by module; `tests/testthat/` is
+what says which file holds which.
 
-- `test-grouping-interface.R` covers shared local behavior through the public
-  verbs, including Grouping plans, labels, factors, duplicate policies,
-  persistent groups, result grouping, summary selections, nesting, and the
-  documented `marginplyr_error` handler.
-- `test-margin-id.R` covers Grouping set occurrence identifiers across all
-  public verbs, including local, native, portable, duplicate, nesting,
-  collision, missing-value, zero-row, and laziness semantics.
-- `test-margin-order.R` covers `.sort` across all four public verbs per ADR
-  0018: the key and what follows from it, `"first"` reversing the Grouping
-  bits alone, factor level order, missing values last, fixed-key contiguity,
-  composite dimensions, duplicate occurrences, the `"none"` default, and the
-  vocabulary error. It asserts rows rather than the key builder, because the
-  ADR leaves each adapter to resolve the key in what its own query can name;
-  its two rendered-SQL tests carry only what rows cannot show.
-- `test-margin-label.R` covers Margin labels through the public verbs: named
-  per-dimension labels, the eight-case factor NA contract of ADR 0012, label
-  placement, collisions including unused factor levels, and typed missing
-  values on dtplyr, Arrow, portable SQL, and DuckDB.
-- `test-summarize-operation.R`, `test-expand-operation.R`, and
-  `test-nest-operation.R` cover lifecycle ordering and the single typed
-  metadata snapshot through public calls. `test-nest-operation.R` also covers
-  the nesting duplicate-drop policy and quosure environments of both nesting
-  verbs.
-- `test-share.R` covers contextual-share semantics through
-  `summarize_with_margins()`: rollup levels, typed grouping identity against
-  the default Margin label, missing keys separated from displayed margins,
-  the direct and `across()` grammar, source type and cardinality, output-name
-  collisions, dependency provenance, single evaluation of captured
-  expressions, and error precedence. Its Total-share tests state only what is
-  the second denominator's own — which plans it accepts, interchangeable
-  duplicate Grand total occurrences, the fixed-key stand-in used when `.by` is
-  empty, and that each diagnostic names the helper the caller wrote.
-- `test-grouping-backends.R` covers Arrow and dtplyr metadata behavior,
-  native and portable SQL strategy, lazy query composition, collision checks,
-  internal-name safety, and live DuckDB equivalence. It also carries the
-  Absorbing-backend contract of ADR 0025 in two parts, since one alone would
-  fail without saying why: that Arrow still absorbs the expressions the refusal
-  is asserted over, and that the refusal is raised for them across every Arrow
-  input class.
-- `test-share-backends.R` covers contextual-share adapter behavior for both
-  denominators, including targeted pre-query Arrow rejection, dtplyr
-  execution-time validation, lazy SQL composition, live SQLite portable
-  execution, and live DuckDB native-versus-portable results.
-- `test-inspect-grouping.R` covers `inspect_grouping()` as an ordinary tibble
-  per ADR 0013, including both formats, plan order, and that a lazy input is
-  inspected without executing a Margin operation.
-- `test-execution-conditions.R` covers the Condition context of ADR 0021
-  through `summarize_with_margins()`: a warning every grouping set raises
-  reported once with its count and under the caller's own column names,
-  branches raising different diagnostics reported one by one, the caller's
-  columns and verb in an error's context, the propagated class and cause, ten
-  keys substituted without corruption, a Package condition raised beside them
-  left alone, a warning a branch raised surviving a later branch's error, and
-  the lazy non-goal. Two of its cases hold the identity to what
-  a message says rather than to how it was laid out or what a value happens to
-  contain: one runs at five console widths, because cli wraps a bullet it
-  cannot fit, and one uses a grouping value and a caller diagnostic that carry
-  a bullet marker of their own. Its two snapshots carry the rendered messages,
-  because the identity is derived from rendered text and no structural
-  assertion would see dplyr reword it. Its one test of an internal helper is
-  the documented exception: the class half of a Repeated condition's identity,
-  and an empty message, are both unreachable through a verb, because dplyr
-  aggregates a branch's warnings into one condition of its own before
-  signalling. It also covers the shared condition-chain reader, which is the
-  module's and is reached without a verb: a chain arrives from a caller's own
-  selection failure, so the tests build one and take the two tidyselect shapes
-  from tidyselect itself. Neither consumer's diagnostic would report a
-  traversal that changed shape, which is why the reader is not asserted through
-  them alone.
-- `test-get-col-names.R` and `test-factor.R` cover the focused metadata and
-  factor backend contracts.
-- `test-grouping-plan.R` covers the backend-independent Grouping
-  specification compiler directly, including the complete kind-nesting
-  grammar, phase-sensitive empty rules, error precedence, and expansion order.
-  One of its contracts is asserted below the public seam because nothing above
-  it can see them: the nested kinds each parent kind admits, since a derivation
-  that stopped working and a position that admits nothing answer the same empty
-  set. A second is asserted through the seam with an observation from below it
-  — the number of times a colliding name's binding is read, counted through an
-  active binding, which reports every read where a promise reports the first.
-- `test-documentation.R` covers the reference documentation's own contracts:
-  that an italicised section cross-reference resolves in the topic it
-  promises, that every user-facing topic offers related-topic links, and that
-  the Grouping-identity comparison has exactly one canonical home.
-- `test-utils.R` and `test-retail-sales.R` cover the shared assertion helpers
-  and the documented properties of the bundled dataset.
+A test asserting below the seam, or through it on an observation from below,
+says why in its own file, beside the assertion that reason licenses.
 
 Package conditions are not tested in one file. Each module's tests assert the
-`marginplyr_error` class next to the behavior that raises it — the "use the
-package condition seam" tests in `test-grouping-interface.R`,
-`test-margin-label.R`, `test-summarize-operation.R`, `test-nest-operation.R`,
-`test-inspect-grouping.R`, and `test-utils.R` — while the matching
-"retain their class and cause" and "preserve user-expression conditions" tests
-assert that an External condition keeps its original class. Keeping the two
-halves adjacent is what makes the boundary in ADR 0015 reviewable.
+`marginplyr_error` class next to the behavior that raises it, while the
+matching tests assert that an External condition keeps its original class.
+Keeping the two halves adjacent is what makes the boundary in ADR 0015
+reviewable.
 
 Backend tests may instrument a backend seam or inspect semantic query shape,
 but should not couple to the Margin operation representation or require

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -788,5 +788,16 @@ rejection with evidence. Naming which one is what the disposition does, and a
 comment is not among them: a finding a comment would answer is one of the
 others.
 
+A finding about prose is one of four: the prose is false, it duplicates an
+argument another file owns and can drift from it, it breaks a rule a repository
+document states, or something a repository document is required to hold is
+missing from it. How prose reads is not one, and the ledger records no finding
+that is.
+
+Two answers join the list above when a finding is about prose. A claim found
+false is deleted rather than restated, as *Code comments* in `AGENTS.md`
+requires of a comment. A finding this branch's Acceptance does not reach
+becomes a ticket rather than prose added here.
+
 Where code is misread without a comment, the finding is the naming or the
 decomposition that allowed the misreading, and it is reported as that.

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -1,3 +1,6 @@
+# ADR 0013 owns the decision that a Grouping plan is inspected as an ordinary
+# tibble, which is what these assert through `inspect_grouping()`.
+
 test_that("inspect_grouping describes a rollup in Grouping plan order", {
   data <- data.frame(
     fixed = 1L,

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -1,3 +1,6 @@
+# Margin labels through the public verbs. ADR 0012 owns the contract separating
+# a factor's NA level from a missing Margin value, which these assert.
+
 test_that("named Margin labels apply per dimension and default to last", {
   data <- data.frame(
     first = factor(c("a", "b"), levels = c("a", "b")),


### PR DESCRIPTION
Closes #284.

Three commits, +215 / -95. Two bounds and one mapping, in the layers this
repository already has.

## What lands

**`design/architecture.md`, *Answering a review*.** A finding about prose is
one of four — false, a drifting duplicate, a broken rule, or a required thing
missing — and how prose reads is not one. Two answers join the disposition list
for prose: a claim found false is deleted rather than restated, citing
*Code comments* for the rule #283 just gave it; and a finding this branch's
Acceptance does not reach becomes a ticket rather than prose added here.

The four are read off the ledger rather than invented. Its 67 findings are each
one of them — `:359` and `:363` false, `:352` duplicate, `:658` and `:674` a
broken rule, `:297` a required thing missing — and none is of how a sentence
reads. This is in the norm
layer because it binds any reviewer, not only the skill below.

**`.github/scripts/verify-context-budget.R`, run by `lint.yaml`.** The closure
`CLAUDE.md` pulls in is read before every task. It now carries a measured
baseline, and a byte over fails with the remedy in the message. It derives the
closure by following `@` references rather than naming `AGENTS.md`, and asserts
that it read at least one before trusting its total, since a reference reader
that stopped working would report one small file and pass.

It fired for real on this branch when #283's paragraph arrived from `main`. The
baseline moves to include it, and the commit says nothing paid for it: #283 was
merged before this gate existed, so the ratchet starts from the tree that holds
it.

**`design/agents/code-review.md`.** The adaptation layer already maps a skill's
vocabulary onto this repository — `triage-labels.md` has a
`Label in mattpocock/skills` column — and this joins it for
`mattpocock-skills:code-review`. It records that `/setup-matt-pocock-skills` is
not run here, because the `docs/agents/issue-tracker.md` it would write is
inside altdoc's generated site, and that a second run over the same fixed point
reads the first run's answers. `AGENTS.md` gains one pointer line, in the shape
the three beside it already have.

**`## Test seams` loses its inventory.** It named 18 of the 33 test files
present, against 8 of the 9 when `957356c` wrote it. Every seam exception it
held is a second copy — `test-margin-order.R:1`, `test-grouping-plan.R:319`
`:578` `:936`, `test-execution-conditions.R:148` `:611` `:758` `:917`,
`test-share.R:1946` `:2047` — so the rule stays and each reason stays beside
the assertion it licenses. Two ADR citations were not second copies, and moved
into the two tests that observe them.

## What does not land, and why

`## Module responsibilities` names 13 of 23 files and is left alone: the ten it
omits are four public-verb wrappers whose lifecycle `margin-operation.R` owns
and documents, two files that are roxygen with one line of code, and four
modules — 296 lines between them — that are a gap in a map rather than a
duplicate of one.

`AGENTS.md`'s own Tier split, the prose #268 left in ADR 0008 and
`test-grouping-interface.R`, and the six verifiers whose workflow step can be
dropped without detection are each their own ticket. #284 says so.

## Verification

Full suite on this branch: 5,104 passed, 0 failed, 0 skipped, `NOT_CRAN` set.
`lintr::lint_package()` clean. The budget gate was exercised against a `/tmp`
copy: one byte added to `AGENTS.md` fails, an unresolvable `@` reference fails,
and a reference reader that matches nothing fails naming itself rather than the
repository.

## Review

None yet. This is the change that introduces the scope rule, so reviewing it is
the first chance to see whether the rule reaches the reviewer at all — the
limitation the new `design/agents/code-review.md` does not claim to close, since
the skill builds its own sub-agent prompts.

No ledger entry: every changed line is a comment or a document, and the fix is
its own diff under `design/review-dispositions.md`'s prose exemption. The
verifier script is new rather than a fix.
