### PR TITLE
Read a recognized nested specification argument once

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -173,11 +173,8 @@ prepare_grouping_plan <- function(.data,
       }
       # Preflighted once and handed to every compilation pass -- both of them
       # where the plan is settled by names alone, and the one below otherwise.
-      # This is the only reading of a nested argument the call makes, so a
-      # recognized one is evaluated once however many passes run; preflighting
-      # per pass would evaluate it once per pass. ADR-0008 holds the number and
-      # timing of evaluations fixed, and its amendment for a recognized nested
-      # argument is what sets it at one.
+      # This is the call's only reading of a nested argument, so a recognized
+      # one is evaluated once whichever passes run (ADR-0008).
       preflight <- preflight_grouping_spec(grouping_spec, data_vars)
       if (preflight$name_only) {
         # Reject name-only plan errors before acquiring typed metadata. The
@@ -335,17 +332,17 @@ grouping_name_proxy <- function(data_vars) {
   stats::setNames(as.list(seq_along(data_vars)), data_vars)
 }
 
-# The one site that reads a nested argument. What it returns is the
-# specification together with the reading each argument got, so the compilation
-# passes below take none of their own: `args` is parallel to `spec$args`, and
-# holds this function's own answer for a nested specification and `NULL` for a
-# column selection. ADR 0008's amendment for a recognized nested argument is
-# what accepts the reading moving here, and states the counts that hold.
+# The only site that reads a nested argument. It answers with the
+# specification, whether names alone settle the plan, and one record per
+# argument: `quo` is the caller's quosure and `nested` is this function's
+# answer for it, a preflight of the same shape for a nested specification and
+# `NULL` for a column selection. Expansion below reads that answer instead of
+# taking one, which is what holds a recognized argument to one evaluation
+# (ADR 0008).
 #
-# An empty `args` beside a non-`NULL` `spec` is a specification with no
-# arguments, not a specification nothing was read for: the two are told apart
-# by `spec`, which is `NULL` only for the absent `.grouping` that
-# `compile_grouping_spec_impl()` fills in.
+# `spec` is `NULL` only for the absent `.grouping`, which
+# `compile_grouping_spec_impl()` fills in. An empty `args` beside any other
+# `spec` is a specification a caller wrote no arguments for.
 preflight_grouping_spec <- function(grouping_spec, data_vars) {
   stopifnot(is.character(data_vars), !anyNA(data_vars))
   validate_grouping_spec_early(grouping_spec)
@@ -363,13 +360,14 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
     if (is.null(nested)) {
       check_ambiguous_nested_name(arg, grouping_spec, rule, data_vars)
       name_only <- name_only && is_name_only_selection(arg, data_vars)
+      args[[i]] <- list(quo = arg, nested = NULL)
       next
     }
 
     nested_preflight <- preflight_grouping_spec(nested, data_vars)
     rule$validate_nested(grouping_spec, nested_preflight$spec)
     name_only <- name_only && nested_preflight$name_only
-    args[[i]] <- nested_preflight
+    args[[i]] <- list(quo = arg, nested = nested_preflight)
   }
   list(spec = grouping_spec, args = args, name_only = name_only)
 }
@@ -536,10 +534,8 @@ admitted_nested_kinds <- local({
 #
 # `preflight` carries the reading each nested argument got, so a caller running
 # more than one pass over one specification hands the same preflight to each
-# and no pass reads a caller's nested quosure at all. A recognized nested
-# argument is therefore evaluated once per call, whichever passes run
-# (ADR-0008). A column selection is not: each pass resolves one for itself,
-# against its own proxy.
+# and no pass reads a nested quosure of its own. A recognized nested argument
+# is therefore evaluated once per call, whichever passes run (ADR-0008).
 compile_grouping_spec <- function(
   .grouping,
   data_vars,
@@ -565,8 +561,8 @@ compile_grouping_spec <- function(
   )
 }
 
-# `preflight` rather than a specification, because expansion below reads each
-# nested argument's reading off it instead of taking one (ADR 0008).
+# Takes the preflight rather than the specification inside it, because
+# expansion below needs the reading each nested argument got (ADR 0008).
 compile_grouping_spec_impl <- function(preflight,
                                        data_vars,
                                        data_proxy,
@@ -602,9 +598,9 @@ compile_grouping_spec_impl <- function(preflight,
     )
   }
 
-  # The absent `.grouping`, which stands for the empty grouping set. It has no
-  # arguments, so there is nothing for the preflight to have read and the
-  # substitute is complete.
+  # The absent `.grouping` stands for the empty grouping set. Preflighted
+  # rather than written out here, so that one function answers what a record
+  # holds.
   if (is.null(preflight$spec)) {
     preflight <- preflight_grouping_spec(
       new_grouping_spec("set", list()),
@@ -698,12 +694,11 @@ compile_grouping_spec_impl <- function(preflight,
   )
 }
 
-# Expansion takes a preflight rather than a specification, so that a nested
-# argument's reading is read off `preflight$args` rather than taken again
-# (ADR 0008). `data_vars` is gone from the whole chain with the reading: it was
-# what `grouping_arg_spec()` decided a bare name against, and nothing else here
-# asked for it. A column selection is still resolved per pass, against the
-# proxy the pass was given.
+# The families a specification expands to. Every function below it takes the
+# preflight the caller holds, and reads each argument's reading off the record
+# beside that argument's quosure rather than taking one (ADR 0008). A column
+# selection is resolved here and not there, so it is resolved once per pass,
+# against the proxy that pass was given.
 expand_grouping_family <- function(preflight, data_proxy) {
   rule <- find_grouping_kind_rule(preflight$spec$type)
   if (is.null(rule)) {
@@ -717,17 +712,18 @@ expand_single_grouping_set <- function(preflight, data_proxy) {
 }
 
 resolve_grouping_set <- function(preflight, data_proxy) {
-  args <- preflight$spec$args
-  if (length(args) == 0L) {
+  if (length(preflight$args) == 0L) {
     return(character())
   }
 
   cols <- unlist(
     lapply(
-      seq_along(args),
-      function(i) {
-        stopifnot(is.null(preflight$args[[i]]))
-        resolve_grouping_selection(args[[i]], data_proxy)
+      preflight$args,
+      function(arg) {
+        # A `set` admits no nested kind, so the preflight refused one before
+        # this ran (ADR 0015, #159).
+        stopifnot(is.null(arg$nested))
+        resolve_grouping_selection(arg$quo, data_proxy)
       }
     ),
     use.names = FALSE
@@ -736,16 +732,14 @@ resolve_grouping_set <- function(preflight, data_proxy) {
 }
 
 expand_grouping_sets <- function(preflight, data_proxy) {
-  args <- preflight$spec$args
   unlist(
     lapply(
-      seq_along(args),
-      function(i) {
-        nested <- preflight$args[[i]]
-        if (is.null(nested)) {
-          return(list(resolve_grouping_selection(args[[i]], data_proxy)))
+      preflight$args,
+      function(arg) {
+        if (is.null(arg$nested)) {
+          return(list(resolve_grouping_selection(arg$quo, data_proxy)))
         }
-        expand_grouping_family(nested, data_proxy)
+        expand_grouping_family(arg$nested, data_proxy)
       }
     ),
     recursive = FALSE
@@ -753,18 +747,16 @@ expand_grouping_sets <- function(preflight, data_proxy) {
 }
 
 resolve_grouping_units <- function(preflight, data_proxy) {
-  args <- preflight$spec$args
   units <- unlist(
     lapply(
-      seq_along(args),
-      function(i) {
-        nested <- preflight$args[[i]]
-        if (is.null(nested)) {
-          cols <- resolve_grouping_selection(args[[i]], data_proxy)
+      preflight$args,
+      function(arg) {
+        if (is.null(arg$nested)) {
+          cols <- resolve_grouping_selection(arg$quo, data_proxy)
           return(lapply(cols, function(col) col))
         }
-        stopifnot(identical(nested$spec$type, "set"))
-        cols <- resolve_grouping_set(nested, data_proxy)
+        stopifnot(identical(arg$nested$spec$type, "set"))
+        cols <- resolve_grouping_set(arg$nested, data_proxy)
         if (length(cols) == 0L) {
           abort_empty_composite()
         }
@@ -811,17 +803,15 @@ expand_cube <- function(preflight, data_proxy) {
 
 expand_grouping_product <- function(preflight, data_proxy) {
   product <- list(character())
-  args <- preflight$spec$args
-  if (length(args) == 0L) {
+  if (length(preflight$args) == 0L) {
     return(product)
   }
 
-  for (i in seq_along(args)) {
-    nested <- preflight$args[[i]]
-    family <- if (is.null(nested)) {
-      list(resolve_grouping_selection(args[[i]], data_proxy))
+  for (arg in preflight$args) {
+    family <- if (is.null(arg$nested)) {
+      list(resolve_grouping_selection(arg$quo, data_proxy))
     } else {
-      expand_grouping_family(nested, data_proxy)
+      expand_grouping_family(arg$nested, data_proxy)
     }
 
     product <- unlist(

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -173,10 +173,11 @@ prepare_grouping_plan <- function(.data,
       }
       # Preflighted once and handed to every compilation pass -- both of them
       # where the plan is settled by names alone, and the one below otherwise.
-      # Preflight is not a free re-run: `grouping_arg_spec()` evaluates a
-      # symbol or a nested constructor argument, so preflighting per pass would
-      # evaluate a caller's quosure once per pass rather than once, and
-      # ADR-0008 holds the number and timing of evaluations fixed.
+      # This is the only reading of a nested argument the call makes, so a
+      # recognized one is evaluated once however many passes run; preflighting
+      # per pass would evaluate it once per pass. ADR-0008 holds the number and
+      # timing of evaluations fixed, and its amendment for a recognized nested
+      # argument is what sets it at one.
       preflight <- preflight_grouping_spec(grouping_spec, data_vars)
       if (preflight$name_only) {
         # Reject name-only plan errors before acquiring typed metadata. The
@@ -334,17 +335,30 @@ grouping_name_proxy <- function(data_vars) {
   stats::setNames(as.list(seq_along(data_vars)), data_vars)
 }
 
+# The one site that reads a nested argument. What it returns is the
+# specification together with the reading each argument got, so the compilation
+# passes below take none of their own: `args` is parallel to `spec$args`, and
+# holds this function's own answer for a nested specification and `NULL` for a
+# column selection. ADR 0008's amendment for a recognized nested argument is
+# what accepts the reading moving here, and states the counts that hold.
+#
+# An empty `args` beside a non-`NULL` `spec` is a specification with no
+# arguments, not a specification nothing was read for: the two are told apart
+# by `spec`, which is `NULL` only for the absent `.grouping` that
+# `compile_grouping_spec_impl()` fills in.
 preflight_grouping_spec <- function(grouping_spec, data_vars) {
   stopifnot(is.character(data_vars), !anyNA(data_vars))
   validate_grouping_spec_early(grouping_spec)
   if (is.null(grouping_spec)) {
-    return(list(spec = NULL, name_only = TRUE))
+    return(list(spec = NULL, args = list(), name_only = TRUE))
   }
 
   rule <- find_grouping_kind_rule(grouping_spec$type)
   stopifnot(!is.null(rule))
   name_only <- TRUE
-  for (arg in grouping_spec$args) {
+  args <- vector("list", length(grouping_spec$args))
+  for (i in seq_along(grouping_spec$args)) {
+    arg <- grouping_spec$args[[i]]
     nested <- grouping_arg_spec(arg, data_vars)
     if (is.null(nested)) {
       check_ambiguous_nested_name(arg, grouping_spec, rule, data_vars)
@@ -355,8 +369,9 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
     nested_preflight <- preflight_grouping_spec(nested, data_vars)
     rule$validate_nested(grouping_spec, nested_preflight$spec)
     name_only <- name_only && nested_preflight$name_only
+    args[[i]] <- nested_preflight
   }
-  list(spec = grouping_spec, name_only = name_only)
+  list(spec = grouping_spec, args = args, name_only = name_only)
 }
 
 # The spelling a nested position reads an argument by: the caller's expression
@@ -519,9 +534,12 @@ admitted_nested_kinds <- local({
 # which keeps `match_margin_choice()`'s "an untouched formal stands for its
 # first entry" idiom working for a narrowed vocabulary.
 #
-# `preflight` lets a caller running more than one pass over one specification
-# hand the same preflight to each, rather than paying a second evaluation of
-# the caller's quosures for a result that cannot differ (ADR-0008).
+# `preflight` carries the reading each nested argument got, so a caller running
+# more than one pass over one specification hands the same preflight to each
+# and no pass reads a caller's nested quosure at all. A recognized nested
+# argument is therefore evaluated once per call, whichever passes run
+# (ADR-0008). A column selection is not: each pass resolves one for itself,
+# against its own proxy.
 compile_grouping_spec <- function(
   .grouping,
   data_vars,
@@ -538,7 +556,7 @@ compile_grouping_spec <- function(
   )
   stopifnot(identical(preflight$spec, .grouping))
   compile_grouping_spec_impl(
-    preflight$spec,
+    preflight,
     data_vars = data_vars,
     data_proxy = data_proxy,
     .by = .by,
@@ -547,7 +565,9 @@ compile_grouping_spec <- function(
   )
 }
 
-compile_grouping_spec_impl <- function(.grouping,
+# `preflight` rather than a specification, because expansion below reads each
+# nested argument's reading off it instead of taking one (ADR 0008).
+compile_grouping_spec_impl <- function(preflight,
                                        data_vars,
                                        data_proxy,
                                        .by,
@@ -582,13 +602,17 @@ compile_grouping_spec_impl <- function(.grouping,
     )
   }
 
-  if (is.null(.grouping)) {
-    .grouping <- new_grouping_spec("set", list())
+  # The absent `.grouping`, which stands for the empty grouping set. It has no
+  # arguments, so there is nothing for the preflight to have read and the
+  # substitute is complete.
+  if (is.null(preflight$spec)) {
+    preflight <- preflight_grouping_spec(
+      new_grouping_spec("set", list()),
+      data_vars
+    )
   }
 
-  expanded <- unname(
-    expand_grouping_family(.grouping, data_vars, data_proxy)
-  )
+  expanded <- unname(expand_grouping_family(preflight, data_proxy))
   dimensions <- unique(unlist(expanded, use.names = FALSE))
 
   overlap <- intersect(.by, dimensions)
@@ -662,7 +686,7 @@ compile_grouping_spec_impl <- function(.grouping,
 
   structure(
     list(
-      kind = .grouping$type,
+      kind = preflight$spec$type,
       by = unique(.by),
       dimensions = dimensions,
       sets = normalized,
@@ -674,30 +698,36 @@ compile_grouping_spec_impl <- function(.grouping,
   )
 }
 
-expand_grouping_family <- function(spec, data_vars, data_proxy) {
-  rule <- find_grouping_kind_rule(spec$type)
+# Expansion takes a preflight rather than a specification, so that a nested
+# argument's reading is read off `preflight$args` rather than taken again
+# (ADR 0008). `data_vars` is gone from the whole chain with the reading: it was
+# what `grouping_arg_spec()` decided a bare name against, and nothing else here
+# asked for it. A column selection is still resolved per pass, against the
+# proxy the pass was given.
+expand_grouping_family <- function(preflight, data_proxy) {
+  rule <- find_grouping_kind_rule(preflight$spec$type)
   if (is.null(rule)) {
     stop("Unknown grouping specification kind.", call. = FALSE)
   }
-  rule$expand(spec, data_vars, data_proxy)
+  rule$expand(preflight, data_proxy)
 }
 
-expand_single_grouping_set <- function(spec, data_vars, data_proxy) {
-  list(resolve_grouping_set(spec, data_vars, data_proxy))
+expand_single_grouping_set <- function(preflight, data_proxy) {
+  list(resolve_grouping_set(preflight, data_proxy))
 }
 
-resolve_grouping_set <- function(spec, data_vars, data_proxy) {
-  if (length(spec$args) == 0L) {
+resolve_grouping_set <- function(preflight, data_proxy) {
+  args <- preflight$spec$args
+  if (length(args) == 0L) {
     return(character())
   }
 
   cols <- unlist(
     lapply(
-      spec$args,
-      function(arg) {
-        nested <- grouping_arg_spec(arg, data_vars)
-        stopifnot(is.null(nested))
-        resolve_grouping_selection(arg, data_proxy)
+      seq_along(args),
+      function(i) {
+        stopifnot(is.null(preflight$args[[i]]))
+        resolve_grouping_selection(args[[i]], data_proxy)
       }
     ),
     use.names = FALSE
@@ -705,34 +735,36 @@ resolve_grouping_set <- function(spec, data_vars, data_proxy) {
   unique(cols)
 }
 
-expand_grouping_sets <- function(spec, data_vars, data_proxy) {
+expand_grouping_sets <- function(preflight, data_proxy) {
+  args <- preflight$spec$args
   unlist(
     lapply(
-      spec$args,
-      function(arg) {
-        nested <- grouping_arg_spec(arg, data_vars)
+      seq_along(args),
+      function(i) {
+        nested <- preflight$args[[i]]
         if (is.null(nested)) {
-          return(list(resolve_grouping_selection(arg, data_proxy)))
+          return(list(resolve_grouping_selection(args[[i]], data_proxy)))
         }
-        expand_grouping_family(nested, data_vars, data_proxy)
+        expand_grouping_family(nested, data_proxy)
       }
     ),
     recursive = FALSE
   )
 }
 
-resolve_grouping_units <- function(spec, data_vars, data_proxy) {
+resolve_grouping_units <- function(preflight, data_proxy) {
+  args <- preflight$spec$args
   units <- unlist(
     lapply(
-      spec$args,
-      function(arg) {
-        nested <- grouping_arg_spec(arg, data_vars)
+      seq_along(args),
+      function(i) {
+        nested <- preflight$args[[i]]
         if (is.null(nested)) {
-          cols <- resolve_grouping_selection(arg, data_proxy)
+          cols <- resolve_grouping_selection(args[[i]], data_proxy)
           return(lapply(cols, function(col) col))
         }
-        stopifnot(identical(nested$type, "set"))
-        cols <- resolve_grouping_set(nested, data_vars, data_proxy)
+        stopifnot(identical(nested$spec$type, "set"))
+        cols <- resolve_grouping_set(nested, data_proxy)
         if (length(cols) == 0L) {
           abort_empty_composite()
         }
@@ -743,13 +775,13 @@ resolve_grouping_units <- function(spec, data_vars, data_proxy) {
   )
 
   if (length(units) == 0L) {
-    abort_empty_grouping_units(spec$type)
+    abort_empty_grouping_units(preflight$spec$type)
   }
   units
 }
 
-expand_rollup <- function(spec, data_vars, data_proxy) {
-  units <- resolve_grouping_units(spec, data_vars, data_proxy)
+expand_rollup <- function(preflight, data_proxy) {
+  units <- resolve_grouping_units(preflight, data_proxy)
   lapply(
     rev(seq.int(0L, length(units))),
     function(n) {
@@ -758,8 +790,8 @@ expand_rollup <- function(spec, data_vars, data_proxy) {
   )
 }
 
-expand_cube <- function(spec, data_vars, data_proxy) {
-  units <- resolve_grouping_units(spec, data_vars, data_proxy)
+expand_cube <- function(preflight, data_proxy) {
+  units <- resolve_grouping_units(preflight, data_proxy)
   n <- length(units)
   indices <- unlist(
     lapply(
@@ -777,18 +809,19 @@ expand_cube <- function(spec, data_vars, data_proxy) {
   )
 }
 
-expand_grouping_product <- function(spec, data_vars, data_proxy) {
+expand_grouping_product <- function(preflight, data_proxy) {
   product <- list(character())
-  if (length(spec$args) == 0L) {
+  args <- preflight$spec$args
+  if (length(args) == 0L) {
     return(product)
   }
 
-  for (arg in spec$args) {
-    nested <- grouping_arg_spec(arg, data_vars)
+  for (i in seq_along(args)) {
+    nested <- preflight$args[[i]]
     family <- if (is.null(nested)) {
-      list(resolve_grouping_selection(arg, data_proxy))
+      list(resolve_grouping_selection(args[[i]], data_proxy))
     } else {
-      expand_grouping_family(nested, data_vars, data_proxy)
+      expand_grouping_family(nested, data_proxy)
     }
 
     product <- unlist(

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -409,6 +409,58 @@ records under *the handler the read is wrapped in* is made once more. An error
 is caught and a condition is not, so a method that warns on its way to
 answering still answers.
 
+## Amendment: one reading of a recognized nested argument
+
+The constraint holding the number and timing of evaluations does so "without a
+separately accepted decision", and this is that decision, for every argument a
+Nested specification position recognizes as a specification. It accepts what
+*Considered options* below defers — "a normalized or validated specification
+tree was deferred because caching nested interpretation can change quosure or
+symbol evaluation counts" — in the narrow form that sentence describes, and
+changes those counts on purpose. Nothing else about the specification tree is
+normalized: the caller's own quosures are what the passes still resolve a
+column selection from.
+
+The structural preflight was already the first reader of every nested argument,
+and it now records what each one resolved to alongside the specification it
+returns. Expansion reads that record instead of asking `grouping_arg_spec()`
+again, so the compilation passes read no nested argument at all — the deferred
+cache, kept to one call rather than held across calls.
+
+**Evaluations.** Four shapes reach a nested position, and this is where their
+counts are written down. Each is a count per call, not per pass.
+
+| The argument | Evaluations | Where |
+| --- | --- | --- |
+| A nested constructor call, and a bare name bound to a specification | 1 | the preflight |
+| A bare name that is a column and is bound to a specification of an admitted kind | 1 | the preflight, per ADR 0026, and then refused |
+| A column selection | 1 per compilation pass — 2 where the plan is settled by names alone, 1 otherwise | each pass, against that pass's own proxy |
+| A call the spelling declines to evaluate, such as a caller's own function | 1 | the selection resolution that refuses it (#190) |
+
+The first row is what moves, from 3 and 2 to 1 and 1 (#260): a recognized
+argument was read by the preflight and then again by each pass, so its count
+followed the number of passes, which is decided by whether names alone settle
+the plan — a property of the whole specification and not of that argument. It
+no longer does. The other three rows are unchanged, and the second and fourth
+are stated here because a table of what a nested position costs that named only
+some of its arguments would be read as naming all of them.
+
+**Timing.** The first reading of every argument is where it was: the preflight
+still reads in argument order, and still stops at the first argument it
+refuses. What moves is that the later readings do not happen, so whatever
+forcing a recognized argument does is done before typed metadata is acquired
+and not again after it.
+
+**What does not move.** Which arguments are recognized, and by what spelling,
+are untouched — the gate is the same function, called from one site instead of
+five. So are grouping-set membership, ordering, duplicate handling, and
+Grouping identifiers; error condition classes, messages, public call contexts,
+and detection order; laziness and metadata acquisition counts; and the Grouping
+plan and its consumers. A specification that compiled compiles to the same
+plan, because a reading taken once and a reading taken three times differ only
+where the argument answers differently each time, and an argument that does
+that is one whose count this amendment is about.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:
@@ -450,7 +502,9 @@ different while merely moving the dispatch into `UseMethod()`.
 A normalized or validated specification tree was deferred because caching
 nested interpretation can change quosure or symbol evaluation counts. It is
 not required to centralize the rules and would broaden the compatibility
-surface of this change.
+surface of this change. The amendment *one reading of a recognized nested
+argument* above accepts it, in the narrow form this paragraph describes and
+with the counts it changes stated.
 
 A separate rules file was rejected for now because the rules do not form an
 independent module; they are the grammar used exclusively by Grouping plan

--- a/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
+++ b/design/adr/0026-refuse-a-nested-name-two-readings-claim.md
@@ -194,6 +194,25 @@ written more than once. This decision accepts that rather than hiding it, since
 the alternative to reading the binding is deciding by the input, which is the
 defect.
 
+## Amendment: the spelling gate no longer runs per pass
+
+*Where the decision is made* and *Decide in the spelling gate* above both reject
+the gate on a count the gate no longer has. #260 moved the reading of every
+recognized nested argument into the preflight, which records it for the
+compilation passes, so the gate runs once for an operation rather than once per
+pass. Deciding a collision there would now read a colliding binding once too,
+and the two placements cost the same.
+
+What the placement rests on after that is the rest of those sections, which is
+untouched: the gate reports which reading it took and not why, so the check
+re-asks the two conditions on the branch the gate answered "selection" on, and
+the refusal has to fire before `grouping_selection_proxy()`. Nothing asks it to
+move, and it stays.
+
+The count this ADR sets is unchanged — 1 for a colliding name, from 0 — and it
+is now one row of the table in ADR 0008's amendment for a recognized nested
+argument, which is where the counts of all four shapes are written down.
+
 ## Documentation consequences
 
 `CONTEXT.md`'s *Nested specification position* defines the term and names the

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -100,9 +100,12 @@ replaced by a Package condition naming the recognized forms and the binding
 that works. Being marginplyr's own report about a position of its own, it is
 parentless, as a share selection naming something ineligible is. The refused
 value is read from the condition rather than by evaluating the argument a
-second time to identify it, which is what keeps the number and timing of
-caller-quosure evaluations fixed for every argument whose reading it does not
-decide. The replacement covers the argument the position owns and not a part
+second time to identify it, so such an argument is evaluated once: by the
+selection resolution that refuses it. What every shape of nested argument costs
+a caller is written down in one place, the *one reading of a recognized nested
+argument* amendment to
+[ADR 0008](adr/0008-centralize-grouping-specification-kind-rules.md). The
+replacement covers the argument the position owns and not a part
 of one: a specification written inside a selection keeps tidyselect's report,
 which names the sub-selection and is accurate about it — and where the input
 has a column of that name, tidyselect refuses nothing at all, because the
@@ -121,9 +124,11 @@ a position admits is derived by asking that position's own rule from the kind
 registry, so there is no second list of what nests inside what, and it is
 asked before the binding is read: a position admitting no kind reads nothing.
 Where the binding is read it is read once, in the preflight, which runs once
-for an operation and is handed to the compilation passes — the one place from
-which the answer is not recomputed per pass. That read is the one caller
-evaluation this position adds, and ADR 0026 records what it costs.
+for an operation and is handed to the compilation passes. So is every other
+nested argument the position recognizes as a specification: the preflight
+records what each one resolved to, and the passes read that record rather than
+evaluating the argument again. That read is the one caller evaluation this
+position adds, and ADR 0026 records what it costs.
 
 ### Margin label (`R/margin-label.R`)
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -100,10 +100,9 @@ replaced by a Package condition naming the recognized forms and the binding
 that works. Being marginplyr's own report about a position of its own, it is
 parentless, as a share selection naming something ineligible is. The refused
 value is read from the condition rather than by evaluating the argument a
-second time to identify it, so such an argument is evaluated once: by the
-selection resolution that refuses it. What every shape of nested argument costs
-a caller is written down in one place, the *one reading of a recognized nested
-argument* amendment to
+second time to identify it, so identifying it adds no evaluation. What each
+shape of nested argument costs a caller is written down in one place, the *one
+reading of a recognized nested argument* amendment to
 [ADR 0008](adr/0008-centralize-grouping-specification-kind-rules.md). The
 replacement covers the argument the position owns and not a part
 of one: a specification written inside a selection keeps tidyselect's report,

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -1021,8 +1021,7 @@ test_that("an unrecognized nested argument is evaluated as a selection is", {
 # The two shapes the test above does not reach, which are the two a nested
 # position recognizes as a specification. Each is read in the preflight and
 # nowhere else, so it is evaluated once per call however many compilation
-# passes run -- the count ADR 0008's amendment for a recognized nested argument
-# accepts, and what #260 moved it to from three.
+# passes run (ADR 0008, #260).
 #
 # The counted selection travels beside it in every specification below, because
 # a count of one would also be what a call that compiled nothing produced. It
@@ -1089,28 +1088,32 @@ test_that("a recognized nested specification is evaluated once", {
     list(forced = forced, selected = selected, result = result)
   }
 
-  # Which parent positions admit a nested specification, and which kind each
-  # admits, are derived from the kind registry rather than listed, so a sixth
-  # kind is covered without editing this test (ADR 0008). The parent handed to
-  # the derivation is a specification a caller could have written, which is
-  # what `admitted_nested_kinds()`'s memo expects of the first ask for a kind.
-  positions <- Filter(Negate(is.null), lapply(
-    names(grouping_kind_rules()),
-    function(parent_kind) {
-      rule <- grouping_kind_rules()[[parent_kind]]
-      admitted <- admitted_nested_kinds(
-        eval(rlang::call2(rule$constructor, quote(region))),
-        rule
-      )
-      if (length(admitted) == 0L) {
-        return(NULL)
+  # Every parent position, against every nested kind that position admits,
+  # derived from the kind registry rather than listed: a sixth kind is covered
+  # as a parent and as a nested argument without editing this test (ADR 0008).
+  # A position admitting no kind contributes none, which is `grouping_set()`.
+  # The parent handed to the derivation is a specification a caller could have
+  # written, which is what `admitted_nested_kinds()`'s memo expects of the
+  # first ask for a kind.
+  positions <- unlist(
+    lapply(
+      names(grouping_kind_rules()),
+      function(parent_kind) {
+        rule <- grouping_kind_rules()[[parent_kind]]
+        admitted <- admitted_nested_kinds(
+          eval(rlang::call2(rule$constructor, quote(region))),
+          rule
+        )
+        lapply(admitted, function(nested_kind) {
+          list(
+            parent = rule$constructor,
+            nested = grouping_kind_rules()[[nested_kind]]$constructor
+          )
+        })
       }
-      list(
-        parent = rule$constructor,
-        nested = grouping_kind_rules()[[admitted[[1L]]]]$constructor
-      )
-    }
-  ))
+    ),
+    recursive = FALSE
+  )
   # Every count below is taken once per position, so a set that arrived empty
   # is a set that passes.
   expect_gt(length(positions), 0L)
@@ -1143,22 +1146,32 @@ test_that("a recognized nested specification is evaluated once", {
   )
   predicate <- rlang::call2("where", quote(is.character), .ns = "tidyselect")
 
-  for (position in positions) {
-    forms <- list(
+  # The parent is namespace-qualified and the nested argument is not. Where a
+  # position nests a kind inside itself -- `grouping_sets(grouping_sets(...))`
+  # -- one shadow would otherwise intercept the caller's own parent call too
+  # and count it. The nested spelling stays bare, which is the spelling the
+  # gate reads, and the parent is not what is being counted.
+  parent_call <- function(position, ...) {
+    rlang::call2(position$parent, ..., .ns = "marginplyr")
+  }
+  position_forms <- function(position) {
+    list(
       list(bind = bind_name(position$nested), arg = quote(s)),
       list(
         bind = bind_constructor(position$nested),
         arg = rlang::call2(position$nested, quote(region))
       )
     )
+  }
 
-    for (form in forms) {
+  for (position in positions) {
+    for (form in position_forms(position)) {
       # Settled by name alone, so the plan is compiled against the names first
       # and against the typed snapshot after, and the selection is resolved in
       # each.
       name_only <- measure(
         form$bind,
-        rlang::call2(position$parent, form$arg, selection)
+        parent_call(position, form$arg, selection)
       )
       expect_identical(name_only$forced, 1L)
       expect_identical(name_only$selected, 2L)
@@ -1168,7 +1181,7 @@ test_that("a recognized nested specification is evaluated once", {
       # recognized argument is read the same once.
       withheld <- measure(
         form$bind,
-        rlang::call2(position$parent, form$arg, selection, predicate)
+        parent_call(position, form$arg, selection, predicate)
       )
       expect_identical(withheld$forced, 1L)
       expect_identical(withheld$selected, 1L)
@@ -1183,13 +1196,15 @@ test_that("a recognized nested specification is evaluated once", {
   # reaches both paths.
   remote <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
   for (position in positions) {
-    lazy <- measure(
-      bind_name(position$nested),
-      rlang::call2(position$parent, quote(s), selection),
-      input = quote(remote)
-    )
-    expect_identical(lazy$forced, 1L)
-    expect_identical(lazy$selected, 2L)
+    for (form in position_forms(position)) {
+      lazy <- measure(
+        form$bind,
+        parent_call(position, form$arg, selection),
+        input = quote(remote)
+      )
+      expect_identical(lazy$forced, 1L)
+      expect_identical(lazy$selected, 2L)
+    }
   }
 })
 

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -885,12 +885,9 @@ test_that("a colliding nested name is read once, in the preflight", {
   expect_identical(in_set$reads, 0L)
   expect_identical(in_set$result$included, "(s)")
 
-  # The check sits in the preflight, which runs once for an operation and is
-  # handed to the compilation passes, where the gate runs again on each.
-  # Moving it into the gate would read this binding once per pass instead of
-  # once in all -- three times here, by the count the last assertion in this
-  # test pins -- and make that many of whatever forcing it does visible to the
-  # caller.
+  # The check sits in the preflight, beside the gate whose answer it re-asks.
+  # The preflight runs once for an operation and is handed to the compilation
+  # passes, so this binding is read once whichever passes run.
   not_a_spec <- count_reads(
     "s",
     1,
@@ -911,17 +908,19 @@ test_that("a colliding nested name is read once, in the preflight", {
   )
   expect_identical(twice$reads, 2L)
 
-  # Outside a collision nothing moves: a bound name the input holds no column
-  # for is read in the preflight and once per compilation pass, as it was
-  # before this refusal existed. Both counts are here because the number of
-  # passes is what differs -- a plan settled by name alone is compiled against
-  # the names first, so that a plan error need not wait for a backend read.
+  # Outside a collision the count is the same one: a bound name the input holds
+  # no column for is a nested specification the position recognizes, and every
+  # such argument is read in the preflight and nowhere else. Both paths are
+  # here because the number of compilation passes is what differs between them
+  # -- a plan settled by name alone is compiled against the names first, so
+  # that a plan error need not wait for a backend read -- and the count no
+  # longer moves with it (#260).
   name_only <- count_reads(
     "t",
     rollup(value),
     quote(inspect_grouping(data, .grouping = grouping_sets(t)))
   )
-  expect_identical(name_only$reads, 3L)
+  expect_identical(name_only$reads, 1L)
   expect_identical(name_only$result$included, c("(value)", "()"))
   with_predicate <- count_reads(
     "t",
@@ -932,7 +931,7 @@ test_that("a colliding nested name is read once, in the preflight", {
       .duplicates = "keep"
     ))
   )
-  expect_identical(with_predicate$reads, 2L)
+  expect_identical(with_predicate$reads, 1L)
   expect_identical(
     with_predicate$result$included,
     c("(value)", "()", "(s, grade)")
@@ -982,7 +981,7 @@ test_that("a Margin verb refuses an ambiguous nested name", {
   expect_identical(nrow(column), 2L)
 })
 
-test_that("recognizing a nested specification adds no caller evaluation", {
+test_that("an unrecognized nested argument is evaluated as a selection is", {
   data <- data.frame(
     region = c("E", "E", "W"),
     grade = c("a", "b", "a"),
@@ -1017,6 +1016,181 @@ test_that("recognizing a nested specification adds no caller evaluation", {
     .grouping = grouping_sets(tidyselect::all_of(counted("region")), grade)
   )
   expect_identical(selection_calls, 2L)
+})
+
+# The two shapes the test above does not reach, which are the two a nested
+# position recognizes as a specification. Each is read in the preflight and
+# nowhere else, so it is evaluated once per call however many compilation
+# passes run -- the count ADR 0008's amendment for a recognized nested argument
+# accepts, and what #260 moved it to from three.
+#
+# The counted selection travels beside it in every specification below, because
+# a count of one would also be what a call that compiled nothing produced. It
+# is name-only, so it is resolved once per pass, and the two paths differ in
+# how many passes run.
+test_that("a recognized nested specification is evaluated once", {
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    grade = c("a", "b", "a"),
+    units = c(1, 3, 6)
+  )
+
+  forced <- 0L
+  selected <- 0L
+  counted <- function(x) {
+    selected <<- selected + 1L
+    x
+  }
+
+  # A name bound to a specification. The name is not a column of the input, so
+  # ADR 0026's refusal is not in play and the position reads the binding.
+  bind_name <- function(nested_constructor) {
+    nested_spec <- eval(rlang::call2(nested_constructor, quote(region)))
+    function(env) {
+      makeActiveBinding(
+        "s",
+        function() {
+          forced <<- forced + 1L
+          nested_spec
+        },
+        env
+      )
+    }
+  }
+
+  # A nested constructor call. The spelling is what opens the gate, and what
+  # runs once it is open is the caller's own binding (ADR 0019), so shadowing
+  # the constructor counts the evaluations.
+  bind_constructor <- function(nested_constructor) {
+    real <- getExportedValue("marginplyr", nested_constructor)
+    shadow <- function(...) {
+      forced <<- forced + 1L
+      real(...)
+    }
+    function(env) {
+      assign(nested_constructor, shadow, envir = env)
+    }
+  }
+
+  measure <- function(bind, spec_call, input = quote(data)) {
+    forced <<- 0L
+    selected <<- 0L
+    env <- rlang::env(rlang::current_env())
+    bind(env)
+    result <- eval(
+      rlang::call2(
+        "inspect_grouping",
+        input,
+        .grouping = spec_call,
+        .duplicates = "keep"
+      ),
+      envir = env
+    )
+    list(forced = forced, selected = selected, result = result)
+  }
+
+  # Which parent positions admit a nested specification, and which kind each
+  # admits, are derived from the kind registry rather than listed, so a sixth
+  # kind is covered without editing this test (ADR 0008). The parent handed to
+  # the derivation is a specification a caller could have written, which is
+  # what `admitted_nested_kinds()`'s memo expects of the first ask for a kind.
+  positions <- Filter(Negate(is.null), lapply(
+    names(grouping_kind_rules()),
+    function(parent_kind) {
+      rule <- grouping_kind_rules()[[parent_kind]]
+      admitted <- admitted_nested_kinds(
+        eval(rlang::call2(rule$constructor, quote(region))),
+        rule
+      )
+      if (length(admitted) == 0L) {
+        return(NULL)
+      }
+      list(
+        parent = rule$constructor,
+        nested = grouping_kind_rules()[[admitted[[1L]]]]$constructor
+      )
+    }
+  ))
+  # Every count below is taken once per position, so a set that arrived empty
+  # is a set that passes.
+  expect_gt(length(positions), 0L)
+
+  # The mechanism, before any count is concluded from it: a counter that
+  # stopped counting reports the same clean run as a package that stopped
+  # evaluating, so each binding is shown to report the one reading it is about
+  # to be asked for.
+  for (position in positions) {
+    probe <- rlang::env(rlang::current_env())
+
+    forced <- 0L
+    bind_name(position$nested)(probe)
+    expect_s3_class(probe$s, "margin_grouping_spec")
+    expect_identical(forced, 1L)
+
+    forced <- 0L
+    bind_constructor(position$nested)(probe)
+    expect_s3_class(
+      eval(rlang::call2(position$nested, quote(region)), envir = probe),
+      "margin_grouping_spec"
+    )
+    expect_identical(forced, 1L)
+  }
+
+  selection <- rlang::call2(
+    "all_of",
+    rlang::call2("counted", "grade"),
+    .ns = "tidyselect"
+  )
+  predicate <- rlang::call2("where", quote(is.character), .ns = "tidyselect")
+
+  for (position in positions) {
+    forms <- list(
+      list(bind = bind_name(position$nested), arg = quote(s)),
+      list(
+        bind = bind_constructor(position$nested),
+        arg = rlang::call2(position$nested, quote(region))
+      )
+    )
+
+    for (form in forms) {
+      # Settled by name alone, so the plan is compiled against the names first
+      # and against the typed snapshot after, and the selection is resolved in
+      # each.
+      name_only <- measure(
+        form$bind,
+        rlang::call2(position$parent, form$arg, selection)
+      )
+      expect_identical(name_only$forced, 1L)
+      expect_identical(name_only$selected, 2L)
+
+      # A predicate elsewhere in the specification withholds the name-only
+      # pass. One pass fewer resolves the selection one time fewer, and the
+      # recognized argument is read the same once.
+      withheld <- measure(
+        form$bind,
+        rlang::call2(position$parent, form$arg, selection, predicate)
+      )
+      expect_identical(withheld$forced, 1L)
+      expect_identical(withheld$selected, 1L)
+    }
+  }
+
+  # A lazy input reaches the name-only path, where the two passes read
+  # different proxies and the count is still one. It reaches no further: the
+  # `postgres` kind holds no `collect_selection_proxy`, so a specification
+  # carrying a predicate is refused there before a count could be taken. No
+  # optional backend is needed for either, and a local data frame above
+  # reaches both paths.
+  remote <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres())
+  for (position in positions) {
+    lazy <- measure(
+      bind_name(position$nested),
+      rlang::call2(position$parent, quote(s), selection),
+      input = quote(remote)
+    )
+    expect_identical(lazy$forced, 1L)
+    expect_identical(lazy$selected, 2L)
+  }
 })
 
 test_that("empty grouping rules preserve their phase and error precedence", {


### PR DESCRIPTION
Closes #260.

## Disposition

The ticket required a maintainer's decision between *Assert what is there* and *Reduce it first*. **Reduce it first** was chosen and recorded on the ticket (#260 comment); the reasoning is there rather than repeated here.

## What changed

The two shapes a Nested specification position recognizes as a specification — a nested constructor call, and a bare name bound to one — were each evaluated three times where the plan is settled by names alone and twice where one compilation pass is withheld: once by `preflight_grouping_spec()` to find out what the argument is, and again by every expansion site, each of which called `grouping_arg_spec()` for itself.

The preflight now records what each nested argument resolved to, parallel to `spec$args`, and expansion reads that record instead of taking a reading of its own. A recognized argument is evaluated once per call, whichever passes run. `data_vars` leaves the whole expansion chain with the reading — it was what the gate decided a bare name against, and nothing else there asked for it.

Unchanged: which arguments are recognized and by what spelling; a column selection at one resolution per compilation pass; the colliding name ADR 0026 refuses, at one; the caller's own function #190 reports on, at one.

## Where the counts are written down

ADR 0008's new amendment *one reading of a recognized nested argument*, as a table over the four shapes. `design/architecture.md` and both comments in `R/grouping-plan.R` that describe the shared preflight cite it and state the number for the position they are about, rather than re-deriving it.

ADR 0026 gains *the spelling gate no longer runs per pass*: its *Where the decision is made* and *Decide in the spelling gate* sections both reject deciding a collision in the gate on a per-pass count the gate no longer has. The placement stands on the rest of those sections, which is untouched.

## Tests

`test-grouping-plan.R` gains *a recognized nested specification is evaluated once*, covering both forms on both paths. It derives the parent positions from `grouping_kind_rules()` via `admitted_nested_kinds()`, so a sixth kind is covered without editing it — four positions today (`grouping_sets`, `rollup`, `cube`, `grouping_spec`); `grouping_set` admits no nested kind and is excluded by the derivation, and the set is asserted non-empty before anything iterates over it. Each counter is shown to report a reading before a count is concluded from it. A counted name-only selection travels beside the recognized argument in every specification it compiles, because a count of one is also what a call that compiled nothing would produce: it reads 2 on the name-only path and 1 where a predicate withholds a pass, so the paths are shown to differ while the recognized count does not. A `dbplyr::simulate_postgres()` input covers the name-only path; no test added here needs an optional backend.

The two counts already asserted in the sibling tests still hold. *a colliding nested name is read once, in the preflight* had two assertions of the old 3 and 2 for a non-colliding bound name; both are now 1, with the comments corrected. *recognizing a nested specification adds no caller evaluation* is renamed to *an unrecognized nested argument is evaluated as a selection is*, which is what it measures — the ticket's own observation about that title.

Verified the new test fails against the pre-change implementation (3 and 2 where 1 is expected), so it is load-bearing.

## Local gates run

- full `testthat::test_local()` — pass
- `lintr::lint_package()` — no lints
- `Rscript .github/scripts/verify-suite-coverage.R` — 631 tests, all execute in at least one single-backend configuration
- `Rscript .github/scripts/verify-context-budget.R` — 38753 / 38810 bytes, unchanged

No roxygen or `README.Rmd` change, so nothing generated needs regenerating.

## Out of scope, observed

`test-diagnostic-pluralization.R`'s `pluralizing_coverage()` table carries line references into `test-grouping-plan.R` that were already stale at the merge-base — `:915 and :768` for `compile_grouping_spec_impl`, whose two arms are actually near `:1591` and `:1738` there, and the four `abort_by_rename` / `abort_grouping_rename` references likewise. The table's own comment says a line reference is review surface and unchecked. Not touched here; worth a ticket.