### PR TITLE
Say where a review record goes, and what state it may be written in

### DIFF
--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -14,9 +14,20 @@ So the branch is pushed and the pull request is open *before* the record is writ
 
 The fixed point is the merge-base with `main`, which is what the three-dot form `git diff <base>...HEAD` computes. Reviewing against a `main` the branch has fallen behind reports that gap as though it were the branch's.
 
-The record names, per finding: the snapshot SHA, the finding's ID, the line, the contract it violates, the counterexample, whether it is in scope, the disposition, and the evidence. The disposition list is *Answering a review*'s, and a comment is not on it.
+What the record carries is small, because most of a review is recorded by what it produced. A finding answered in code is recorded by the code and by the test that fails without it; one answered in prose is recorded by the diff that changed the prose. Restating either is a second copy nothing compares against the first, which is what *Code comments* in `AGENTS.md` refuses for a comment, on an argument that does not stop at comments.
 
-`design/review-dispositions.md` is where a disposition goes that reading the diff cannot settle, and that file states which ones those are. It is named here because the skill knows nothing about it and will not raise it: a review answered entirely in prose, or by fixes whose commits name a test that fails without them, owes it nothing, while one that refactored a test, added an assertion that passes either way, or rejected an alternative owes it an entry. #280's review owed three and was written without them until the omission was noticed by hand.
+So the record says what the round raised and what became of each finding, and stops. What a disposition needs beyond that is decided by its kind, and every kind already has a home:
+
+| the disposition | what records it |
+|---|---|
+| fixed in code | the commit that names the finding, and the test that fails without the fix |
+| fixed in prose | the diff that changed the prose |
+| rejected, where a test, a comment, or a runnable command already answers it | that test, comment, or command |
+| an alternative weighed and rejected | *Considered options* in the ADR holding the decision it would have changed |
+| a premise measured false | a dated note under `investigation/` |
+| a site deliberately left alone | a comment at the site, or the ADR that leaves it |
+
+Nine of the thirteen rejections in `design/review-dispositions.md` point at column two rather than holding anything themselves, which is what the table is derived from. While that file exists it takes whatever column two does not; #288 asks whether anything does not.
 
 ## What the skill looks for, and what is here
 

--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -6,6 +6,18 @@ What may be a finding, and how one is answered, is not here. `design/architectur
 
 That section binds a reviewer only if the reviewer is handed it. This skill composes its own sub-agent prompts (`SKILL.md`, step 4), so pass what a finding about prose may be alongside the standards sources, in the same call.
 
+## What is reviewed, and where the record goes
+
+The subject is a diff, so the record goes where the diff is: the pull request. An issue gets a pointer and not a copy — the issue is where the ticket is argued, and a second copy of the record is one more thing to keep in step.
+
+So the branch is pushed and the pull request is open *before* the record is written. A record names the snapshot it read, and a SHA on an unpushed branch resolves for nobody: #280's review was posted to the issue while its branch was still local, so every SHA in it cited a commit no reader could open, and the record had to be moved (PR #286). For the same reason, rebase before the review and not after — a rebase rewrites the SHAs a published record already named.
+
+The fixed point is the merge-base with `main`, which is what the three-dot form `git diff <base>...HEAD` computes. Reviewing against a `main` the branch has fallen behind reports that gap as though it were the branch's.
+
+The record names, per finding: the snapshot SHA, the finding's ID, the line, the contract it violates, the counterexample, whether it is in scope, the disposition, and the evidence. The disposition list is *Answering a review*'s, and a comment is not on it.
+
+`design/review-dispositions.md` is where a disposition goes that reading the diff cannot settle, and that file states which ones those are. It is named here because the skill knows nothing about it and will not raise it: a review answered entirely in prose, or by fixes whose commits name a test that fails without them, owes it nothing, while one that refactored a test, added an assertion that passes either way, or rejected an alternative owes it an entry. #280's review owed three and was written without them until the omission was noticed by hand.
+
 ## What the skill looks for, and what is here
 
 | The skill looks for | Here |


### PR DESCRIPTION
`design/agents/code-review.md` maps the review skill onto this repository. It said what a finding may be and where that rule lives, but nothing about where the *record* of a review lands, what state the branch has to be in when one is written, or how much of a review needs recording at all.

#280's review is what showed the gap. The record went to the issue while the branch was still local, so every SHA it named cited a commit no reader could open; it was moved to #286 after the fact. The same review owed `design/review-dispositions.md` three entries and was written without them, because the skill composes its own sub-agent prompts and knows about neither that file nor *Answering a review* — the condition `fe0f6a5` wrote down for one rule, applied to the other.

## What this adds

**Where the record goes, and in what state.** On the pull request; the issue gets a pointer, not a copy. So the branch is pushed and the PR open before the record is written, and a rebase happens before the review rather than after it has published SHAs. The fixed point is the merge-base, so a branch behind `main` does not report that gap as its own.

**How much is recorded.** Little. A finding answered in code is recorded by the code and by the test that fails without it; one answered in prose is recorded by the diff. Restating either is a second copy nothing compares against the first — the objection *Code comments* in `AGENTS.md` makes to a comment re-deriving an ADR, which does not stop at comments.

**Where the rest goes, by kind.** A table routing an alternative weighed and rejected to the ADR's *Considered options*, a premise measured false to a dated `investigation/` note, and a site deliberately left alone to a comment at the site. None of these is new: 9 of the 26 ADRs already carry *Considered options*, and `investigation/` holds 26 notes under a stated convention.

The table is derived rather than invented. Nine of the thirteen rejections in `design/review-dispositions.md` point at a test, a command, an issue, or a comment rather than holding anything themselves — `L998`'s evidence is "the comment above `check_ambiguous_nested_name()` ... which is where both grounds are written for the next reader". #288 asks whether anything is left for that file once column two is subtracted.

## History

The first commit required a record naming eight things per finding. That came from one ticket's instructions, and `c2a4947` removes it: promoting a task's instructions to a standing rule is how a document acquires a requirement nobody argued for.

## Cost

The file is not in the always-loaded closure — `CLAUDE.md` pulls `AGENTS.md` and nothing further — so this costs no context budget. `verify-context-budget.R` passes unchanged at 38396/38396.

No ledger entry: both commits are prose and the second leg exempts them.