### PR TITLE
Refuse an empty argument in a nested specification position

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,12 +24,15 @@ is a column selection. Redundant parentheses are transparent to that reading,
 around the name or around the whole call, because `(` is the identity
 function. A spelling the position does not recognize is never
 evaluated to find out, because a selection such as `starts_with("re")` has no
-meaning outside a selection context. Both readings claim one argument at once:
-a bare name that is a column of the input and is also bound, in the caller's
-environment, to a specification of a kind the position admits — which kinds
-those are varies by constructor. How that name is written settles neither
-reading, so it is refused rather than resolved. ADR 0026 decides that, and
-holds the admitted kinds and what the read costs a caller.
+meaning outside a selection context. An argument the caller left empty gets
+neither reading, and is refused naming the constructor and the position; a
+trailing comma is not one, because R captures no argument for it. Both
+readings claim one argument at once: a bare name that is a column of the
+input and is also bound, in the caller's environment, to a specification of a
+kind the position admits — which kinds those are varies by constructor. How
+that name is written settles neither reading, so it is refused rather than
+resolved. ADR 0026 decides that, and holds the admitted kinds and what the
+read costs a caller.
 _Avoid_: Nested grouping, nested slot
 
 **Grouping plan**:

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,12 @@
   parentheses are transparent to every one of these readings, as they are
   elsewhere, because `(` is the identity function: `(s)`, `(!!s)`, and
   `(rollup(region))` are the arguments they wrap, however many pairs deep, and
-  both refusals reach a parenthesized argument as they reach a bare one.
+  both refusals reach a parenthesized argument as they reach a bare one. An
+  argument you left empty gets neither reading, and is refused naming the
+  constructor and the position — `grouping_sets(, region)` reports that its
+  first argument is empty — rather than reporting an internal name you never
+  wrote. A trailing comma is not an empty argument, because R captures no
+  argument for it.
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -225,6 +225,17 @@ abort_empty_grouping_units <- function(kind) {
   abort_marginplyr("{.fun {kind}} requires at least one dimension.")
 }
 
+# The refusal of an argument the caller left empty. It names the position
+# because that is all there is to name: the argument has no spelling for
+# ADR 0024's rule to quote, so the count of arguments before it is the only
+# thing that points at the comma the caller wrote (#261).
+abort_empty_grouping_arg <- function(constructor, position) {
+  abort_marginplyr(c(
+    "Argument {position} of {.fun {constructor}} is empty.",
+    i = "Remove the comma, or write the columns that position selects."
+  ))
+}
+
 abort_empty_composite <- function() {
   abort_marginplyr(
     "An empty {.fun grouping_set} cannot be a composite dimension."
@@ -356,6 +367,14 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   args <- vector("list", length(grouping_spec$args))
   for (i in seq_along(grouping_spec$args)) {
     arg <- grouping_spec$args[[i]]
+    # Asked of the quosure, which is an object like any other, and before
+    # anything reads the expression out of it -- the rule `R/utils.R` states
+    # for every reader a walk asks first (#168, #174). The refusal is here
+    # rather than in the reader below because this is the frame holding what
+    # the diagnostic names: the constructor and the argument's position (#261).
+    if (rlang::quo_is_missing(arg)) {
+      abort_empty_grouping_arg(rule$constructor, i)
+    }
     nested <- grouping_arg_spec(arg, data_vars)
     if (is.null(nested)) {
       check_ambiguous_nested_name(arg, grouping_spec, rule, data_vars)
@@ -406,11 +425,10 @@ nested_arg_expr <- function(arg) {
 # `is_name_part()` rather than a bare symbol test. Both halves are the rule
 # `R/utils.R` states for every reader a walk asks first: binding R's empty
 # argument raises `missingArgError` on the next read of it, and the empty
-# argument is itself a symbol whose name is `""` (#168, #174). No empty
-# argument reaches this function today, because `grouping_arg_spec()` binds
-# one a line earlier and raises there, which is #261; following the rule here
-# is what keeps this from becoming a second site of it once that one is
-# fixed.
+# argument is itself a symbol whose name is `""` (#168, #174). The caller
+# refuses an empty argument before either reader is reached (#261), so the rule
+# is followed here for what a caller could stop holding rather than for what one
+# arrives with.
 #
 # A binding that raises when it is read is not a specification, so the
 # selection reading stands where it raises, and so does an object carrying the
@@ -914,6 +932,11 @@ grouping_constructor_names <- function() {
   ))
 }
 
+# The specification a nested argument is, or `NULL` where it is a column
+# selection. Every caller holds that `arg` carries an expression rather than R's
+# empty argument -- `preflight_grouping_spec()` by refusing one (#261), the
+# restart below by the reading its own comment gives -- which is what lets the
+# local hold what the quosure carries without the missing marker reaching it.
 grouping_arg_spec <- function(arg, data_vars) {
   expr <- rlang::quo_get_expr(arg)
   # A redundantly parenthesized argument is read as the argument it wraps, as

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -225,10 +225,12 @@ abort_empty_grouping_units <- function(kind) {
   abort_marginplyr("{.fun {kind}} requires at least one dimension.")
 }
 
-# The refusal of an argument the caller left empty. It names the position
-# because that is all there is to name: the argument has no spelling for
-# ADR 0024's rule to quote, so the count of arguments before it is the only
-# thing that points at the comma the caller wrote (#261).
+# The refusal of an argument the caller left empty. `position` is the
+# argument's index in the specification's `args`, which is the position the
+# caller wrote it at: every constructor takes `...` alone, so
+# `rlang::enquos(...)` captures one element per written argument. The index is
+# what the diagnostic points with because the argument has no spelling for
+# ADR 0024's rule to quote (#261).
 abort_empty_grouping_arg <- function(constructor, position) {
   abort_marginplyr(c(
     "Argument {position} of {.fun {constructor}} is empty.",
@@ -367,12 +369,24 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   args <- vector("list", length(grouping_spec$args))
   for (i in seq_along(grouping_spec$args)) {
     arg <- grouping_spec$args[[i]]
-    # Asked of the quosure, which is an object like any other, and before
-    # anything reads the expression out of it -- the rule `R/utils.R` states
-    # for every reader a walk asks first (#168, #174). The refusal is here
-    # rather than in the reader below because this is the frame holding what
-    # the diagnostic names: the constructor and the argument's position (#261).
-    if (rlang::quo_is_missing(arg)) {
+    # The first test is asked of the quosure, which is an object like any
+    # other, and before anything reads the expression out of it -- the rule
+    # `R/utils.R` states for every reader a walk asks first (#168, #174). The
+    # refusal is here rather than in the reader below because this is the frame
+    # holding what the diagnostic names: the constructor and the argument's
+    # position (#261).
+    #
+    # The second is the same argument written inside redundant parentheses,
+    # which every other reading here sees through (#178, #259) and which this
+    # one has to see through for the same reason: `(` is the identity function,
+    # so the pair wraps nothing to read either. Only an injection or a
+    # constructed call spells it, since the parser rejects `f((), x)`.
+    # Unrefused it reaches `is_name_only_expr()`, where the empty argument is a
+    # symbol whose name is `""` and `rlang::env_has()` raises an untyped
+    # condition for a zero-length variable name.
+    if (
+      rlang::quo_is_missing(arg) || wraps_empty_argument(nested_arg_expr(arg))
+    ) {
       abort_empty_grouping_arg(rule$constructor, i)
     }
     nested <- grouping_arg_spec(arg, data_vars)
@@ -392,9 +406,11 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 }
 
 # The spelling a nested position reads an argument by: the caller's expression
-# with its redundant parentheses removed (#178, #259). The argument may be one
-# a caller left empty, so the answer may be R's empty argument, and a reader
-# passes it on as a value rather than binding it (#168, #174).
+# with its redundant parentheses removed (#178, #259). It answers the pair
+# wrapping R's empty argument rather than unwrapping to the marker
+# (#168, #174), and that pair is what `preflight_grouping_spec()` reads to
+# refuse an empty argument (#261). Every other caller runs downstream of that
+# refusal and is handed no empty argument at all.
 nested_arg_expr <- function(arg) {
   unparenthesized_value(rlang::quo_get_expr(arg))
 }
@@ -934,9 +950,11 @@ grouping_constructor_names <- function() {
 
 # The specification a nested argument is, or `NULL` where it is a column
 # selection. Every caller holds that `arg` carries an expression rather than R's
-# empty argument -- `preflight_grouping_spec()` by refusing one (#261), the
-# restart below by the reading its own comment gives -- which is what lets the
-# local hold what the quosure carries without the missing marker reaching it.
+# empty argument, wrapped in parentheses or not: `preflight_grouping_spec()`
+# refuses one (#261), and the restart below cannot make one, because
+# `is_parenthesized()` answers `FALSE` for the pair that would hold it. That is
+# what lets the local hold what the quosure carries without the missing marker
+# reaching it.
 grouping_arg_spec <- function(arg, data_vars) {
   expr <- rlang::quo_get_expr(arg)
   # A redundantly parenthesized argument is read as the argument it wraps, as

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -52,6 +52,13 @@
 #'   unless the input has a column named `s`, when the selection takes that
 #'   column, as any selection does with a name the data holds.
 #'
+#'   An argument left empty gets neither reading, and is refused naming the
+#'   constructor and the position: `grouping_sets(, region)` reports that its
+#'   first argument is empty. A trailing comma is not an empty argument,
+#'   because R captures no argument for it, so `grouping_sets(region, )` is
+#'   `grouping_sets(region)`, and passing no arguments at all means what the
+#'   first paragraph above says it means for each constructor.
+#'
 #'   A name both readings claim is refused rather than guessed. Where the
 #'   input has a column named `s` and `s` is also bound to a nested Grouping
 #'   specification the position accepts, the call names both readings and the

--- a/R/utils.R
+++ b/R/utils.R
@@ -323,6 +323,16 @@ is_parenthesized <- function(expr) {
   !identical(unparenthesized_value(expr), expr)
 }
 
+# Whether a pair of parentheses wraps R's empty argument. This is the question
+# `unparenthesized_value()` stopping cannot be read as an answer to: it stops
+# both at a pair holding the empty argument and at everything that is not a
+# pair, and a reader that has to tell an empty argument from an expression
+# needs those apart. Asked of what that function answered, so however many
+# pairs a caller wrapped, one is what arrives here (#261).
+wraps_empty_argument <- function(expr) {
+  is_redundant_parens(expr) && rlang::is_missing(expr[[2L]])
+}
+
 # The head and the arguments of a call a walk descends into, and the node
 # rebuilt around rewritten arguments. `static_call_name()` above answers what a
 # walk asks of a node it does not descend into; these three are what it asks of

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -47,6 +47,13 @@ selection containing something it cannot select, and is refused as one —
 unless the input has a column named \code{s}, when the selection takes that
 column, as any selection does with a name the data holds.
 
+An argument left empty gets neither reading, and is refused naming the
+constructor and the position: \code{grouping_sets(, region)} reports that its
+first argument is empty. A trailing comma is not an empty argument,
+because R captures no argument for it, so \code{grouping_sets(region, )} is
+\code{grouping_sets(region)}, and passing no arguments at all means what the
+first paragraph above says it means for each constructor.
+
 A name both readings claim is refused rather than guessed. Where the
 input has a column named \code{s} and \code{s} is also bound to a nested Grouping
 specification the position accepts, the call names both readings and the

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -618,6 +618,100 @@ test_that("a nested name the input and a binding both claim is refused", {
   )
 })
 
+# The refusal an empty argument gets, over every constructor and both positions
+# `rlang::enquos(...)` captures one for. `inspect_grouping()` is the seam
+# because the diagnostic's whole point is what a caller reads, and the caller
+# meets it through a verb (ADR 0013).
+#
+# The message is asserted in full rather than matched, because what #261 found
+# was not a missing refusal but a diagnostic naming `expr` -- the local
+# `grouping_arg_spec()` bound the missing marker to -- and blaming that
+# function's own call. A match on the part that is right cannot see either.
+empty_grouping_arg_message <- function(constructor, position) {
+  paste0(
+    "Argument ", position, " of `", constructor, "()` is empty.\n",
+    "i Remove the comma, or write the columns that position selects."
+  )
+}
+
+test_that("a leading or interior empty argument is refused in every kind", {
+  data <- data.frame(
+    region = c("a", "b"),
+    grade = c("x", "y"),
+    value = c(1, 2)
+  )
+  # Derived from the kind table, so a sixth constructor arrives here as a case
+  # the loop covers rather than as one nothing does. The loop iterates over this
+  # set, so a set that arrived empty is a set that passes.
+  constructors <- grouping_constructor_names()
+  expect_true("grouping_sets" %in% constructors)
+
+  # The two shapes, with the argument number each leaves empty. A trailing one
+  # is not among them: `rlang::enquos(...)` captures no argument for it, which
+  # is the reading the test below holds unchanged.
+  shapes <- list(
+    list(position = 1L, args = list(rlang::missing_arg(), quote(region))),
+    list(
+      position = 2L,
+      args = list(quote(region), rlang::missing_arg(), quote(grade))
+    )
+  )
+
+  for (constructor in constructors) {
+    for (shape in shapes) {
+      spec <- eval(rlang::call2(constructor, !!!shape$args))
+      error <- expect_error(inspect_grouping(data, .grouping = spec))
+      expect_s3_class(error, "marginplyr_error")
+      expect_identical(
+        conditionMessage(error),
+        empty_grouping_arg_message(constructor, shape$position)
+      )
+      # The call the caller wrote, not the reader that found the empty
+      # argument. `conditionCall()` was `grouping_arg_spec(arg, data_vars)`.
+      expect_identical(conditionCall(error)[[1L]], quote(inspect_grouping))
+    }
+  }
+
+  # One level in, where the constructor the refusal names is the inner one:
+  # that is the call holding the comma the caller wrote.
+  nested <- expect_error(inspect_grouping(
+    data,
+    .grouping = grouping_sets(grouping_set(, region))
+  ))
+  expect_s3_class(nested, "marginplyr_error")
+  expect_identical(
+    conditionMessage(nested),
+    empty_grouping_arg_message("grouping_set", 1L)
+  )
+})
+
+test_that("an empty slot the package already had a reading for keeps it", {
+  data <- data.frame(region = c("a", "b"), value = c(1, 2))
+  region_only <- inspect_grouping(data, .grouping = grouping_sets(region))
+  grand_total <- inspect_grouping(data)
+
+  # A trailing empty argument, which the refusal above cannot reach and must
+  # not start reaching: `rlang::enquos(...)` captures one argument for
+  # `f(region, )` and two for `f(, region)`.
+  expect_identical(
+    inspect_grouping(data, .grouping = grouping_sets(region, )),
+    region_only
+  )
+  # An empty `.by` and an empty `.grouping` are arguments of the verb rather
+  # than of a constructor, so neither reaches the loop the refusal sits in.
+  expect_identical(
+    inspect_grouping(data, .by = , .grouping = grouping_sets(region)),
+    region_only
+  )
+  expect_identical(inspect_grouping(data, .grouping = ), grand_total)
+  # `grouping_set()` with no arguments at all is the empty grouping set, which
+  # is documented and is not an empty argument.
+  expect_identical(
+    inspect_grouping(data, .grouping = grouping_sets(grouping_set())),
+    grand_total
+  )
+})
+
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so
 # what a method raising took from it was a compiled call rather than a

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -646,14 +646,36 @@ test_that("a leading or interior empty argument is refused in every kind", {
   constructors <- grouping_constructor_names()
   expect_true("grouping_sets" %in% constructors)
 
-  # The two shapes, with the argument number each leaves empty. A trailing one
-  # is not among them: `rlang::enquos(...)` captures no argument for it, which
-  # is the reading the test below holds unchanged.
+  # A pair of redundant parentheses around an argument, built rather than
+  # written: the parser rejects `f((), x)`, so a constructed call is how a pair
+  # holding the empty argument is spelled at all.
+  parens <- function(expr) as.call(list(as.name("("), expr))
+
+  # The shapes, with the argument number each leaves empty. A trailing empty
+  # argument is not among them: `rlang::enquos(...)` captures no argument for
+  # it, which is the reading the test below holds unchanged.
+  #
+  # The parenthesized spellings are here because `(` is the identity function,
+  # so a pair wraps nothing to read either, and every other reading this
+  # position takes sees through one (#178, #259). One pair and two, since what
+  # sees through them unwraps until it stops. Unrefused, such an argument
+  # reaches `is_name_only_expr()`, where the empty argument is a symbol whose
+  # name is `""` and `rlang::env_has()` raises an untyped condition for a
+  # zero-length variable name -- #261's own defect at the spelling #259 made
+  # transparent.
   shapes <- list(
     list(position = 1L, args = list(rlang::missing_arg(), quote(region))),
     list(
       position = 2L,
       args = list(quote(region), rlang::missing_arg(), quote(grade))
+    ),
+    list(
+      position = 1L,
+      args = list(parens(rlang::missing_arg()), quote(region))
+    ),
+    list(
+      position = 2L,
+      args = list(quote(region), parens(parens(rlang::missing_arg())))
     )
   )
 
@@ -685,7 +707,7 @@ test_that("a leading or interior empty argument is refused in every kind", {
   )
 })
 
-test_that("an empty slot the package already had a reading for keeps it", {
+test_that("the empty spellings that already had a reading keep it", {
   data <- data.frame(region = c("a", "b"), value = c(1, 2))
   region_only <- inspect_grouping(data, .grouping = grouping_sets(region))
   grand_total <- inspect_grouping(data)


### PR DESCRIPTION
Closes #261.

## What changed

A leading or interior empty argument to a Grouping specification constructor
reported an rlang argument name the caller never wrote:

```r
inspect_grouping(d, .grouping = grouping_sets(, region))
#> Error: argument "expr" is missing, with no default
```

`expr` is the local `grouping_arg_spec()` binds from
`rlang::quo_get_expr(arg)`; forcing it at the next read raises base R's untyped
`missingArgError`, and `conditionCall()` was `grouping_arg_spec(arg,
data_vars)`. It now reads:

```r
#> Error in `inspect_grouping()`:
#> ! Argument 1 of `grouping_sets()` is empty.
#> i Remove the comma, or write the columns that position selects.
```

## The disposition

Refusal, [recorded on the ticket](https://github.com/sayuks/marginplyr/issues/261#issuecomment-5460611345)
rather than the empty selection `dplyr::select()` reads the same shape as.
`select()`'s arguments are one selection between them, so an argument selecting
nothing is the identity and there is nothing further to decide. A
`grouping_sets()` argument is one grouping set, so "selects no column" does not
say whether the caller asked for the empty grouping set — which
`grouping_set()` already spells — or for no set at all. And the position
refuses this argument elsewhere already: `grouping_helper_vars()` refuses an
empty one ahead of its arity checks (#181), so that the diagnostic describes
what the caller wrote rather than whatever a later check reached first.

## Where the refusal sits

In `preflight_grouping_spec()`'s loop rather than in the reader below it,
because that is the frame holding what the diagnostic names. The argument has
no spelling for ADR 0024's rule to quote, so the constructor and the count of
arguments before it are the only things that point at the comma.

`rlang::quo_is_missing()` is asked of the quosure, before anything reads the
expression out of it, which is the rule `R/utils.R` states. That makes "`arg`
carries an expression" a contract `grouping_arg_spec()` holds rather than
re-establishes, so its local binding stands and gains a header saying who holds
it; `check_ambiguous_nested_name()`'s comment, which named this ticket as the
reason no empty argument reached it, is corrected to say what now keeps one
away.

## Tests

The constructors are derived from `grouping_kind_rules()`. Both positions
`rlang::enquos(...)` captures an empty argument for are covered, plus one
nested a level in, where the refusal names the inner constructor. The message
is asserted in full and `conditionCall()` is read, since a match on the part
that was already right could see neither defect.

A second test holds the four readings that must not move: a trailing comma, an
empty `.by`, an empty `.grouping`, and `grouping_set()` with no arguments at
all.

ADR 0008's test strategy asked for "syntactically empty arguments for every
kind" and that coverage was never written; this is it. No test added here
requires a member of `optional_backends()`.

## Documentation

`CONTEXT.md`'s *Nested specification position*, `?grouping_set`, and `NEWS.md`
each gain the rule in the paragraph already stating how a nested argument is
read.

## Acceptance criteria

- [x] A leading or interior empty argument in every nested position raises a
      `marginplyr_error` that names no rlang or marginplyr internal.
- [x] The constructors the assertion covers are derived from
      `grouping_kind_rules()`.
- [x] A trailing empty argument keeps the reading it has today.
- [x] An empty `.by` and an empty `.grouping` keep the readings they have today.
- [x] No test added by this ticket requires a member of `optional_backends()`.

## Local checks

`testthat::test_local()` under `NOT_CRAN=true`, `lintr::lint_package()`,
`spelling::spell_check_package()`, `roxygen2::roxygenise()`, and
`Rscript .github/scripts/verify-context-budget.R` all pass.