### PR TITLE
Record a Grouping plan's kind as the name it spells (#317)

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -714,10 +714,9 @@ compile_grouping_spec_impl <- function(preflight,
 
   structure(
     list(
-      # The name the field spells, not the field as read, so that a consumer
-      # comparing this with `identical()` compares what the specification said
-      # and no attribute it carried (#317, ADR 0008). The preflight above ran
-      # the guard, so the field is one name and this is never `NULL`.
+      # The name the field spells, not the field as read (#317, ADR 0008). The
+      # preflight above ran the guard, so the field is one name and this is
+      # never `NULL`.
       kind = grouping_kind_name(preflight$spec$type),
       by = unique(.by),
       dimensions = dimensions,

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -714,7 +714,11 @@ compile_grouping_spec_impl <- function(preflight,
 
   structure(
     list(
-      kind = preflight$spec$type,
+      # The name the field spells, not the field as read, so that a consumer
+      # comparing this with `identical()` compares what the specification said
+      # and no attribute it carried (#317, ADR 0008). The preflight above ran
+      # the guard, so the field is one name and this is never `NULL`.
+      kind = grouping_kind_name(preflight$spec$type),
       by = unique(.by),
       dimensions = dimensions,
       sets = normalized,
@@ -900,24 +904,26 @@ grouping_kind_rules <- local({
 })
 
 # The name a kind read off an object is, or `NULL` where it is none: one
-# character element with the class off, and not the missing one. Every caller
+# character element carrying no attribute, and not the missing one. Every caller
 # holds a value nothing has validated, and every reader of one shares this, as
 # they share the read in `grouping_spec_kind()`. What it decides, why it answers
-# with the name rather than with whether there is one, and why nothing here is
-# asked of the object's own methods are ADR 0008's, in its amendment for a kind
-# classified with its class off.
+# with the name rather than with whether there is one, and why the answer
+# carries no attribute are ADR 0008's, in its amendments for a kind classified
+# with its class off and for a kind read as a name and compared as a value.
 grouping_kind_name <- function(kind) {
   # `is.character()` and `unclass()` are primitives that dispatch on neither S3
   # nor S4, so neither reaches a method the value carries: the type test is R's
   # own, and stripping is what puts the two questions below to a character
   # vector with no class rather than to whatever the class defines for them
-  # (#289). Only the class comes off, so a name and any other attribute the
-  # value carried survive onto the answer; `%in%` and `[[` are what the callers
-  # put it to, and neither reads one.
+  # (#289). Every remaining attribute comes off with it, because `identical()`
+  # reads them all and that is what a consumer compares this answer with (#317).
+  # `attributes<-` is a primitive too, and by then there is no class left for
+  # anything to dispatch on.
   if (!is.character(kind)) {
     return(NULL)
   }
   name <- unclass(kind)
+  attributes(name) <- NULL
   if (length(name) != 1L || is.na(name)) {
     return(NULL)
   }

--- a/R/share.R
+++ b/R/share.R
@@ -710,8 +710,14 @@ share_grouping_spec_validator <- function(kinds) {
 }
 
 check_parent_grouping_spec <- function(grouping_spec) {
+  # The field is read bare rather than through `grouping_spec_kind()`, because
+  # `validate_grouping_spec_early()` has run by the time this validator is
+  # called and is what establishes there is a kind to read.
   kind <- if (is.null(grouping_spec)) NULL else grouping_spec$type
-  if (!identical(kind, "rollup")) {
+  # Classified rather than compared as read: `identical()` reads every
+  # attribute, so a kind spelling `rollup` under a name or a class was refused
+  # here while compiling as a rollup plan (#317).
+  if (!identical(grouping_kind_name(kind), "rollup")) {
     abort_ambiguous_parent()
   }
   invisible(NULL)
@@ -1898,6 +1904,8 @@ check_share_grouping_kinds <- function(plan, kinds) {
 }
 
 check_parent_grouping_kind <- function(plan) {
+  # A plan records the name its compilation classified, so this comparison is
+  # against a bare string and needs no classification of its own (#317).
   if (!identical(plan$kind, "rollup")) {
     abort_ambiguous_parent()
   }

--- a/R/share.R
+++ b/R/share.R
@@ -714,9 +714,9 @@ check_parent_grouping_spec <- function(grouping_spec) {
   # `validate_grouping_spec_early()` has run by the time this validator is
   # called and is what establishes there is a kind to read.
   kind <- if (is.null(grouping_spec)) NULL else grouping_spec$type
-  # Classified rather than compared as read: `identical()` reads every
-  # attribute, so a kind spelling `rollup` under a name or a class was refused
-  # here while compiling as a rollup plan (#317).
+  # Classified rather than compared as read (#317, ADR 0008): what this reader
+  # holds is the caller's own specification and not a plan, whose kind field is
+  # already the name.
   if (!identical(grouping_kind_name(kind), "rollup")) {
     abort_ambiguous_parent()
   }

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -574,6 +574,76 @@ not reached. The field is read once at each reader, as those two amendments
 left it. How often classifying asks the value's own methods is fixed by no
 decision, and it is now none, at every reader.
 
+## Amendment: a kind read as a name and compared as a value
+
+The amendment above decides what comes off a kind while it is classified, and
+leaves everything but the class on. That answer is enough for what read it then
+— `%in%`, `[[`, and the `cat()` a printed line ends at — and it is not enough
+for `identical()`, which is what a share compares a kind with. The constraint
+holding the Grouping plan representation and its consumers fixed is amended by
+#317, for the one field a plan records a kind in.
+
+`grouping_kind_name()` answers with a bare name: every attribute comes off, not
+only the class. The name a kind is does not depend on what the value carrying it
+was labelled with, which is the same argument the class came off under, made
+about the rest of the attributes. `unclass()` takes the class and
+`attributes<-` takes what is left. The second is a primitive like the first
+two, so `setMethod()` refuses a method for it with the same "must supply a
+function skeleton" the amendment above records — and by the time it is called
+there is no class left for anything to dispatch on in any case, an S4 object
+extending `character` having unclassed to a character whose `class()` is
+`"character"`.
+
+**What a plan records.** The name, rather than the field as read. Every plan is
+compiled from a preflighted specification, so the field is one name by the time
+it is recorded and the classification never answers `NULL` there — what it
+removes is the attributes a caller's kind carried onto the plan. Putting the
+question here rather than at each consumer is what makes a plan's kind one
+string by construction: `identical()` on it then reads what the specification
+said and nothing about how it was stored, for every consumer this plan reaches
+and every one written later.
+
+**What the share readers ask.** `check_parent_grouping_kind()` compares
+`plan$kind` directly, because a plan holds a name. `check_parent_grouping_spec()`
+runs before a plan exists — it is installed as the specification validator, and
+`validate_grouping_spec_early()` has already established there is a kind to read
+— so it classifies the field it read and compares that. The two readers agree
+because both compare a name, and not because both were written to remember to.
+
+**What moves.** A specification whose kind spells `rollup` under any attribute
+compiled as a rollup and was refused by `share_of_parent()` as though it were
+not one, which is the defect. It is accepted now, in both shapes: a kind
+carrying names, which reached the field before the amendment above, and a kind
+carrying a class, which reaches it because that amendment stopped a class on a
+kind being a reason to refuse the specification. No refusal changes its
+condition class, its message, its call context, or its position in the detection
+order, and no specification that was accepted is refused — the change is one
+population moving from refused to accepted, at one guard.
+
+**Evaluations.** The constraint holding the number and timing of evaluations is
+not reached. Each site reads its field once, as the amendments above left it,
+and classifying asks the value's own methods nothing.
+
+**What does not move.** Nothing a constructor builds: `rollup()` stores the
+string `"rollup"`, so stripping is the identity for every kind marginplyr
+writes, and grouping-set membership, ordering, duplicate handling, and Grouping
+identifiers are untouched for every specification. The other consumers of a
+classified kind read no attribute either: `%in%` compares values, `[[` indexes
+a list by one, and the printed line reaches `cat()`, which renders a vector's
+values and not what it is labelled with — so a kind no rule knows prints the
+same line as it did, under a name, a class, or a dimension.
+
+**Considered options.** Classifying at each consumer of `plan$kind` instead was
+rejected: it leaves the plan holding a value whose attributes decide nothing,
+puts the same question at every reader present and future, and makes the two
+share readers agree by convention. Normalizing the specification object rather
+than the plan was rejected because the specification is the caller's object and
+this package rewrites none — the amendment *one reading of a recognized nested
+argument* above records the specification tree as unnormalized on purpose.
+Recording the name without widening what `grouping_kind_name()` strips was
+tried on #289's branch and reverted: `unclass()` removes the class and nothing
+else, so it does not close the defect for a kind carrying names.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -926,9 +926,9 @@ test_that("a kind whose classification lies is no more a name for it", {
 # field as read, so that comparison reads what the specification said and no
 # attribute the caller's value carried (#317, ADR 0008).
 #
-# The attributes are written one per case rather than together, because
-# `identical()` fails on any one of them: a strip that took the class and left
-# the names would pass a case carrying both.
+# One attribute per case, so that a strip taking one and not another fails
+# naming which. A case carrying several would catch the same partial strip and
+# report only that something survived.
 test_that("a plan records its kind as a bare name", {
   decorated <- list(
     c(nm = "rollup"),

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -921,6 +921,30 @@ test_that("a kind whose classification lies is no more a name for it", {
   }
 })
 
+# The plan's own copy of the kind, which `check_parent_grouping_kind()` compares
+# with `identical()`. It is the name the compilation classified and not the
+# field as read, so that comparison reads what the specification said and no
+# attribute the caller's value carried (#317, ADR 0008).
+#
+# The attributes are written one per case rather than together, because
+# `identical()` fails on any one of them: a strip that took the class and left
+# the names would pass a case carrying both.
+test_that("a plan records its kind as a bare name", {
+  decorated <- list(
+    c(nm = "rollup"),
+    structure("rollup", class = "decorated_grouping_kind"),
+    structure("rollup", dim = 1L)
+  )
+  for (kind in decorated) {
+    plan <- compile_against(
+      new_grouping_spec(kind, list(rlang::quo(a), rlang::quo(b))),
+      c("a", "b")
+    )
+    expect_identical(plan$kind, "rollup")
+    expect_equal(plan$sets, list(c("a", "b"), "a", character()))
+  }
+})
+
 test_that("the ambiguity refusal names a working spelling for each reading", {
   # Both spellings are executed rather than described, and they are read back
   # out of the diagnostic that printed them, so an advice line that stopped
@@ -1620,7 +1644,9 @@ test_that("a malformed grouping specification is refused by both guards", {
 # `set` underneath every shape, so what each route answers is what it answers
 # for the name underneath, and that is what the comparison asserts: a plain
 # `set` is the same call with nothing carrying a method, in every part of the
-# answer the classification decides. Both positions, for
+# answer the classification decides. The compiled plan's own kind field is one
+# of those parts since #317, where it stopped recording the field as read and
+# started recording the name. Both positions, for
 # the reason the test above writes every object in both, and the public routes
 # as well, because that is where the defect was reported and a guard is reached
 # from them through the whole lifecycle rather than the compiler alone.
@@ -1645,21 +1671,12 @@ test_that("a grouping specification kind is classified with its class off", {
 
   for (kind in kinds) {
     spec <- new_grouping_spec(kind, list())
-    # A compiled plan records the kind field as it was read, class and all, so
-    # the plan compiled from this specification holds the object where the one
-    # compiled from a plain `set` holds the string. That field is asserted here
-    # and set aside below rather than compared; #317 is where what a plan
-    # should record is decided.
-    expect_identical(calls$top(spec)$kind, kind)
-
     for (route in names(calls)) {
-      answered <- calls[[route]](spec)
-      expected <- calls[[route]](plain)
-      if (inherits(answered, "margin_grouping_plan")) {
-        answered$kind <- NULL
-        expected$kind <- NULL
-      }
-      expect_identical(answered, expected, info = route)
+      expect_identical(
+        calls[[route]](spec),
+        calls[[route]](plain),
+        info = route
+      )
     }
   }
 })

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -396,6 +396,54 @@ test_that("Parent shares require one pure rollup", {
   }
 })
 
+# A kind is one name, and what the value carrying it was labelled with is no
+# part of that name. Such a specification compiled as a rollup and was refused
+# by the Parent share as though it were not one (#317), which is why the
+# accepted half compares against the plain `rollup()` result rather than
+# asserting that the call returns: a Parent share that compiled against the
+# wrong sets would return too.
+#
+# Both shapes reach the kind field. A name always did; a class reaches it
+# because #289 stopped a class on a kind being a reason to refuse the
+# specification. The refused half is over the same two shapes, because a
+# comparison that stopped discriminating passes the accepted half alone.
+#
+# Asserted through `share_of_parent()` rather than through `plan$kind`, because
+# the field is internal and the refusal is what a caller sees.
+test_that("a rollup kind is one whatever attribute it carries", {
+  data <- data.frame(a = c("x", "x", "y"), b = c("p", "q", "p"), value = 1:3)
+  decorated <- function(kind) {
+    list(
+      named = c(nm = kind),
+      classed = structure(kind, class = "decorated_grouping_kind")
+    )
+  }
+  share <- function(spec) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      share = share_of_parent(total),
+      .grouping = spec
+    )
+  }
+  spec <- function(kind) {
+    new_grouping_spec(kind, list(rlang::quo(a), rlang::quo(b)))
+  }
+
+  expected <- share(rollup(a, b))
+  for (kind in decorated("rollup")) {
+    expect_equal(share(spec(kind)), expected)
+  }
+
+  for (kind in decorated("cube")) {
+    error <- expect_error(
+      share(spec(kind)),
+      "requires `.grouping` to be one pure `rollup\\(\\)`"
+    )
+    expect_s3_class(error, "marginplyr_error")
+  }
+})
+
 test_that("direct Parent-share syntax and dependency errors are targeted", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
 


### PR DESCRIPTION
Closes #317.

## The defect

A compiled Grouping plan recorded its kind as the specification's `type` field
was read, attributes and all:

```r
kind = preflight$spec$type,
```

`R/share.R` then compared that field with `identical()`, which reads every
attribute. A kind spelling `rollup` under a name or a class compiled as a rollup
plan and was refused by `share_of_parent()` as though it were not one — the same
call without the Parent share returns the rollup's sets.

## The decision

Recorded in ADR 0008, as the amendment *a kind read as a name and compared as a
value*.

- **What `grouping_kind_name()` answers with.** A bare name: every attribute
  comes off, not only the class #289 took. `unclass()` takes the class and
  `attributes<-` takes what is left; the second is a primitive like the first
  two, so `setMethod()` refuses a method for it, and by the time it is called
  there is no class left for anything to dispatch on in any case.
- **What a plan records.** That answer. A plan is compiled from a preflighted
  specification, so the field is one name by then and the classification never
  answers `NULL` there — what it removes is the attributes a caller's kind
  carried onto the plan. Putting the question here rather than at each consumer
  makes a plan's kind one string by construction, for every consumer the plan
  reaches and every one written later.
- **What the share readers ask.** `check_parent_grouping_kind()` compares
  `plan$kind` directly, because a plan holds a name.
  `check_parent_grouping_spec()` runs before a plan exists, so it classifies the
  field it read. The two agree because both compare a name, not because both
  were written to remember to.

## What moves

One population, at one guard: a specification whose kind spells `rollup` under
an attribute goes from refused to accepted. No refusal changes its condition
class, message, call context, or position in the detection order, and no
specification that was accepted is refused. Nothing a constructor builds is
affected — `rollup()` stores the string `"rollup"`, so stripping is the identity
for every kind marginplyr writes. The other consumers of a classified kind read
no attribute either: `%in%` compares values, `[[` indexes a list by one, and the
printed line reaches `cat()`, which renders values and not labels.

## Tests

- `test-share.R` — through `share_of_parent()` rather than the plan field, since
  the field is internal and the refusal is what a caller sees. Both shapes the
  ticket names, compared against the plain `rollup()` result rather than merely
  asserted to return; and the refused pair as well, because a comparison that
  stopped discriminating passes the accepted half alone.
- `test-grouping-plan.R` — what the plan records, one attribute per case, since
  `identical()` fails on any one of them.
- `test-grouping-plan.R`'s class-off test stops setting the kind field aside; it
  now compares it, and its comment says why.

Both new tests fail without the change. No test added or changed here requires
an optional backend.

## Local checks

`lintr::lint_package()` clean; full `testthat::test_local()` green;
`verify-suite-coverage.R` verified all 640 tests execute in at least one
single-backend configuration. No generated file changes (no roxygen, README, or
`man/` edits).