### PR TITLE
Refuse a grouping kind that cannot be classified, in marginplyr's own words

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -9,16 +9,14 @@ validate_grouping_spec_early <- function(grouping_spec) {
     ))
   }
 
-  kind <- grouping_spec_kind(grouping_spec)
+  # Classified where it is read, so that what this guard holds from here on is
+  # a name and not a value that might still refuse to be one (#280).
+  kind <- grouping_kind_name(grouping_spec_kind(grouping_spec))
   # A catch of its own, because the two fields are not read together: an object
   # can refuse one while answering the other, and this is the only reader of
   # `args` before the guard below has run.
   args <- tryCatch(grouping_spec$args, error = function(cnd) NULL)
-  if (
-    !is.character(kind) ||
-      length(kind) != 1L ||
-      !is.list(args)
-  ) {
+  if (is.null(kind) || !is.list(args)) {
     abort_invalid_grouping_spec()
   }
 
@@ -392,8 +390,10 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # class with no kind to read -- an atomic vector given the class offers no
 # field to read at all, which `grouping_spec_kind()` answers with `NULL`, and
 # a list without the field answers `NULL` too, neither of which is a kind this
-# position could admit. That reading is the guard's own, so the two cannot
-# disagree about what a kind is readable off. Both catches are narrow
+# position could admit. So is a kind that raises on being classified, which
+# `grouping_kind_name()` answers with `NULL` (#280). Both that reading and that
+# classification are the guard's own, so the two cannot disagree about what a
+# kind is or about what one is readable off. All three catches are narrow
 # in what they decide and not in what they swallow: everything they hide is a
 # failure to produce a specification of an admitted kind, which is a
 # specification reading that is not available. That is where the ADR-0015 line
@@ -429,12 +429,8 @@ check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
   if (!inherits(value, "margin_grouping_spec")) {
     return(invisible(NULL))
   }
-  kind <- grouping_spec_kind(value)
-  if (
-    !is.character(kind) ||
-      length(kind) != 1L ||
-      !kind %in% admitted
-  ) {
+  kind <- grouping_kind_name(grouping_spec_kind(value))
+  if (is.null(kind) || !kind %in% admitted) {
     return(invisible(NULL))
   }
   abort_ambiguous_nested_name(name)
@@ -834,20 +830,44 @@ grouping_kind_rules <- local({
   }
 })
 
-# Whether a kind read off an object is a name at all: one string, and not the
-# missing one. The lookup below needs this much before it can be made, and
-# answers `NULL` both for a kind that fails it and for a name it does not know,
-# so a caller that has to tell those apart asks this instead of reading that
-# answer.
-is_grouping_kind_name <- function(kind) {
-  is.character(kind) && length(kind) == 1L && !is.na(kind)
+# The name a kind read off an object is, or `NULL` where it is none: a name is
+# one string, and not the missing one. Every caller holds a value nothing has
+# validated, which is why this answers with the name rather than with whether
+# there is one. Deciding reaches the value's own `is.na()` and `length()`
+# methods, and either can raise instead of answering; a raise is no answer, so
+# the value is no name, exactly as a value answering with two of them is none
+# (#280).
+#
+# The class is stripped from the answer because it is what carries those
+# methods, and the questions asked of a name are not done being asked here:
+# `%in%` reaches `as.character()`, which dispatches too, so a caller that
+# classified a kind and then matched what it classified would raise on the line
+# after this catch. The registry lookup below dispatches on the list and not on
+# the index, so it is inside for the other reason -- one place asks a kind
+# anything.
+#
+# The catch is narrow in what it decides and not in what it swallows, exactly
+# as the read's in `grouping_spec_kind()` is: a value no name can be got out of
+# has none, whatever stopped it. It catches an error and not a condition, so a
+# method that warns on its way to answering still answers.
+grouping_kind_name <- function(kind) {
+  tryCatch(
+    if (is.character(kind) && length(kind) == 1L && !is.na(kind)) {
+      unclass(kind)
+    },
+    error = function(cnd) NULL
+  )
 }
 
+# `NULL` both for a kind that is no name and for a name the registry does not
+# know, so a caller that has to tell those apart asks `grouping_kind_name()`
+# instead of reading this answer.
 find_grouping_kind_rule <- function(kind) {
-  if (!is_grouping_kind_name(kind)) {
+  name <- grouping_kind_name(kind)
+  if (is.null(name)) {
     return(NULL)
   }
-  grouping_kind_rules()[[kind]]
+  grouping_kind_rules()[[name]]
 }
 
 grouping_constructor_names <- function() {

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -832,31 +832,30 @@ grouping_kind_rules <- local({
 
 # The name a kind read off an object is, or `NULL` where it is none: a name is
 # one string, and not the missing one. Every caller holds a value nothing has
-# validated, which is why this answers with the name rather than with whether
-# there is one. Deciding reaches the value's own `is.na()` and `length()`
-# methods, and either can raise instead of answering; a raise is no answer, so
-# the value is no name, exactly as a value answering with two of them is none
-# (#280).
-#
-# The class is stripped from the answer because it is what carries those
-# methods, and the questions asked of a name are not done being asked here:
-# `%in%` reaches `as.character()`, which dispatches too, so a caller that
-# classified a kind and then matched what it classified would raise on the line
-# after this catch. The registry lookup below dispatches on the list and not on
-# the index, so it is inside for the other reason -- one place asks a kind
-# anything.
-#
-# The catch is narrow in what it decides and not in what it swallows, exactly
-# as the read's in `grouping_spec_kind()` is: a value no name can be got out of
-# has none, whatever stopped it. It catches an error and not a condition, so a
-# method that warns on its way to answering still answers.
+# validated, and every reader of one shares this, as they share the read in
+# `grouping_spec_kind()`. What it decides, why it answers with the name rather
+# than with whether there is one, and what the class coming off that answer
+# costs are ADR 0008's, in its amendment for a kind the guard could not
+# classify.
 grouping_kind_name <- function(kind) {
-  tryCatch(
+  # `is.na()` and `length()` are generic, so these are the value's own methods
+  # and one may raise instead of answering. A raise is no answer, so the value
+  # is no name -- the reading that leaves the guards their own refusal (#280).
+  name <- tryCatch(
     if (is.character(kind) && length(kind) == 1L && !is.na(kind)) {
       unclass(kind)
     },
     error = function(cnd) NULL
   )
+  # Asked again of the answer, which has no class left to dispatch on, so this
+  # is R's own reading and not a method's. The questions above were put to the
+  # classed value, and a method that answers wrongly rather than by raising
+  # passes them: `length()` reporting `1` over two strings returned two, and
+  # `%in%` at the caller in `check_ambiguous_nested_name()` raised on it.
+  if (!is.character(name) || length(name) != 1L || is.na(name)) {
+    return(NULL)
+  }
+  name
 }
 
 # `NULL` both for a kind that is no name and for a name the registry does not

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -247,13 +247,11 @@ print.margin_grouping_spec <- function(x, ...) {
 # kind that is no name decides the last, which falls here as the empty string
 # (#268).
 #
-# `is.na()` and `length()` are generic, so deciding which of the three a
-# character kind takes reaches methods of the value's own, and either can raise
-# instead of answering. `grouping_kind_name()` is where that is caught, for the
-# guards as much as for this line: #268 caught it here alone, and #280 moved
-# the catch to the classifier when it gave the guards the same answer. What
-# this site holds afterwards is a name or nothing, so the `cat()` below takes a
-# character whichever branch answers.
+# Deciding which of the three a kind takes is `grouping_kind_name()`'s, which
+# every reader of an unvalidated kind shares: a value whose own `is.na()` or
+# `length()` raises is no name there rather than an error here. What this site
+# holds afterwards is a name or nothing, so the `cat()` below takes a character
+# whichever branch answers.
 grouping_kind_printed_name <- function(kind) {
   name <- grouping_kind_name(kind)
   if (is.null(name)) {

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -249,20 +249,16 @@ print.margin_grouping_spec <- function(x, ...) {
 #
 # `is.na()` and `length()` are generic, so deciding which of the three a
 # character kind takes reaches methods of the value's own, and either can raise
-# instead of answering; a kind of another type is refused by `is.character()`,
-# which does not dispatch, before they are reached. That the catch is the
-# answer to that is the same amendment's. Its extent is what only this site
-# knows: the registry lookup is inside it, since its own guard asks those two
-# again, and the caller's `cat()` is outside, taking a character whichever
-# answer this returns.
+# instead of answering. `grouping_kind_name()` is where that is caught, for the
+# guards as much as for this line: #268 caught it here alone, and #280 moved
+# the catch to the classifier when it gave the guards the same answer. What
+# this site holds afterwards is a name or nothing, so the `cat()` below takes a
+# character whichever branch answers.
 grouping_kind_printed_name <- function(kind) {
-  tryCatch(
-    if (!is_grouping_kind_name(kind)) {
-      ""
-    } else {
-      rule <- find_grouping_kind_rule(kind)
-      if (is.null(rule)) kind else rule$constructor
-    },
-    error = function(cnd) ""
-  )
+  name <- grouping_kind_name(kind)
+  if (is.null(name)) {
+    return("")
+  }
+  rule <- find_grouping_kind_rule(name)
+  if (is.null(rule)) name else rule$constructor
 }

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -367,21 +367,41 @@ which is what `check_ambiguous_nested_name()` did. The registry lookup needs no
 such protection — `[[` dispatches on the list and not on the index — and is
 inside the shared function anyway, so that one place asks a kind anything.
 
+The answer is then classified a second time, and that is not the first
+repeated. Catching what a method raises answers only the method that fails to
+answer; a method that answers wrongly passes the catch, and `length()`
+reporting `1` over two strings is such an answer. The first classification is
+put to the value the caller holds, so it is the value's own methods that
+answer it; the second is put to the answer, which has no class left to
+dispatch on, so it is R's reading of a character vector and cannot be a
+method's. What the function returns is therefore one string because nothing it
+returns has been taken on a method's word — not because the object was
+believed and then trusted. Whether the object *said* it was one string is what
+the first classification decides, and it decides it for the printed line, per
+the amendment above.
+
 **The nested-name site.** That site is not a guard and its answer is not a
 guard's: a kind it cannot classify is not a kind the position admits, so the
 column reading stands, which is the answer a binding that raises when it is
-read already gets. Two behaviours move there. A kind whose `length()` or
-`as.character()` raises reached the caller as an untyped error and now decides
-nothing; and a kind whose `is.na()` raises was refused as ambiguous, because
-that site never asked `is.na()`, and now declines. Classifying in one place is
-what removes the second, and an accidental difference between two sites reading
-one field is what this ADR centralizes kinds to avoid.
+read already gets. Three behaviours move there. A kind whose `length()` raises
+reached the caller as an untyped error and now decides nothing. A kind whose
+`as.character()` raises reached them the same way and is now classified, the
+class coming off before `%in%` is reached, so it is refused as ambiguous —
+which is what a kind spelling `set` in that position is for, and the raising
+method never bore on it. And a kind whose `is.na()` raises was refused as
+ambiguous, because that site never asked `is.na()`, and now declines.
+Classifying in one place is what removes the last, and an accidental difference
+between two sites reading one field is what this ADR centralizes kinds to
+avoid.
 
 **Evaluations.** The constraint holding the number and timing of evaluations is
 not reached. The field is read once, as the amendments above left it. How often
-classifying asks the value's own methods falls rather than rises — the registry
-lookup's own guard asked them a second time and is now handed a plain string —
-and no decision fixes that count, which the amendment above already records.
+classifying asks the value's own methods is fixed by no decision, which the
+amendment above already records, and it moves in both directions: it falls at
+the guards and at the printed line, where the registry lookup's own guard asked
+them a second time and is now handed a plain string; and it is unchanged in
+number at the nested-name site, which asks `is.na()` where it did not and
+reaches `as.character()` where it no longer does.
 
 **The handler the classification is wrapped in.** `tryCatch(error = )` a third
 time, so the trade the amendment for a specification the printer could not read

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -287,10 +287,10 @@ condition a call raises rather than to a printed line.
 unchanged for every object whose `$` is an ordinary field read — is what moves
 here, and it moves for exactly the three shapes #264 pinned against it: `1:3`
 printed `123`, `c("a", "b")` printed `ab`, and `NA_character_` printed `NA`.
-Each prints the empty name now: `is_grouping_kind_name()` is asked before the
-registry is — the predicate `find_grouping_kind_rule()` asks, so that what may
-be printed and what may be looked up remain one question — and a kind that is
-no name answers nothing without reaching the fallback at all.
+Each prints the empty name now: the value is classified before the registry is
+asked — by the same classification `find_grouping_kind_rule()` makes, so that
+what may be printed and what may be looked up remain one question — and a kind
+that is no name answers nothing without reaching the fallback at all.
 
 What those lines were evidence of goes with them. #264 pinned them because this
 printed line was where a reader narrowed to a character scalar could be seen —
@@ -299,8 +299,8 @@ and the line no longer varies with that narrowing. No test distinguishes it
 now, since a guard refuses an object no rule answers for and is given no rule
 whichever way the reader answers. One behaviour still does, and it is the one
 #280 is filed for: a kind whose classification raises reaches a guard as an
-error rather than as a value. Until that ticket decides, the reader's contract
-is recorded here rather than observed.
+error rather than as a value. The amendment below decides it, and the tests it
+names are where the reader's contract is observed.
 
 The line printed instead is not new: an object answering no kind prints it, an
 object whose kind cannot be read prints it per the amendment above, and a kind
@@ -322,6 +322,72 @@ kind one stores is one name, so the branch is not reached. The constraint on
 the number and timing of evaluations is not reached either — the kind is read
 once, as the amendment above left it, and the predicate reads the value that
 read returned rather than the field again.
+
+## Amendment: the condition class of a kind the guard could not classify
+
+The amendment above says the guards are left alone and why, and #280 is where
+that was reconsidered. The constraint holding error condition classes fixed is
+amended a fifth time, at the two guards in `validate_grouping_spec_early()`,
+and in the direction #262 already chose for the read there.
+
+A kind that was read still has to be classified, and deciding whether it is one
+name asks the value's own `is.na()` and `length()` methods. Either can raise
+instead of answering, and what came out of the guard was then whatever the
+object raised — `simpleError` for a `stop()` in the method, a class of the
+object's own where it aborted with one — in place of the
+`Invalid grouping specification.` refusal below it. The class such a call
+raises therefore moves to `marginplyr_error`, for the same reason #262 gives:
+this is the guard's own answer arriving rather than a new one being chosen,
+since ADR 0015 already assigns a malformed specification reaching this guard a
+Package condition and the refusal was already written for an object whose
+fields do not read as a specification's.
+
+Nothing else in the constraint moves with it. Every object that reached the
+refusal reaches it with the same message, the same call context, and at the
+same point, and no specification that compiled stops compiling: a kind that is
+one name and not the missing one is classified as it was and looked up as it
+was.
+
+**Where the classification is made.** The amendment above put a catch on this
+question in `print.margin_grouping_spec()`, and said its extent was what only
+that site knew. Giving the guards the same answer makes that false, so the
+catch moves down into `grouping_kind_name()`, which every reader of an
+unvalidated kind now shares as they already share `grouping_spec_kind()`. One
+function reads the field, one classifies what the read returned, and neither
+site can disagree with the other about what a kind is. The printer keeps no
+catch of its own: what it holds after classifying is a name or nothing.
+
+**What the classification answers with.** `grouping_kind_name()` answers with
+the name rather than with whether there is one, and the class is stripped from
+that answer. The class is what carries the raising methods, and the questions
+asked of a kind are not done being asked when it has been classified: `%in%`
+reaches `as.character()`, which dispatches too. A caller that classified a kind
+and then matched what it classified would raise on the line after the catch,
+which is what `check_ambiguous_nested_name()` did. The registry lookup needs no
+such protection — `[[` dispatches on the list and not on the index — and is
+inside the shared function anyway, so that one place asks a kind anything.
+
+**The nested-name site.** That site is not a guard and its answer is not a
+guard's: a kind it cannot classify is not a kind the position admits, so the
+column reading stands, which is the answer a binding that raises when it is
+read already gets. Two behaviours move there. A kind whose `length()` or
+`as.character()` raises reached the caller as an untyped error and now decides
+nothing; and a kind whose `is.na()` raises was refused as ambiguous, because
+that site never asked `is.na()`, and now declines. Classifying in one place is
+what removes the second, and an accidental difference between two sites reading
+one field is what this ADR centralizes kinds to avoid.
+
+**Evaluations.** The constraint holding the number and timing of evaluations is
+not reached. The field is read once, as the amendments above left it. How often
+classifying asks the value's own methods falls rather than rises — the registry
+lookup's own guard asked them a second time and is now handed a plain string —
+and no decision fixes that count, which the amendment above already records.
+
+**The handler the classification is wrapped in.** `tryCatch(error = )` a third
+time, so the trade the amendment for a specification the printer could not read
+records under *the handler the read is wrapped in* is made once more. An error
+is caught and a condition is not, so a method that warns on its way to
+answering still answers.
 
 ## Test strategy
 

--- a/design/review-dispositions.md
+++ b/design/review-dispositions.md
@@ -1157,6 +1157,75 @@ same position takes #190's refusal for an object of any other storage.
 
 ---
 
+## 12. The review of #280's branch
+
+A two-axis review of the branch implementing #280, run in one round and
+answered on the branch in `9195644`, whose message names each finding it
+answers. The pull request carries the round in full — snapshot, finding, line,
+contract, counterexample, scope, disposition, evidence — and is the record;
+the issue holds a pointer to it.
+
+Seven findings, and five of them leave nothing owed here. The correctness
+finding both axes raised independently is exempt under the first leg:
+`9195644` names it and lands the test that fails without it, which is where
+this file stops and the diff starts. Four more moved only prose — two source
+comments re-deriving ADR 0008's own argument or narrating the rounds that
+produced them, and two sentences of that ADR measured false — and the second
+leg exempts each.
+
+What reaches this file is what a reader of the diff cannot check by reading
+it: one test refactor, whose executable lines no counterfactual covers; one
+assertion that passes with or without the change it was added for; and one
+alternative weighed and rejected, which no diff holds at all.
+
+**The forged-kind fixture is built three times** (Standards, Fowler
+*Duplicated Code*). **Fixed**, and the entry is here because the fix changes
+executable lines that no test fails without — the blunt line this file draws
+at the executable rather than at what a diff happens to show. The duplication
+is not cosmetic: nothing unregisters an S3 method, so two sites spelling one
+class name each get whichever was registered last, in whichever order testthat
+ran their files. *Evidence:* the hazard reproduces in two lines —
+`registerS3method("is.na", "shared_name", function(x, ...) stop("site A"),
+envir = asNamespace("base"))` followed by the same call binding
+`function(x, ...) FALSE` answers `FALSE`, the first method unreachable.
+`tests/testthat/helper-forged-kinds.R` now holds `kind_answering()`, deriving
+the class name from a per-site `purpose` and the generics, and the five call
+sites in `test-grouping-interface.R` and `test-grouping-plan.R` take it from
+there; `git show 9195644 -- tests/` is the change, and the full suite under
+`NOT_CRAN=true` is green across it.
+
+**The acceptance's blame clause is unasserted** (Spec). **Fixed, and it was
+never broken** — which is why it is here rather than exempt. #280 asks for
+`marginplyr_error` "blamed on the call the caller wrote", and the branch's
+first commit asserted the class and the message alone. The blame was already
+correct, so the assertion added for it passes against the code before the fix
+as well as after, and its diff establishes nothing a reader could check.
+*Evidence:* `test-grouping-plan.R` "a grouping specification kind that raises
+is refused by the guard" now asserts
+`rlang::call_name(conditionCall(error))` for both public routes; the measured
+value before the assertion was written was
+`inspect_grouping(d, .grouping = spec)`. The neighbouring test this one was
+told to sit beside still omits it, and that is left alone: the guard it covers
+is reached from the compiler, which has no call a caller wrote.
+
+**Stripping the class before classifying, rather than after** (raised in
+answering the correctness finding). **Rejected.** It is the stronger fix on its
+face: `is.character()` and `unclass()` can be intercepted by neither S3 nor S4,
+so a classification that strips first cannot reach a method of the value's own
+and is total by construction, with no catch and none of the exiting-handler
+trade ADR 0008 records. It was rejected because being total that way means
+never asking the value's own methods, which is the question #268 decided the
+printed line asks. *Evidence:* `setMethod("is.character", ...)` and
+`setMethod("unclass", ...)` both refuse with *must supply a function skeleton*,
+which is the half that makes the alternative total; and substituting it for
+`grouping_kind_name()`'s body fails seven assertions —
+`test-grouping-interface.R:1255` and `:1282`, which are #268's, and
+`test-grouping-plan.R:452`, `:1064`, `:1065`, `:1066`, which are this
+ticket's. Reversing a decision recorded in ADR 0008 is a ticket's to do, and
+this branch's acceptance does not reach it.
+
+---
+
 ## Status
 
 Every observation from every recorded review is dispositioned above, or is

--- a/tests/testthat/helper-forged-kinds.R
+++ b/tests/testthat/helper-forged-kinds.R
@@ -1,0 +1,38 @@
+# A Grouping specification kind carrying `kind` under a class whose methods are
+# `methods`, so that classifying it reaches a method of the object's own rather
+# than R's reading of a character vector. Every reader of a kind nothing has
+# validated is asserted against one -- the two guards, the nested-name check,
+# and the printed line -- and what each varies is the method and not the kind
+# underneath: `set` is a kind all four accept, so a refusal, a declined reading,
+# or an empty printed name is the classification's answer and not the name's.
+#
+# Shared because the hazard is in the registration and not in the fixture.
+# `registerS3method()` into base's namespace is what puts a method on a
+# primitive, nothing takes it off again, and the class is what a method is
+# looked up by -- so two sites that spelled one class name would each get
+# whichever method was registered last, in whichever order testthat ran their
+# files. `purpose` is what keeps them apart, and the generics are in the name
+# so that one site can forge two objects answering different questions.
+kind_answering <- function(methods, purpose, kind = "set") {
+  class_name <- paste0(
+    "marginplyr_kind_",
+    purpose,
+    "_",
+    paste(sub(".", "_", names(methods), fixed = TRUE), collapse = "_")
+  )
+  for (generic in names(methods)) {
+    registerS3method(
+      generic,
+      class_name,
+      methods[[generic]],
+      envir = asNamespace("base")
+    )
+  }
+  structure(kind, class = class_name)
+}
+
+# The method every site but one registers: a kind that raises instead of
+# answering the question being put to it.
+raising_kind_method <- function(x, ...) {
+  rlang::abort("classifying this kind raises")
+}

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1213,8 +1213,8 @@ test_that("a printed Grouping specification asks for a kind it may not have", {
 # What the shapes vary is why the kind is no name -- its type, its length, its
 # missingness -- against a line that does not vary, which is why they are
 # asserted together rather than one by one. None of them reaches `cat()`:
-# `is_grouping_kind_name()` refuses each first -- four for their type, and the
-# three character ones for their length or their missingness.
+# `grouping_kind_name()` answers nothing for each first -- four for their type,
+# and the three character ones for their length or their missingness.
 test_that("a printed Grouping specification omits a kind that is no name", {
   no_name <- list(
     `a longer vector` = 1:3,
@@ -1242,8 +1242,10 @@ test_that("a printed Grouping specification omits a kind that is no name", {
 # a classification that answers names `grouping_set`: the empty name is what
 # says the catch fired, and the named line is what says it did not.
 #
-# The guards read the same field and reach the same methods, and are left
-# alone: the amendment says why, and #280 is where they are filed.
+# The guards read the same field and reach the same methods, and #280 gave them
+# the same answer, which is what moved the catch into `grouping_kind_name()`.
+# What that leaves here is this line, which is where the catch firing is
+# visible as a printed line rather than as a condition class.
 test_that("a printed Grouping specification classifies a kind that may raise", {
   kind_answering <- function(generic, suffix, method) {
     class_name <- paste0("marginplyr_kind_", suffix)
@@ -1265,9 +1267,9 @@ test_that("a printed Grouping specification classifies a kind that may raise", {
   # kind that warns is still a kind. Catching `condition` would take the
   # warning for a failure to answer and name nothing, so this is what fails if
   # the catch is ever widened to one. The warnings are read as a set because
-  # classifying asks the method more than once -- the predicate asks, and the
-  # registry lookup's own guard asks again -- and no decision fixes that count
-  # the way ADR 0008 fixes the count of field reads.
+  # nothing fixes how often classifying asks the method the way ADR 0008 fixes
+  # the count of field reads -- the registry lookup asked it a second time
+  # before #280 handed that lookup a classified name.
   warns <- kind_answering("is.na", "is_na_warns", function(x, ...) {
     warning("classifying this kind warns")
     FALSE

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1247,19 +1247,12 @@ test_that("a printed Grouping specification omits a kind that is no name", {
 # What that leaves here is this line, which is where the catch firing is
 # visible as a printed line rather than as a condition class.
 test_that("a printed Grouping specification classifies a kind that may raise", {
-  kind_answering <- function(generic, suffix, method) {
-    class_name <- paste0("marginplyr_kind_", suffix)
-    registerS3method(generic, class_name, method, envir = asNamespace("base"))
-    structure("set", class = class_name)
-  }
-
-  raises <- function(x, ...) rlang::abort("classifying this kind raises")
   for (generic in c("is.na", "length")) {
-    suffix <- paste0(sub(".", "_", generic, fixed = TRUE), "_raises")
-    expect_empty_name_line(
-      new_grouping_spec(kind_answering(generic, suffix, raises), list()),
-      info = generic
+    kind <- kind_answering(
+      stats::setNames(list(raising_kind_method), generic),
+      "printed_raising"
     )
+    expect_empty_name_line(new_grouping_spec(kind, list()), info = generic)
   }
 
   # An error is caught and nothing else is, which is a choice rather than the
@@ -1270,10 +1263,13 @@ test_that("a printed Grouping specification classifies a kind that may raise", {
   # nothing fixes how often classifying asks the method the way ADR 0008 fixes
   # the count of field reads -- the registry lookup asked it a second time
   # before #280 handed that lookup a classified name.
-  warns <- kind_answering("is.na", "is_na_warns", function(x, ...) {
-    warning("classifying this kind warns")
-    FALSE
-  })
+  warns <- kind_answering(
+    list(is.na = function(x, ...) {
+      warning("classifying this kind warns")
+      FALSE
+    }),
+    "printed_warning"
+  )
   raised <- character()
   line <- withCallingHandlers(
     utils::capture.output(print(new_grouping_spec(warns, list()))),

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -443,20 +443,10 @@ test_that("a nested name the input and a binding both claim is refused", {
 # kind this position admits, so the column reading stands -- the answer a
 # binding that raises when it is read already gets. `as.character()` is the
 # third: `%in%` dispatches through it, so a kind that classified was matched
-# with the class it carries still on it. Every shape holds `set` underneath,
-# which this position admits, so the third is refused as ambiguous and the
-# first two would be if they could be classified.
+# with the class it carries still on it, and now is not. Every shape holds
+# `set` underneath, which this position admits, so the third is refused as
+# ambiguous and the first two would be if they could be classified.
 test_that("a colliding binding whose kind may raise loses its reading", {
-  raises <- function(x, ...) rlang::abort("classifying this kind raises")
-  kind_answering <- function(generic) {
-    class_name <- paste0(
-      "marginplyr_nested_kind_",
-      sub(".", "_", generic, fixed = TRUE),
-      "_raises"
-    )
-    registerS3method(generic, class_name, raises, envir = asNamespace("base"))
-    structure("set", class = class_name)
-  }
   compile_colliding <- function(kind) {
     env <- rlang::env(rlang::caller_env(), s = new_grouping_spec(kind, list()))
     compile_against(
@@ -464,18 +454,80 @@ test_that("a colliding binding whose kind may raise loses its reading", {
       c("s", "value")
     )
   }
+  raising <- function(generic) {
+    kind_answering(
+      stats::setNames(list(raising_kind_method), generic),
+      "nested_raising"
+    )
+  }
 
   for (generic in c("is.na", "length")) {
     expect_identical(
-      compile_colliding(kind_answering(generic))$sets,
+      compile_colliding(raising(generic))$sets,
       list("s"),
       info = generic
     )
   }
 
-  refused <- expect_error(compile_colliding(kind_answering("as.character")))
+  refused <- expect_error(compile_colliding(raising("as.character")))
   expect_s3_class(refused, "marginplyr_error")
   expect_identical(conditionMessage(refused), ambiguous_s_message)
+})
+
+# The other way a method takes the classification away from R: by answering,
+# and answering wrongly. A catch answers a method that fails to answer, and a
+# `length()` reporting `1` over two strings passes one -- so a classification
+# that caught what its questions raised and then returned the value it had
+# asked about returned two strings under a contract promising one, and `%in%`
+# on the line after raised the untyped error the catch was put there to remove.
+#
+# The answer is classified a second time for that, with no class left on it to
+# dispatch. The colliding reading is what holds that: delete the second
+# classification and it raises `'length = 2' in coercion to 'logical(1)'`
+# instead of declining.
+#
+# The guard is asserted too, and it is characterization rather than the same
+# evidence -- it refuses either way. What refuses it without the second
+# classification is `[[`, which answers nothing for an index of two elements
+# and nothing for one of none, so the sentence the caller reads is the registry
+# lookup's accident rather than the guard's reading. Both lengths are written
+# because they are two accidents and not one. Making it the guard's own is what
+# the second classification does here, and an accident that stopped holding
+# would be read as this test's subject failing.
+test_that("a kind whose classification lies is no more a name for it", {
+  lying <- function(kind, length_answer) {
+    kind_answering(
+      list(
+        length = function(x) length_answer,
+        is.na = function(x, ...) FALSE
+      ),
+      paste0("nested_lying_", length_answer),
+      kind = kind
+    )
+  }
+  two_strings <- lying(c("set", "sets"), 1L)
+  no_strings <- lying(character(), 1L)
+
+  env <- rlang::env(
+    rlang::current_env(),
+    s = new_grouping_spec(two_strings, list())
+  )
+  expect_identical(
+    compile_against(
+      eval(quote(grouping_sets(s)), envir = env),
+      c("s", "value")
+    )$sets,
+    list("s")
+  )
+
+  for (kind in list(two_strings, no_strings)) {
+    error <- expect_error(compile_against(new_grouping_spec(kind, list()), "a"))
+    expect_s3_class(error, "marginplyr_error")
+    expect_identical(
+      conditionMessage(error),
+      "Invalid grouping specification."
+    )
+  }
 })
 
 test_that("the ambiguity refusal names a working spelling for each reading", {
@@ -990,18 +1042,16 @@ test_that("a malformed grouping specification is refused by both guards", {
 # well, because that is where the defect was reported and a guard is reached
 # from them through the whole lifecycle rather than the compiler alone.
 test_that("a grouping specification kind that raises is refused by the guard", {
-  raises <- function(x, ...) rlang::abort("classifying this kind raises")
   kinds <- lapply(c("is.na", "length"), function(generic) {
-    class_name <- paste0(
-      "marginplyr_guard_kind_",
-      sub(".", "_", generic, fixed = TRUE),
-      "_raises"
+    kind_answering(
+      stats::setNames(list(raising_kind_method), generic),
+      "guard_raising"
     )
-    registerS3method(generic, class_name, raises, envir = asNamespace("base"))
-    structure("set", class = class_name)
   })
   data <- data.frame(a = 1)
-  public <- list(
+  calls <- list(
+    top = function(spec) compile_against(spec, "a"),
+    nested = function(spec) compile_against(grouping_sets(spec), "a"),
     inspect_grouping = function(spec) inspect_grouping(data, .grouping = spec),
     summarize_with_margins = function(spec) {
       summarize_with_margins(data, n = dplyr::n(), .grouping = spec)
@@ -1010,19 +1060,24 @@ test_that("a grouping specification kind that raises is refused by the guard", {
 
   for (kind in kinds) {
     spec <- new_grouping_spec(kind, list())
-    calls <- c(
-      list(
-        top = function(spec) compile_against(spec, "a"),
-        nested = function(spec) compile_against(grouping_sets(spec), "a")
-      ),
-      public
-    )
     for (route in names(calls)) {
       error <- expect_error(calls[[route]](spec))
       expect_s3_class(error, "marginplyr_error")
       expect_identical(
         conditionMessage(error),
         "Invalid grouping specification.",
+        info = route
+      )
+    }
+
+    # Blamed on the verb the caller wrote, which is the acceptance's other half
+    # and what a condition raised out of a method would not have been: the
+    # method's own call is what `stop()` in one blames. Only the public routes
+    # are asked, an internal caller having no call a caller wrote.
+    for (route in c("inspect_grouping", "summarize_with_margins")) {
+      expect_identical(
+        rlang::call_name(conditionCall(expect_error(calls[[route]](spec)))),
+        route,
         info = route
       )
     }

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -433,6 +433,51 @@ test_that("a nested name the input and a binding both claim is refused", {
   )
 })
 
+# The other reader of a kind nothing has validated, and the one where the
+# guards' answer is not the answer: this site declines rather than refuses, so
+# what a method raising took from it was a compiled call rather than a
+# diagnostic (#280).
+#
+# Three methods, because this site asks one the guards do not. `is.na()` and
+# `length()` are the guards' pair, and a kind neither can classify is not a
+# kind this position admits, so the column reading stands -- the answer a
+# binding that raises when it is read already gets. `as.character()` is the
+# third: `%in%` dispatches through it, so a kind that classified was matched
+# with the class it carries still on it. Every shape holds `set` underneath,
+# which this position admits, so the third is refused as ambiguous and the
+# first two would be if they could be classified.
+test_that("a colliding binding whose kind may raise loses its reading", {
+  raises <- function(x, ...) rlang::abort("classifying this kind raises")
+  kind_answering <- function(generic) {
+    class_name <- paste0(
+      "marginplyr_nested_kind_",
+      sub(".", "_", generic, fixed = TRUE),
+      "_raises"
+    )
+    registerS3method(generic, class_name, raises, envir = asNamespace("base"))
+    structure("set", class = class_name)
+  }
+  compile_colliding <- function(kind) {
+    env <- rlang::env(rlang::caller_env(), s = new_grouping_spec(kind, list()))
+    compile_against(
+      eval(quote(grouping_sets(s)), envir = env),
+      c("s", "value")
+    )
+  }
+
+  for (generic in c("is.na", "length")) {
+    expect_identical(
+      compile_colliding(kind_answering(generic))$sets,
+      list("s"),
+      info = generic
+    )
+  }
+
+  refused <- expect_error(compile_colliding(kind_answering("as.character")))
+  expect_s3_class(refused, "marginplyr_error")
+  expect_identical(conditionMessage(refused), ambiguous_s_message)
+})
+
 test_that("the ambiguity refusal names a working spelling for each reading", {
   # Both spellings are executed rather than described, and they are read back
   # out of the diagnostic that printed them, so an advice line that stopped
@@ -928,6 +973,57 @@ test_that("a malformed grouping specification is refused by both guards", {
       expect_identical(
         conditionMessage(error),
         "Invalid grouping specification."
+      )
+    }
+  }
+})
+
+# The second hazard the read left, and #262's answer for the read applied to it
+# (#280). A kind that was read still has to be classified, and deciding whether
+# it is one name asks the value's own `is.na()` and `length()` methods; either
+# can raise instead of answering, and what came out of the guard was then
+# whatever the object raised, in place of the refusal below it.
+#
+# `set` underneath every shape, so nothing here is refused for the name it
+# holds: a classification that answered would compile. Both positions, for the
+# reason the test above writes every object in both, and the public routes as
+# well, because that is where the defect was reported and a guard is reached
+# from them through the whole lifecycle rather than the compiler alone.
+test_that("a grouping specification kind that raises is refused by the guard", {
+  raises <- function(x, ...) rlang::abort("classifying this kind raises")
+  kinds <- lapply(c("is.na", "length"), function(generic) {
+    class_name <- paste0(
+      "marginplyr_guard_kind_",
+      sub(".", "_", generic, fixed = TRUE),
+      "_raises"
+    )
+    registerS3method(generic, class_name, raises, envir = asNamespace("base"))
+    structure("set", class = class_name)
+  })
+  data <- data.frame(a = 1)
+  public <- list(
+    inspect_grouping = function(spec) inspect_grouping(data, .grouping = spec),
+    summarize_with_margins = function(spec) {
+      summarize_with_margins(data, n = dplyr::n(), .grouping = spec)
+    }
+  )
+
+  for (kind in kinds) {
+    spec <- new_grouping_spec(kind, list())
+    calls <- c(
+      list(
+        top = function(spec) compile_against(spec, "a"),
+        nested = function(spec) compile_against(grouping_sets(spec), "a")
+      ),
+      public
+    )
+    for (route in names(calls)) {
+      error <- expect_error(calls[[route]](spec))
+      expect_s3_class(error, "marginplyr_error")
+      expect_identical(
+        conditionMessage(error),
+        "Invalid grouping specification.",
+        info = route
       )
     }
   }


### PR DESCRIPTION
Closes #280.

## What moved

`is.na()` and `length()` are generic, so a forged `.grouping` whose kind carries a method of its own took the guards' answer away from them: the object's error came out of `validate_grouping_spec_early()` in place of `Invalid grouping specification.`. `check_ambiguous_nested_name()` reached the same methods and one more — `%in%` dispatches through `as.character()` — and there an untyped error replaced a compiled call.

`grouping_kind_name()` answers a kind's name or nothing. It catches what classifying raises, exactly as `grouping_spec_kind()` catches what reading raises, and strips the class from the answer so nothing downstream dispatches on it again. The catch #268 put in the printer moves there, since every reader of an unvalidated kind now shares one classification. The answer is then classified a second time, with no class left on it to dispatch, because a catch answers only a method that *fails* to answer — one that answers *wrongly* passes it.

`check_ambiguous_nested_name()` is not named by the ticket and is fixed here anyway: it is the same reader's other consumer, and a fix holding at one site and not the other would read as a fix. Its answer differs — it declines where a guard refuses — and ADR 0008 records that, along with the one behaviour that moves there in the other direction.

## Decision record

ADR 0008's condition-class constraint moves a fifth time, in the direction #262 chose for the read. The amendment states what does not move with it, what the second classification is for, what the nested-name site does instead, and the evaluation counts at each of the three sites.

## Review

A two-axis review (`mattpocock-skills:code-review`) ran over `e2dbff3`, one round, both axes carrying `design/architecture.md`'s *Answering a review* alongside the standards sources as `design/agents/code-review.md` requires. Seven findings, none about how a sentence reads. Answers are in `9195644`; the full record is in the first comment below.

`design/review-dispositions.md` §12 carries the three the diff cannot settle by being read: a test refactor, an assertion that passes either way, and an alternative weighed and rejected.

## Gates

`NOT_CRAN=true testthat::test_local()` green; `lintr::lint_package()` after `pkgload::load_all(".")` reports no lints; `verify-context-budget.R` passes at 38396/38396; `roxygen2::roxygenise()` produces no diff and no generated file is touched.
