### PR TITLE
Assert every verifier is still reached by something (#292)

### DIFF
--- a/.github/scripts/check-tarball.R
+++ b/.github/scripts/check-tarball.R
@@ -25,11 +25,9 @@ source(".github/scripts/ci-helpers.R")
 source(".github/scripts/verify-library-isolation.R", local = new.env())
 
 # Asserts that every other verifier in that directory is still reached by a
-# workflow step or by a script that is. It runs here for the same reason the
-# assertion above does, one level out: a verifier reached only by a step is
-# silenced by deleting that step, and deleting this `source()` means editing a
-# script whose job is to check a tarball. That is where the regress stops, and
-# `verify-verifier-invocation.R`'s header says why it stops there (#292).
+# workflow step or by a script that is. It runs here rather than as its own
+# step for the same reason the assertion above does, one level out; the
+# script's own header says where that regress stops (#292).
 source(".github/scripts/verify-verifier-invocation.R", local = new.env())
 
 tarball_dir <- Sys.getenv("MARGINPLYR_TARBALL_DIR", "tarball")

--- a/.github/scripts/check-tarball.R
+++ b/.github/scripts/check-tarball.R
@@ -24,6 +24,14 @@ source(".github/scripts/ci-helpers.R")
 # separate environment keeps its working names off this one.
 source(".github/scripts/verify-library-isolation.R", local = new.env())
 
+# Asserts that every other verifier in that directory is still reached by a
+# workflow step or by a script that is. It runs here for the same reason the
+# assertion above does, one level out: a verifier reached only by a step is
+# silenced by deleting that step, and deleting this `source()` means editing a
+# script whose job is to check a tarball. That is where the regress stops, and
+# `verify-verifier-invocation.R`'s header says why it stops there (#292).
+source(".github/scripts/verify-verifier-invocation.R", local = new.env())
+
 tarball_dir <- Sys.getenv("MARGINPLYR_TARBALL_DIR", "tarball")
 check_dir <- check_directory()
 label <- check_label()

--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,8 +24,11 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 38810L
-baseline_note <- "#298 moving three review instructions into the closure"
+baseline_bytes <- 39223L
+baseline_note <- paste(
+  "#292 adding the verifier-invocation rule, paid for by nothing:",
+  "the gate it names is what makes every other one here undeletable"
+)
 
 entry <- "CLAUDE.md"
 

--- a/.github/scripts/verify-verifier-invocation.R
+++ b/.github/scripts/verify-verifier-invocation.R
@@ -33,24 +33,30 @@ workflows_dir <- ".github/workflows"
 
 # A full-line comment is not code, in YAML or in R -- both spell one the same
 # way, so one rule covers both files. It has to be dropped before anything is
-# read: every verifier here is named in prose somewhere, this file included, so
-# a reader counting a mention as a call would find all of them invoked. A
-# comment placed after code on the same line is not stripped, and a call
-# commented out that way would still be counted; the probe below fixes what
-# this reader does rather than leaving it to be inferred.
+# read: a workflow comment quoting a gate's command for a reader to run it
+# locally is not a step, and counting one would report a verifier as invoked by
+# prose. A comment placed after code on the same line is not stripped, and a
+# call commented out that way would still be counted; the probe below fixes
+# what this reader does rather than leaving it to be inferred.
 executable_lines <- function(lines) {
   lines[!grepl("^[[:space:]]*#", lines)]
 }
 
 # The two forms that actually run a script here: `Rscript <path>` in a workflow
-# step, and `source("<path>")` from another script. Matching a bare path
-# instead would count a step's `name:`, an artifact path, or a `--file`
-# argument that names one, and this gate passing for a script nothing runs is
-# the result it exists to refuse. The match ends at the file name, so
+# step, and `source("<path>")` from another script. The prefix is what
+# separates either from a bare path, which a step's `name:` or an artifact
+# value may carry without running anything. A workflow value outside `run:`
+# that spells the whole command would still be counted; nothing here does, and
+# narrowing the match to a line beginning `run:` would miss the later lines of
+# a block scalar, which is a shape a step may legitimately take.
+#
+# `scripts_dir` is escaped into the pattern rather than pasted, so its `.`
+# matches a dot and not any character. The match ends at the file name, so
 # `basename()` is what reads it back out.
 invocation <- paste0(
   "(Rscript[[:space:]]+|source\\([[:space:]]*[\"'])",
-  scripts_dir, "/[A-Za-z0-9._-]+\\.R"
+  gsub(".", "\\.", scripts_dir, fixed = TRUE),
+  "/[A-Za-z0-9._-]+\\.R"
 )
 
 invoked <- function(lines) {
@@ -63,9 +69,7 @@ invoked_by_file <- function(path) {
 }
 
 # The mechanism, before the verdict, in all three ways it can arrive vacuous.
-verifiers <- sort(basename(
-  list.files(scripts_dir, pattern = "^verify-.*\\.R$")
-))
+verifiers <- sort(list.files(scripts_dir, pattern = "^verify-.*\\.R$"))
 workflows <- sort(
   list.files(workflows_dir, pattern = "\\.ya?ml$", full.names = TRUE)
 )
@@ -180,7 +184,7 @@ if (length(uninvoked) > 0L) {
       "the assertion: a step can be deleted on its own, and a `source()` ",
       "cannot be, without editing the script that does the work."
     ),
-    paste(sprintf("`%s`", sort(uninvoked)), collapse = ", ")
+    paste(sprintf("`%s`", uninvoked), collapse = ", ")
   ))
 }
 
@@ -197,9 +201,8 @@ if (length(absent) > 0L) {
 }
 
 if (length(problems) > 0L) {
-  # `call. = FALSE` because `check-tarball.R` sources this file: without it the
-  # message arrives wrapped in `Error in eval(ei, envir)` and a `source ->
-  # withVisible` traceback, which buries the one line that names the cause.
+  # `call. = FALSE` because `check-tarball.R` sources this file; what the
+  # wrapping looks like without it is in `verify-library-isolation.R`.
   stop(call. = FALSE, paste(problems, collapse = " "))
 }
 

--- a/.github/scripts/verify-verifier-invocation.R
+++ b/.github/scripts/verify-verifier-invocation.R
@@ -1,0 +1,212 @@
+# Confirms that every verifier in this directory is still run by something.
+#
+# Each `verify-*.R` here asserts a property nothing else in the repository
+# fails on, and each is reached by a workflow step. Deleting the step deletes
+# the assertion and nothing reports it: the job still runs, still passes, and
+# the diff is a few lines of YAML that read like cleanup. A gate that stops
+# asserting reports nothing, which is the shape every one of these scripts
+# exists to refuse (#292).
+#
+# The rule is one sentence: every `verify-*.R` under `.github/scripts/` is
+# either named by a workflow step or sourced by a script that is. The set is
+# derived from the directory rather than listed, so a verifier added tomorrow
+# is covered without an edit here -- and a list would name what it named when
+# it was written, which is the failure this script is about.
+#
+# `check-tarball.R` sources it rather than a workflow calling it as a step,
+# which is what `verify-library-isolation.R` already does and for the same
+# reason: a script reached only by a step is a script one deleted step
+# silences. The regress stops there rather than at a count of levels. Removing
+# this `source()` means editing a script whose job is to check a tarball, and
+# removing that job's step means no tarball is checked -- which no diff can
+# make look like cleanup. Guarding `check-tarball.R`'s own step is therefore
+# deliberately not attempted.
+#
+# Run it locally with:
+#
+#     Rscript .github/scripts/verify-verifier-invocation.R
+
+source(".github/scripts/ci-helpers.R")
+
+scripts_dir <- ".github/scripts"
+workflows_dir <- ".github/workflows"
+
+# A full-line comment is not code, in YAML or in R -- both spell one the same
+# way, so one rule covers both files. It has to be dropped before anything is
+# read: every verifier here is named in prose somewhere, this file included, so
+# a reader counting a mention as a call would find all of them invoked. A
+# comment placed after code on the same line is not stripped, and a call
+# commented out that way would still be counted; the probe below fixes what
+# this reader does rather than leaving it to be inferred.
+executable_lines <- function(lines) {
+  lines[!grepl("^[[:space:]]*#", lines)]
+}
+
+# The two forms that actually run a script here: `Rscript <path>` in a workflow
+# step, and `source("<path>")` from another script. Matching a bare path
+# instead would count a step's `name:`, an artifact path, or a `--file`
+# argument that names one, and this gate passing for a script nothing runs is
+# the result it exists to refuse. The match ends at the file name, so
+# `basename()` is what reads it back out.
+invocation <- paste0(
+  "(Rscript[[:space:]]+|source\\([[:space:]]*[\"'])",
+  scripts_dir, "/[A-Za-z0-9._-]+\\.R"
+)
+
+invoked <- function(lines) {
+  found <- regmatches(lines, gregexpr(invocation, lines))
+  unique(basename(unlist(found)))
+}
+
+invoked_by_file <- function(path) {
+  invoked(executable_lines(readLines(path, warn = FALSE)))
+}
+
+# The mechanism, before the verdict, in all three ways it can arrive vacuous.
+verifiers <- sort(basename(
+  list.files(scripts_dir, pattern = "^verify-.*\\.R$")
+))
+workflows <- sort(
+  list.files(workflows_dir, pattern = "\\.ya?ml$", full.names = TRUE)
+)
+
+if (length(verifiers) == 0L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "No `verify-*.R` was found under `%s`, so the loop below iterates over ",
+      "nothing and this script passes on any repository. Fix the derivation ",
+      "in this file before trusting what it reports."
+    ),
+    scripts_dir
+  ))
+}
+
+if (length(workflows) == 0L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "No workflow was found under `%s`, so nothing could be found invoking ",
+      "anything. That is this script reading the wrong place, not %d ",
+      "verifier(s) that stopped running."
+    ),
+    workflows_dir, length(verifiers)
+  ))
+}
+
+# The reader itself, asked the two questions it has to answer differently. A
+# reader that stopped discarding comments reports every verifier as invoked and
+# passes; one that stopped matching reports every verifier as dead and fails
+# naming the repository. Both are answered here, where the diagnosis is this
+# file.
+probe <- c(
+  sprintf("        run: Rscript %s/probe-invoked.R", scripts_dir),
+  sprintf("      # Rscript %s/probe-mentioned.R", scripts_dir)
+)
+if (!identical(invoked(executable_lines(probe)), "probe-invoked.R")) {
+  stop(call. = FALSE, paste0(
+    "The invocation reader in this script does not separate a call from a ",
+    "mention of one, so every verdict below would be about the reader. Fix ",
+    "`executable_lines()` and the `invocation` pattern here before reading ",
+    "the repository."
+  ))
+}
+
+# Walks out from the workflow steps: a script a step names is reached, and so
+# is anything a reached script sources. `via` records how each was reached, so
+# the summary says which step or which script carries it and a reader chasing a
+# failure has the chain rather than a verdict.
+via <- character()
+pending <- character()
+
+for (workflow in workflows) {
+  for (name in invoked_by_file(workflow)) {
+    if (!(name %in% names(via))) {
+      via[[name]] <- sprintf("step in `%s`", basename(workflow))
+      pending <- c(pending, name)
+    }
+  }
+}
+
+# A path that is run but answers to no file: the step or the `source()` fails
+# at run time, so this is reported rather than skipped over, and reported here
+# because skipping it silently is what would let the walk end early.
+absent <- character()
+
+while (length(pending) > 0L) {
+  name <- pending[[1L]]
+  pending <- pending[-1L]
+  path <- file.path(scripts_dir, name)
+  if (!file.exists(path)) {
+    absent <- c(absent, name)
+    next
+  }
+  for (sourced in invoked_by_file(path)) {
+    if (!(sourced %in% names(via))) {
+      via[[sourced]] <- sprintf("sourced by `%s`", name)
+      pending <- c(pending, sourced)
+    }
+  }
+}
+
+route <- function(name) {
+  if (name %in% names(via)) via[[name]] else "**run by nothing**"
+}
+
+write_step_summary(c(
+  "## Verifier invocation",
+  "",
+  sprintf(
+    "%d verifier(s) under `%s`, against %d workflow(s).",
+    length(verifiers), scripts_dir, length(workflows)
+  ),
+  "",
+  sprintf("- **%s** — %s", verifiers, vapply(verifiers, route, character(1)))
+))
+
+problems <- character()
+
+uninvoked <- setdiff(verifiers, names(via))
+if (length(uninvoked) > 0L) {
+  # The remedy is part of the message, as `verify-suite-coverage.R`'s is: a
+  # gate that only refuses invites the script to be deleted rather than run.
+  problems <- c(problems, sprintf(
+    paste0(
+      "These verifiers are named by no workflow step and sourced by no ",
+      "script that is, so what each of them asserts is asserted nowhere: %s. ",
+      "Give each one a `run: Rscript` step in the workflow whose job it ",
+      "belongs to, or source it from a script that already has one, as ",
+      "`check-tarball.R` sources `verify-library-isolation.R` and this ",
+      "script. ",
+      "Prefer the second where a job's own work would be incomplete without ",
+      "the assertion: a step can be deleted on its own, and a `source()` ",
+      "cannot be, without editing the script that does the work."
+    ),
+    paste(sprintf("`%s`", sort(uninvoked)), collapse = ", ")
+  ))
+}
+
+if (length(absent) > 0L) {
+  problems <- c(problems, sprintf(
+    paste0(
+      "These paths are run as scripts under `%s` but no file answers them: ",
+      "%s. Point the caller at the file's current name, or delete the call ",
+      "with the script it named."
+    ),
+    scripts_dir,
+    paste(sprintf("`%s`", sort(unique(absent))), collapse = ", ")
+  ))
+}
+
+if (length(problems) > 0L) {
+  # `call. = FALSE` because `check-tarball.R` sources this file: without it the
+  # message arrives wrapped in `Error in eval(ei, envir)` and a `source ->
+  # withVisible` traceback, which buries the one line that names the cause.
+  stop(call. = FALSE, paste(problems, collapse = " "))
+}
+
+message(sprintf(
+  paste0(
+    "Verified: all %d verifier(s) under %s are named by a workflow step or ",
+    "sourced by a script that is."
+  ),
+  length(verifiers), scripts_dir
+))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -536,6 +536,15 @@ one job body also closed #73, which asked for an assertion that every job
 withholding optional backends checks a tarball: with a single body there is no
 second shape for such a job to have.
 
+### Verifier invocation
+
+Every `verify-*.R` under `.github/scripts/` is reached by a workflow step or by
+a script that is, and `verify-verifier-invocation.R` fails when one is reached
+by neither. It derives the set from the directory, so a verifier added tomorrow
+is covered without an edit here. `check-tarball.R` sources it, and the script's
+own header says why it is not a step of its own. Run it locally with
+`Rscript .github/scripts/verify-verifier-invocation.R`.
+
 ### Queries against a lazy input
 
 marginplyr sends no query that reads a lazy input's data unless the caller


### PR DESCRIPTION
Closes #292.

## What this adds

`.github/scripts/verify-verifier-invocation.R`. It derives the set of
`verify-*.R` under `.github/scripts/` from the directory and fails unless each
member is named by a workflow step or sourced by a script that is. Reaching is
transitive: the walk starts at the scripts workflow steps name and follows
`source()` calls out from there, so `verify-library-isolation.R` is reached
through `check-tarball.R`.

`check-tarball.R` sources it, as it already sources `verify-library-isolation.R`
and for the same reason one level out. Guarding `check-tarball.R`'s own step is
out of scope, per the issue: removing the `source()` means editing a script
whose job is to check a tarball, and removing that job's step means no tarball
is checked.

`AGENTS.md` gains the rule, and `verify-context-budget.R`'s baseline moves in
the same commit that spends it.

## What counts as an invocation

`Rscript <path>` on a workflow line, or `source("<path>")` in a script, with
full-line comments discarded first. Matching a bare path would count a step's
`name:` or an artifact value, and a workflow comment quoting a gate's command
for a local run is not a step — `release-matrix.yaml:56` is one.

## Mechanism assertions

Each fails naming the script rather than the repository:

- no `verify-*.R` found — the loop iterates over nothing;
- no workflow found — nothing could be found invoking anything;
- the reader applied to a probe pair (one `run:` line, one commented line) does
  not return exactly the uncommented one.

## Demonstrated against a copy under `/tmp`

`git archive HEAD` into `/tmp`, then, one at a time:

| change | result |
|---|---|
| baseline copy | passes, 8 verifiers, each with its route |
| a `run: Rscript .github/scripts/verify-*.R` step deleted | fails naming that verifier |
| the `source()` deleted from `check-tarball.R` | fails naming `verify-library-isolation.R` |
| `verify-site.R` renamed with the step left as it was | fails twice: the new name is run by nothing, and the path the step names answers to no file |
| every `verify-*.R` moved away | fails naming its own derivation |
| `.github/workflows/` moved away | fails naming its own reading |
| comment stripping disabled | fails naming its own reader |

## Review

One round, recorded in a comment below.