### PR TITLE
Carry the three review instructions in the closure that reaches every task

### DIFF
--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,8 +24,8 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 38396L
-baseline_note <- "this gate, its entry in AGENTS.md, and #283's paragraph"
+baseline_bytes <- 38810L
+baseline_note <- "#298 moving three review instructions into the closure"
 
 entry <- "CLAUDE.md"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,13 @@ This is a single-context repo. Read the root `CONTEXT.md` and relevant ADRs unde
 
 ### Code review
 
-Reviews run through `mattpocock-skills:code-review`. See `design/agents/code-review.md`.
+Reviews run through `mattpocock-skills:code-review`, which composes its own
+sub-agent prompts, so what an invocation does not carry does not reach either
+axis. Pass what a finding about prose may be — *Answering a review* in
+`design/architecture.md` — alongside the standards sources. Review against the
+merge-base with `main`, and push the branch and open the pull request before
+writing the record, which goes there. `design/agents/code-review.md` maps the
+rest of what the skill expects onto this repository.
 
 ### Investigation notes
 

--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -2,17 +2,15 @@
 
 Reviews here run through that skill. It reviews the diff since a fixed point on two axes — Standards and Spec — as parallel sub-agents. This file maps what it expects onto what this repository has.
 
-What may be a finding, and how one is answered, is not here. `design/architecture.md`'s *Answering a review* governs that, for this reviewer and for any other.
-
-That section binds a reviewer only if the reviewer is handed it. This skill composes its own sub-agent prompts (`SKILL.md`, step 4), so pass what a finding about prose may be alongside the standards sources, in the same call.
+What may be a finding, and how one is answered, is not here. `design/architecture.md`'s *Answering a review* governs that, for this reviewer and for any other. `AGENTS.md` carries what the invocation has to hand this skill, because `SKILL.md` step 4 composes both sub-agent prompts from the standards sources the call names and nothing else reaches them.
 
 ## What is reviewed, and where the record goes
 
 The subject is a diff, so the record goes where the diff is: the pull request. An issue gets a pointer and not a copy — the issue is where the ticket is argued, and a second copy of the record is one more thing to keep in step.
 
-So the branch is pushed and the pull request is open *before* the record is written. A record names the snapshot it read, and a SHA on an unpushed branch resolves for nobody: #280's review was posted to the issue while its branch was still local, so every SHA in it cited a commit no reader could open, and the record had to be moved (PR #286). For the same reason, rebase before the review and not after — a rebase rewrites the SHAs a published record already named.
+A record names the snapshot it read, which is why `AGENTS.md` has the branch pushed and the pull request open before one is written: a SHA on an unpushed branch resolves for nobody. #280's review was posted to the issue while its branch was still local, so every SHA in it cited a commit no reader could open, and the record had to be moved (PR #286). For the same reason, rebase before the review and not after — a rebase rewrites the SHAs a published record already named.
 
-The fixed point is the merge-base with `main`, which is what the three-dot form `git diff <base>...HEAD` computes. Reviewing against a `main` the branch has fallen behind reports that gap as though it were the branch's.
+`git diff <base>...HEAD` is the three-dot form that computes the merge-base `AGENTS.md` names as the fixed point. Reviewing against a `main` the branch has fallen behind reports that gap as though it were the branch's.
 
 What the record carries is small, because most of a review is recorded by what it produced. A finding answered in code is recorded by the code and by the test that fails without it; one answered in prose is recorded by the diff that changed the prose. Restating either is a second copy nothing compares against the first, which is what *Code comments* in `AGENTS.md` refuses for a comment, on an argument that does not stop at comments.
 


### PR DESCRIPTION
Closes #298.

Three instructions move from behind a pointer into `AGENTS.md`; the argument
for each stays in the file it is about. +8 / -8 across three files, and the
baseline moves 414 bytes.

## Why these three and not the rest of that file

Each is spent by the time anything could notice it was missing.

| the instruction | what is lost when the invocation does not carry it |
|---|---|
| pass what a finding about prose may be | `SKILL.md` step 4 composes both sub-agent prompts from the standards sources the call names; nothing else reaches them |
| push and open the PR before writing the record | the record names SHAs nobody can open — PR #286 moved #280's for this |
| review against the merge-base | `main`'s gap is reported as the branch's |

The rest of `design/agents/code-review.md` — the mapping table, the disposition
homes, why `/setup-matt-pocock-skills` is not run here — is reached when it is
needed. These three are not reachable in time.

This is the split *Always-loaded context* asks every section to make, and this
section had it backwards: the instruction was behind the pointer and the
argument was in front of nothing.

## What stays where

`design/agents/code-review.md` keeps the evidence and states none of the three
a second time: `SKILL.md` step 4's mechanics, #280 and #286, that
`git diff <base>...HEAD` is what computes the merge-base, and that a rebase
after a review rewrites SHAs a published record already named.

## The baseline

It moves 414 bytes, and nothing paid for it. What would have paid is the 62
lines of *Installation instructions* that `test-documentation.R:262-297` already
holds — but spending them here would make #295's judgement about budget rather
than about placement, so that ticket keeps them.

The gate fired first, which is what it is for: `over by 414`, with the remedy in
the message. This is the case its `AGENTS.md` entry admits — an instruction a
task needs loaded before it knows the branch applies.

## Not a hook

A `PreToolUse` hook on the `Skill` tool would deliver the same file
mechanically. It was built, and withdrawn (PR #297): configuring the harness is
not this repository's to do, and it was reaching for a mechanism to fix what
was really a placement error. A correctly placed instruction needs nothing
behind it.

## Verification

`verify-context-budget.R` passes at 38,810 of 38,810. `test-documentation.R`
passes. `lintr` clean on the changed script. Grepped the three instructions out
of `design/agents/code-review.md` and the four pieces of evidence still in it.