### PR TITLE
Cut the argument #268 owns from ADR 0008's amendment (#296)

### DIFF
--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -308,9 +308,6 @@ environment among them — `cat()` rendering anything of no length as nothing.
 Which of them a given object is goes unreported, for the reason the amendment
 above gives.
 
-The alternatives weighed against dropping the field, and what each would have
-had to promise, are #268's.
-
 ## Amendment: the condition class of a kind the guard could not classify
 
 The amendment above says the guards are left alone and why, and #280 is where
@@ -384,12 +381,12 @@ avoid.
 
 **Evaluations.** The constraint holding the number and timing of evaluations is
 not reached. The field is read once, as the amendments above left it. How often
-classifying asks the value's own methods is fixed by no decision, which the
-amendment above already records, and it moves in both directions: it falls at
-the guards and at the printed line, where the registry lookup's own guard asked
-them a second time and is now handed a plain string; and it is unchanged in
-number at the nested-name site, which asks `is.na()` where it did not and
-reaches `as.character()` where it no longer does.
+classifying asks the value's own methods is fixed by no decision, and it moves
+in both directions: it falls at the guards and at the printed line, where the
+registry lookup's own guard asked them a second time and is now handed a plain
+string; and it is unchanged in number at the nested-name site, which asks
+`is.na()` where it did not and reaches `as.character()` where it no longer
+does.
 
 **The handler the classification is wrapped in.** `tryCatch(error = )` a third
 time, so the trade the amendment for a specification the printer could not read

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -268,10 +268,9 @@ constructor name the registry holds, or the kind itself, which
 The qualification is the read's as much as this one's. `tryCatch(error = )`
 catches a condition for what it says it is, so a condition raised with `stop()`
 whose class does not inherit `error` is caught by neither and reaches the
-caller. Widening either to `condition` is the rewrite #268 rejects, since it
-would take a warning signalled on the way to answering for a failure to answer,
-and a test holds that direction. Under `options(warn = 2)` a warning is an
-error and is caught, which is R's semantics for the option rather than
+caller. A warning signalled on the way to answering is not taken for a failure
+to answer, and a test holds that direction. Under `options(warn = 2)` a warning
+is an error and is caught, which is R's semantics for the option rather than
 something decided here.
 
 A completed line is also not always one line. A kind that is one name and
@@ -309,19 +308,8 @@ environment among them — `cat()` rendering anything of no length as nothing.
 Which of them a given object is goes unreported, for the reason the amendment
 above gives.
 
-Rendering the field rather than dropping it is the alternative, and it was
-rejected for what it would have to promise. A rendering that always works is
-one marginplyr chooses for objects it never builds: `deparse()` and `format()`
-are both unbounded in length, and `format()` dispatches, so a `format()` method
-of the value's own raises exactly where the rendering is supposed to save the
-line. Guarding the `cat()` call is not an alternative at all, since the opening
-of the line is written by the time it raises.
-
-Nothing a constructor builds is affected, here as in the amendment above: every
-kind one stores is one name, so the branch is not reached. The constraint on
-the number and timing of evaluations is not reached either — the kind is read
-once, as the amendment above left it, and the predicate reads the value that
-read returned rather than the field again.
+The alternatives weighed against dropping the field, and what each would have
+had to promise, are #268's.
 
 ## Amendment: the condition class of a kind the guard could not classify
 


### PR DESCRIPTION
Closes #296.

`design/architecture.md`'s amendment rule holds that an amendment records what
the decision now is and what moved with it, and cites the ticket for why.
Three passages of ADR 0008's *the printed line for a kind that is no name*
were the ticket's argument instead.

## What changed

- The rejected alternatives — widening either catch to `condition`, and
  rendering the field rather than dropping it — reduce to one sentence naming
  #268 as where they are read. `design/agents/code-review.md` routes an
  alternative weighed and rejected to *Considered options* in the ADR holding
  the decision it would have changed; that decision is #268's, so the ticket
  is the home and not this ADR.
- The paragraph on what the change does not affect goes. What a constructor
  builds is already stated by the amendment above it, and the evaluations
  position by that amendment and again by the one below.

## What stayed

Every behaviour claim, including the clauses a later amendment supersedes:
the `tryCatch(error = )` qualification, the printed line the #264 pins now
render, and the sentence leaving the guards alone that the #280 amendment
cites. The qualification keeps what it says about a warning signalled on the
way to answering — `test-grouping-interface.R` holds that direction — with
only the rejected rewrite dropped from the sentence.

The amendment runs 80 lines where it ran 93.

## Verification

`test-grouping-plan.R` and `test-grouping-interface.R` pass, and the tests
asserting the behaviour #268 landed are untouched. Documentation only: no
file the package build reaches is changed.