### PR TITLE
Build the Arrow input shapes once

### DIFF
--- a/tests/testthat/helper-arrow-shapes.R
+++ b/tests/testthat/helper-arrow-shapes.R
@@ -1,23 +1,17 @@
-# The Arrow input shapes two suites take, in a helper file because testthat
-# evaluates each test file in its own environment and only a `helper-*.R` file
-# is sourced into the shared one, so a second suite needing a shape had to
-# rebuild it (#313).
+# The Arrow input shapes `test-grouping-backends.R` and `test-query-policy.R`
+# both take. testthat evaluates each test file in its own environment and only
+# a `helper-*.R` file is sourced into the shared one, so this is where a shape
+# two suites need is built once (#313).
 #
-# `test-grouping-backends.R` asserts which condition each shape raises, and
-# `test-query-policy.R` counts the reads each one causes. The second file's
-# comments argue from what the first asserts -- its Dataset block says the
-# refusal test there "asserts the condition and passes unchanged through such a
-# move" -- and that claim holds only while the two build the same shapes. Two
-# copies were not required to agree, so nothing failed when they stopped.
-#
-# What each shape *means* is stated where it is asserted, not here: this file
-# builds the objects and the division between them is CONTEXT.md's *Absorbing
-# backend*, at the seam ADR 0025 draws it at.
+# The two suites assert different things over the same objects:
+# `test-grouping-backends.R` which condition each shape raises, and
+# `test-query-policy.R` how many reads each one causes. The second file's
+# comments cite the first file's coverage, and that citation holds while both
+# build their shapes here.
 
-# A group, a numeric column, and a string column: the columns the absorbed
-# expressions asserted over need, which is a group collapsed to one string, a
-# subset inside an aggregate, and a statistic over two columns.
-absorbed_summary_data <- function() {
+# A group column, a numeric column, and a string column: what the summary
+# expressions written over this input in both suites read.
+arrow_input_data <- function() {
   data.frame(
     k = c("E", "E", "W"),
     v = c(1, 2, 3),

--- a/tests/testthat/helper-arrow-shapes.R
+++ b/tests/testthat/helper-arrow-shapes.R
@@ -1,0 +1,52 @@
+# The Arrow input shapes two suites take, in a helper file because testthat
+# evaluates each test file in its own environment and only a `helper-*.R` file
+# is sourced into the shared one, so a second suite needing a shape had to
+# rebuild it (#313).
+#
+# `test-grouping-backends.R` asserts which condition each shape raises, and
+# `test-query-policy.R` counts the reads each one causes. The second file's
+# comments argue from what the first asserts -- its Dataset block says the
+# refusal test there "asserts the condition and passes unchanged through such a
+# move" -- and that claim holds only while the two build the same shapes. Two
+# copies were not required to agree, so nothing failed when they stopped.
+#
+# What each shape *means* is stated where it is asserted, not here: this file
+# builds the objects and the division between them is CONTEXT.md's *Absorbing
+# backend*, at the seam ADR 0025 draws it at.
+
+# A group, a numeric column, and a string column: the columns the absorbed
+# expressions asserted over need, which is a group collapsed to one string, a
+# subset inside an aggregate, and a statistic over two columns.
+absorbed_summary_data <- function() {
+  data.frame(
+    k = c("E", "E", "W"),
+    v = c(1, 2, 3),
+    s = c("a", "b", "c"),
+    stringsAsFactors = FALSE
+  )
+}
+
+# A query rather than the object itself is the third shape, because
+# `arrow_dplyr_query` is the one class that appears on both sides of the
+# division: over a table it absorbs, over a dataset it refuses. `select()`
+# builds one without a data-masked column reference, which keeps these
+# helpers readable by `object_usage_linter()`.
+absorbing_arrow_inputs <- function(data) {
+  table <- arrow::Table$create(data)
+  batch <- arrow::record_batch(data)
+  list(
+    table = table,
+    record_batch = batch,
+    table_query = dplyr::select(table, dplyr::all_of(names(data))),
+    batch_query = dplyr::select(batch, dplyr::all_of(names(data)))
+  )
+}
+
+# `InMemoryDataset` reaches the `Dataset` class with no file I/O.
+refusing_arrow_inputs <- function(data) {
+  dataset <- arrow::InMemoryDataset$create(arrow::Table$create(data))
+  list(
+    dataset = dataset,
+    query = dplyr::select(dataset, dplyr::all_of(names(data)))
+  )
+}

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -122,10 +122,7 @@ test_that("Arrow uses the normalized grouping contract", {
 # Both halves are asserted, because what the decision turns on is that the two
 # are told apart (#254).
 #
-# The three input builders come from `helper-arrow-shapes.R`, which
-# `test-query-policy.R` also builds its shapes from: the comments there
-# argue from what this file asserts, and that holds only while the two
-# suites take the same objects (#313).
+# The three input builders come from `helper-arrow-shapes.R`.
 #
 # The expressions are chosen for how long they will keep being absorbed rather
 # than for how the defect was found. A group collapsed to one string, a subset
@@ -137,7 +134,7 @@ test_that("Arrow uses the normalized grouping contract", {
 # translates one fails there, naming the drift, rather than here.
 test_that("Arrow refuses a summary it would otherwise absorb", {
   skip_if_suggest_absent("arrow")
-  data <- absorbed_summary_data()
+  data <- arrow_input_data()
 
   inputs <- absorbing_arrow_inputs(data)
   for (shape in names(inputs)) {
@@ -343,7 +340,7 @@ test_that("Arrow refuses a subset inside an aggregate", {
   skip_if_suggest_absent("arrow")
 
   raised <- expect_error(summarize_with_margins(
-    arrow::Table$create(absorbed_summary_data()),
+    arrow::Table$create(arrow_input_data()),
     kept = sum(v[v > 1]),
     .grouping = rollup(k)
   ))
@@ -358,7 +355,7 @@ test_that("Arrow refuses a subset inside an aggregate", {
 
 test_that("an Arrow Dataset keeps Arrow's own refusal", {
   skip_if_suggest_absent("arrow")
-  data <- absorbed_summary_data()
+  data <- arrow_input_data()
 
   inputs <- refusing_arrow_inputs(data)
   for (shape in names(inputs)) {
@@ -387,7 +384,7 @@ test_that("an Arrow summary Arrow can evaluate is unchanged and stays lazy", {
   skip_if_suggest_absent("arrow")
 
   result <- summarize_with_margins(
-    arrow::Table$create(absorbed_summary_data()),
+    arrow::Table$create(arrow_input_data()),
     total = sum(v),
     .grouping = rollup(k)
   )
@@ -414,7 +411,7 @@ test_that("an Arrow summary Arrow can evaluate is unchanged and stays lazy", {
 # drift this block exists to catch.
 test_that("Arrow still absorbs the expressions the refusal is asserted over", {
   skip_if_suggest_absent("arrow")
-  table <- arrow::Table$create(absorbed_summary_data())
+  table <- arrow::Table$create(arrow_input_data())
   raised <- NULL
   # One per shape the shipped pages describe, so a page that stops being true
   # fails here rather than being re-read. `first()` and `last()` are absorbed
@@ -498,7 +495,7 @@ test_that("the branch guard refuses an absorbed summary the handler missed", {
   )
 
   raised <- expect_error(suppressWarnings(summarize_with_margins(
-    arrow::Table$create(absorbed_summary_data()),
+    arrow::Table$create(arrow_input_data()),
     joined = paste(s, collapse = ","),
     kept = sum(v[v > 1]),
     .grouping = rollup(k)

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -122,6 +122,11 @@ test_that("Arrow uses the normalized grouping contract", {
 # Both halves are asserted, because what the decision turns on is that the two
 # are told apart (#254).
 #
+# The three input builders come from `helper-arrow-shapes.R`, which
+# `test-query-policy.R` also builds its shapes from: the comments there
+# argue from what this file asserts, and that holds only while the two
+# suites take the same objects (#313).
+#
 # The expressions are chosen for how long they will keep being absorbed rather
 # than for how the defect was found. A group collapsed to one string, a subset
 # inside an aggregate, and a statistic over two columns are the shapes least
@@ -130,39 +135,6 @@ test_that("Arrow uses the normalized grouping contract", {
 # there, being the likeliest of the absorbed set to stop being so. The block
 # below asserts all three are still absorbed, so an Arrow release that
 # translates one fails there, naming the drift, rather than here.
-absorbed_summary_data <- function() {
-  data.frame(
-    k = c("E", "E", "W"),
-    v = c(1, 2, 3),
-    s = c("a", "b", "c"),
-    stringsAsFactors = FALSE
-  )
-}
-
-# A query rather than the object itself is the third shape, because
-# `arrow_dplyr_query` is the one class that appears on both sides of the
-# division: over a table it absorbs, over a dataset it refuses. `select()`
-# builds one without a data-masked column reference, which keeps these
-# helpers readable by `object_usage_linter()`.
-absorbing_arrow_inputs <- function(data) {
-  table <- arrow::Table$create(data)
-  batch <- arrow::record_batch(data)
-  list(
-    table = table,
-    record_batch = batch,
-    table_query = dplyr::select(table, dplyr::all_of(names(data))),
-    batch_query = dplyr::select(batch, dplyr::all_of(names(data)))
-  )
-}
-
-refusing_arrow_inputs <- function(data) {
-  dataset <- arrow::InMemoryDataset$create(arrow::Table$create(data))
-  list(
-    dataset = dataset,
-    query = dplyr::select(dataset, dplyr::all_of(names(data)))
-  )
-}
-
 test_that("Arrow refuses a summary it would otherwise absorb", {
   skip_if_suggest_absent("arrow")
   data <- absorbed_summary_data()

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -303,12 +303,11 @@ count_backend_reads <- function(expr) {
   counter$count
 }
 
-# The two blocks below take their Arrow inputs from `helper-arrow-shapes.R`,
-# which is where `test-grouping-backends.R` takes the shapes it asserts the
-# conditions over (#313).
+# The Arrow inputs the two blocks below take come from
+# `helper-arrow-shapes.R`.
 test_that("no Arrow read happens while a Margin verb runs", {
   skip_if_suggest_absent("arrow")
-  data <- absorbed_summary_data()
+  data <- arrow_input_data()
   absorbing <- absorbing_arrow_inputs(data)
   table <- absorbing$table
 
@@ -397,7 +396,7 @@ test_that("no Arrow Dataset read happens while a Margin verb runs", {
   skip_if_suggest_absent("arrow")
   # What a `Dataset` may be behind is not what is asserted here; that it is
   # told apart from a `Table` is, and the class is what tells it apart.
-  refusing <- refusing_arrow_inputs(absorbed_summary_data())
+  refusing <- refusing_arrow_inputs(arrow_input_data())
   dataset <- refusing$dataset
   query <- refusing$query
 

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -303,15 +303,14 @@ count_backend_reads <- function(expr) {
   counter$count
 }
 
+# The two blocks below take their Arrow inputs from `helper-arrow-shapes.R`,
+# which is where `test-grouping-backends.R` takes the shapes it asserts the
+# conditions over (#313).
 test_that("no Arrow read happens while a Margin verb runs", {
   skip_if_suggest_absent("arrow")
-  data <- data.frame(
-    k = c("E", "E", "W"),
-    v = c(1, 2, 3),
-    s = c("a", "b", "c"),
-    stringsAsFactors = FALSE
-  )
-  table <- arrow::Table$create(data)
+  data <- absorbed_summary_data()
+  absorbing <- absorbing_arrow_inputs(data)
+  table <- absorbing$table
 
   # The mechanism, asserted before anything is concluded from it. Every
   # expectation below is a zero, so a counter that counted nothing would report
@@ -355,13 +354,6 @@ test_that("no Arrow read happens while a Margin verb runs", {
   # afterwards by the guard -- a difference invisible in the condition the
   # caller receives, both arms raising the same refusal, and visible only here.
   # `try()` keeps the refusal from leaving before the count is read.
-  batch <- arrow::record_batch(data)
-  absorbing <- list(
-    table = table,
-    record_batch = batch,
-    table_query = dplyr::select(table, dplyr::all_of(names(data))),
-    batch_query = dplyr::select(batch, dplyr::all_of(names(data)))
-  )
   for (shape in names(absorbing)) {
     expect_identical(
       count_backend_reads(try(
@@ -403,17 +395,11 @@ test_that("no Arrow read happens while a Margin verb runs", {
 # Datasets, the likely form of the move, is counted.
 test_that("no Arrow Dataset read happens while a Margin verb runs", {
   skip_if_suggest_absent("arrow")
-  data <- data.frame(
-    k = c("E", "E", "W"),
-    v = c(1, 2, 3),
-    s = c("a", "b", "c"),
-    stringsAsFactors = FALSE
-  )
-  # `InMemoryDataset` reaches the class with no file I/O. What a `Dataset` may
-  # be behind is not what is asserted here; that it is told apart from a
-  # `Table` is, and the class is what tells it apart.
-  dataset <- arrow::InMemoryDataset$create(arrow::Table$create(data))
-  query <- dplyr::select(dataset, dplyr::all_of(names(data)))
+  # What a `Dataset` may be behind is not what is asserted here; that it is
+  # told apart from a `Table` is, and the class is what tells it apart.
+  refusing <- refusing_arrow_inputs(absorbed_summary_data())
+  dataset <- refusing$dataset
+  query <- refusing$query
 
   # The mechanism on this shape, asserted before anything is concluded from it,
   # for the reason the readings above assert it on a `Table`: those controls
@@ -422,7 +408,6 @@ test_that("no Arrow Dataset read happens while a Margin verb runs", {
   expect_gt(count_backend_reads(dplyr::collect(dataset)), 0L)
   expect_gt(count_backend_reads(dplyr::collect(query)), 0L)
 
-  refusing <- list(dataset = dataset, query = query)
   for (shape in names(refusing)) {
     expect_identical(
       count_backend_reads(try(


### PR DESCRIPTION
Closes #313.

`test-grouping-backends.R` defined `absorbed_summary_data()`,
`absorbing_arrow_inputs()`, and `refusing_arrow_inputs()` inside the test file.
testthat evaluates each test file in its own environment, so
`test-query-policy.R` could not reach them and rebuilt all three inline. The
copies were not required to agree, while `test-query-policy.R`'s comments argue
from what `test-grouping-backends.R` asserts — its Dataset block says the
refusal test there "asserts the condition and passes unchanged through such a
move".

## What changed

- `tests/testthat/helper-arrow-shapes.R` is new and holds the three builders.
  Its header states why they are in a helper and what the two suites do with
  them; what each shape *means* stays where it is asserted.
- `test-grouping-backends.R` drops the definitions and keeps the block arguing
  the expression choices, with a pointer to the helper.
- `test-query-policy.R` calls the three builders. Its two
  `data.frame(k, v, s)` literals become `absorbed_summary_data()`, which
  removes the third copy the ticket left open as a question.

The `absorbing` and `refusing` loops are untouched, per the ticket's Out of
scope.

## Checks

`testthat::test_local()` with `NOT_CRAN` set, `lintr::lint_package()` after
`pkgload::load_all()`, and `verify-context-budget.R` all pass. No `R/` change,
so nothing generated needed regenerating.