### PR TITLE
Compare a nested kind as a name (#324)

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -276,7 +276,11 @@ allow_nested_grouping <- function(parent, nested) {
 }
 
 validate_nested_grouping_units <- function(parent, nested) {
-  if (!identical(nested$type, "set")) {
+  # Classified rather than compared as read (#324, ADR 0008): what this reader
+  # holds is a nested specification the caller wrote and not a plan. The
+  # diagnostic keeps the parent's field as read: `cli::format_inline()` renders
+  # a vector's values and reaches no method an attribute could carry.
+  if (!identical(grouping_kind_name(nested$type), "set")) {
     abort_marginplyr(paste0(
       "{.fun {parent$type}} only accepts columns or {.fun grouping_set} ",
       "composite dimensions."
@@ -790,7 +794,10 @@ resolve_grouping_units <- function(preflight, data_proxy) {
           cols <- resolve_grouping_selection(arg$quo, data_proxy)
           return(lapply(cols, function(col) col))
         }
-        stopifnot(identical(arg$nested$spec$type, "set"))
+        # Classified as the guard that admitted this argument classifies
+        # (#324): a comparison on the field as read fires here, untyped, for
+        # exactly the population that guard now admits.
+        stopifnot(identical(grouping_kind_name(arg$nested$spec$type), "set"))
         cols <- resolve_grouping_set(arg$nested, data_proxy)
         if (length(cols) == 0L) {
           abort_empty_composite()

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -278,8 +278,8 @@ allow_nested_grouping <- function(parent, nested) {
 validate_nested_grouping_units <- function(parent, nested) {
   # Classified rather than compared as read (#324, ADR 0008): what this reader
   # holds is a nested specification the caller wrote and not a plan. The
-  # diagnostic keeps the parent's field as read: `cli::format_inline()` renders
-  # a vector's values and reaches no method an attribute could carry.
+  # diagnostic below keeps the parent's field as read, which the same amendment
+  # decides.
   if (!identical(grouping_kind_name(nested$type), "set")) {
     abort_marginplyr(paste0(
       "{.fun {parent$type}} only accepts columns or {.fun grouping_set} ",

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -675,11 +675,16 @@ a `stopifnot()` message, which is the untyped condition the guard exists to
 replace.
 
 **What moves.** A nested specification whose kind spells `set` under any
-attribute goes from refused to accepted inside `rollup()` and `cube()`, at one
-guard. No refusal changes its condition class, its message, its call context, or
-its position in the detection order, and no specification that was accepted is
-refused. Nothing a constructor builds is affected: `grouping_set()` stores the
-string `"set"`.
+attribute reads inside `rollup()` and `cube()` as the same specification with a
+bare `set` does, at one guard. A non-empty one is accepted where it was refused.
+An empty one is refused still, and by the refusal the bare spelling already
+receives — `abort_empty_composite()`, the line after the comparison — rather
+than by the nesting refusal that used to stand in front of it. That
+sub-population is the one place this amendment moves a refusal instead of
+removing one, so its message and its position in the detection order both
+change; its condition class does not. No other refusal changes in any respect,
+and no specification that was accepted is refused. Nothing a constructor builds
+is affected: `grouping_set()` stores the string `"set"`.
 
 **Evaluations.** The constraint holding the number and timing of evaluations is
 not reached. The guard reads its field once, as every reader above does, and
@@ -700,6 +705,14 @@ its sentence either way. Classifying where the field is read is what the
 amendments above left in place at every other reader, and it is what makes the
 two guards over a caller's specification agree by construction rather than by
 convention.
+
+A `grouping_kind_is(kind, name)` predicate over the three sites that now spell
+`identical(grouping_kind_name(x), <name>)` was rejected. It would not make the
+classification unforgettable, which is the only thing that would buy: a site
+written later can still compare the field as read, and what stops one is this
+ADR and the review that reads it against the code. What it would add is a second
+name restating `grouping_kind_name()`'s contract, for three comparisons that are
+against different literals, in two files, for three different decisions.
 
 ## Test strategy
 

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -644,6 +644,63 @@ Recording the name without widening what `grouping_kind_name()` strips was
 tried on #289's branch and reverted: `unclass()` removes the class and nothing
 else, so it does not close the defect for a kind carrying names.
 
+## Amendment: a nested kind read as a name
+
+The amendment above scoped its answer to the one field a plan records a kind in
+and left every other `identical()` on a kind field where it stood.
+`validate_nested_grouping_units()` is the other one: it decides whether a nested
+argument is the composite dimension `rollup()` and `cube()` admit, and it
+compared the field as read. So a nested `grouping_set` spelling `set` under an
+attribute was refused where the same specification with a bare `set` compiled,
+which is the defect. The constraint holding error condition classes, messages,
+and detection order fixed is amended by #324, for that guard.
+
+**What the guard compares.** The name, classified where it reads. What this
+reader holds is the caller's own nested specification and not a plan, so it
+classifies the field it read, as `check_parent_grouping_spec()` does above.
+
+**What the diagnostic renders.** Unchanged, and it reads the parent's field as
+read. `abort_marginplyr()` expands a message through `cli::format_inline()`,
+which renders a vector's values: it drops names and `dim`, and reaches neither
+an `as.character()` nor a `format()` method a class on the kind defines, so
+`{.fun {parent$type}}` already spells the name. That is the argument the
+amendment above made about `cat()` for the printed line, made about the writer a
+diagnostic goes through.
+
+**What moves with the guard.** `resolve_grouping_units()` asserts the same
+field one pass later, and it is classified too. The assert was unreachable while
+the guard refused this population; admitting the population is what makes it
+reachable, and left as read it would refuse exactly that population again — with
+a `stopifnot()` message, which is the untyped condition the guard exists to
+replace.
+
+**What moves.** A nested specification whose kind spells `set` under any
+attribute goes from refused to accepted inside `rollup()` and `cube()`, at one
+guard. No refusal changes its condition class, its message, its call context, or
+its position in the detection order, and no specification that was accepted is
+refused. Nothing a constructor builds is affected: `grouping_set()` stores the
+string `"set"`.
+
+**Evaluations.** The constraint holding the number and timing of evaluations is
+not reached. The guard reads its field once, as every reader above does, and
+classifying asks the value's own methods nothing.
+
+**What does not move.** The remaining reads of a kind field.
+`abort_empty_grouping_units()` takes one for a message alone, which renders the
+name for the reason above; `admitted_nested_kinds()` keys its memo on one, and
+`[[` indexes a list by a value, so every spelling of a parent's kind reaches the
+same entry; `find_grouping_kind_rule()` classifies already.
+
+**Considered options.** Having the preflight hand the rule the name it already
+classified was rejected. `validate_nested` is one contract across the five kind
+rules, and `admitted_nested_kinds()` puts each rule to a stand-in specification
+built per kind, so the parameter would be a name at one caller and a
+specification at the other; the guard also needs the parent specification for
+its sentence either way. Classifying where the field is read is what the
+amendments above left in place at every other reader, and it is what makes the
+two guards over a caller's specification agree by construction rather than by
+convention.
+
 ## Test strategy
 
 Before replacing the branches, add characterization coverage for:

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -958,6 +958,12 @@ test_that("a plan records its kind as a bare name", {
 # because a comparison that stopped discriminating passes the accepted half
 # alone.
 #
+# The empty composite beside each accepted shape is the one refusal this change
+# moves rather than removes: the guard admits it now, so the empty-composite
+# refusal one line on is what it meets. It is asserted against the message the
+# bare `set` receives rather than against that sentence, which is what makes it
+# the same reading and not a second one.
+#
 # The last loop is what the parent's kind decides, which is the diagnostic and
 # not the comparison: the sentence names the parent, so a parent whose own kind
 # carries an attribute has to render the same one.
@@ -988,15 +994,18 @@ test_that("a nested set kind is one whatever attribute it carries", {
       "composite dimensions."
     )
   }
-  refused <- function(spec, parent, shape) {
-    error <- expect_error(totals(spec), info = paste(parent, shape))
+  refused <- function(spec, message, where) {
+    error <- expect_error(totals(spec), info = where)
     expect_s3_class(error, "marginplyr_error")
-    expect_identical(conditionMessage(error), refusal(parent), info = shape)
+    expect_identical(conditionMessage(error), message, info = where)
   }
 
   for (parent in names(parents)) {
     build <- parents[[parent]]
     expected <- totals(build(grouping_set(a, b)))
+    empty <- conditionMessage(
+      expect_error(totals(build(!!new_grouping_spec("set", list()))))
+    )
 
     admitted <- decorated("set")
     for (shape in names(admitted)) {
@@ -1005,11 +1014,20 @@ test_that("a nested set kind is one whatever attribute it carries", {
         expected,
         info = paste(parent, shape)
       )
+      refused(
+        build(!!new_grouping_spec(admitted[[shape]], list())),
+        empty,
+        paste(parent, shape, "empty")
+      )
     }
 
     rejected <- decorated("cube")
     for (shape in names(rejected)) {
-      refused(build(!!composite(rejected[[shape]])), parent, shape)
+      refused(
+        build(!!composite(rejected[[shape]])),
+        refusal(parent),
+        paste(parent, shape)
+      )
     }
 
     naming <- decorated(parent)
@@ -1019,8 +1037,8 @@ test_that("a nested set kind is one whatever attribute it carries", {
           naming[[shape]],
           list(rlang::quo(!!composite("cube")))
         ),
-        parent,
-        shape
+        refusal(parent),
+        paste(parent, shape)
       )
     }
   }

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -945,6 +945,87 @@ test_that("a plan records its kind as a bare name", {
   }
 })
 
+# The other kind field an `identical()` reads: the one a nested argument's
+# specification carries, which the guard admitting a composite dimension
+# compares (#324, ADR 0008). A nested `grouping_set` spelling `set` under an
+# attribute was refused inside `rollup()` and `cube()` while the same
+# specification with a bare `set` compiled.
+#
+# Both parents, because they share the guard, and both halves of what it
+# decides. The accepted half compares against the plain `grouping_set()` result
+# rather than asserting that the call returns, because an argument admitted and
+# then resolved wrongly returns too; the refused half is over the same shapes,
+# because a comparison that stopped discriminating passes the accepted half
+# alone.
+#
+# The last loop is what the parent's kind decides, which is the diagnostic and
+# not the comparison: the sentence names the parent, so a parent whose own kind
+# carries an attribute has to render the same one.
+#
+# Asserted through a Margin verb rather than through the guard, because the
+# guard is internal and the refusal is what a caller sees. That route is also
+# what reaches the assert in `resolve_grouping_units()`, which the guard's
+# refusal stood in front of.
+test_that("a nested set kind is one whatever attribute it carries", {
+  data <- data.frame(a = c("x", "x", "y"), b = c("p", "q", "p"), value = 1:3)
+  parents <- list(rollup = rollup, cube = cube)
+  decorated <- function(kind) {
+    list(
+      named = c(nm = kind),
+      classed = structure(kind, class = "decorated_grouping_kind"),
+      dimmed = structure(kind, dim = 1L)
+    )
+  }
+  composite <- function(kind) {
+    new_grouping_spec(kind, list(rlang::quo(a), rlang::quo(b)))
+  }
+  totals <- function(spec) {
+    summarize_with_margins(data, total = sum(value), .grouping = spec)
+  }
+  refusal <- function(parent) {
+    paste0(
+      "`", parent, "()` only accepts columns or `grouping_set()` ",
+      "composite dimensions."
+    )
+  }
+  refused <- function(spec, parent, shape) {
+    error <- expect_error(totals(spec), info = paste(parent, shape))
+    expect_s3_class(error, "marginplyr_error")
+    expect_identical(conditionMessage(error), refusal(parent), info = shape)
+  }
+
+  for (parent in names(parents)) {
+    build <- parents[[parent]]
+    expected <- totals(build(grouping_set(a, b)))
+
+    admitted <- decorated("set")
+    for (shape in names(admitted)) {
+      expect_equal(
+        totals(build(!!composite(admitted[[shape]]))),
+        expected,
+        info = paste(parent, shape)
+      )
+    }
+
+    rejected <- decorated("cube")
+    for (shape in names(rejected)) {
+      refused(build(!!composite(rejected[[shape]])), parent, shape)
+    }
+
+    naming <- decorated(parent)
+    for (shape in names(naming)) {
+      refused(
+        new_grouping_spec(
+          naming[[shape]],
+          list(rlang::quo(!!composite("cube")))
+        ),
+        parent,
+        shape
+      )
+    }
+  }
+})
+
 test_that("the ambiguity refusal names a working spelling for each reading", {
   # Both spellings are executed rather than described, and they are read back
   # out of the diagnostic that printed them, so an advice line that stopped


### PR DESCRIPTION
Closes #324.

## The defect

`validate_nested_grouping_units()` compared a nested specification's kind with
`identical()` on the field as read:

```r
if (!identical(nested$type, "set")) {
```

A nested `grouping_set` whose kind spells `set` while carrying any attribute was
therefore refused inside `rollup()` and `cube()`, where the same specification
with a bare `"set"` compiles. #317 scoped its answer to the one field a plan
records a kind in and deliberately did not reach this guard, which reads a
caller's nested specification rather than a plan.

## The decision

Recorded in ADR 0008, as the amendment *a nested kind read as a name*.

- **What the guard compares.** The name, classified where it reads — as
  `check_parent_grouping_spec()` does, since what this reader holds is the
  caller's own specification and not a plan.
- **What moves with it.** `resolve_grouping_units()`'s assert on the same field
  one pass later. It was unreachable while the guard refused this population;
  admitting the population makes it reachable, and left as read it would refuse
  exactly that population again with an untyped `stopifnot()` message.
- **What the diagnostic renders.** Unchanged. `abort_marginplyr()` expands a
  message through `cli::format_inline()`, which renders a vector's values: it
  drops names and `dim` and reaches neither an `as.character()` nor a `format()`
  method a class on the kind defines, so `{.fun {parent$type}}` already spells
  the name. Measured, not assumed — the test asserts it over a parent whose own
  kind carries each attribute.
- **Rejected.** Having the preflight hand the rule the name it already
  classified, and a `grouping_kind_is()` predicate over the three sites now
  spelling `identical(grouping_kind_name(x), <name>)`. The ADR says why for
  each.

## What moves

A nested specification whose kind spells `set` under any attribute reads inside
`rollup()` and `cube()` as the same specification with a bare `set` does, at one
guard.

- A non-empty one is accepted where it was refused.
- An empty one is refused still, and by the refusal the bare spelling already
  receives — `abort_empty_composite()`, the line after the comparison — rather
  than by the nesting refusal that used to stand in front of it. That
  sub-population is the one place this change moves a refusal instead of
  removing one, so its message and its position in the detection order both
  change; its condition class does not.

No other refusal changes in any respect, and no specification that was accepted
is refused. Nothing a constructor builds is affected — `grouping_set()` stores
the string `"set"`. The remaining reads of a kind field do not move:
`abort_empty_grouping_units()` takes one for a message alone,
`admitted_nested_kinds()` keys its memo on one and `[[` indexes a list by a
value, and `find_grouping_kind_rule()` classifies already.

## Tests

`test-grouping-plan.R` — through `summarize_with_margins()` rather than the
guard, since the guard is internal and the refusal is what a caller sees, and
because that route is also what reaches the assert one pass later. Both parents,
three attribute shapes, and:

- the accepted half compared against the plain `grouping_set()` result rather
  than merely asserted to return;
- the empty composite beside each accepted shape, asserted against the message
  the bare `set` receives rather than against that sentence;
- the refused half over the same shapes, since a comparison that stopped
  discriminating passes the accepted half alone;
- a parent whose own kind carries each attribute, which is what pins the
  diagnostic.

The test fails without either half of the change: without the guard's
classification it fails on the guard's refusal, and without the assert's it
fails on `identical(arg$nested$spec$type, "set") is not TRUE`. No test added
here requires an optional backend.

## Local checks

`lintr::lint_package()` clean; full `testthat::test_local()` green;
`verify-context-budget.R` unchanged at 39223 bytes;
`verify-suite-coverage.R` verified all 641 tests execute in at least one
single-backend configuration. No generated file changes (no roxygen, README, or
`man/` edits).

Review record: the round is in the comment below.