### PR TITLE
Refuse a nested specification stored as a function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,10 @@
   specification. That refusal is now marginplyr's own diagnostic, naming the
   recognized forms and the binding that works — `s <- my_spec(region)`, then
   `grouping_sets(s, grade)` — rather than tidyselect reporting the
-  specification as an unusable column selection. A name both readings claim —
+  specification as an unusable column selection. It is the diagnostic whatever
+  the specification is stored as, including a function, which tidyselect calls
+  as a column predicate rather than refusing: that case reported an error about
+  a call you never wrote (#265). A name both readings claim —
   a column of your input that is also bound to a nested specification the
   position accepts — is refused rather than resolved by whichever the data
   happens to have, and the refusal names the spelling for each reading:

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,10 +11,10 @@
   specification. That refusal is now marginplyr's own diagnostic, naming the
   recognized forms and the binding that works — `s <- my_spec(region)`, then
   `grouping_sets(s, grade)` — rather than tidyselect reporting the
-  specification as an unusable column selection. It is the diagnostic whatever
-  the specification is stored as, including a function, which tidyselect calls
-  as a column predicate rather than refusing: that case reported an error about
-  a call you never wrote (#265). A name both readings claim —
+  specification as an unusable column selection. It is also the diagnostic for
+  a specification stored as a function, which tidyselect calls as a column
+  predicate rather than refusing, so the call reported an error about a call
+  you never wrote (#265). A name both readings claim —
   a column of your input that is also bound to a nested specification the
   position accepts — is refused rather than resolved by whichever the data
   happens to have, and the refusal names the spelling for each reading:

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -990,21 +990,136 @@ grouping_arg_spec <- function(arg, data_vars) {
 # `abort_share_source_name()` does for the same reason. Every other failure is
 # an External condition and is re-raised as it arrived, with its own class,
 # diagnostic, and cause.
+#
+# A specification stored as a function is refused from the frames instead,
+# because tidyselect refuses no function: it calls one, as the predicate form
+# of a selection, so the caller was left with base R's untyped complaint about
+# the call tidyselect made and no condition named the object (#265). The two
+# readings answer one question and reach one refusal. Which of them is
+# available is decided by how the object is stored and not by what it is, which
+# is why neither is written as the other's fallback.
+#
+# The frames are read as the error unwinds and the condition after it, because
+# a predicate is applied inside `resolve_column_selection()` and the frames
+# that applied it are gone once it returns.
 resolve_grouping_selection <- function(arg, data_proxy) {
+  selection <- sys.nframe()
+  predicate <- FALSE
   tryCatch(
-    resolve_column_selection(
-      arg,
-      data_proxy,
-      on_rename = abort_grouping_rename
+    withCallingHandlers(
+      resolve_column_selection(
+        arg,
+        data_proxy,
+        on_rename = abort_grouping_rename
+      ),
+      error = function(cnd) {
+        if (is_grouping_spec_predicate(selection, nested_arg_expr(arg))) {
+          predicate <<- TRUE
+        }
+      }
     ),
     error = function(cnd) {
       label <- rlang::as_label(nested_arg_expr(arg))
-      if (!is_grouping_spec_subscript(cnd, label)) {
+      if (!predicate && !is_grouping_spec_subscript(cnd, label)) {
         stop(cnd)
       }
       abort_nested_grouping_spec(label)
     }
   )
+}
+
+# Whether the failure now unwinding is a specification tidyselect took for a
+# predicate, in a position that can speak for it.
+#
+# The label comparison `is_grouping_spec_subscript()` makes has no counterpart
+# here, since a condition tidyselect raised about a predicate names no
+# subscript, so the same distinction is drawn from the caller's own expression:
+# tidyselect walks the operators below in parts and evaluates everything else
+# whole. A part is what it applied under one of them, and the position does not
+# speak for a part of an argument, for the reason recorded above
+# `is_grouping_spec_subscript()`.
+#
+# The operators are the ones tidyselect's walk descends into -- its documented
+# selection grammar, `c()`, `-`, `:`, `!`, `&`, `|`, and the `/` it reads as a
+# set difference -- together with the scalar-boolean and arithmetic spellings
+# it refuses in place of one of them, which cost nothing to name and are
+# refused before anything under them is walked. `(` is not among them because
+# `nested_arg_expr()` has already dropped a redundant pair, and a quosure is
+# not, because `is_nameable_call()` declines the call to `~` that one is.
+is_grouping_spec_predicate <- function(selection, expr) {
+  operators <- c("c", "-", ":", "!", "&", "|", "&&", "||", "*", "/", "^")
+  if (!is_nameable_call(expr)) {
+    return(FALSE)
+  }
+  name <- static_call_name(expr)
+  if (!is.null(name) && name %in% operators) {
+    return(FALSE)
+  }
+  any(vapply(
+    selection_frames(selection),
+    holds_grouping_spec_function,
+    logical(1)
+  ))
+}
+
+# The frames tidyselect opened under this selection, outermost first.
+#
+# A frame is tidyselect's by the namespace its function closes over, never by
+# name: reading a private name is what `:::` is, and a namespace that stopped
+# opening these frames answers with none rather than raising, which leaves a
+# caller the untyped diagnostic they had before this refusal existed.
+selection_frames <- function(selection) {
+  namespace <- asNamespace("tidyselect")
+  frames <- list()
+  for (index in seq_len(sys.nframe())) {
+    if (index <= selection) {
+      next
+    }
+    if (identical(environment(sys.function(index)), namespace)) {
+      frames <- c(frames, list(sys.frame(index)))
+    }
+  }
+  frames
+}
+
+# Whether a frame holds a specification stored as a function.
+#
+# This is where the object is read, because tidyselect holds the value it is
+# applying in a binding of the frame that applies it, and that binding outlives
+# the call: a predicate whose output tidyselect rejects has already returned.
+# What was measured of that frame, and of the shapes a specification stored as
+# a function reaches it in, is in
+# `investigation/reading-a-specification-tidyselect-called.md`.
+#
+# A specification stored as anything else is not looked for here. That one
+# tidyselect refuses rather than calls, so it arrives in a condition that names
+# both the object and the subscript refused, and reading it from a frame
+# instead would answer for a sub-selection the position does not speak for.
+#
+# Nothing is forced to answer. A binding tidyselect has not forced is skipped,
+# because forcing one can evaluate the caller's argument a second time
+# (ADR 0008); an active binding is skipped because reading one runs a function;
+# and `...` is skipped because it is not a binding a value can be read out of.
+# What is left can still raise -- a formal a caller of tidyselect left missing
+# is bound and unreadable -- and a value that cannot be read is not one
+# carrying the class.
+holds_grouping_spec_function <- function(frame) {
+  names <- setdiff(ls(frame, all.names = TRUE), "...")
+  if (length(names) == 0L) {
+    return(FALSE)
+  }
+  readable <- !rlang::env_binding_are_lazy(frame, names) &
+    !rlang::env_binding_are_active(frame, names)
+  for (name in names[readable]) {
+    value <- tryCatch(
+      get(name, envir = frame, inherits = FALSE),
+      error = function(cnd) NULL
+    )
+    if (is.function(value) && inherits(value, "margin_grouping_spec")) {
+      return(TRUE)
+    }
+  }
+  FALSE
 }
 
 # The refused subscript travels in the condition's `i` field, at whatever depth

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -1001,10 +1001,14 @@ grouping_arg_spec <- function(arg, data_vars) {
 #
 # The frames are read as the error unwinds and the condition after it, because
 # a predicate is applied inside `resolve_column_selection()` and the frames
-# that applied it are gone once it returns.
+# that applied it are gone once it returns. What the handler keeps is the
+# condition it read them on, not that it read them: a calling handler runs for
+# every error signalled under the selection, one tidyselect goes on to recover
+# from included, and a reading kept as a flag would answer for whatever failed
+# after it instead.
 resolve_grouping_selection <- function(arg, data_proxy) {
-  selection <- sys.nframe()
-  predicate <- FALSE
+  selection_frame <- sys.nframe()
+  predicate <- NULL
   tryCatch(
     withCallingHandlers(
       resolve_column_selection(
@@ -1013,14 +1017,16 @@ resolve_grouping_selection <- function(arg, data_proxy) {
         on_rename = abort_grouping_rename
       ),
       error = function(cnd) {
-        if (is_grouping_spec_predicate(selection, nested_arg_expr(arg))) {
-          predicate <<- TRUE
+        if (is_grouping_spec_predicate(selection_frame, nested_arg_expr(arg))) {
+          predicate <<- cnd
         }
       }
     ),
     error = function(cnd) {
       label <- rlang::as_label(nested_arg_expr(arg))
-      if (!predicate && !is_grouping_spec_subscript(cnd, label)) {
+      raised <- !is.null(predicate) &&
+        any(vapply(condition_chain(cnd), identical, logical(1), predicate))
+      if (!raised && !is_grouping_spec_subscript(cnd, label)) {
         stop(cnd)
       }
       abort_nested_grouping_spec(label)
@@ -1033,10 +1039,13 @@ resolve_grouping_selection <- function(arg, data_proxy) {
 #
 # The label comparison `is_grouping_spec_subscript()` makes has no counterpart
 # here, since a condition tidyselect raised about a predicate names no
-# subscript, so the same distinction is drawn from the caller's own expression:
-# tidyselect walks the operators below in parts and evaluates everything else
-# whole. A part is what it applied under one of them, and the position does not
-# speak for a part of an argument, for the reason recorded above
+# subscript. The same distinction is drawn twice instead, because a part of an
+# argument reaches this in two ways and neither reading answers the other. The
+# caller's expression is the first: tidyselect walks the operators below in
+# parts and evaluates everything else whole, so a part is what it applied under
+# one of them. Which frame holds the object is the second, and
+# `selection_frames()` is where that half is. The position does not speak for a
+# part of an argument, for the reason recorded above
 # `is_grouping_spec_subscript()`.
 #
 # The operators are the ones tidyselect's walk descends into -- its documented
@@ -1046,7 +1055,7 @@ resolve_grouping_selection <- function(arg, data_proxy) {
 # refused before anything under them is walked. `(` is not among them because
 # `nested_arg_expr()` has already dropped a redundant pair, and a quosure is
 # not, because `is_nameable_call()` declines the call to `~` that one is.
-is_grouping_spec_predicate <- function(selection, expr) {
+is_grouping_spec_predicate <- function(selection_frame, expr) {
   operators <- c("c", "-", ":", "!", "&", "|", "&&", "||", "*", "/", "^")
   if (!is_nameable_call(expr)) {
     return(FALSE)
@@ -1056,28 +1065,57 @@ is_grouping_spec_predicate <- function(selection, expr) {
     return(FALSE)
   }
   any(vapply(
-    selection_frames(selection),
+    selection_frames(selection_frame),
     holds_grouping_spec_function,
     logical(1)
   ))
 }
 
-# The frames tidyselect opened under this selection, outermost first.
+# The frames tidyselect's own walk opened under this selection, outermost
+# first.
 #
 # A frame is tidyselect's by the namespace its function closes over, never by
 # name: reading a private name is what `:::` is, and a namespace that stopped
 # opening these frames answers with none rather than raising, which leaves a
 # caller the untyped diagnostic they had before this refusal existed.
-selection_frames <- function(selection) {
+#
+# The walk is what the first of them opens, `resolve_column_selection()` having
+# called `tidyselect::eval_select()`, and the first exported function reached
+# after it is where the walk stops being what is running: a selection helper
+# the caller wrote, holding what the caller handed it. `starts_with(spec)`,
+# `all_of(spec)`, and `last_col(spec)` each fail a type check under one of
+# those, with the specification bound to a formal of the helper or of an
+# internal function it delegates to, having applied nothing. The scan therefore
+# stops there rather than skipping the helper's own frame, which would still
+# reach what it delegates to. Refusing under one of them would answer for a
+# part of an argument, which is the distinction recorded above
+# `is_grouping_spec_subscript()`.
+selection_frames <- function(selection_frame) {
   namespace <- asNamespace("tidyselect")
+  exported <- mget(
+    getNamespaceExports("tidyselect"),
+    envir = namespace,
+    mode = "function",
+    ifnotfound = list(NULL)
+  )
   frames <- list()
+  entered <- FALSE
   for (index in seq_len(sys.nframe())) {
-    if (index <= selection) {
+    if (index <= selection_frame) {
       next
     }
-    if (identical(environment(sys.function(index)), namespace)) {
-      frames <- c(frames, list(sys.frame(index)))
+    fn <- sys.function(index)
+    if (!identical(environment(fn), namespace)) {
+      next
     }
+    if (!entered) {
+      entered <- TRUE
+      next
+    }
+    if (any(vapply(exported, identical, logical(1), fn))) {
+      break
+    }
+    frames <- c(frames, list(sys.frame(index)))
   }
   frames
 }

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -461,6 +461,57 @@ plan, because a reading taken once and a reading taken three times differ only
 where the argument answers differently each time, and an argument that does
 that is one whose count this amendment is about.
 
+## Amendment: the condition class of a specification stored as a function
+
+The constraint holding error condition classes fixed is amended a sixth time,
+by #265, at the selection resolution and in the direction #262 chose for the
+guard: this is a refusal that was already written arriving, rather than a new
+one being chosen.
+
+#190 gave a Nested specification position its own refusal for a specification
+that reaches it where a column selection is expected, and wrote it from the
+condition tidyselect raises about a subscript it will not use. tidyselect
+raises no such condition about a function: `is.function()` decides its first
+branch, before any class is read, so it calls the value as the predicate form
+of a selection. What came out of the position was then whatever the call
+produced — `simpleError` naming `X[[i]]` for a signature tidyselect cannot
+call, the class the body raised for one it can, and tidyselect's own report
+about a predicate's output for one that returns the wrong thing. The class such
+a call raises therefore moves to `marginplyr_error`, and the diagnostic to the
+refusal #190 already writes for every other way of storing the same object.
+
+**What decides it.** The object is read from the frames tidyselect applied it
+from, as the error unwinds, and the argument's own expression decides whether
+the position speaks for it. Neither is a second reading of the caller's
+quosure, which is what the constraint below forbids and what #190's refusal
+avoids by reading the condition. The evidence for both — that the frame holding
+the value outlives the call, that no condition carries it, and that
+`allow_predicates = FALSE` answers by removing `where()` rather than by
+identifying anything — is in
+`investigation/reading-a-specification-tidyselect-called.md`.
+
+**Evaluations.** The constraint holding the number and timing of evaluations is
+not reached. The table above gives such an argument one evaluation, in the
+selection resolution that refuses it, and it has one still: the frames are
+read, not the quosure. A binding tidyselect has not forced is skipped for that
+reason and not for tidiness.
+
+**What does not move.** The wording of the refusal, and every object that
+reached it before, are untouched. So is the rule that the position speaks for
+its own argument and not for a part of one: a specification applied from under
+an operator tidyselect walks in parts keeps tidyselect's report, exactly as a
+specification refused inside `c()` does. The distinction is drawn from the
+caller's expression here, because a condition about a predicate names no
+subscript to compare a label with.
+
+**What is left.** One shape of the same object is unreached: a function that is
+a valid predicate as well as a specification — one argument, a logical scalar
+back — is applied without failing, so the position receives a selection instead
+of a refusal and no condition exists to read the frames from. Nothing marginplyr
+constructs has that shape, since a constructor builds a list. It is recorded
+here because an amendment saying a class of errors moved should say which
+errors were not there to move.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -481,13 +481,14 @@ a call raises therefore moves to `marginplyr_error`, and the diagnostic to the
 refusal #190 already writes for every other way of storing the same object.
 
 **What decides it.** The object is read from the frames tidyselect applied it
-from, as the error unwinds, and the argument's own expression decides whether
-the position speaks for it. Neither is a second reading of the caller's
-quosure, which is what the constraint below forbids and what #190's refusal
-avoids by reading the condition. The evidence for both — that the frame holding
-the value outlives the call, that no condition carries it, and that
-`allow_predicates = FALSE` answers by removing `where()` rather than by
-identifying anything — is in
+from, as the error unwinds. Neither that nor the two readings that decide
+whether the position speaks for it — the argument's own expression, and which
+of those frames holds the object — is a second reading of the caller's quosure,
+which is what the constraint below forbids and what #190's refusal avoids by
+reading the condition. The evidence — that the frame holding the value outlives
+the call, that no condition carries it, that a selection helper the caller
+called holds it without applying it, and that `allow_predicates = FALSE`
+answers by removing `where()` rather than by identifying anything — is in
 `investigation/reading-a-specification-tidyselect-called.md`.
 
 **Evaluations.** The constraint holding the number and timing of evaluations is
@@ -498,11 +499,13 @@ reason and not for tidiness.
 
 **What does not move.** The wording of the refusal, and every object that
 reached it before, are untouched. So is the rule that the position speaks for
-its own argument and not for a part of one: a specification applied from under
-an operator tidyselect walks in parts keeps tidyselect's report, exactly as a
-specification refused inside `c()` does. The distinction is drawn from the
-caller's expression here, because a condition about a predicate names no
-subscript to compare a label with.
+its own argument and not for a part of one: a specification under an operator
+tidyselect walks in parts, and one a selection helper the caller called was
+handed, each keep tidyselect's report, exactly as a specification refused
+inside `c()` does. The distinction is drawn twice here, from the caller's
+expression and from which frame holds the object, because a condition about a
+predicate names no subscript to compare a label with and because the two
+shapes reach it separately.
 
 **What is left.** One shape of the same object is unreached: a function that is
 a valid predicate as well as a specification — one argument, a logical scalar

--- a/investigation/reading-a-specification-tidyselect-called.md
+++ b/investigation/reading-a-specification-tidyselect-called.md
@@ -1,0 +1,84 @@
+# Reading a specification tidyselect called
+
+Investigated: 2026-08-29
+
+Measured while deciding how a nested Grouping specification position could
+refuse a specification stored as a function (#265). #190's refusal is written
+from the condition tidyselect raises about a subscript it will not use; a
+function is not such a subscript, so that condition never exists. The question
+was where else the object can be read from, given that evaluating the caller's
+argument a second time to find out is what ADR 0008 forbids.
+
+## Environment
+
+| Component | Version |
+|---|---|
+| R | 4.6.1 |
+| tidyselect | 1.2.1 |
+| rlang | 1.3.0 |
+| vctrs | 0.7.3 |
+
+## What tidyselect does with a function
+
+`tidyselect:::as_indices_sel_impl()` branches on `is.function(x)` before
+anything else. `is.function()` is not generic and the branch precedes every
+other test, so no class, method, or attribute on the value changes the
+decision: a function is applied as the predicate form of a selection, and a
+value of any other type reaches `as_indices_impl()`, which is what raises the
+`vctrs_error_subscript_type` condition carrying `i` and `subscript_arg` that
+#190 reads.
+
+The application is `map(data, predicate)` — `lapply()` — followed by a loop
+calling `check_predicate_output()` over what it returned. Four shapes of a
+`margin_grouping_spec` stored as a function were measured against
+`inspect_grouping()`:
+
+| Stored as | What the caller received before #265 |
+|---|---|
+| `function() 1` | `simpleError`: `unused argument (X[[i]])` |
+| `function(x) stop("inside")` | whatever the body raised |
+| `function(x) "no"` | tidyselect: `Predicate must return TRUE or FALSE, not a string.` |
+| `function(x) TRUE` | no error; every column selected |
+
+The first three name nothing the caller wrote. The fourth is a valid predicate
+as well as a specification and produces no condition at all, so nothing on the
+error path reaches it.
+
+## Where the object is readable
+
+`eval_select(allow_predicates = FALSE)` refuses a function instead of calling
+one, but it refuses every function: `where(is.numeric)` returns a function and
+was refused by the same branch, with a `tidyselect_error_predicates_unsupported`
+condition carrying neither the value nor a subscript label. It answers the
+diagnostic question by removing a documented selection form and without
+identifying the object, so it answers neither half.
+
+The frames tidyselect opened are the remaining source, and they outlive the
+call: `as_indices_sel_impl()` binds the value to `predicate` before applying
+it, and its frame is still on the stack for all three failing shapes above —
+including the third, where the predicate has already returned. Read at the
+moment the error unwinds, through a calling handler, the object is reachable
+for each of them. Read after `eval_select()` returns, it is reachable for none.
+
+The frames were identified by the namespace their function closes over —
+`identical(environment(sys.function(i)), asNamespace("tidyselect"))` — rather
+than by any private name. Scanning their bindings for a function carrying the
+class answered `TRUE` for the three failing shapes and `FALSE` for an ordinary
+selection, a `where()` predicate, a `where()` predicate that raises, a missing
+column, and the non-function specification #190 already refuses.
+
+Two properties of that scan were measured rather than assumed. `ls()` on a
+frame lists `...`, which `get()` cannot read as a value; and a formal a caller
+left missing is listed and raises when read. Both were reached in the shapes
+above before they were excluded.
+
+## What a scan cannot separate
+
+A condition names the subscript it refused, so #190 can compare that label with
+the argument's own and decline to speak for a part of an argument. A frame scan
+has no such label. Measured against tidyselect's walk, `c(f(), grade)` and
+`-f()` apply the predicate from a part, and both leave the same frames on the
+stack as a bare `f()` does, so the two are indistinguishable from the frames
+alone. What separates them is the caller's expression: `walk_data_tree()`
+descends into `c`, `-`, `:`, `!`, `&`, `|`, `/`, and `(`, refuses `&&`, `||`,
+`*`, `^`, and `~` before descending, and evaluates every other call whole.

--- a/investigation/reading-a-specification-tidyselect-called.md
+++ b/investigation/reading-a-specification-tidyselect-called.md
@@ -72,6 +72,27 @@ frame lists `...`, which `get()` cannot read as a value; and a formal a caller
 left missing is listed and raises when read. Both were reached in the shapes
 above before they were excluded.
 
+## A frame holding the object is not a frame that applied it
+
+The scan as first written answered `TRUE` for five arguments in which nothing
+was applied at all. `tidyselect::starts_with(f())`, `any_of(f())`,
+`all_of(f())`, and `last_col(f())` each fail a type check — `match` must be a
+character vector, `offset` a single integer, `all_of()`'s argument a subscript
+— with the specification bound to a formal, of the helper or of an internal
+function it delegates to: `all_of()` reaches `as_indices_impl()`, which is
+tidyselect's and not exported, so excluding exported frames alone does not
+reach it.
+
+What separates the two is where the exported frame sits. `eval_select()` is
+exported and is the entry, so every frame is under one; the first exported
+function reached *after* it is a helper the caller wrote, and everything deeper
+is that helper's. Stopping the scan there answered `FALSE` for all five and
+left the three failing shapes above answering `TRUE`.
+
+`where(fn)` was measured separately because it does not fail: it returns a
+closure of its own that calls `fn`, so the specification is never a binding of
+a tidyselect frame and the scan answers `FALSE` whatever the stopping rule is.
+
 ## What a scan cannot separate
 
 A condition names the subscript it refused, so #190 can compare that label with

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -302,11 +302,21 @@ test_that("a nested specification stored as a function is refused", {
   )
 
   # The position does not speak for a part of an argument it did not refuse,
-  # which is the rule a value tidyselect does refuse is held to as well. An
-  # argument written with an operator tidyselect walks in parts keeps
-  # tidyselect's own report, whatever the part turned out to be.
-  for (selection in list(quote(c(spec_from_caller(), grade)),
-                         quote(-spec_from_caller()))) {
+  # which is the rule a value tidyselect does refuse is held to as well. Two
+  # shapes reach that rule, and neither is answered by the other: an argument
+  # written with an operator tidyselect walks in parts, and one handed to a
+  # selection helper the caller called, which fails a type check of its own
+  # with the specification bound below it and nothing applied.
+  parts <- list(
+    quote(c(spec_from_caller(), grade)),
+    quote(-spec_from_caller()),
+    quote(tidyselect::all_of(spec_from_caller())),
+    quote(tidyselect::any_of(spec_from_caller())),
+    quote(tidyselect::starts_with(spec_from_caller())),
+    quote(tidyselect::last_col(spec_from_caller())),
+    quote(tidyselect::where(spec_from_caller()))
+  )
+  for (selection in parts) {
     spec <- eval(
       rlang::call2("grouping_sets", selection),
       envir = rlang::current_env()

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -250,6 +250,95 @@ test_that("a nested specification position recognizes a spelling or a name", {
   )
 })
 
+# tidyselect refuses a specification it cannot use as a subscript, and #190's
+# refusal is written from that condition. It refuses no function: it calls one,
+# as the predicate form of a selection, so a specification stored as a function
+# took the same position with no condition naming it and the caller got base
+# R's untyped complaint about the call tidyselect made (#265).
+test_that("a nested specification stored as a function is refused", {
+  data_vars <- c("region", "grade", "value")
+  refusal <- paste0(
+    "is a grouping specification, but a nested position recognizes one only ",
+    "when it is a call to `grouping_set()`, `grouping_sets()`, `rollup()`, ",
+    "`cube()`, or `grouping_spec()`, or a name bound to a specification.\n",
+    "i Anything else is read as a column selection.\n",
+    "i Assign the specification to a name first, then use that name here."
+  )
+
+  # Three functions, because what a caller sees depended on the signature the
+  # specification happened to be stored with and not on the position: tidyselect
+  # cannot call the first, calls the second and is aborted by it, and calls the
+  # third and rejects what it returned. Each carries the class the position
+  # exists to recognize, so each gets the one refusal.
+  stored_as <- function(fn) structure(fn, class = "margin_grouping_spec")
+  stored <- list(
+    uncallable = function() stored_as(function() 1),
+    aborting = function() stored_as(function(x) stop("inside")),
+    unusable = function() stored_as(function(x) "no")
+  )
+  for (name in names(stored)) {
+    spec_from_caller <- stored[[name]]
+    refused <- expect_error(compile_against(
+      grouping_sets(spec_from_caller(), grade),
+      data_vars
+    ))
+    expect_s3_class(refused, "marginplyr_error")
+    expect_identical(
+      conditionMessage(refused),
+      paste0("`spec_from_caller()` ", refusal)
+    )
+  }
+
+  # The parenthesized spelling is the argument it wraps here too, as it is for
+  # every other reading a nested position takes (#178, #259).
+  spec_from_caller <- stored$uncallable
+  parenthesized <- expect_error(compile_against(
+    grouping_sets((spec_from_caller()), grade),
+    data_vars
+  ))
+  expect_identical(
+    conditionMessage(parenthesized),
+    paste0("`spec_from_caller()` ", refusal)
+  )
+
+  # The position does not speak for a part of an argument it did not refuse,
+  # which is the rule a value tidyselect does refuse is held to as well. An
+  # argument written with an operator tidyselect walks in parts keeps
+  # tidyselect's own report, whatever the part turned out to be.
+  for (selection in list(quote(c(spec_from_caller(), grade)),
+                         quote(-spec_from_caller()))) {
+    spec <- eval(
+      rlang::call2("grouping_sets", selection),
+      envir = rlang::current_env()
+    )
+    embedded <- expect_error(compile_against(spec, data_vars))
+    expect_false(inherits(embedded, "marginplyr_error"))
+  }
+
+  # A selection that fails for a reason of its own is untouched.
+  unknown <- expect_error(
+    compile_against(grouping_sets(unknown, grade), data_vars)
+  )
+  expect_false(inherits(unknown, "marginplyr_error"))
+
+  # What a caller sees, on the reproduction the ticket was filed with, and
+  # beside it the selection whose value really is a predicate -- the one the
+  # refusal has to leave alone, and the one that made a function unreadable
+  # from the condition in the first place.
+  data <- data.frame(region = c("a", "b"), value = c(1, 2))
+  end_to_end <- expect_error(
+    inspect_grouping(data, .grouping = grouping_sets(spec_from_caller()))
+  )
+  expect_s3_class(end_to_end, "marginplyr_error")
+  expect_equal(
+    inspect_grouping(
+      data,
+      .grouping = grouping_sets(tidyselect::where(is.character))
+    ),
+    inspect_grouping(data, .grouping = grouping_sets(region))
+  )
+})
+
 test_that("a nested column selection is unaffected by the specification rule", {
   data_vars <- c("region", "region_code", "grade", "value")
   compile <- function(spec) {


### PR DESCRIPTION
Closes #265.

## What was wrong

#190's refusal is written from the condition tidyselect raises about a subscript it will not use. tidyselect raises no such condition about a function: `is.function()` decides its first branch, before any class is read, so it calls the value as the predicate form of a selection. A `margin_grouping_spec` stored as a function therefore reached a nested position carrying the class that position exists to recognize, and the caller received a diagnostic naming nothing they wrote:

| Stored as | Before |
|---|---|
| `function() 1` | `simpleError`: `unused argument (X[[i]])` |
| `function(x) stop("inside")` | whatever the body raised |
| `function(x) "no"` | `Predicate must return TRUE or FALSE, not a string.` |

All three now get #190's refusal, unchanged in wording, with the `marginplyr_error` class ADR 0015 assigns it.

## How

The object is read from the frames tidyselect applied it from, as the error unwinds, and the argument's own expression decides whether the position speaks for it. Neither is a second reading of the caller's quosure — ADR 0008's evaluation-count table is unchanged, and a binding tidyselect has not forced is skipped for that reason. The frames are tidyselect's by the namespace their function closes over, never by a private name, so a release that stops opening them leaves the caller the untyped diagnostic they had rather than raising.

The rule that a position speaks for its own argument and not for a part of one is kept, and drawn differently because it has to be: a condition about a predicate names no subscript to compare a label with. tidyselect walks `c`, `-`, `:`, `!`, `&`, `|`, and `/` in parts, so an argument written with one of those keeps tidyselect's own report, exactly as a specification refused inside `c()` does.

## Not reached

A function that is a valid predicate as well as a specification — one argument, a logical scalar back — is applied without failing, so no condition exists to read the frames from and the position receives a selection. Nothing a constructor builds has that shape. ADR 0008's amendment records it rather than leaving it implied.

## Records

- `design/adr/0008-…`: the amendment for the condition class, its sixth.
- `investigation/reading-a-specification-tidyselect-called.md`: what was measured of tidyselect 1.2.1 — where the value is readable, the four shapes, and why `allow_predicates = FALSE` answers neither half of the question.
- `NEWS.md`: the #190 bullet now covers every way of storing the object.

## Checks

`testthat::test_local()` (632 tests, all pass), `lintr::lint_package()` (no lints), `Rscript .github/scripts/verify-suite-coverage.R`, `Rscript .github/scripts/verify-context-budget.R`, `roxygen2::roxygenise()` (no diff). The new test fails in 8 assertions without the change.