### PR TITLE
Cut what the ADRs and the tests own from R/summary-selections.R (#273)

### DIFF
--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -89,11 +89,11 @@ check_option_named_summaries <- function(dots) {
     # the option they were reaching for leaves them looking for a word that is
     # not in their code.
     if (matched %in% names(removed_summary_options)) {
-      # Two `abort_marginplyr()` calls rather than one: what the branch
-      # chooses is a whole main line, which is what ADR 0023's third amendment
-      # admits, and a template bound outside the call it raises from is what
-      # the structural gate refuses. The cost is the `i` bullet the two arms
-      # share, written out in each.
+      # Two `abort_marginplyr()` calls rather than one: the branch chooses a
+      # whole main line, which ADR 0023's third amendment admits, where one
+      # call would need a template bound elsewhere, which its *Two rules are
+      # gated* refuses. The cost is the `i` bullet the two arms share, written
+      # out in each.
       #
       # That bullet is the option's own guidance, which is written in the
       # table above rather than beside either call, so it arrives interpolated
@@ -146,20 +146,17 @@ check_summary_context_helpers <- function(dots) {
     return(invisible(NULL))
   }
 
-  # `does not support` still opens the message deliberately, which is what ADR
-  # 0019 asks of it: six assertions match that phrase by regular expression
-  # rather than by condition class.
+  # `does not support` opens the message deliberately, which is what ADR 0019
+  # asks of it.
   #
   # The helpers do not follow that phrase in the same line. They arrive alone
   # in an `i` bullet, per ADR 0023's condition 2, because how many of them the
   # caller wrote is the caller's decision.
   #
-  # The sentence after the helpers is the part #172 added, because a caller who
-  # had bound one of these names themselves was told only that the verb refused
-  # the helper and had no way to learn that their own function was never going
-  # to run (ADR 0019). It inflects a demonstrative, a noun, and two verbs, and
-  # `cli::qty()` is what carries the count to all four: the vector deciding it
-  # is no longer in the line they sit in.
+  # What the last bullet says is ADR 0019's decision. It inflects a
+  # demonstrative, a noun, and two verbs, and `cli::qty()` is what carries the
+  # count to all four: the vector deciding it is no longer in the line they sit
+  # in.
   abort_marginplyr(c(
     "{.fun summarize_with_margins} does not support:",
     i = "{.fun {unsupported}}.",

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -89,14 +89,11 @@ check_option_named_summaries <- function(dots) {
     # the option they were reaching for leaves them looking for a word that is
     # not in their code.
     if (matched %in% names(removed_summary_options)) {
-      # Two calls rather than the one opening this branch used to bind and
-      # hand to a single call, because the structural gate reads
-      # `abort_marginplyr()`'s own argument and refuses a template bound
-      # elsewhere -- the shape `abort_share_helper_position()` records in
-      # `R/share.R` and three further sites in that file cite. What the branch
+      # Two `abort_marginplyr()` calls rather than one: what the branch
       # chooses is a whole main line, which is what ADR 0023's third amendment
-      # admits; the cost is the `i` bullet the two arms share, written out in
-      # each.
+      # admits, and a template bound outside the call it raises from is what
+      # the structural gate refuses. The cost is the `i` bullet the two arms
+      # share, written out in each.
       #
       # That bullet is the option's own guidance, which is written in the
       # table above rather than beside either call, so it arrives interpolated
@@ -153,19 +150,9 @@ check_summary_context_helpers <- function(dots) {
   # 0019 asks of it: six assertions match that phrase by regular expression
   # rather than by condition class.
   #
-  # What no longer follows it in the same line is the helpers, which arrive
-  # alone in an `i` bullet, per ADR 0023's condition 2: how many of them the
-  # caller wrote is the caller's decision. Five of those six read across the
-  # break unchanged -- four join the phrase to a helper name with `.*`, which
-  # spans a newline in R's default regular expressions, and one matches the
-  # phrase alone. Four assertions spelled the two as one run and could not, so
-  # each is re-pinned where it sits: the sixth of that census, in
-  # `test-summarize-operation.R`, and a `fixed = TRUE` match in
-  # `test-static-expression-analysis.R`, both now spelling the break; and the
-  # two in `test-contextual-helpers.R`, which is where the opening is asserted
-  # at the site the wording is decided, as byte-exact identities of each arm --
-  # one of them against the other, since what it asserts is that a
-  # parenthesized spelling reaches the same refusal.
+  # The helpers do not follow that phrase in the same line. They arrive alone
+  # in an `i` bullet, per ADR 0023's condition 2, because how many of them the
+  # caller wrote is the caller's decision.
   #
   # The sentence after the helpers is the part #172 added, because a caller who
   # had bound one of these names themselves was told only that the verb refused
@@ -439,11 +426,8 @@ rewrite_summary_selections <- function(expr,
 
   # The head is qualified before either branch reads the call, so every rebuild
   # below inherits it through `rebuild_static_call()` and no branch has to
-  # remember. This is what makes the call that executes the call this function
-  # analyzed: an unqualified head reaches the data mask resolved by ordinary
-  # lexical lookup, and a caller's own `across` then ran underneath a
-  # grouping-column exclusion check that had already passed on dplyr's
-  # (#172, ADR 0019).
+  # remember. ADR 0019's *Analysis and execution must agree* is authoritative
+  # for why a recognized head is qualified at all.
   expr <- qualify_static_spelling(expr, "selection", call_name)
 
   if (call_name %in% c("across", "if_any", "if_all")) {


### PR DESCRIPTION
Second file of #273, after #331 took `R/conditions.R`. This file's four scan hits
are read and decided; three are cut and one is left alone.

## What each was

| site (at `origin/main`) | category | where the deleted text belongs |
|---|---|---|
| `:92` | 1 + 3 | ADR 0023 *Two rules are gated* and its third amendment; a past-form record of what the branch used to be |
| `:156` | 3 | the commit that re-pinned the assertions, and the three test files themselves |
| `:440` | 1 | ADR 0019 *Analysis and execution must agree* |
| `:737` | 2 | nothing -- left alone |

## `:156`, which *Acceptance* names

Thirteen lines describing what four assertions in `test-summarize-operation.R`,
`test-static-expression-analysis.R`, and `test-contextual-helpers.R` were
re-pinned to. *Code comments*: "A comment describes the code it sits beside, in
the present tense. What a review found, which round answered it, and what a test
elsewhere now covers are things the code does not hold."

The site keeps ADR 0023's condition 2 and which way it falls under it. **No test
file is named anywhere in `R/summary-selections.R` now.** The review checked the
other direction too: `test-contextual-helpers.R:681-687` already carries the
six-assertion census in the present tense at the site, and all four re-pinned
assertions exist and assert what the comment described, so nothing is lost by
deleting the description of them.

## `:92`

Two things in one paragraph. That the branch raises from two calls where one
"used to bind and hand to a single call" is a past-form record. The gate argument
beside it is ADR 0023's, in *Two rules are gated* and in the second amendment's
closing line, "a constant bound elsewhere stays refused".

The pointer to `abort_share_helper_position()` in `R/share.R` goes with them: ADR
0023's **third amendment** holds the decision and names that refusal as its own
example --

> What an R branch may choose is a whole element or a whole clause, which is what
> `R/share.R`'s helper-position refusal and `R/grouping-plan.R`'s two renaming
> refusals already do

-- and the **first** amendment says why such a rule stops living in a code
comment: one of three sites "said so -- in a code comment, where it governed one
file while the other two re-derived it". A comment citing that comment instead of
the ADR is the shape those amendments were written to end.

## `:440`

Re-derived ADR 0019's *Analysis and execution must agree* down to the mechanism:
an unqualified head resolved by ordinary lexical lookup in the data mask, and a
caller's own `across` running underneath a grouping-column exclusion check that
had already passed on dplyr's. That section carries the argument and the runnable
reproduction. What the site keeps is the ordering only this location knows -- the
head is qualified before either branch reads the call, so every rebuild inherits
it through `rebuild_static_call()` and no branch has to remember.

## `:737`, left alone

ADR 0005 is fifteen lines saying a locally detectable error is rejected before a
backend read. It does not hold this header's contract, and it does not hold the
distinction the header draws from the `character()` the caller above returns --
there the template could not be evaluated at all and the analysis does not know
the names; here it knows them and knows they are wrong. That is this site's own
fact and the citation does the one job a citation does. This is #273's category
2, and it is why the file still reports one scan hit.

## Two sub-threshold paragraphs, cut after the review

`:152` and `:170` are in the two blocks this branch rewrote, fall under the same
rule, and sit under the scan's seven-line threshold, so #273 has not measured
them. Both review axes raised them, and `c5e5811` cuts them:

- `:152` -- "six assertions match that phrase by regular expression rather than by
  condition class" is ADR 0019:142-144 almost verbatim, one line above a
  paragraph rewritten for that defect.
- `:170` -- "the part #172 added" is a past-change record over a reason ADR
  0019:136-140 holds.

Cutting them moves nothing the scan reports, since neither reaches the threshold.
`:101` is left alone and is the one the issue's boundary does reach: it cites no
ADR.

## The count

**31 paragraphs / 265 lines** at `origin/main` -> **28 / 237**.
`R/summary-selections.R` goes from four hits to one.

## Checks

- `lintr::lint_package()` after `pkgload::load_all(".")`: no lints.
- `testthat::test_local()`: green, no failures, no skips, no warnings. Run again
  after `c5e5811`.

Comments only, no roxygen, so `man/`, `NAMESPACE`, and `README.md` are unaffected.

Refs #273