### PR TITLE
Delete the argument `inst/suggests/guard.R` already holds (#294)

### DIFF
--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,7 +24,7 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 34839L
+baseline_bytes <- 34826L
 baseline_note <- paste(
   "#294 deleting the argument *Optional-dependency guards* restated:",
   "`inst/suggests/guard.R` already held it, so nothing paid for this"

--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,10 +24,10 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 39223L
+baseline_bytes <- 34839L
 baseline_note <- paste(
-  "#292 adding the verifier-invocation rule, paid for by nothing:",
-  "the gate it names is what makes every other one here undeletable"
+  "#294 deleting the argument *Optional-dependency guards* restated:",
+  "`inst/suggests/guard.R` already held it, so nothing paid for this"
 )
 
 entry <- "CLAUDE.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,82 +317,16 @@ as it stood.
 ### Optional-dependency guards
 
 Every guard deciding whether optional code runs goes through
-`marginplyr_suggest_available()` in `inst/suggests/guard.R`. Never
-`requireNamespace()` and never `rlang::is_installed()`, which answer "is it
-installed" and not "is it new enough" — the question DESCRIPTION actually asks,
-since several Suggests carry a version constraint. An installed-but-too-old
-package passes an installation check, the guarded code runs, and it fails at
-the feature instead of skipping (#123). `duckdb (>= 1.5.5)` is the case that
-showed it: under 1.5.4.x `duckdb::duckdb(shared_home = FALSE)` is a hard error
-rather than a degraded result.
+`marginplyr_suggest_available()` in `inst/suggests/guard.R`. That file's header
+is authoritative for why the guard exists and why it is reached by `source()`
+rather than exported.
 
-`R CMD check` is not the exposure. It stops at `checking package dependencies`
-with "required and available but unsuitable version" before any test, example,
-or vignette runs, so CRAN, the release matrix, and any local check were always
-safe. What the guard covers is everything that is not `R CMD check`:
-`devtools::test()`, `pkgload::load_all()` plus `testthat::test_local()`, an
-example run interactively, and the site build — whose `Config/Needs/website`
-entries carry no versions, so a site job can legitimately install a version the
-package's own Suggests entry rejects.
-
-*Suggest* and *backend* are used from here on in the senses *Release matrix*
-below separates them into, since the helpers this section names are shared with
-the jobs that section describes.
-
-DESCRIPTION states each constraint and the guard is the only thing that reads
-one, so there is no version written down twice and nothing to keep in step. The
-guard lives under `inst/` for the reason `must-error.R` does: the four
-vignettes, the four examples, and
-`tests/testthat/helper-optional-backends.R` each reach it in one `source()`
-call on a `system.file()` path, and a copy in `tests/` would be the copy the
-shipped sites drift from. Registering an optional Suggest with the test suite
-still means editing the two places *Release matrix* names — a version is not a
-third place, because the guard reads it.
-
-`suggest_available()` consults the guard, so a too-old package skips rather
-than running, unless the job named it in `MARGINPLYR_REQUIRED_SUGGESTS` — then
-it errors, exactly as an absent required package does, and a `backend` job
-holding a stale version reds as a failure rather than passing on a skipped
-suite. The skip says which case it is: `{duckdb} 1.5.4.3 is installed, but
-marginplyr requires >= 1.5.5`, deliberately not the `{pkg} is not installed`
-wording, which would send a reader looking for a package sitting in their
-library. A `backend` job cannot produce that skip — a package it named errors
-and one it withheld is not installed — but the wording is still what stops
-`verify-backend.R` attributing a version failure to a withheld package if one
-ever reached that path. A package hidden by `MARGINPLYR_HIDE_SUGGESTS` keeps
-the absent wording, because a simulated absence that announced a version is a
-skip neither `verify-suite-coverage.R` nor `verify-depends-only.R` could
-attribute.
-
-Guarding on a package DESCRIPTION does not suggest is an error, not an answer.
-`suggest_available()` already refuses a package `optional_suggests()` does not
-name, but a vignette and an example have no such registry, and a typo or a
-dependency that moved to `Config/Needs/website` would otherwise guard on
-installation alone while reading as protection.
-
-Two scans in `test-documentation.R` are what keep this from decaying, and they
-scan rather than list, for the reason every other gate here derives rather than
-lists. Each runs over three sources — the Rd topics, the vignette sources, and
-both halves of the README: no page may name a version-blind guard, and a page
-using the guard must source it and vice versa. The Rd half reads `man/` when it
-is present and `tools::Rd_db("marginplyr")` otherwise, so it holds under
-`R CMD check` too; the vignette half is repository-only, because `R CMD check`
-unpacks the tarball beside the `.Rcheck` directory rather than inside it; the
-README is read from the repository where there is one, and otherwise from the
-installed `README.md`, which exists only from R 4.6.0 — "Package `README.md`
-files are now installed and featured in HTML help" — while `DESCRIPTION`
-supports 4.1.0, so an oldrel job checking a tarball reaches neither half. The
-README is in the set because it is installation documentation, which is where a
-version-blind test is likeliest to be written in the first place — the same
-reason `verify-site.R` forbids `installed.packages` anywhere on the rendered
-site. Prose that needs to name a version-blind call has to spell it some other
-way — the scan is deliberately blunt.
-
-A source is added where it is reachable rather than skipped for where it is
-not, since a skip naming no withheld backend is what `verify-backend.R` fails a
-job over. Reaching nothing at all is the other case, and
-`documentation_sources()` stops on it: every scan iterates over that set, so a
-set that arrived empty is a set that passes.
+Two files assert it, and each states its own reasons. Two scans in
+`tests/testthat/test-documentation.R` hold every shipped page to the rule, over
+the Rd topics, the vignette sources, and both halves of the README.
+`tests/testthat/helper-optional-backends.R` is where a test reaches the guard,
+through `skip_if_suggest_absent()` or `suggest_available()`, and where the
+wording of the resulting skip is fixed for `verify-backend.R`.
 
 ### Release matrix
 
@@ -404,8 +338,7 @@ companions its entry declares. `MARGINPLYR_REQUIRED_SUGGESTS` names all of
 them, so any one of them failing to install fails the job instead of skipping
 its tests.
 
-Two words are in use in this section and in *Optional-dependency guards*
-above, and they name different sets (#185). A *Suggest* is an optional package
+Two words are in use in this section, and they name different sets (#185). A *Suggest* is an optional package
 the test suite guards on — an entry in `optional_suggest_spec()`. A *backend*
 is the narrower thing a generated job exists for: the subset
 `optional_backends()` returns, which is what those jobs iterate over. `DBI` is
@@ -422,8 +355,8 @@ CRAN's minimal flavors but means a green job proves nothing about it. Every
 such test goes through `skip_if_suggest_absent()` or `suggest_available()` from
 `tests/testthat/helper-optional-backends.R` — never `skip_if_not_installed()`
 or `rlang::is_installed()` directly, since those cannot be told to fail — and
-never `requireNamespace()` either, for the separate reason in
-*Optional-dependency guards* above. (`skip_if_not_installed("dbplyr")` is not
+never `requireNamespace()` either, for the separate reason
+`inst/suggests/guard.R` gives. (`skip_if_not_installed("dbplyr")` is not
 an exception: dbplyr is an Import, so it is never absent.)
 
 Snapshot expectations run only where `NOT_CRAN` is set: testthat skips them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,11 +95,12 @@ direction today. A branch first evaluated on the day of the release is a
 branch nothing has ever run, which is the objection *Chunks that must fail*
 makes to an assertion that cannot fail.
 
-The scan is deliberately blunt, as the version-blind guard scan above is:
-prose that needs to name the CRAN installation call has to spell it some other
-way. Its markers all name marginplyr, because the README's comparison table
-links to another package's CRAN page and that is not a claim about this one,
-and they match case-insensitively, because `cran.r-project.org` and
+The scan is deliberately blunt, as the version-blind guard scan beside it in
+`test-documentation.R` is: prose that needs to name the CRAN installation call
+has to spell it some other way. Its markers all name marginplyr, because the
+README's comparison table links to another package's CRAN page and that is not
+a claim about this one, and they match case-insensitively, because
+`cran.r-project.org` and
 `CRAN.R-project.org` are one host and a claim is not less of one for being
 typed the second way.
 
@@ -321,12 +322,12 @@ Every guard deciding whether optional code runs goes through
 is authoritative for why the guard exists and why it is reached by `source()`
 rather than exported.
 
-Two files assert it, and each states its own reasons. Two scans in
-`tests/testthat/test-documentation.R` hold every shipped page to the rule, over
-the Rd topics, the vignette sources, and both halves of the README.
-`tests/testthat/helper-optional-backends.R` is where a test reaches the guard,
-through `skip_if_suggest_absent()` or `suggest_available()`, and where the
-wording of the resulting skip is fixed for `verify-backend.R`.
+Two scans in `tests/testthat/test-documentation.R` assert it, over the Rd
+topics, the vignette sources, and both halves of the README. A test reaches the
+guard through `skip_if_suggest_absent()` or `suggest_available()` in
+`tests/testthat/helper-optional-backends.R`, which is also where the wording of
+the resulting skip is fixed for `verify-backend.R`. Each file states its own
+reasons.
 
 ### Release matrix
 
@@ -338,10 +339,11 @@ companions its entry declares. `MARGINPLYR_REQUIRED_SUGGESTS` names all of
 them, so any one of them failing to install fails the job instead of skipping
 its tests.
 
-Two words are in use in this section, and they name different sets (#185). A *Suggest* is an optional package
-the test suite guards on — an entry in `optional_suggest_spec()`. A *backend*
-is the narrower thing a generated job exists for: the subset
-`optional_backends()` returns, which is what those jobs iterate over. `DBI` is
+Two words are in use in this section, and they name different sets (#185). A
+*Suggest* is an optional package the test suite guards on — an entry in
+`optional_suggest_spec()`. A *backend* is the narrower thing a generated job
+exists for: the subset `optional_backends()` returns, which is what those jobs
+iterate over. `DBI` is
 a Suggest and not a backend — it has no job of its own — while `data.table` is
 both, and what its job proves is an input class rather than a query
 translation. A Suggested package only a vignette or an example guards on is

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -138,11 +138,19 @@ test_that("the Grouping-identity comparison has exactly one canonical home", {
 # Both names the *Release matrix* section forbids are scanned, not only the one
 # #123 found. The rlang spelling even takes a version argument of its own,
 # which makes it the likelier of the two to arrive looking correct.
+#
+# The scan is deliberately blunt: prose that needs to name a version-blind call
+# has to spell it some other way.
 version_blind_guards <- c("requireNamespace", "is_installed")
 
 # Both halves of the README are pages: `README.Rmd` is where a claim is
 # written, and `README.md` is what a reader on GitHub is shown and what the
 # website's home page includes.
+#
+# The README is in the set because it is installation documentation, which is
+# where a version-blind test is likeliest to be written in the first place --
+# the same reason `verify-site.R` forbids `installed.packages` anywhere on the
+# rendered site.
 #
 # A repository run reads both. A check run reads whichever half R installed,
 # and that is a question about the R running the check, not about this package:


### PR DESCRIPTION
Closes #294.

`AGENTS.md`'s *Optional-dependency guards* restated in 79 always-loaded lines the argument `inst/suggests/guard.R:1-30` makes in its own header. `guard.R:29-30` had already settled the split — the header owns the argument, `AGENTS.md` owns the rule and what asserts it — so the section is reduced to that.

## What was deleted, and where it already was

| the argument | already held at |
|---|---|
| `requireNamespace()` answers "installed", not "new enough" | `guard.R:4-6` |
| `duckdb (>= 1.5.5)`, `shared_home = FALSE` a hard error under 1.5.4.x (#123) | `guard.R:7-10` |
| `R CMD check` stops before any test runs, so the exposure is everything else | `guard.R:12-17` |
| DESCRIPTION states each constraint once, and the guard is its only reader | `guard.R:19-21` |
| it lives under `inst/` for the reason `must-error.R` does | `guard.R:21-24` |
| guarding on a package DESCRIPTION does not suggest is an error | `guard.R:94-100` |
| the skip wording `verify-backend.R` matches on | `tests/testthat/helper-optional-backends.R:300-315`, `:228-236`, `:288-296` |
| what the two scans read, and why each source is added where it is reachable | `tests/testthat/test-documentation.R:126-141`, `:143-153`, `:167-194`, `:400-414` |

## What moved rather than being deleted

The scans paragraph held two sentences `test-documentation.R` did not: why the README is in the scanned set, now in the `readme_sources()` header, and that the scan is deliberately blunt, now in the `version_blind_guards` header — which the `cran_claims` comment below it was already citing as though it were stated there.

## Consequences

The *Suggest*/*backend* terminology note scoped a section that no longer uses either word, so it goes too; *Release matrix* is where the distinction is stated. Two references in that section followed it: it no longer claims both words are in use in *Optional-dependency guards*, and the `requireNamespace()` reason it cites now names `inst/suggests/guard.R`.

`wc -c CLAUDE.md AGENTS.md` falls 39223 → 34839, and `verify-context-budget.R`'s baseline falls with it in the same commit.

## Verification

- `Rscript .github/scripts/verify-context-budget.R` — passes at the new baseline
- full `testthat::test_local()` — passes
- `lintr::lint_package()` after `pkgload::load_all()` — no lints