### PR TITLE
Hand the reviewer its contract instead of pointing at it

### DIFF
--- a/.claude/hooks/code-review-contract.sh
+++ b/.claude/hooks/code-review-contract.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Hands `design/agents/code-review.md` to the session that is about to run a
+# review, as a `PreToolUse` hook on the `Skill` tool.
+#
+# `AGENTS.md` points at that file, and a pointer is read only if the reader goes
+# looking. What it holds is not advice: the skill composes its own sub-agent
+# prompts, so a scope the invocation does not carry reaches neither axis; a
+# record written before the branch is pushed names SHAs nobody can open (#286);
+# and a fixed point that is not the merge-base reports `main`'s gap as the
+# branch's. Each of those is spent before anything fails, so there is nothing to
+# gate afterwards. This is what makes the file arrive rather than be looked up.
+#
+# It injects the file rather than a copy of what the file says, so there is
+# nothing here to drift from it. Editing the contract is editing that file.
+#
+# Silence is the only failure mode: outside a repository, on any other skill, or
+# with the file absent, it exits 0 and adds nothing.
+
+set -u
+
+input=$(cat)
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+contract="$root/design/agents/code-review.md"
+[ -f "$contract" ] || exit 0
+
+# Matches the plugin skill and the built-in one alike: what the contract governs
+# is a review of this repository, not one reviewer's implementation of it.
+printf '%s' "$input" |
+  jq -e '(.tool_input.skill // "") | test("code-review")' >/dev/null 2>&1 || exit 0
+
+jq -n --rawfile contract "$contract" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: (
+      "This repository adapts that skill. `design/agents/code-review.md`, in full:\n\n"
+      + $contract
+    )
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "r=$(git rev-parse --show-toplevel 2>/dev/null) && exec \"$r/.claude/hooks/code-review-contract.sh\" || true",
+            "timeout": 10,
+            "statusMessage": "Reading design/agents/code-review.md"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ _quarto/*
 sandbox/
 /doc/
 /Meta/
+
+# Worktrees created under the project directory; the settings and hooks beside
+# them are tracked.
+.claude/worktrees/

--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -6,6 +6,8 @@ What may be a finding, and how one is answered, is not here. `design/architectur
 
 That section binds a reviewer only if the reviewer is handed it. This skill composes its own sub-agent prompts (`SKILL.md`, step 4), so pass what a finding about prose may be alongside the standards sources, in the same call.
 
+`.claude/hooks/code-review-contract.sh` puts this file in front of the session that invokes the skill, so editing it changes what every later review is handed.
+
 ## What is reviewed, and where the record goes
 
 The subject is a diff, so the record goes where the diff is: the pull request. An issue gets a pointer and not a copy — the issue is where the ticket is argued, and a second copy of the record is one more thing to keep in step.


### PR DESCRIPTION
`AGENTS.md` names `design/agents/code-review.md` in one line. A pointer is read
only if the reader goes looking, and what that file holds cannot be picked up
afterwards — each of its three constraints is spent before anything could fail,
so there is nothing to gate after the fact.

| the constraint | what is lost if the invocation does not carry it |
|---|---|
| pass what a finding about prose may be, alongside the standards sources | the skill composes both sub-agent prompts itself (`SKILL.md`, step 4), so the scope reaches neither axis |
| push the branch and open the PR before writing the record | the record names SHAs nobody can open — #286 had to move #280's for this |
| the fixed point is the merge-base | `main`'s gap is reported as the branch's |

## What lands

A `PreToolUse` hook on the `Skill` tool, in `.claude/settings.json`, running
`.claude/hooks/code-review-contract.sh`. The harness runs it, so it does not
depend on the model deciding to read a file first.

**It injects the file, not a copy of what the file says.** There is nothing here
to drift from the contract, and editing the contract is editing that file —
which the file now says of itself, since a reader deciding whether to change it
is deciding what every later review is handed.

It matches the built-in `code-review` skill as well as the plugin's: what the
contract governs is a review of this repository, not one reviewer's
implementation of it.

## Verification

Piped the payload the hook receives, against the exact command string in
`settings.json`:

| case | result |
|---|---|
| `mattpocock-skills:code-review` | injects the file |
| built-in `code-review` | injects the file |
| `tdd` | injects nothing |
| invoked from `R/` | resolves the same file as from the root |
| invoked outside a repository | exits 0, silent |

`jq -e '.hooks.PreToolUse[] \| select(.matcher == "Skill") \| .hooks[] \| select(.type == "command") \| .command'` exits 0.
`verify-context-budget.R` is unchanged at 38,383 of 38,396 — `.claude/` and
`design/agents/` are outside the always-loaded closure. `test-documentation.R`
passes.

**Not proved firing live.** `.claude/settings.json` did not exist when this
session started, so the settings watcher is not watching that directory; the
hook is written and pipe-tested but takes effect after `/hooks` or a restart.

## Also

`.claude/` was untracked, so `.claude/worktrees/` is ignored now that the
settings and hook beside it are not. `.Rbuildignore` already excluded the
directory, so nothing reaches the tarball.

## What does not land

Anything in `AGENTS.md`. The pointer there is the fallback for a reader whose
settings do not load, and stating the hook beside it would be a second copy of
what the hook's own header argues — at a cost inside the budget that gate holds.

No ledger entry: the ledger was retired in #288, and what this produced is the
hook and its pipe-tested behaviour.