### PR TITLE
Delete the argument `release-matrix.yaml` and its scripts already hold (#293)

### DIFF
--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,10 +24,11 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 34826L
+baseline_bytes <- 30155L
 baseline_note <- paste(
-  "#294 deleting the argument *Optional-dependency guards* restated:",
-  "`inst/suggests/guard.R` already held it, so nothing paid for this"
+  "#293 deleting the argument *Release matrix* restated:",
+  "`release-matrix.yaml` and the scripts it names already held it,",
+  "so nothing paid for this"
 )
 
 entry <- "CLAUDE.md"

--- a/.github/scripts/verify-suite-coverage.R
+++ b/.github/scripts/verify-suite-coverage.R
@@ -4,7 +4,9 @@
 # between them they execute every test that requires at most one backend. A test
 # that requires two is executed by none of them: it skips in every job, and
 # every job still reports success. Nothing about a green workflow says which
-# case a test is in.
+# case a test is in. It skips in a job that happens to hold both as well,
+# because this script hides all but one whatever the run's library holds, which
+# is why the guarantee does not rest on a job's package count.
 #
 # `release-matrix.yaml` used to answer that by naming contract tests in a
 # `proves` list per job. Naming catches a deleted test, which is also the most

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -56,6 +56,14 @@
 # before pushing: `Rscript .github/scripts/verify-suite-coverage.R` gives the
 # same verdict locally that the job gives in CI.
 #
+# Snapshot expectations run only where `NOT_CRAN` is set: testthat skips them
+# under CRAN semantics, so a snapshot never fails in a job that emulates CRAN.
+# That is the `backend` jobs, which set it in the workflow, and the `structure`
+# job, whose script sets it so a local run matches CI. `structure` takes no
+# `needs`, so in practice it is the first job to report a stale snapshot -- but
+# it runs against the working tree, and a `backend` job is still what proves
+# the snapshot inside `R CMD check`.
+#
 # The `backend` matrix is generated rather than written out because every field
 # in it was a restatement of the same table -- which package to install, which
 # absence must fail the job, what to call the cache. The cost is that this file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,14 +331,6 @@ reasons.
 
 ### Release matrix
 
-`.github/workflows/release-matrix.yaml` checks one built tarball rather than
-the working tree, because a check that passes on the development tree can be
-passing on a file the tarball does not ship. Each of its `backend` jobs is for
-one member of `optional_backends()`, and installs that member plus the
-companions its entry declares. `MARGINPLYR_REQUIRED_SUGGESTS` names all of
-them, so any one of them failing to install fails the job instead of skipping
-its tests.
-
 Two words are in use in this section, and they name different sets (#185). A
 *Suggest* is an optional package the test suite guards on — an entry in
 `optional_suggest_spec()`. A *backend* is the narrower thing a generated job
@@ -361,13 +353,12 @@ never `requireNamespace()` either, for the separate reason
 `inst/suggests/guard.R` gives. (`skip_if_not_installed("dbplyr")` is not
 an exception: dbplyr is an Import, so it is never absent.)
 
-Snapshot expectations run only where `NOT_CRAN` is set: testthat skips them
-under CRAN semantics, so a snapshot never fails in a job that emulates CRAN.
-That is the `backend` jobs, which set it in the workflow, and the `structure`
-job, whose script sets it so a local run matches CI. `structure` takes no
-`needs`, so in practice it is the first job to report a stale snapshot — but it
-runs against the working tree, and a `backend` job is still what proves the
-snapshot inside `R CMD check`.
+`.github/workflows/release-matrix.yaml`'s header is authoritative for how the
+jobs divide the work, which of them set `NOT_CRAN`, and the `cache-version`
+scheme that keeps their libraries apart. Each verifier under
+`.github/scripts/` states its own mechanism, and
+`tests/testthat/helper-optional-backends.R` states what each column of the
+table decides.
 
 An installed package still does not prove its tests ran, and the answer is
 structural rather than a list of test names (#93). One policy carries it:
@@ -389,48 +380,6 @@ paragraph could be trusted to keep current, which is the objection it would be
 built to answer. What cannot drift from the gate is not prose at all, but the
 remedies `verify-suite-coverage.R` prints when it fires (#220).
 
-While that holds, the `backend` jobs cover the whole suite by construction —
-each installs one backend, plus whatever companions its entry declares, and
-withholds everything else, so between them they execute every test that
-requires at most one. A test requiring two is executed by none of them and
-skips in all of them — including in a job that happens to hold both, because
-`verify-suite-coverage.R` hides all but one whatever a job installs, which is
-why the guarantee does not rest on a job's package count. Splitting such a test
-is the fix, and the
-idiom that makes it free is in `test-margin-order.R`: compare each backend
-against the **local** result, which needs no optional backend, so a backend
-cannot pass by being self-consistently wrong the way two agreeing backends can.
-
-Two gates hold the policy up, and neither is a list:
-
-- `verify-suite-coverage.R`, run by the `structure` job, runs the whole suite
-  once per optional backend with the others hidden through
-  `MARGINPLYR_HIDE_SUGGESTS`, and fails naming any test that executed in no
-  configuration. It asserts its own mechanism before concluding anything, since
-  a simulation that stopped working would report that every test runs
-  everywhere. Run it locally with
-  `Rscript .github/scripts/verify-suite-coverage.R`; it gives the same verdict
-  as CI.
-- `verify-backend.R`, inside each `backend` job, reads that job's own testthat
-  log and fails unless the suite started, passed something, failed nothing, and
-  skipped nothing for a reason other than a backend the job withheld. A stray
-  `skip_if()`, a `skip_on_os()`, or `NOT_CRAN` being dropped so snapshots skip
-  all fail the job now; none of them did under the old named-test gate.
-
-Which packages a job installs is the whole signal of that design, so the
-dependency cache is part of it. `setup-r-dependencies@v2` falls back to a
-`restore-keys` prefix of `<os>-<R version>-<arch>-<cache-version>-`, which
-means every job sharing a `cache-version` shares a library. Each dependency
-request therefore gets its own value — `full-1`, `hard-1`,
-`backend-<name>-1`, named in `release-matrix.yaml`'s header — and a new job
-that copies an existing `cache-version` inherits that job's library rather than
-installing its own. `verify-library-isolation.R` is what keeps the scheme
-honest, since a wrong cache key is otherwise indistinguishable from a correct
-run: it fails the job when an optional backend the job did not declare in
-`MARGINPLYR_REQUIRED_SUGGESTS` is on `.libPaths()`. `check-tarball.R` sources
-it rather than the workflow calling it as a step, so the assertion cannot be
-dropped from a job that still checks a tarball.
-
 Registering an optional Suggest with the test suite means editing two places.
 Every partial edit fails loudly:
 
@@ -444,32 +393,13 @@ Every partial edit fails loudly:
    `{<package>} is not installed` line that no test would produce. The
    `backend` job the entry generates does not fail — it installs the package,
    runs a suite that never mentions it, and finds nothing to complain about,
-   which is why `depends-only` is the gate named here. An `asserted = FALSE`
-   entry claims no absence
-   and gets no job, so nothing asserts it — which is the DBI case above, and
-   the reason that value exists. `companions` names what the generated job
-   installs alongside the entry, which is how `DBI` reaches the driver jobs
-   without a job of its own. It is also how an entry declares what its own
-   dependencies drag in, and there the companion is a tracked entry rather
-   than an untracked one: dtplyr declares `Imports: data.table`, so its job
-   installs data.table whichever way the entry is written, and leaving it
-   undeclared makes `verify-library-isolation.R` fail the job for a leak that
-   is really the requested package's own closure.
+   which is why `depends-only` is the gate named here.
 2. the `skip_if_suggest_absent()` or `suggest_available()` call in the tests.
    Doing only this errors immediately: those helpers refuse a package
    `optional_suggests()` does not name, since nothing would execute it and
    nothing would assert it absent.
 
-There is no third place, and that is the point (#93). The `backend` matrix used
-to be four hand-written entries, so a backend could be tracked by the tests and
-executed by no job — `verify-matrix-coverage.R` and the `coverage` job existed
-only to catch that (#71), and both are gone. `generate-backend-matrix.R` builds
-the matrix from the table instead, deriving each job's `required` list,
-installed packages, and `cache-version`, and writes what it produced to the step
-summary because `release-matrix.yaml` no longer shows its own jobs. Generating
-one job body also closed #73, which asked for an assertion that every job
-withholding optional backends checks a tarball: with a single body there is no
-second shape for such a job to have.
+There is no third place, and that is the point (#93).
 
 ### Verifier invocation
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -633,8 +633,8 @@ tests it executes (#93). Coverage is structural instead, resting on a policy
 about what a test may require, whose one home is `AGENTS.md`'s *Release matrix*
 section, rather than on a list of what each job must run.
 
-`AGENTS.md` is the operational reference for the jobs, the verifier scripts,
-and the sites registering an optional Suggest has to touch.
+`AGENTS.md` is the operational reference for the sites registering an optional
+Suggest has to touch.
 
 ## Extending backend support
 


### PR DESCRIPTION
*Release matrix* was 142 of `AGENTS.md`'s 642 lines, and most of it was not
the rule. Each paragraph is deleted, moved, or kept.

Deleted, with the line that already held it:

- the tarball-not-working-tree opening, one backend plus companions per job,
  and `MARGINPLYR_REQUIRED_SUGGESTS` turning a failed install into a failed
  job: `release-matrix.yaml:1-10`, `:26-30`, `:32-38`, `:416-419`.
- coverage by construction and the `test-margin-order.R` idiom that makes
  splitting a two-backend test free: `verify-suite-coverage.R:3-7`, `:22-27`,
  and `release-matrix.yaml:32-38`.
- the two-gate list. `verify-suite-coverage.R:29-49` states its own
  simulation, its mechanism assertion, and the local invocation;
  `verify-backend.R:16-32` states what it reads from the testthat log and
  names the same stray `skip_if()`, `skip_on_os()`, and dropped `NOT_CRAN`;
  `release-matrix.yaml:40-51` states both as layers.
- the `cache-version` and `restore-keys` scheme, and what
  `verify-library-isolation.R` asserts about it: `release-matrix.yaml:73-101`,
  `verify-library-isolation.R:1-16`, `generate-backend-matrix.R:53-57`.
- what the `asserted` and `companions` columns decide, including the `DBI` and
  dtplyr cases: `helper-optional-backends.R:154-176`.
- the history of the hand-written matrix, the retired `coverage` job (#71),
  and #73: `generate-backend-matrix.R:1-21`, `release-matrix.yaml:67-71`,
  `:170-179`.

Moved, and why the target did not already hold it:

- the `NOT_CRAN` paragraph, to `release-matrix.yaml`'s header. That file
  argues `NOT_CRAN` twice at job scope -- the `backend` env comment for why
  those jobs opt out, and `verify-suite-coverage.R:53-57` for why the
  simulation sets it -- and neither is a statement across jobs. Which job
  reports a stale snapshot first, and that a `backend` job is still what
  proves a snapshot inside `R CMD check`, was written down only here.

Kept: the Suggest/backend distinction, which `helper-optional-backends.R:9-10`
names this section as the home of; the rule that a guarded test goes through
`skip_if_suggest_absent()` or `suggest_available()`, which
`test-documentation.R:138` scans against; the one-backend policy sentence and
the argument for its single home, which `verify-suite-coverage.R:17` quotes and
attributes here; and the two-place registration procedure with the partial
edit that `depends-only` fails on.

`baseline_bytes` falls from 34826 to 30155, which is the new measurement.
Nothing paid for it: every deletion is a second copy, and the one move is a
paragraph leaving the closure for the file it describes.

Refs #293

Closes #293