### PR TITLE
Say what `## Module responsibilities` holds (#291)

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -53,6 +53,10 @@ on a verb kind.
 
 ## Module responsibilities
 
+Each subsection below is one module's ownership contract, written where the
+file it names does not make its own boundaries readable; `R/` is what says
+which files exist.
+
 ### Margin operation (`R/margin-operation.R`)
 
 Owns the shared prepare and finalize lifecycle, common option normalization,

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -53,9 +53,10 @@ on a verb kind.
 
 ## Module responsibilities
 
-Each subsection below is one module's ownership contract, written where the
-file it names does not make its own boundaries readable; `R/` is what says
-which files exist.
+Each subsection here writes down what one module owns and what it leaves to
+another, which its file does not show on its own; the section covers the
+modules where that has been needed, and not the contents of `R/`, which is
+what says which files exist.
 
 ### Margin operation (`R/margin-operation.R`)
 


### PR DESCRIPTION
Closes #291.

`design/architecture.md:54` opens twelve `### Name (R/file.R)` subsections and says nothing about what set they are, so a reader takes the section for the map of `R/` and finds ten of its twenty-three files missing. It is not that map, and #291 rules out making it one: each subsection is an ownership contract, and a file whose own contents make its boundaries readable has none to write there.

One sentence under the heading states the scope and names `R/` as what says which files exist, in the idiom *Test seams* already uses for `tests/testthat/`.

Against the acceptance conditions:

- the section states its own scope, so a reader does not measure it against `ls R/*.R`;
- no subsection is added or removed;
- the sentence names no file, so adding an `R/*.R` needs no edit here.

Writing the four missing ownership contracts is out of scope per the ticket.

No R code changed, and `design/` is `.Rbuildignore`d, so no gate reads the edited section — `verify-context-budget.R` still passes at 39223 bytes (this file is not in the always-loaded closure).