### PR TITLE
Watch tibble::as_tibble in the caused-read gate

### DIFF
--- a/tests/testthat/_snaps/query-policy.md
+++ b/tests/testthat/_snaps/query-policy.md
@@ -3,16 +3,17 @@
     Code
       lazy_execution_entry_points()
     Output
-        package            name subject_test
-      1   dplyr         collect        FALSE
-      2   dplyr         compute        FALSE
-      3   dplyr            pull        FALSE
-      4    base   as.data.frame         TRUE
-      5     DBI      dbGetQuery        FALSE
-      6     DBI     dbSendQuery        FALSE
-      7     DBI dbSendStatement        FALSE
-      8     DBI         dbFetch        FALSE
-      9     DBI     dbReadTable        FALSE
+         package            name subject_test
+      1    dplyr         collect        FALSE
+      2    dplyr         compute        FALSE
+      3    dplyr            pull        FALSE
+      4     base   as.data.frame         TRUE
+      5   tibble       as_tibble         TRUE
+      6      DBI      dbGetQuery        FALSE
+      7      DBI     dbSendQuery        FALSE
+      8      DBI dbSendStatement        FALSE
+      9      DBI         dbFetch        FALSE
+      10     DBI     dbReadTable        FALSE
 
 # marginplyr functions reaching an execution entry point
 

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -70,26 +70,38 @@ find_local_assignment <- function(fn, var_name) {
 # ordinary query-building call. `dplyr::show_query()` is deliberately absent
 # -- ADR 0020 states that it runs nothing.
 #
+# `tibble::as_tibble` is a member because it is the generic that receives the
+# caller's lazy object on a conversion path where `as.data.frame` receives only
+# a local one: converting a dtplyr step evaluates the step first and converts
+# the resulting `data.table`, so the read goes uncounted (#301).
+# `as.data.frame()` written directly against that same input is counted, dtplyr
+# registering a method the base generic dispatches from, so what this entry
+# covers is the conversion and not the backend. It is traced at the generic
+# rather than at `as_tibble.dtplyr_step`, for the reason given below for
+# `dplyr::collect`.
+#
 # `subject_test` says whether counting an invocation requires knowing what the
 # call was applied to, and it is enumerated for the same reason the membership
 # is. `as.data.frame` needs one because its name is also how unrelated code
 # converts unrelated objects -- a verb reads its input's schema through it
-# repeatedly, and no such conversion reaches a backend. No `DBI::` entry takes
-# one: invoking it is itself a read, and its first argument is a connection
-# rather than the caller's data, so a subject test there would count nothing at
-# all.
+# repeatedly, and no such conversion reaches a backend. `as_tibble` needs one
+# for the same reason, and reaches it on the path this entry exists for:
+# converting a dtplyr step invokes the generic twice, once on the step and once
+# on the local table it produced. No `DBI::` entry takes one: invoking it is
+# itself a read, and its first argument is a connection rather than the caller's
+# data, so a subject test there would count nothing at all.
 lazy_execution_entry_points <- function() {
   data.frame(
     package = c(
-      "dplyr", "dplyr", "dplyr", "base",
+      "dplyr", "dplyr", "dplyr", "base", "tibble",
       "DBI", "DBI", "DBI", "DBI", "DBI"
     ),
     name = c(
-      "collect", "compute", "pull", "as.data.frame",
+      "collect", "compute", "pull", "as.data.frame", "as_tibble",
       "dbGetQuery", "dbSendQuery", "dbSendStatement", "dbFetch", "dbReadTable"
     ),
     subject_test = c(
-      FALSE, FALSE, FALSE, TRUE,
+      FALSE, FALSE, FALSE, TRUE, TRUE,
       FALSE, FALSE, FALSE, FALSE, FALSE
     ),
     stringsAsFactors = FALSE
@@ -364,6 +376,48 @@ test_that("no Arrow read happens while a Margin verb runs", {
       info = shape
     )
   }
+})
+
+# The conversion path the catalog's `tibble::as_tibble` entry exists for, and
+# the backend that takes it.
+#
+# Every expectation here names the package it calls into. `trace()` rewrites a
+# namespace binding and the copy an importing package's imports environment
+# holds, but not the one the attached `package:tibble` environment holds, which
+# is where a bare `as_tibble()` written here would resolve -- so that spelling
+# counts nothing while reading exactly as these do (#303).
+#
+# The two deprecated spellings are asserted because one entry covering all three
+# is the reason there is one entry: both delegate to the generic from inside
+# tibble's own namespace, so the caller's spelling does not decide whether the
+# traced binding is reached.
+test_that("a dtplyr materialization through the as_tibble family is counted", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.frame(
+    k = c("E", "E", "W"),
+    v = c(1, 2, 3),
+    stringsAsFactors = FALSE
+  )
+
+  expect_gt(count_backend_reads(tibble::as_tibble(dtplyr::lazy_dt(data))), 0L)
+  expect_gt(count_backend_reads(dplyr::as_tibble(dtplyr::lazy_dt(data))), 0L)
+  expect_gt(
+    count_backend_reads(
+      suppressWarnings(tibble::as.tibble(dtplyr::lazy_dt(data)))
+    ),
+    0L
+  )
+  expect_gt(
+    count_backend_reads(
+      suppressWarnings(tibble::as_data_frame(dtplyr::lazy_dt(data)))
+    ),
+    0L
+  )
+
+  # The other direction, for the reason the `as.data.frame` controls give
+  # above: a subject test answering `TRUE` for everything leaves every zero in
+  # this file reading exactly as it does now.
+  expect_identical(count_backend_reads(tibble::as_tibble(data)), 0L)
 })
 
 test_that("backend kinds granted the collect_selection_proxy capability", {


### PR DESCRIPTION
Closes #301.

#300 gave the catalog a subject test and put `as.data.frame` behind one, which
counts every conversion reaching it while the caller's lazy object is still the
subject. One conversion path reaches it only after that has stopped being true:
`as_tibble()` on a dtplyr step evaluates the step and converts the resulting
`data.table`, so the entry sees a local table and the read is counted zero while
three rows come back. The generic that does see the step is
`tibble::as_tibble`, which the catalog did not name. One row added,
subject-tested; two test files, no change under `R/`.

## What the entry covers, and what it does not

The conversion, not the backend. Measured on both sides of this branch:

| expression | main | here | rows |
|---|---|---|---|
| `tibble::as_tibble(<lazy_dt>)` | 0 | 1 | 3 |
| `dplyr::as_tibble(<lazy_dt>)` | 0 | 1 | 3 |
| `as.tibble(<lazy_dt>)` | 0 | 1 | 3 |
| `as_data_frame(<lazy_dt>)` | 0 | 1 | 3 |
| `as.data.frame(<lazy_dt>)` | 1 | 1 | 3 |

The last row is why the header says conversion rather than backend: dtplyr
registers an `as.data.frame` method, so the base generic is reached with the
step and that spelling was never the gap. The subjects the generic actually
sees are `dtplyr_step_first, data.table` on that path and `data.table` alone on
the `as_tibble` one.

The three remaining spellings close from the one entry because the two
deprecated ones delegate to the generic from inside tibble's own namespace, so
the caller's spelling does not decide whether the traced binding is reached.

## Why the generic, and why a subject test

Traced at the generic for the reason #254 gives for `dplyr::collect`, not for
the reason #301's body gives. That body says no `as_tibble` method is registered
for `dtplyr_step`; `as_tibble.dtplyr_step` is registered, and tracing a method
would see only a by-name call. The generic runs before dispatch, which is where
the step is still the subject.

The subject test is what the entry needs rather than an option it takes.
Converting a dtplyr step invokes the generic twice — once on the step, once on
the local table it produced — so an unfiltered entry would report two for one
read, and would count every `as_tibble()` any package makes on a local frame.

## What holds it

Both directions, as the `as.data.frame` controls do: a subject test answering
`TRUE` for everything and one answering `FALSE` for everything leave every zero
in the file reading exactly as it does now. The negative control is the local
frame.

Every expectation names its package. `trace()` rewrites a namespace binding and
the copy an importing package's imports environment holds, but not the attached
`package:tibble` one, so a bare `as_tibble()` written in a test counts nothing
while reading exactly as these do. That is #303, along with the
nested-entry-point hole it shares a cause with; neither is answered here.

The dtplyr assertions sit in a `test_that()` of their own behind
`skip_if_suggest_absent("dtplyr")`, so no test requires two members of
`optional_backends()`. `verify-suite-coverage.R` passes with the new test
executing in exactly one of the five single-backend configurations.

## Not changed

The Arrow test, in every number it asserts — both positive controls, the schema
and local-frame negatives, the two verb zeroes, and the four refusal shapes —
measured with the entry present. The reach snapshot, since `R/` writes no
`as_tibble()` call on data; its three mentions are all roxygen.

ADR 0020 is untouched. Membership is what the snapshot records, and the
decision, its two exemptions, and its test strategy are unchanged.

`summarize_with_margins()` on dtplyr goes from 1 to 2 — exemption 1 of ADR 0020
counted at two entries on one path. Nothing asserts it, as nothing asserts the 3
`collect()` already reports on duckdb. #304 holds what that number's name costs.
