### PR TITLE
State each review-record argument once, and record a review that did not run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,13 +626,12 @@ This is a single-context repo. Read the root `CONTEXT.md` and relevant ADRs unde
 
 ### Code review
 
-Reviews run through `mattpocock-skills:code-review`, which composes its own
-sub-agent prompts, so what an invocation does not carry does not reach either
-axis. Pass what a finding about prose may be — *Answering a review* in
-`design/architecture.md` — alongside the standards sources. Review against the
-merge-base with `main`, and push the branch and open the pull request before
-writing the record, which goes there. `design/agents/code-review.md` maps the
-rest of what the skill expects onto this repository.
+Reviews run through `mattpocock-skills:code-review`. Pass what a finding about
+prose may be — *Answering a review* in `design/architecture.md` — alongside the
+standards sources. Review against the merge-base with `main`, and push the
+branch and open the pull request before writing the record, which goes there. A
+branch that ran no review records that instead. `design/agents/code-review.md`
+maps the rest of what the skill expects onto this repository.
 
 ### Investigation notes
 

--- a/design/agents/code-review.md
+++ b/design/agents/code-review.md
@@ -2,11 +2,13 @@
 
 Reviews here run through that skill. It reviews the diff since a fixed point on two axes — Standards and Spec — as parallel sub-agents. This file maps what it expects onto what this repository has.
 
-What may be a finding, and how one is answered, is not here. `design/architecture.md`'s *Answering a review* governs that, for this reviewer and for any other. `AGENTS.md` carries what the invocation has to hand this skill, because `SKILL.md` step 4 composes both sub-agent prompts from the standards sources the call names and nothing else reaches them.
+What may be a finding, and how one is answered, is not here. `design/architecture.md`'s *Answering a review* governs that, for this reviewer and for any other. `AGENTS.md` carries what the invocation has to hand this skill, because `SKILL.md` step 4 composes both sub-agent prompts from the standards sources the call names.
 
 ## What is reviewed, and where the record goes
 
 The subject is a diff, so the record goes where the diff is: the pull request. An issue gets a pointer and not a copy — the issue is where the ticket is argued, and a second copy of the record is one more thing to keep in step.
+
+`AGENTS.md` has a branch that ran no review record that, because a missing record reads exactly like a round that raised nothing. #300 merged two test files with no round run and no record; #305, of the same shape, ran one that raised three findings and posted them. Nothing in #300 tells the two apart, and it opened 81 minutes after #299 put the review instructions in the always-loaded closure — so what it was missing was a clause and not the reach to find one. One sentence is the whole record when no round ran, and it is what makes a skipped review a decision rather than the absence of one.
 
 A record names the snapshot it read, which is why `AGENTS.md` has the branch pushed and the pull request open before one is written: a SHA on an unpushed branch resolves for nobody. #280's review was posted to the issue while its branch was still local, so every SHA in it cited a commit no reader could open, and the record had to be moved (PR #286). For the same reason, rebase before the review and not after — a rebase rewrites the SHAs a published record already named.
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -672,14 +672,10 @@ material. They are separate from the generated package site in `docs/`;
 packages. Internal architecture is not duplicated into the README or
 vignettes.
 
-A review is not written down a second time. What a review produced records it:
-the commit that names a finding, the test that fails without the fix, the diff
-that changed the prose. What a review decided without producing anything goes
-where that kind of decision lives — an ADR's *Considered options* for an
-alternative weighed and rejected, a dated `investigation/` note for a premise
-measured false, a comment at the site for a site deliberately left alone.
-`design/agents/code-review.md` routes them, and #288 is where a ledger holding
-the same dispositions a third time was retired.
+A review gets no file here. What a review produced records it, and what it
+decided without producing anything goes where that kind of decision already
+lives; `design/agents/code-review.md` routes both by kind, and #288 is where a
+ledger holding the same dispositions again was retired.
 
 An ADR is amended when its decision changed observably, and the amendment
 records what the decision now is and what moved with it. The argument for


### PR DESCRIPTION
Closes #306. Three files, all `.Rbuildignore`d — `lint.yaml`'s context-budget gate is the only CI path any of them reaches.

## The routing, stated once

`design/architecture.md`'s *Repository placement* restated five of the six rows of `design/agents/code-review.md`'s disposition table and then pointed at the table. #290 put it there on purpose — "now states the same thing in one paragraph instead of pointing at a file" — and the result does both, so a row added to either goes stale with nothing reading them together. It already had: the paragraph said the ledger held its dispositions "a third time" where the table's file and #288 both say a second.

That section keeps the claim it owns, which is a placement claim and not a routing one: a review gets no file under `design/`. Every route the paragraph named is in the table already, checked row by row.

## The clause the rule lacked

#287 said where a record goes and what state the branch must be in. It never said a branch owes one, so no record has two readings:

| | round run | record |
|---|---|---|
| #300 — two test files, +149 / -39 | none | none |
| #305 — same shape | one, three findings | posted |

#300 opened 81 minutes after #299 merged, moving the review instructions into the always-loaded closure, so this is not a branch that failed to reach the rule — the rule had no clause it could have reached. A branch that ran no review now records that, which is one sentence and makes a skip a decision.

It goes in the closure rather than behind the pointer for the same reason #299's three do: an agent that never invokes the skill never opens `design/agents/code-review.md`, and that agent is precisely the case this governs.

## What paid for it

A deletion in the same section, and the round on this branch is what found it. `AGENTS.md` said the skill "composes its own sub-agent prompts, so what an invocation does not carry does not reach either axis"; `design/agents/code-review.md` said the same as "nothing else reaches them". Both are false — the always-loaded closure reaches a sub-agent whether or not the invocation names it — so both are deleted rather than restated, per *Answering a review*. The instruction to pass the standards sources stands without either, and `SKILL.md` step 4 still says what composes the prompts.

The baseline does not move: **38,753 of 38,810**, verified by `.github/scripts/verify-context-budget.R`.

## Not done here

The #300 case is now recorded rather than gated. Nothing fails when a pull request carries no record, consistent with how this repository treats the comment policy and the dependency audit — and unlike the closure, a record's presence has no derivation that could stand in for reading it.