### PR TITLE
Classify a grouping kind with its class off

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -714,11 +714,7 @@ compile_grouping_spec_impl <- function(preflight,
 
   structure(
     list(
-      # The classified name rather than the field, so that what a reader of the
-      # plan compares is the name the guard admitted. `share.R` asks
-      # `identical(plan$kind, "rollup")`, which a kind carrying a class answers
-      # `FALSE` to while compiling as one (#289).
-      kind = grouping_kind_name(preflight$spec$type),
+      kind = preflight$spec$type,
       by = unique(.by),
       dimensions = dimensions,
       sets = normalized,
@@ -903,18 +899,21 @@ grouping_kind_rules <- local({
   }
 })
 
-# The name a kind read off an object is, or `NULL` where it is none: a name is
-# one string, and not the missing one. Every caller holds a value nothing has
-# validated, and every reader of one shares this, as they share the read in
-# `grouping_spec_kind()`. What it decides, why it answers with the name rather
-# than with whether there is one, and why nothing here is asked of the object's
-# own methods are ADR 0008's, in its amendment for a kind classified with its
-# class off.
+# The name a kind read off an object is, or `NULL` where it is none: one
+# character element with the class off, and not the missing one. Every caller
+# holds a value nothing has validated, and every reader of one shares this, as
+# they share the read in `grouping_spec_kind()`. What it decides, why it answers
+# with the name rather than with whether there is one, and why nothing here is
+# asked of the object's own methods are ADR 0008's, in its amendment for a kind
+# classified with its class off.
 grouping_kind_name <- function(kind) {
   # `is.character()` and `unclass()` are primitives that dispatch on neither S3
   # nor S4, so neither reaches a method the value carries: the type test is R's
-  # own, and stripping is what puts the two questions below to a plain character
-  # vector rather than to whatever the class defines for them (#289).
+  # own, and stripping is what puts the two questions below to a character
+  # vector with no class rather than to whatever the class defines for them
+  # (#289). Only the class comes off, so a name and any other attribute the
+  # value carried survive onto the answer; `%in%` and `[[` are what the callers
+  # put it to, and neither reads one.
   if (!is.character(kind)) {
     return(NULL)
   }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -10,7 +10,7 @@ validate_grouping_spec_early <- function(grouping_spec) {
   }
 
   # Classified where it is read, so that what this guard holds from here on is
-  # a name and not a value that might still refuse to be one (#280).
+  # a name and not the value it was read off (#280).
   kind <- grouping_kind_name(grouping_spec_kind(grouping_spec))
   # A catch of its own, because the two fields are not read together: an object
   # can refuse one while answering the other, and this is the only reader of
@@ -451,20 +451,18 @@ nested_arg_expr <- function(arg) {
 # class with no kind to read -- an atomic vector given the class offers no
 # field to read at all, which `grouping_spec_kind()` answers with `NULL`, and
 # a list without the field answers `NULL` too, neither of which is a kind this
-# position could admit. So is a kind that raises on being classified, which
-# `grouping_kind_name()` answers with `NULL` (#280). Both that reading and that
-# classification are the guard's own, so the two cannot disagree about what a
-# kind is or about what one is readable off. All three catches are narrow
-# in what they decide and not in what they swallow: everything they hide is a
-# failure to produce a specification of an admitted kind, which is a
-# specification reading that is not available. That is where the ADR-0015 line
-# falls too, because nothing here is deciding what such an object is -- a list
-# carrying the class and no kind, bound to a name nothing shadows, still
-# reaches `validate_grouping_spec_early()` and is refused in its own words.
-# So does an atomic vector carrying it, since #262 stopped that guard reading
-# a field before it had established the object can be read: what a colliding
-# name withholds here is a Package condition in either shape, not an untyped
-# one.
+# position could admit. Both that reading and the classification below are the
+# guard's own, so the two cannot disagree about what a kind is or about what one
+# is readable off. The evaluation's catch and the read's are narrow in what they
+# decide and not in what they swallow: everything they hide is a failure to
+# produce a specification of an admitted kind, which is a specification reading
+# that is not available. That is where the ADR-0015 line falls too, because
+# nothing here is deciding what such an object is -- a list carrying the class
+# and no kind, bound to a name nothing shadows, still reaches
+# `validate_grouping_spec_early()` and is refused in its own words. So does an
+# atomic vector carrying it, since #262 stopped that guard reading a field
+# before it had established the object can be read: what a colliding name
+# withholds here is a Package condition in either shape, not an untyped one.
 #
 # `rule` is the parent's own, which the caller already holds because it
 # validates nested arguments with it; deriving it again here would be the same
@@ -716,7 +714,11 @@ compile_grouping_spec_impl <- function(preflight,
 
   structure(
     list(
-      kind = preflight$spec$type,
+      # The classified name rather than the field, so that what a reader of the
+      # plan compares is the name the guard admitted. `share.R` asks
+      # `identical(plan$kind, "rollup")`, which a kind carrying a class answers
+      # `FALSE` to while compiling as one (#289).
+      kind = grouping_kind_name(preflight$spec$type),
       by = unique(.by),
       dimensions = dimensions,
       sets = normalized,
@@ -905,25 +907,19 @@ grouping_kind_rules <- local({
 # one string, and not the missing one. Every caller holds a value nothing has
 # validated, and every reader of one shares this, as they share the read in
 # `grouping_spec_kind()`. What it decides, why it answers with the name rather
-# than with whether there is one, and what the class coming off that answer
-# costs are ADR 0008's, in its amendment for a kind the guard could not
-# classify.
+# than with whether there is one, and why nothing here is asked of the object's
+# own methods are ADR 0008's, in its amendment for a kind classified with its
+# class off.
 grouping_kind_name <- function(kind) {
-  # `is.na()` and `length()` are generic, so these are the value's own methods
-  # and one may raise instead of answering. A raise is no answer, so the value
-  # is no name -- the reading that leaves the guards their own refusal (#280).
-  name <- tryCatch(
-    if (is.character(kind) && length(kind) == 1L && !is.na(kind)) {
-      unclass(kind)
-    },
-    error = function(cnd) NULL
-  )
-  # Asked again of the answer, which has no class left to dispatch on, so this
-  # is R's own reading and not a method's. The questions above were put to the
-  # classed value, and a method that answers wrongly rather than by raising
-  # passes them: `length()` reporting `1` over two strings returned two, and
-  # `%in%` at the caller in `check_ambiguous_nested_name()` raised on it.
-  if (!is.character(name) || length(name) != 1L || is.na(name)) {
+  # `is.character()` and `unclass()` are primitives that dispatch on neither S3
+  # nor S4, so neither reaches a method the value carries: the type test is R's
+  # own, and stripping is what puts the two questions below to a plain character
+  # vector rather than to whatever the class defines for them (#289).
+  if (!is.character(kind)) {
+    return(NULL)
+  }
+  name <- unclass(kind)
+  if (length(name) != 1L || is.na(name)) {
     return(NULL)
   }
   name

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -258,10 +258,9 @@ print.margin_grouping_spec <- function(x, ...) {
 # (#268).
 #
 # Deciding which of the three a kind takes is `grouping_kind_name()`'s, which
-# every reader of an unvalidated kind shares: a value whose own `is.na()` or
-# `length()` raises is no name there rather than an error here. What this site
-# holds afterwards is a name or nothing, so the `cat()` below takes a character
-# whichever branch answers.
+# every reader of an unvalidated kind shares. What this site holds afterwards is
+# a name or nothing, so the `cat()` below takes a character whichever branch
+# answers.
 grouping_kind_printed_name <- function(kind) {
   name <- grouping_kind_name(kind)
   if (is.null(name)) {

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -515,6 +515,70 @@ constructs has that shape, since a constructor builds a list. It is recorded
 here because an amendment saying a class of errors moved should say which
 errors were not there to move.
 
+## Amendment: a kind classified with its class off
+
+The amendments *the printed line for a kind that is no name* and *the condition
+class of a kind the guard could not classify* decide what a reader does when
+classifying a kind raises. This one decides that classifying a kind does not
+raise, which reverses both of them (#289). The constraint holding error
+condition classes fixed is amended a seventh time, and in the opposite
+direction to the fifth: a guard that raised `marginplyr_error` for a kind
+carrying a raising method now compiles it, and the nested-name site raises one
+where it raised nothing. Every kind that is no name still gets the same
+refusal, with the same message and the same call context, and detection order
+does not move.
+
+`grouping_kind_name()` strips the class before it classifies rather than after.
+`is.character()` answers for the type, `unclass()` takes the class off, and
+`length()` and `is.na()` are then put to a plain character vector. Neither call
+of the first pair can be intercepted: both are primitives that dispatch on
+neither S3 nor S4, so `setMethod()` refuses a method for either — "must supply
+a function skeleton" — and a `registerS3method()` into `base` is ignored, with
+`is.character()` answering `TRUE` for a classed character that has registered
+one. An S4 object extending `character` unclasses to a character whose
+`class()` is `"character"`, so an S4 `length()` or `is.na()` method the object
+carried is not found on the answer either.
+
+What that buys is the removal of the mechanism those two put in. The
+`tryCatch(error = )` goes, and with it a third making of the trade recorded
+above under *the handler the read is wrapped in*: an exiting handler unwinds a
+condition that a calling handler of the caller's would otherwise have resumed
+from, and a `signalCondition()` inheriting `error` without stopping is caught
+rather than resumed. That trade is still made wherever a field is read, and no
+longer where a kind is classified. The second classification goes with it,
+because the first is already R's own reading of a character vector: a
+`length()` answering `1` over two strings is an answer nothing takes now.
+
+**What a raising method decides.** Nothing, at any of the four readers.
+
+- The printed line names the constructor of the kind underneath, where it
+  printed the empty name. `structure("set", class = "raises")` prints
+  `grouping_set`, the kind being `set` and the class carrying a method that was
+  never relevant to it.
+- The guards in `validate_grouping_spec_early()` admit it, where they refused
+  it. The `Invalid grouping specification.` refusal still answers every kind
+  that is no name — two strings, none, or the missing one — and answers it on
+  the stripped value, so a `length()` claiming `1` over two strings does not
+  reach the decision.
+- The nested-name site refuses it as ambiguous, where a raising `is.na()` or
+  `length()` left the column reading standing. All three methods that site ever
+  reached — those two and the `as.character()` that `%in%` dispatches through —
+  are unreachable, so a kind spelling `set` there is refused for spelling `set`,
+  which is what the refusal is for.
+
+**The Grouping plan's kind.** The constraint holding the plan representation
+fixed is reached, in the `kind` field alone: it records the classified name
+rather than the field it was read off. No plan a caller can construct changes,
+every kind a constructor stores being one name already. What it decides is what
+a plan built from a forged kind holds, which is newly a question because such a
+kind now compiles: `R/share.R` asks `identical(plan$kind, "rollup")`, and the
+field would answer `FALSE` for a plan that compiled as a rollup.
+
+**Evaluations.** The constraint holding the number and timing of evaluations is
+not reached. The field is read once at each reader, as those two amendments
+left it. How often classifying asks the value's own methods is fixed by no
+decision, and it is now none, at every reader.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -530,14 +530,17 @@ does not move.
 
 `grouping_kind_name()` strips the class before it classifies rather than after.
 `is.character()` answers for the type, `unclass()` takes the class off, and
-`length()` and `is.na()` are then put to a plain character vector. Neither call
-of the first pair can be intercepted: both are primitives that dispatch on
-neither S3 nor S4, so `setMethod()` refuses a method for either — "must supply
-a function skeleton" — and a `registerS3method()` into `base` is ignored, with
-`is.character()` answering `TRUE` for a classed character that has registered
-one. An S4 object extending `character` unclasses to a character whose
-`class()` is `"character"`, so an S4 `length()` or `is.na()` method the object
-carried is not found on the answer either.
+`length()` and `is.na()` are then put to a character vector with no class.
+Only the class comes off — a name and any other attribute the value carried
+survive onto the answer, and `%in%` and `[[`, which are what the callers put it
+to, read neither. Neither call of the first pair can be intercepted: both are
+primitives that dispatch on neither S3 nor S4, so `setMethod()` refuses a
+method for either — "must supply a function skeleton" — and a
+`registerS3method()` into `base` is ignored, with `is.character()` answering
+`TRUE` for a classed character that has registered one. An S4 object extending
+`character` unclasses to a character whose `class()` is `"character"`, so an S4
+`length()` or `is.na()` method the object carried is not found on the answer
+either.
 
 What that buys is the removal of the mechanism those two put in. The
 `tryCatch(error = )` goes, and with it a third making of the trade recorded
@@ -565,14 +568,6 @@ because the first is already R's own reading of a character vector: a
   reached — those two and the `as.character()` that `%in%` dispatches through —
   are unreachable, so a kind spelling `set` there is refused for spelling `set`,
   which is what the refusal is for.
-
-**The Grouping plan's kind.** The constraint holding the plan representation
-fixed is reached, in the `kind` field alone: it records the classified name
-rather than the field it was read off. No plan a caller can construct changes,
-every kind a constructor stores being one name already. What it decides is what
-a plan built from a forged kind holds, which is newly a question because such a
-kind now compiles: `R/share.R` asks `identical(plan$kind, "rollup")`, and the
-field would answer `FALSE` for a plan that compiled as a rollup.
 
 **Evaluations.** The constraint holding the number and timing of evaluations is
 not reached. The field is read once at each reader, as those two amendments

--- a/tests/testthat/helper-forged-kinds.R
+++ b/tests/testthat/helper-forged-kinds.R
@@ -1,10 +1,10 @@
 # A Grouping specification kind carrying `kind` under a class whose methods are
-# `methods`, so that classifying it reaches a method of the object's own rather
-# than R's reading of a character vector. Every reader of a kind nothing has
-# validated is asserted against one -- the two guards, the nested-name check,
-# and the printed line -- and what each varies is the method and not the kind
-# underneath: `set` is a kind all four accept, so a refusal, a declined reading,
-# or an empty printed name is the classification's answer and not the name's.
+# `methods`, so that a reader putting a question to the object rather than to
+# its stripped value reaches one. Every reader of a kind nothing has validated
+# is asserted against one -- the two guards, the nested-name check, and the
+# printed line -- and what each varies is the method and not the kind
+# underneath: `set` is a kind all four accept, so the answer each gives for
+# `set` is what says no method was reached.
 #
 # Shared because the hazard is in the registration and not in the fixture.
 # `registerS3method()` into base's namespace is what puts a method on a
@@ -31,8 +31,10 @@ kind_answering <- function(methods, purpose, kind = "set") {
   structure(kind, class = class_name)
 }
 
-# The method every site but one registers: a kind that raises instead of
-# answering the question being put to it.
+# The method every site but one registers: a kind that raises rather than
+# answer, so that a reader reaching it fails visibly instead of agreeing with
+# the reader that does not. Nothing asserts the message, since a reader that
+# reaches this method is a reader whose test has already failed.
 raising_kind_method <- function(x, ...) {
   rlang::abort("classifying this kind raises")
 }

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1142,12 +1142,11 @@ test_that("a printed Grouping specification names the constructor called", {
 })
 
 # The line a specification with no name to print prints, and the invisible
-# return a print method makes whatever it printed. The three tests below assert
-# it of shapes that reach it for four different reasons -- a kind that is
-# absent, a kind that cannot be read, a kind that is no name, a kind that
-# raises on being classified -- and that one line covers them all is the
-# decision itself, so those tests ask
-# for it in one place. The counting test further down spells the line out
+# return a print method makes whatever it printed. The two tests below assert
+# it of shapes that reach it for three different reasons -- a kind that is
+# absent, a kind that cannot be read, a kind that is no name -- and that one
+# line covers them all is the decision itself, so those tests ask for it in one
+# place. The counting test further down spells the line out
 # instead, having a read count to assert beside it. A shape that raises fails
 # here as an error, since the raise leaves `capture.output()` with nothing to
 # return and the comparison below is never made.
@@ -1234,52 +1233,55 @@ test_that("a printed Grouping specification omits a kind that is no name", {
   }
 })
 
-# The last question this line asks of a value nothing has validated. Deciding
-# whether a kind is one name asks the value's own `is.na()` and `length()`,
-# both of which an object carrying the class can answer by raising, so the
-# printed line is at the mercy of a method of the object's the way it was of a
-# `$` of the object's until #264. Every shape here holds `set` underneath, so
-# a classification that answers names `grouping_set`: the empty name is what
-# says the catch fired, and the named line is what says it did not.
-#
-# The guards read the same field and reach the same methods, and #280 gave them
-# the same answer, which is what moved the catch into `grouping_kind_name()`.
-# What that leaves here is this line, which is where the catch firing is
-# visible as a printed line rather than as a condition class.
-test_that("a printed Grouping specification classifies a kind that may raise", {
+# The last question this line asks of a value nothing has validated, and the
+# one that stopped being asked of the object. Deciding whether a kind is one
+# name is put to the kind with its class off, so no method the class carries is
+# reached: `is.character()` and `unclass()` dispatch on neither S3 nor S4, and
+# `length()` and `is.na()` are then asked of a plain character vector (#289).
+# Every shape here holds `set` underneath, so the named line is what says the
+# method went unasked, and the empty name is what would say the classification
+# put its questions to the object and got no answer.
+test_that("a printed Grouping specification never asks a kind's methods", {
   for (generic in c("is.na", "length")) {
     kind <- kind_answering(
       stats::setNames(list(raising_kind_method), generic),
       "printed_raising"
     )
-    expect_empty_name_line(new_grouping_spec(kind, list()), info = generic)
+    expect_identical(
+      utils::capture.output(print(new_grouping_spec(kind, list()))),
+      "<marginplyr grouping specification: grouping_set>",
+      info = generic
+    )
   }
 
-  # An error is caught and nothing else is, which is a choice rather than the
-  # limit of one: a method may signal a warning on its way to answering, and a
-  # kind that warns is still a kind. Catching `condition` would take the
-  # warning for a failure to answer and name nothing, so this is what fails if
-  # the catch is ever widened to one. The warnings are read as a set because
-  # nothing fixes how often classifying asks the method the way ADR 0008 fixes
-  # the count of field reads -- the registry lookup asked it a second time
-  # before #280 handed that lookup a classified name.
-  warns <- kind_answering(
-    list(is.na = function(x, ...) {
-      warning("classifying this kind warns")
-      FALSE
-    }),
-    "printed_warning"
+  # The catch this line still has is the field read's, and an error is caught
+  # and nothing else is, which is a choice rather than the limit of one: a
+  # field may signal a warning on its way to answering, and a kind that warns
+  # is still a kind. Catching `condition` would take the warning for a failure
+  # to read and name nothing, so this is what fails if that catch is ever
+  # widened to one. The warnings are read as a set because how often the field
+  # is read is what the counting test below pins.
+  warns <- rlang::new_environment(list(args = list()))
+  makeActiveBinding(
+    "type",
+    function() {
+      warning("reading this kind warns")
+      "set"
+    },
+    warns
   )
   raised <- character()
   line <- withCallingHandlers(
-    utils::capture.output(print(new_grouping_spec(warns, list()))),
+    utils::capture.output(
+      print(structure(warns, class = "margin_grouping_spec"))
+    ),
     warning = function(cnd) {
       raised <<- c(raised, conditionMessage(cnd))
       invokeRestart("muffleWarning")
     }
   )
   expect_identical(line, "<marginplyr grouping specification: grouping_set>")
-  expect_setequal(raised, "classifying this kind warns")
+  expect_setequal(raised, "reading this kind warns")
 })
 
 # What the reading did not leave alone, in the part of it that can be held to a

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1236,11 +1236,11 @@ test_that("a printed Grouping specification omits a kind that is no name", {
 # The last question this line asks of a value nothing has validated, and the
 # one that stopped being asked of the object. Deciding whether a kind is one
 # name is put to the kind with its class off, so no method the class carries is
-# reached: `is.character()` and `unclass()` dispatch on neither S3 nor S4, and
-# `length()` and `is.na()` are then asked of a plain character vector (#289).
-# Every shape here holds `set` underneath, so the named line is what says the
-# method went unasked, and the empty name is what would say the classification
-# put its questions to the object and got no answer.
+# reached; ADR 0008's amendment for a kind classified with its class off is
+# where that holds and what makes it total. Every shape here holds `set`
+# underneath, so the named line is what says the method went unasked, and the
+# empty name is what would say the classification put its questions to the
+# object and got no answer.
 test_that("a printed Grouping specification never asks a kind's methods", {
   for (generic in c("is.na", "length")) {
     kind <- kind_answering(

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -835,18 +835,17 @@ test_that("the empty spellings that already had a reading keep it", {
 
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so
-# what a method raising took from it was a compiled call rather than a
-# diagnostic (#280).
+# what a method could take from it was a compiled call rather than a diagnostic
+# (#280).
 #
-# Three methods, because this site asks one the guards do not. `is.na()` and
-# `length()` are the guards' pair, and a kind neither can classify is not a
-# kind this position admits, so the column reading stands -- the answer a
-# binding that raises when it is read already gets. `as.character()` is the
-# third: `%in%` dispatches through it, so a kind that classified was matched
-# with the class it carries still on it, and now is not. Every shape holds
-# `set` underneath, which this position admits, so the third is refused as
-# ambiguous and the first two would be if they could be classified.
-test_that("a colliding binding whose kind may raise loses its reading", {
+# Three methods, because those are the three a kind was ever asked here.
+# `is.na()` and `length()` are the guards' pair and `as.character()` is
+# `%in%`'s, and none of them is reached now: the class comes off before any of
+# the three is put to the kind (#289). Every shape holds `set` underneath,
+# which this position admits, so each is refused as ambiguous -- which is what
+# a kind spelling `set` in that position is for, and the methods never bore on
+# it.
+test_that("a colliding binding's kind is classified with its class off", {
   compile_colliding <- function(kind) {
     env <- rlang::env(rlang::caller_env(), s = new_grouping_spec(kind, list()))
     compile_against(
@@ -854,46 +853,38 @@ test_that("a colliding binding whose kind may raise loses its reading", {
       c("s", "value")
     )
   }
-  raising <- function(generic) {
-    kind_answering(
+
+  for (generic in c("is.na", "length", "as.character")) {
+    kind <- kind_answering(
       stats::setNames(list(raising_kind_method), generic),
       "nested_raising"
     )
-  }
-
-  for (generic in c("is.na", "length")) {
+    refused <- expect_error(compile_colliding(kind))
+    expect_s3_class(refused, "marginplyr_error")
     expect_identical(
-      compile_colliding(raising(generic))$sets,
-      list("s"),
+      conditionMessage(refused),
+      ambiguous_s_message,
       info = generic
     )
   }
-
-  refused <- expect_error(compile_colliding(raising("as.character")))
-  expect_s3_class(refused, "marginplyr_error")
-  expect_identical(conditionMessage(refused), ambiguous_s_message)
 })
 
-# The other way a method takes the classification away from R: by answering,
-# and answering wrongly. A catch answers a method that fails to answer, and a
-# `length()` reporting `1` over two strings passes one -- so a classification
-# that caught what its questions raised and then returned the value it had
-# asked about returned two strings under a contract promising one, and `%in%`
-# on the line after raised the untyped error the catch was put there to remove.
+# The other way a method could take the classification away from R: by
+# answering, and answering wrongly. A `length()` reporting `1` over two strings
+# is such an answer, and a classification that took it would return two strings
+# under a contract promising one, on which `%in%` on the line after raised
+# `'length = 2' in coercion to 'logical(1)'`.
 #
-# The answer is classified a second time for that, with no class left on it to
-# dispatch. The colliding reading is what holds that: delete the second
-# classification and it raises `'length = 2' in coercion to 'logical(1)'`
-# instead of declining.
+# Stripping the class is what puts `length()` out of the method's reach
+# (#289), and the colliding reading is where a classification that went back to
+# asking the object shows as a raise rather than as a decline.
 #
 # The guard is asserted too, and it is characterization rather than the same
-# evidence -- it refuses either way. What refuses it without the second
-# classification is `[[`, which answers nothing for an index of two elements
-# and nothing for one of none, so the sentence the caller reads is the registry
-# lookup's accident rather than the guard's reading. Both lengths are written
-# because they are two accidents and not one. Making it the guard's own is what
-# the second classification does here, and an accident that stopped holding
-# would be read as this test's subject failing.
+# evidence -- it refuses either way. What it says is the guard's own refusal
+# because `grouping_kind_name()` answers nothing for both lengths, rather than
+# the registry lookup's accident of answering nothing for an index of two
+# elements and nothing for one of none. Both lengths are written because they
+# are two such accidents and not one.
 test_that("a kind whose classification lies is no more a name for it", {
   lying <- function(kind, length_answer) {
     kind_answering(
@@ -1619,18 +1610,20 @@ test_that("a malformed grouping specification is refused by both guards", {
   }
 })
 
-# The second hazard the read left, and #262's answer for the read applied to it
-# (#280). A kind that was read still has to be classified, and deciding whether
-# it is one name asks the value's own `is.na()` and `length()` methods; either
-# can raise instead of answering, and what came out of the guard was then
-# whatever the object raised, in place of the refusal below it.
+# The second hazard the read left, and the one #289 removed rather than caught.
+# A kind that was read still has to be classified, and asking the value's own
+# `is.na()` and `length()` methods for that put the guard at the mercy of what
+# either raised -- first as an untyped error out of the method, then as this
+# guard's own refusal (#280). Classifying with the class off asks neither, so
+# the kind these objects hold is the kind the guard gets.
 #
-# `set` underneath every shape, so nothing here is refused for the name it
-# holds: a classification that answered would compile. Both positions, for the
-# reason the test above writes every object in both, and the public routes as
-# well, because that is where the defect was reported and a guard is reached
+# `set` underneath every shape, so what each route answers is what it answers
+# for the name underneath, and that is what the comparison asserts: a plain
+# `set` is the same call with nothing carrying a method. Both positions, for
+# the reason the test above writes every object in both, and the public routes
+# as well, because that is where the defect was reported and a guard is reached
 # from them through the whole lifecycle rather than the compiler alone.
-test_that("a grouping specification kind that raises is refused by the guard", {
+test_that("a grouping specification kind is classified with its class off", {
   kinds <- lapply(c("is.na", "length"), function(generic) {
     kind_answering(
       stats::setNames(list(raising_kind_method), generic),
@@ -1647,26 +1640,14 @@ test_that("a grouping specification kind that raises is refused by the guard", {
     }
   )
 
+  plain <- new_grouping_spec("set", list())
+
   for (kind in kinds) {
     spec <- new_grouping_spec(kind, list())
     for (route in names(calls)) {
-      error <- expect_error(calls[[route]](spec))
-      expect_s3_class(error, "marginplyr_error")
       expect_identical(
-        conditionMessage(error),
-        "Invalid grouping specification.",
-        info = route
-      )
-    }
-
-    # Blamed on the verb the caller wrote, which is the acceptance's other half
-    # and what a condition raised out of a method would not have been: the
-    # method's own call is what `stop()` in one blames. Only the public routes
-    # are asked, an internal caller having no call a caller wrote.
-    for (route in c("inspect_grouping", "summarize_with_margins")) {
-      expect_identical(
-        rlang::call_name(conditionCall(expect_error(calls[[route]](spec)))),
-        route,
+        calls[[route]](spec),
+        calls[[route]](plain),
         info = route
       )
     }

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -1619,7 +1619,8 @@ test_that("a malformed grouping specification is refused by both guards", {
 #
 # `set` underneath every shape, so what each route answers is what it answers
 # for the name underneath, and that is what the comparison asserts: a plain
-# `set` is the same call with nothing carrying a method. Both positions, for
+# `set` is the same call with nothing carrying a method, in every part of the
+# answer the classification decides. Both positions, for
 # the reason the test above writes every object in both, and the public routes
 # as well, because that is where the defect was reported and a guard is reached
 # from them through the whole lifecycle rather than the compiler alone.
@@ -1644,12 +1645,21 @@ test_that("a grouping specification kind is classified with its class off", {
 
   for (kind in kinds) {
     spec <- new_grouping_spec(kind, list())
+    # A compiled plan records the kind field as it was read, class and all, so
+    # the plan compiled from this specification holds the object where the one
+    # compiled from a plain `set` holds the string. That field is asserted here
+    # and set aside below rather than compared; #317 is where what a plan
+    # should record is decided.
+    expect_identical(calls$top(spec)$kind, kind)
+
     for (route in names(calls)) {
-      expect_identical(
-        calls[[route]](spec),
-        calls[[route]](plain),
-        info = route
-      )
+      answered <- calls[[route]](spec)
+      expected <- calls[[route]](plain)
+      if (inherits(answered, "margin_grouping_plan")) {
+        answered$kind <- NULL
+        expected$kind <- NULL
+      }
+      expect_identical(answered, expected, info = route)
     }
   }
 })


### PR DESCRIPTION
Closes #289.

## What changes

`grouping_kind_name()` strips a kind's class before classifying it rather than
after, which makes the question total by construction and removes both the
`tryCatch(error = )` and the second classification:

```r
if (!is.character(kind)) return(NULL)
name <- unclass(kind)
if (length(name) != 1L || is.na(name)) return(NULL)
name
```

Neither call the first pair makes can be intercepted. `is.character()` and
`unclass()` are primitives that dispatch on neither S3 nor S4, so `setMethod()`
refuses a method for either, and a `registerS3method()` into `base` is ignored.
An S4 object extending `character` unclasses to a character whose `class()` is
`"character"`, so an S4 `length()` or `is.na()` method it carried is not found
on the answer either. Measured on R 4.6.1.

`unclass()` takes the class off and leaves every other attribute, so the answer
is one character element with no class rather than a plain string. `%in%` and
`[[` are what the callers put it to, and neither reads an attribute.

## What that reverses

ADR 0008's amendments *for a kind that is no name* (#268) and *for a kind the
guard could not classify* (#280) both decide what a reader does when
classifying raises. This decides that classifying does not raise, and the ADR
gains an amendment recording the reversal and naming what moves:

- the printed line names the constructor of the kind underneath, where it
  printed the empty name;
- the guards in `validate_grouping_spec_early()` admit such a kind, where they
  refused it;
- the nested-name site refuses it as ambiguous, where a raising `is.na()` or
  `length()` left the column reading standing.

`structure("set", class = "raises")` is a kind that spells `set`; the class
carries a method that was never relevant to it.

## Tests

The four tests the reversal moves are updated to the decided answer rather than
deleted. The printed line's warning half is retargeted from a classification
method to the field read, which is where the catch it constrains still is.
`helper-forged-kinds.R`'s headers say what the fixture is for now that no
reader reaches a method it registers. No test added or changed here requires an
optional backend.

## What this branch does not change

`compile_grouping_spec_impl()` records the kind field as it was read. Storing
the classified name there was tried and reverted in the review: it is not a
consequence of this decision, and it does not close the defect it claimed to.
#317 carries that defect and the two decisions it needs.

## Checks

Full `testthat::test_local()` with `NOT_CRAN=true`, `lintr::lint_package()`,
`verify-context-budget.R`, and `verify-suite-coverage.R`, all green. No
roxygen, `README.Rmd`, or vignette source changed, so nothing generated moves.
