### PR TITLE
Read a nested argument through its redundant parentheses

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,7 +20,9 @@ An argument of a Grouping specification constructor, where a nested Grouping
 specification and a column selection are both allowed. Which one is meant is
 decided by how the argument is written: a call to a constructor, or a name
 bound to a specification, is a nested specification, and every other argument
-is a column selection. A spelling the position does not recognize is never
+is a column selection. Redundant parentheses are transparent to that reading,
+around the name or around the whole call, because `(` is the identity
+function. A spelling the position does not recognize is never
 evaluated to find out, because a selection such as `starts_with("re")` has no
 meaning outside a selection context. Both readings claim one argument at once:
 a bare name that is a column of the input and is also bound, in the caller's

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,11 @@
   a column of your input that is also bound to a nested specification the
   position accepts — is refused rather than resolved by whichever the data
   happens to have, and the refusal names the spelling for each reading:
-  `all_of("s")` for the column, `!!s` for the specification.
+  `all_of("s")` for the column, `!!s` for the specification. Redundant
+  parentheses are transparent to every one of these readings, as they are
+  elsewhere, because `(` is the identity function: `(s)`, `(!!s)`, and
+  `(rollup(region))` are the arguments they wrap, however many pairs deep, and
+  both refusals reach a parenthesized argument as they reach a bare one.
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -359,6 +359,14 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   list(spec = grouping_spec, name_only = name_only)
 }
 
+# The spelling a nested position reads an argument by: the caller's expression
+# with its redundant parentheses removed (#178, #259). The argument may be one
+# a caller left empty, so the answer may be R's empty argument, and a reader
+# passes it on as a value rather than binding it (#168, #174).
+nested_arg_expr <- function(arg) {
+  unparenthesized_value(rlang::quo_get_expr(arg))
+}
+
 # Refuses the one argument both readings claim: a bare name that is a column of
 # the input and is bound to a specification of a kind this position admits.
 # ADR 0026 holds that decision -- why such a name is refused rather than
@@ -370,6 +378,12 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # "selection" for a symbol, asked again here because the gate reports which
 # reading it took and not why. A name nothing binds has no second reading, and
 # a name the data does not hold is resolved by the gate itself.
+#
+# The name is read through the gate's own parenthesis reading, so a refusal
+# `s` gets is a refusal `(s)` gets. Reading the caller's expression here
+# instead would withhold it from the parenthesized spelling, which is the
+# reading ADR 0026 refuses reached by a pair the gate has already dropped
+# (#259).
 #
 # The kinds this position admits are asked before the binding is read: where a
 # position admits none, the answer is already known, and reading a caller's
@@ -410,10 +424,10 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # lookup twice. It is derived from the parent's kind, so the pair handed to the
 # memo below carries nothing that memo's key does not.
 check_ambiguous_nested_name <- function(arg, parent, rule, data_vars) {
-  if (!is_name_part(rlang::quo_get_expr(arg))) {
+  if (!is_name_part(nested_arg_expr(arg))) {
     return(invisible(NULL))
   }
-  name <- rlang::as_string(rlang::quo_get_expr(arg))
+  name <- rlang::as_string(nested_arg_expr(arg))
   if (
     !name %in% data_vars ||
       !rlang::env_has(rlang::quo_get_env(arg), name, inherit = TRUE)
@@ -879,6 +893,28 @@ grouping_constructor_names <- function() {
 
 grouping_arg_spec <- function(arg, data_vars) {
   expr <- rlang::quo_get_expr(arg)
+  # A pair of redundant parentheses is read through here as it is everywhere
+  # else (#178, ADR 0019): `(` is the identity function, so `(s)` and `s` are
+  # one argument written two ways and every reading below answers the two
+  # alike. The shared readers give a *call* that property already, which is why
+  # `(rollup(region))` was recognized while `(s)` and `(!!s)` were not -- a
+  # shape test put to the caller's own expression reaches none of them (#259).
+  #
+  # By restarting on the argument the pair wraps rather than by rebinding
+  # `expr`, which is the rule `R/utils.R` states and
+  # `static_spelling_reference_name()` follows: what the pair wraps may be R's
+  # empty argument, and binding the missing marker raises `missingArgError` on
+  # the next read of it (#168, #174). `is_parenthesized()` answers `FALSE` for
+  # a constructed pair holding one, so the restart cannot repeat.
+  if (is_parenthesized(expr)) {
+    return(grouping_arg_spec(
+      rlang::new_quosure(
+        unparenthesized_value(expr),
+        rlang::quo_get_env(arg)
+      ),
+      data_vars
+    ))
+  }
   if (
     is.symbol(expr) &&
       is_name_only_expr(
@@ -943,7 +979,7 @@ resolve_grouping_selection <- function(arg, data_proxy) {
       on_rename = abort_grouping_rename
     ),
     error = function(cnd) {
-      label <- rlang::as_label(rlang::quo_get_expr(arg))
+      label <- rlang::as_label(nested_arg_expr(arg))
       if (!is_grouping_spec_subscript(cnd, label)) {
         stop(cnd)
       }
@@ -963,6 +999,16 @@ resolve_grouping_selection <- function(arg, data_proxy) {
 # they have already made. Comparing the labels is what separates the two, and
 # both are written by `rlang::as_label()` from the same expression when the
 # argument as a whole is what was refused.
+#
+# Both sides of that comparison are unparenthesized, which is what makes them
+# comparable at all. tidyselect descends into a `(` call before it refuses
+# anything, so `(f(region))` reaches here reported as `f(region)`, and a label
+# taken from the caller's expression matched neither itself nor the argument it
+# wraps -- so #190's diagnostic was withheld from the parenthesized spelling
+# and the caller received the tidyselect report this exists to replace (#259).
+# `nested_arg_expr()` is what the label is written from for that reason. The
+# sub-selection case is unaffected: `c((s), region)` labels the whole argument,
+# which is not the `s` tidyselect refused inside it.
 #
 # Where a column shares the name, tidyselect refuses nothing and none of this
 # runs: `c(s, region)` selects the column `s`, which is the one reading a

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -893,25 +893,21 @@ grouping_constructor_names <- function() {
 
 grouping_arg_spec <- function(arg, data_vars) {
   expr <- rlang::quo_get_expr(arg)
-  # A pair of redundant parentheses is read through here as it is everywhere
-  # else (#178, ADR 0019): `(` is the identity function, so `(s)` and `s` are
-  # one argument written two ways and every reading below answers the two
-  # alike. The shared readers give a *call* that property already, which is why
-  # `(rollup(region))` was recognized while `(s)` and `(!!s)` were not -- a
-  # shape test put to the caller's own expression reaches none of them (#259).
+  # A redundantly parenthesized argument is read as the argument it wraps, as
+  # it is wherever a reading is taken from `R/utils.R`'s readers (#178,
+  # ADR 0019). The tests below take none: they ask `is.symbol()` and
+  # `is.language()` about the caller's own expression, so this site restarts on
+  # what the pair wraps rather than inheriting the reading (#259).
   #
-  # By restarting on the argument the pair wraps rather than by rebinding
-  # `expr`, which is the rule `R/utils.R` states and
-  # `static_spelling_reference_name()` follows: what the pair wraps may be R's
-  # empty argument, and binding the missing marker raises `missingArgError` on
-  # the next read of it (#168, #174). `is_parenthesized()` answers `FALSE` for
-  # a constructed pair holding one, so the restart cannot repeat.
+  # By restart rather than by rebinding `expr`, which is the rule `R/utils.R`
+  # states and `static_spelling_reference_name()` follows: what a pair wraps
+  # may be R's empty argument, and binding the missing marker raises
+  # `missingArgError` on the next read of it (#168, #174). `is_parenthesized()`
+  # answers `FALSE` for a constructed pair holding one, so the restart cannot
+  # repeat.
   if (is_parenthesized(expr)) {
     return(grouping_arg_spec(
-      rlang::new_quosure(
-        unparenthesized_value(expr),
-        rlang::quo_get_env(arg)
-      ),
+      rlang::new_quosure(nested_arg_expr(arg), rlang::quo_get_env(arg)),
       data_vars
     ))
   }
@@ -1001,14 +997,18 @@ resolve_grouping_selection <- function(arg, data_proxy) {
 # argument as a whole is what was refused.
 #
 # Both sides of that comparison are unparenthesized, which is what makes them
-# comparable at all. tidyselect descends into a `(` call before it refuses
-# anything, so `(f(region))` reaches here reported as `f(region)`, and a label
-# taken from the caller's expression matched neither itself nor the argument it
-# wraps -- so #190's diagnostic was withheld from the parenthesized spelling
-# and the caller received the tidyselect report this exists to replace (#259).
-# `nested_arg_expr()` is what the label is written from for that reason. The
-# sub-selection case is unaffected: `c((s), region)` labels the whole argument,
-# which is not the `s` tidyselect refused inside it.
+# comparable. tidyselect descends into a `(` call before it refuses anything,
+# so `(f(region))` arrives here reported as `f(region)`, and a label written
+# from the caller's expression matches neither that nor the argument it wraps
+# (#259). `nested_arg_expr()` is what the label is written from for that
+# reason.
+#
+# The refusal then names that same label, so `(f(region))` is refused in the
+# words `f(region)` is. ADR 0019's third amendment holds that against
+# ADR 0024's spelling rule.
+#
+# The sub-selection case is unaffected: `c((s), region)` labels the whole
+# argument, which is not the `s` tidyselect refused inside it.
 #
 # Where a column shares the name, tidyselect refuses nothing and none of this
 # runs: `c(s, region)` selects the column `s`, which is the one reading a

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -40,6 +40,9 @@
 #'
 #'   A nested Grouping specification is recognized by how it is written: a
 #'   call to one of these constructors, or a name bound to a specification.
+#'   Redundant parentheses are transparent to that reading, because `(` is the
+#'   identity function: `(s)` is the specification `s` is, and
+#'   `(rollup(region))` is the call it wraps, however many pairs deep.
 #'   Any other argument is a column selection, so a call of your own that
 #'   returns a specification is refused where it is nested even though it is
 #'   accepted as `.grouping` itself. Assign what it returns to a name and use

--- a/R/utils.R
+++ b/R/utils.R
@@ -315,8 +315,8 @@ is_redundant_parens <- function(expr) {
 
 # Whether unwrapping answers a different node, which is what a reader that
 # restarts on what the parentheses wrap has to know before it restarts. Asked
-# here rather than compared at each site so that the three walks that restart
-# share one test, and so that none of them binds the answer to a local: a call
+# here rather than compared at each site so that every reader that restarts
+# shares one test, and so that none of them binds the answer to a local: a call
 # part may be R's empty argument, and `unparenthesized_value()` stops at one
 # rather than answering it.
 is_parenthesized <- function(expr) {

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -600,18 +600,38 @@ two labels could not match and #190's diagnostic was withheld from
 **What the amendment above establishes still stands**, and the correction is to
 its reach rather than to its argument. Identity is still syntactic, a caller
 binding still cannot win, and the reading still lives in one place: these three
-sites now *ask* for it — the first by restarting on the argument the pair wraps,
-the other two through `nested_arg_expr()`, which is `unparenthesized_value()`
-put to a quosure. Nothing is re-implemented, which is what "one place, not one
-place per family" means for a caller.
+sites now *ask* for it, through `nested_arg_expr()`, which is
+`unparenthesized_value()` put to a quosure; the gate additionally restarts on
+the argument the pair wraps, because what follows its shape test is an
+evaluation of that argument. Nothing is re-implemented, which is what "one
+place, not one place per family" means for a caller.
 
-**What a read-through argument costs is the reading of the argument it wraps,
-including how often it is evaluated.** A `(s)` that becomes a recognized name
-is evaluated as a recognized name is, and a `(1)` is evaluated as `1` is, which
-for a literal is one `eval_tidy()` that was not made before. Pinning that
-number is #260's, so what #259 asserts is the equality of the two spellings'
-counts: neither can drift from the other without the assertion failing, and
-nothing pins the same number twice.
+**The refusal names the argument the pair wraps, and that is decided here
+rather than by ADR 0024.** `resolve_grouping_selection()` writes one label, and
+it is both the key compared against tidyselect's subscript and the subject
+`abort_nested_grouping_spec()` names, so `grouping_sets((f(region)))` is
+refused in the words `grouping_sets(f(region))` is refused in. Splitting the
+two would let the refusal name `(f(region))`, which is closer to what ADR 0024
+asks of a Package condition's subject. It is not taken, for the reason the
+first amendment already accepts of a rewritten expression — "a diagnostic dplyr
+raises about that argument echoes it without the pair" — and because a caller
+who wrote one spelling and read the other's diagnostic would be reading a
+difference this whole amendment exists to say does not exist. What ADR 0024
+protects is a spelling a reader searches their source for, and a redundant pair
+is one they find their argument inside of; what it was written for is a value
+whose bytes cli would otherwise collapse, which no parenthesis rule touches.
+
+**What a read-through argument gains is the reading of the argument it wraps,
+and not a further evaluation of it.** A `(s)` that becomes a recognized name is
+evaluated as a recognized name is. No count moves: measured against the
+pre-#259 package over eight argument shapes, each written bare and wrapped in
+one pair and two, with the binding an active binding and the caller's function
+counting its own calls, every count is the count it was. What the gate now
+evaluates and did not recognize — a literal, an injected object — is a
+constant, so nothing a caller wrote runs there to be counted.
+Pinning each form's number is #260's, so what #259 asserts is the equality of
+the two spellings' counts: neither can drift from the other without the
+assertion failing, and nothing pins the same number twice.
 
 **Where a pair is not around the argument, nothing changes.** `c((s), region)`
 is a selection containing a specification, which tidyselect refuses and reports

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -571,3 +571,50 @@ A caller's two mistakes at once are a case of their own, since which message
 wins is a per-helper decision that no equality above would notice changing, and
 so is the named empty argument, which is the only writing that reaches the
 un-injected change recorded above.
+
+## Amendment: the read-through reaches a reading, not an expression
+
+"Redundant parentheses are read through, in one place" above put the reading in
+`R/utils.R`'s shared readers and said that every analysis inherits it, naming
+the constructor gate among them. That is true of what those readers answer — a
+name, a namespace, a head, a set of arguments — and it is not true of a site
+that puts a shape test to the caller's own expression instead of asking one of
+them. Such a site inherits nothing, and there is no reading for it to inherit:
+`is.symbol()` is R's, and `(s)` is a call to `(`.
+
+Three sites in `R/grouping-plan.R` were of that kind, and #259 brings them
+under the rule. `grouping_arg_spec()` recognized a nested constructor call
+through a pair of parentheses, because it reads that call's name through
+`static_spelling_name()`, while asking `is.symbol()` about a name and
+`is.language()` about an injected object — so `(rollup(region))` was the
+specification it is and `(s)` and `(!!s)` were column selections.
+`check_ambiguous_nested_name()` asked `is_name_part()`, so ADR 0026's refusal
+of a name two readings claim was withheld from `(s)`, which selected a
+colliding column silently — the reading that ADR exists to remove, reached by a
+pair of parentheses. And `resolve_grouping_selection()` compared
+`rlang::as_label()` of the caller's expression against the subscript tidyselect
+refused; tidyselect descends into a `(` call before refusing anything, so the
+two labels could not match and #190's diagnostic was withheld from
+`(f(region))`.
+
+**What the amendment above establishes still stands**, and the correction is to
+its reach rather than to its argument. Identity is still syntactic, a caller
+binding still cannot win, and the reading still lives in one place: these three
+sites now *ask* for it — the first by restarting on the argument the pair wraps,
+the other two through `nested_arg_expr()`, which is `unparenthesized_value()`
+put to a quosure. Nothing is re-implemented, which is what "one place, not one
+place per family" means for a caller.
+
+**What a read-through argument costs is the reading of the argument it wraps,
+including how often it is evaluated.** A `(s)` that becomes a recognized name
+is evaluated as a recognized name is, and a `(1)` is evaluated as `1` is, which
+for a literal is one `eval_tidy()` that was not made before. Pinning that
+number is #260's, so what #259 asserts is the equality of the two spellings'
+counts: neither can drift from the other without the assertion failing, and
+nothing pins the same number twice.
+
+**Where a pair is not around the argument, nothing changes.** `c((s), region)`
+is a selection containing a specification, which tidyselect refuses and reports
+for itself; the label the position compares is the whole argument's, which is
+not the sub-selection tidyselect refused. That separation is the reason the
+comparison exists, and reading through does not touch it.

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -587,7 +587,10 @@ under the rule. `grouping_arg_spec()` recognized a nested constructor call
 through a pair of parentheses, because it reads that call's name through
 `static_spelling_name()`, while asking `is.symbol()` about a name and
 `is.language()` about an injected object — so `(rollup(region))` was the
-specification it is and `(s)` and `(!!s)` were column selections.
+specification it is and `(s)` was a column selection. An injected object was
+reached by the second pair rather than the first, `rlang::enquos()` dropping
+one pair around `!!` as it captures: `((!!s))` was a selection where `(!!s)`
+was already the specification.
 `check_ambiguous_nested_name()` asked `is_name_part()`, so ADR 0026's refusal
 of a name two readings claim was withheld from `(s)`, which selected a
 colliding column silently — the reading that ADR exists to remove, reached by a

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -622,13 +622,29 @@ is one they find their argument inside of; what it was written for is a value
 whose bytes cli would otherwise collapse, which no parenthesis rule touches.
 
 **What a read-through argument gains is the reading of the argument it wraps,
-and not a further evaluation of it.** A `(s)` that becomes a recognized name is
-evaluated as a recognized name is. No count moves: measured against the
-pre-#259 package over eight argument shapes, each written bare and wrapped in
-one pair and two, with the binding an active binding and the caller's function
-counting its own calls, every count is the count it was. What the gate now
-evaluates and did not recognize — a literal, an injected object — is a
-constant, so nothing a caller wrote runs there to be counted.
+evaluation count included.** Measured against the pre-#259 package through
+`inspect_grouping()`, with the binding an active binding and the caller's
+function counting its own calls: no *bare* argument's count moves, and a
+parenthesized name gains what the bare name costs. `grouping_sets((s))` reads
+`s` once before and three times after, which is what `grouping_sets(s)` read
+before and reads still — whether the binding is a specification the gate then
+recognizes or something else it then declines, since the gate has to read one
+to tell them apart.
+
+That is a cost, and it is the decision rather than an oversight: a spelling
+read as another spelling costs what that spelling costs, and a parenthesis
+rule that stopped short of the evaluation would be the two readings this
+amendment exists to remove, moved one step down. A pair around a *call* is free
+by comparison, the gate having recognized `(f(x))` all along.
+
+#259's sixth acceptance criterion asks for an unchanged count "for every
+argument whose reading does not change", and blesses the recognized `(s)` that
+gains one. The shape between the two is a parenthesized name bound to
+something that is *not* a specification: the plan is what it was, and the gate
+now reads the binding to establish that. It is the same read on the same line,
+so it is accepted with the criterion's second sentence rather than against its
+first.
+
 Pinning each form's number is #260's, so what #259 asserts is the equality of
 the two spellings' counts: neither can drift from the other without the
 assertion failing, and nothing pins the same number twice.

--- a/design/adr/0024-spell-a-callers-subject-as-the-caller-wrote-it.md
+++ b/design/adr/0024-spell-a-callers-subject-as-the-caller-wrote-it.md
@@ -117,6 +117,13 @@ serial `and` and drops the names bullets are carried in.
 The measurements are in
 `investigation/expanding-a-diagnostic-when-it-is-raised.md`.
 
+What this decision is about is the bytes of a subject surviving from the raise
+to the read. It is not about an expression a static reading has already
+normalized before any condition is built: ADR 0019's third amendment decides
+that a nested position refuses `(f(region))` in the words `f(region)`, and
+scopes this decision there rather than here, where the subject is a value cli
+would otherwise collapse.
+
 ## Considered Options
 
 **Accept the collapsing and document it** — the option #230 opened with, and the

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -170,7 +170,9 @@ ways, and the readers here answer the three alike — which is what gives every
 analysis above that property at once instead of each family recognizing
 whichever forms someone wrote out (#178, ADR 0019). Name and operands are read
 through the same unwrapping, so a node cannot be named as its content and
-subscripted as its wrapper.
+subscripted as its wrapper. What inherits the reading is an answer taken from
+these readers; a site that puts a shape test to the caller's own expression
+asks for it instead, which is ADR 0019's third amendment (#259).
 
 The unwrapping is syntactic and stops there: it reads a name that is written,
 never one that would have to be looked up. So `(get("f"))(x)`, `(function(x)

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -35,6 +35,9 @@ identity product (the empty grouping set).
 
 A nested Grouping specification is recognized by how it is written: a
 call to one of these constructors, or a name bound to a specification.
+Redundant parentheses are transparent to that reading, because \code{(} is the
+identity function: \code{(s)} is the specification \code{s} is, and
+\code{(rollup(region))} is the call it wraps, however many pairs deep.
 Any other argument is a column selection, so a call of your own that
 returns a specification is refused where it is nested even though it is
 accepted as \code{.grouping} itself. Assign what it returns to a name and use

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -313,6 +313,162 @@ test_that("a nested column selection is unaffected by the specification rule", {
   expect_equal(compile(inside)$sets, list(c("region", "grade")))
 })
 
+test_that("a nested argument is read through its redundant parentheses", {
+  data_vars <- c("region", "grade", "value")
+  bound <- rollup(value)
+  env <- rlang::env(rlang::current_env(), s = bound)
+  env$spec_from_caller <- function(...) rollup(...)
+  parenthesized <- function(argument) rlang::call2("(", argument)
+
+  # What the position did with an argument, as one comparable value. A refusal
+  # is as much a reading as a plan is, and the two spellings have to agree
+  # about which refusal as well: an argument read as a selection carries
+  # tidyselect's own condition, and comparing the class with the message is
+  # what keeps that from passing as marginplyr's.
+  outcome <- function(constructor, argument) {
+    tryCatch(
+      compile_against(
+        eval(rlang::call2(constructor, argument), envir = env),
+        data_vars
+      )$sets,
+      error = function(cnd) list(class(cnd), conditionMessage(cnd))
+    )
+  }
+
+  # Every spelling a nested argument can have, so that the rule is one rule
+  # rather than one per shape: the two recognized forms, the injected object
+  # the ambiguity refusal tells a caller to write, a caller's own function, a
+  # column, two selections, and a literal. Each is compared against itself
+  # wrapped in one pair and in two, since `(` is the identity function however
+  # many times it is applied (#178).
+  arguments <- list(
+    name = quote(s),
+    constructor_call = quote(rollup(value)),
+    injected_object = bound,
+    caller_call = quote(spec_from_caller(value)),
+    column = quote(value),
+    selection = quote(c(value, grade)),
+    spec_in_selection = quote(c(s, grade)),
+    literal = 1L
+  )
+
+  # Derived from the registry, so a sixth constructor arrives here as a
+  # position the rule has to hold in rather than as one nothing covers.
+  for (rule in grouping_kind_rules()) {
+    for (argument in arguments) {
+      bare <- suppressWarnings(outcome(rule$constructor, argument))
+      expect_identical(
+        suppressWarnings(outcome(rule$constructor, parenthesized(argument))),
+        bare
+      )
+      expect_identical(
+        suppressWarnings(
+          outcome(rule$constructor, parenthesized(parenthesized(argument)))
+        ),
+        bare
+      )
+    }
+  }
+
+  # The two readings the ticket reproduced, asserted on what a caller sees
+  # rather than on the agreement above: a name bound to a specification
+  # resolves to the plan the bare name resolves to, and a caller's own function
+  # gets #190's diagnostic, on the complete message.
+  data <- data.frame(region = c("a", "b"), value = c(1, 2))
+  expect_identical(
+    eval(quote(inspect_grouping(data, .grouping = grouping_sets((s)))), env),
+    eval(quote(inspect_grouping(data, .grouping = grouping_sets(s))), env)
+  )
+  refused <- expect_error(eval(
+    quote(inspect_grouping(
+      data,
+      .grouping = grouping_sets((spec_from_caller(region)))
+    )),
+    env
+  ))
+  expect_s3_class(refused, "marginplyr_error")
+  expect_identical(
+    conditionMessage(refused),
+    paste0(
+      "`spec_from_caller(region)` is a grouping specification, but a nested ",
+      "position recognizes one only when it is a call to `grouping_set()`, ",
+      "`grouping_sets()`, `rollup()`, `cube()`, or `grouping_spec()`, or a ",
+      "name bound to a specification.\n",
+      "i Anything else is read as a column selection.\n",
+      "i Assign the specification to a name first, then use that name here."
+    )
+  )
+
+  # A pair the caller wrote inside a selection is not a pair around the
+  # argument, so tidyselect keeps the sub-selection it refused and the position
+  # does not speak for it. This is the property the label comparison exists for
+  # and the one a change to it can break, so both spellings are written out.
+  for (selection in list(quote(c(s, region)), quote(c((s), region)))) {
+    spec <- eval(rlang::call2("grouping_sets", selection), envir = env)
+    embedded <- expect_error(suppressWarnings(compile_against(spec, data_vars)))
+    expect_false(inherits(embedded, "marginplyr_error"))
+    expect_match(conditionMessage(embedded), "Can't select columns with `s`")
+  }
+
+  # A colliding column is what ADR 0026 refuses, and a pair of parentheses was
+  # enough to withhold that refusal: `s` was refused while `(s)` selected the
+  # column, silently, which is the reading the ADR exists to remove.
+  for (argument in list(quote(s), quote((s)), quote(((s))))) {
+    spec <- eval(rlang::call2("grouping_sets", argument), envir = env)
+    ambiguous <- expect_error(compile_against(spec, c("s", data_vars)))
+    expect_s3_class(ambiguous, "marginplyr_error")
+    expect_identical(conditionMessage(ambiguous), ambiguous_s_message)
+  }
+})
+
+test_that("a parenthesized nested argument is evaluated as its own count", {
+  data_vars <- c("region", "grade", "value")
+  bound <- rollup(value)
+
+  # How often a caller's quosure runs is what #260 pins for each recognized
+  # form. What belongs here is the weaker property that survives whatever it
+  # pins: reading through a pair of parentheses gives the argument the count of
+  # the argument it wraps, so neither spelling can drift from the other without
+  # this failing. Counting an absolute here would pin the same numbers twice.
+  count_reads <- function(argument) {
+    reads <- 0L
+    env <- rlang::env(rlang::current_env())
+    makeActiveBinding(
+      "s",
+      function() {
+        reads <<- reads + 1L
+        bound
+      },
+      env
+    )
+    env$spec_from_caller <- function(...) {
+      reads <<- reads + 1L
+      rollup(...)
+    }
+    spec <- eval(rlang::call2("grouping_sets", argument), envir = env)
+    tryCatch(
+      suppressWarnings(compile_against(spec, data_vars)),
+      error = function(cnd) NULL
+    )
+    reads
+  }
+
+  # The counter first: a zero below has to be a read that did not happen
+  # rather than a mechanism that stopped counting.
+  expect_identical(count_reads(quote(s)), 2L)
+  expect_identical(count_reads(quote(value)), 0L)
+
+  for (argument in list(quote(s), quote(spec_from_caller(value)))) {
+    bare <- count_reads(argument)
+    expect_gt(bare, 0L)
+    expect_identical(count_reads(rlang::call2("(", argument)), bare)
+    expect_identical(
+      count_reads(rlang::call2("(", rlang::call2("(", argument))),
+      bare
+    )
+  }
+})
+
 test_that("a nested position admits nested kinds by its own parent rule", {
   # The half of "both readings are available" that the input may not answer,
   # and the one thing no behavioural test reaches: an empty answer reads as a

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -320,17 +320,24 @@ test_that("a nested argument is read through its redundant parentheses", {
   env$spec_from_caller <- function(...) rollup(...)
   parenthesized <- function(argument) rlang::call2("(", argument)
 
-  # What the position did with an argument, as one comparable value. A refusal
-  # is as much a reading as a plan is, and the two spellings have to agree
-  # about which refusal as well: an argument read as a selection carries
-  # tidyselect's own condition, and comparing the class with the message is
-  # what keeps that from passing as marginplyr's.
+  # What the position did with an argument, as one comparable value: the whole
+  # Grouping plan where it compiled, since the criterion is the plan and not
+  # its sets alone, and the condition where it did not. A refusal is as much a
+  # reading as a plan is, and the two spellings have to agree about which
+  # refusal as well: an argument read as a selection carries tidyselect's own
+  # condition, and comparing the class with the message is what keeps that from
+  # passing as marginplyr's.
+  #
+  # Warnings are suppressed rather than compared. tidyselect deprecates the
+  # bare external vector two of the arguments below write, and lifecycle
+  # throttles that warning to once a session, so which spelling is warned about
+  # is decided by which ran first.
   outcome <- function(constructor, argument) {
     tryCatch(
       compile_against(
         eval(rlang::call2(constructor, argument), envir = env),
         data_vars
-      )$sets,
+      ),
       error = function(cnd) list(class(cnd), conditionMessage(cnd))
     )
   }
@@ -421,23 +428,28 @@ test_that("a nested argument is read through its redundant parentheses", {
   }
 })
 
-test_that("a parenthesized nested argument is evaluated as its own count", {
+test_that("a parenthesized nested argument is read as often as a bare one", {
   data_vars <- c("region", "grade", "value")
-  bound <- rollup(value)
 
-  # How often a caller's quosure runs is what #260 pins for each recognized
-  # form. What belongs here is the weaker property that survives whatever it
-  # pins: reading through a pair of parentheses gives the argument the count of
-  # the argument it wraps, so neither spelling can drift from the other without
-  # this failing. Counting an absolute here would pin the same numbers twice.
-  count_reads <- function(argument) {
+  # How often a caller's quosure runs for each recognized form is what #260
+  # pins. What belongs here is the property that survives whatever it pins:
+  # reading through a pair of parentheses gives an argument the count of the
+  # argument it wraps, so neither spelling can drift from the other without
+  # this failing. An absolute counted here would pin the same numbers twice.
+  #
+  # `s` is an active binding and `spec_from_caller()` counts its own calls, so
+  # what is counted is every read a caller can observe. A spelling the position
+  # evaluates that reads neither -- a literal, an injected object -- evaluates
+  # a constant, which is why the shapes below are the ones that can be counted
+  # at all.
+  count_reads <- function(argument, value) {
     reads <- 0L
     env <- rlang::env(rlang::current_env())
     makeActiveBinding(
       "s",
       function() {
         reads <<- reads + 1L
-        bound
+        value
       },
       env
     )
@@ -453,17 +465,34 @@ test_that("a parenthesized nested argument is evaluated as its own count", {
     reads
   }
 
-  # The counter first: a zero below has to be a read that did not happen
-  # rather than a mechanism that stopped counting.
-  expect_identical(count_reads(quote(s)), 2L)
-  expect_identical(count_reads(quote(value)), 0L)
+  # The counter first: a zero below has to be a read that did not happen rather
+  # than a mechanism that stopped counting, and a count that moves has to be
+  # this mechanism reporting a read rather than a constant it returns.
+  expect_gt(count_reads(quote(s), rollup(value)), 0L)
+  expect_identical(count_reads(quote(value), rollup(value)), 0L)
 
-  for (argument in list(quote(s), quote(spec_from_caller(value)))) {
-    bare <- count_reads(argument)
+  # Both branches the gate evaluates on and both it declines on, since the
+  # equality has to hold where the pair changed the reading and where it did
+  # not: a name bound to a specification, a name bound to something else, a
+  # caller's own function, and a specification inside a selection.
+  arguments <- list(
+    list(quote(s), rollup(value)),
+    list(quote(s), "region"),
+    list(quote(spec_from_caller(value)), NULL),
+    list(quote(c(s, grade)), rollup(value))
+  )
+  for (argument in arguments) {
+    bare <- count_reads(argument[[1L]], argument[[2L]])
     expect_gt(bare, 0L)
-    expect_identical(count_reads(rlang::call2("(", argument)), bare)
     expect_identical(
-      count_reads(rlang::call2("(", rlang::call2("(", argument))),
+      count_reads(rlang::call2("(", argument[[1L]]), argument[[2L]]),
+      bare
+    )
+    expect_identical(
+      count_reads(
+        rlang::call2("(", rlang::call2("(", argument[[1L]])),
+        argument[[2L]]
+      ),
       bare
     )
   }


### PR DESCRIPTION
Closes #259.

## What this changes

Three readings a Nested specification position makes now read through a
redundantly parenthesized argument, as every reading taken from `R/utils.R`'s
shared readers already did (#178, ADR 0019):

| written | before | after |
|---|---|---|
| `grouping_sets((s))`, `s` bound to a specification | column selection | the specification, as `grouping_sets(s)` |
| `grouping_sets(((!!s)))` | column selection | the specification |
| `grouping_sets((s))`, `s` also a column | selects the column, silently | ADR 0026's ambiguity refusal, as `s` gets |
| `grouping_sets((f(region)))`, `f` a caller's function | tidyselect's subscript error | #190's `marginplyr_error`, as `f(region)` gets |
| `grouping_sets((rollup(region)))` | the specification | unchanged |
| `grouping_sets((!!s))` | the specification | unchanged — `enquos()` drops one pair around `!!` at capture |
| `grouping_sets(c((s), region))` | tidyselect's report | unchanged |

## Decision

#259 required a maintainer's call between two dispositions. The decision is
[recorded on the ticket](https://github.com/sayuks/marginplyr/issues/259#issuecomment-5460036820):
read through in every reading, rather than documenting the name as the one
position the rule does not reach. It rests on two arguments — the rule the
reference page states is about how an argument is written, and `(` is not a way
of writing anything; and `(s)` selected a colliding column silently while `s`
was refused, which is the reading ADR 0026 exists to remove. A third argument
the comment gave was measured false in review and is
[withdrawn](https://github.com/sayuks/marginplyr/issues/259#issuecomment-5460277179).

## How

- `grouping_arg_spec()` restarts on the argument the pair wraps, by recursion
  rather than by rebinding `expr` — the rule `R/utils.R` states and
  `static_spelling_reference_name()` follows, since what a pair wraps may be
  R's empty argument.
- All three sites take the reading from `nested_arg_expr()`, which is
  `unparenthesized_value()` put to a quosure. Nothing re-implements it.

## Evaluation counts

A parenthesized argument gains the count of the argument it wraps; no bare
argument's count moves. Measured against `main`'s `R/` through
`inspect_grouping()`, with the binding an active binding, and re-measured
independently in review over 5 constructors × 10 shapes × 0/1/2 pairs:

| `grouping_sets(…)` | main | branch |
|---|---|---|
| `s` | 3 | 3 |
| `(s)` | 1 | 3 |
| `((s))` | 1 | 3 |

ADR 0019's third amendment records that as the decision it is, and reaches the
ticket's sixth criterion: the criterion blesses the `(s)` that becomes a
recognized name, and the shape between — a parenthesized name bound to
something that is *not* a specification, whose plan is unchanged while the gate
now reads the binding to establish that — is accepted with the criterion's
second sentence rather than against its first.

What the branch *asserts* is the equality of the two spellings' counts, since
pinning each form's number is #260's and nothing may pin it twice.

## #261

Its diagnostic's message and `conditionCall()` are byte-identical to `main`.
The condition's class is not, once `grouping_arg_spec()` is byte-compiled —
`evalError` becomes `getvarError`. That is the compiler's reading of a longer
body and not the raise line, which was checked by moving it. Both are base R's
untyped errors on the path #261 exists to replace, and `?marginplyr`'s contract
covers neither.

## Verification

- `testthat::test_local()` with `NOT_CRAN=true`: full suite passes; the new
  assertions fail against `main`'s `R/`.
- `lintr::lint_package()`: no lints. `spelling::spell_check_package()`: none.
- `verify-suite-coverage.R`: 630 tests, none executing in zero configurations.
- `verify-context-budget.R`: unchanged at baseline.
- All 26 CI checks passed on 4b930cc and again on 634fcf8.

## Review

Three rounds of `mattpocock-skills:code-review`. Round 1 ran both axes and
raised eight findings, answered in 8f1a491. Round 2 verified those answers
against the evidence they landed with and reviewed the executable behaviour
round 1 had not seen — it found the branch's own evaluation-count claim false,
answered in 634fcf8. Round 3 fact-checked every claim the branch's prose makes,
after two measurement errors, and found two more, answered in e40d16d. All
three records are in the comments below.