### PR TITLE
Cut ADR 0019's own amendments from R/utils.R's comments (#273)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -257,11 +257,9 @@ unparenthesized_value <- function(expr) {
   expr
 }
 
-# The name a head or a function reference spells. A head is unwrapped only down
-# to a name, because that is the only thing a head can be unwrapped to without
-# changing what R does with it: `("sum")(1)` is not a call to `sum` but the
-# error R raises for applying a non-function, and `(function(x) x)(1)` names
-# nothing either way. Both keep the answer they have always had.
+# The name a head or a function reference spells, unwrapped only down to a
+# name. ADR 0019's *redundant parentheses are read through, in one place*
+# names that boundary; this is the reader it stops at.
 #
 # The early return is the other half of the missing-marker rule above. This is
 # asked of an argument a caller may have left empty -- an `across()` `.fns` is

--- a/R/utils.R
+++ b/R/utils.R
@@ -164,8 +164,8 @@ assert_lazy_table <- function(x) {
 # for another shape, carrying the formula as the expression that branch then
 # reads `[[2L]]` of (#163). `rlang::call_args()` unwraps the same way, which is
 # how a formula reached the direct-share path and was computed as the share it
-# is not -- measured on 5f078ea, and the one shape of this whose misread raised
-# nothing, which is what the ticket's severity note does not cover.
+# is not -- measured on 5f078ea, and the one shape of this whose misread
+# raises nothing.
 #
 # Every analysis that reads a name recognizes a call by that name, none of them
 # recognizes `~`, and each already has an answer for a name it does not know:
@@ -235,17 +235,11 @@ nameable_call <- function(expr) {
   rebuild_static_call(unwrapped, static_call_args(unwrapped), head = spelled)
 }
 
-# `(` is the identity function, so a redundant pair of parentheses changes
-# nothing about what a call calls or what it is given: `(grouping_id)(region)`,
-# `(grouping_id(region))`, and `grouping_id(region)` are one call written three
-# ways. The three readers below see through them, which is what gives every
-# analysis in the package the same answer for the three at once, rather than
-# each family recognizing whichever spellings someone thought to enumerate
-# (#178, ADR 0019).
-#
-# Identity here stays syntactic. `(get("grouping_id"))(region)` strips to a
-# call rather than to a name, so the head is unresolved and stays that way,
-# which is the conservative #130 policy these three are written not to weaken.
+# The three readers below read through redundant parentheses, so
+# `(grouping_id)(region)`, `(grouping_id(region))`, and `grouping_id(region)`
+# reach every analysis in the package as one call. ADR 0019's *redundant
+# parentheses are read through, in one place* is authoritative for that
+# reading and for where it stops.
 #
 # Everything a pair of parentheses wraps, however many pairs deep. This is the
 # reading for a position holding a value -- a `.fns` argument, a name given to
@@ -433,14 +427,9 @@ is_name_part <- function(part) {
 # `missingArgError` naming this function's own parameter. Handed on as an
 # argument the same value forces without error, and returned it stays a value.
 #
-# What this does not carry across is the environment, and that is the decision
-# rather than a limitation. A Contextual helper's argument is resolved against
-# the Grouping plan by spelling and is never looked up in an environment
-# (ADR 0019), so there is no lookup for a quosure's environment to answer. That
-# is the opposite of the answer #165 reached one layer out, where a walk keeps a
-# quosure's environment because a selection inside it really is evaluated there,
-# and both follow the one rule: the environment is honoured wherever evaluation
-# happens, and these arguments are never evaluated.
+# What this does not carry across is the environment. ADR 0019's *an injected
+# name is read for the name it carries* is authoritative for why discarding it
+# is the decision rather than a limitation.
 unwrap_injected_quosure <- function(part) {
   if (!rlang::is_quosure(part)) {
     return(part)


### PR DESCRIPTION
Third file of #273, after #331 (`R/conditions.R`) and #332 (`R/summary-selections.R`).

## What each was

| site (at `origin/main`) | category | where the deleted text lives |
|---|---|---|
| `:238` | 1 | ADR 0019 *Amendment: redundant parentheses are read through, in one place* |
| `:436` | 1 | ADR 0019 *Amendment: an injected name is read for the name it carries* |
| `:158` | 2, one clause 3 | nothing -- rlang behaviour no ADR holds; the clause is about #163's text |
| `:538` | 2 | nothing -- left alone |

## `:238`

Both of its sentences are the amendment's:

> `(` is the identity function, so all three writings of that call evaluate
> identically and R's own parser records the difference in the tree rather than
> in what runs.

> **One place, not one place per family.** The reading lives in the shared
> readers of `R/utils.R` -- the name, the namespace, the head, and the arguments
> -- so every analysis that reads an expression inherits it.

The site keeps that the three readers below read through the pairs, and cites
the amendment for the reading and for where it stops.

## `:436`

The same ADR's other amendment, restated down to its bolded rule:

> **The environment is discarded, and that follows from the decision above
> rather than sitting beside it.** ... so there is no lookup for a quosure's
> environment to answer.

> That is the opposite of the answer #165 reached one layer out ... **the
> environment is honoured wherever evaluation happens, and these arguments are
> never evaluated.**

The ADR is thicker than the comment was -- it also holds the Grouping
specification constructors as the case showing the rule is about the criterion
and not about ownership -- so nothing moves to it.

## `:158` -- #273 was right about this one

*Problem* names it as correct as written: "that `rlang::call_name()` and
`rlang::call_args()` unwrap a one-sided formula, what that did to the
direct-share path, and where it was measured. External behaviour the code cannot
show." That holds. No ADR carries rlang's unwrapping, and `ADR-0015` is cited
only for which side the untyped condition falls on, which is the one job a
citation has.

Unlike `R/conditions.R:353` in #331, this one survives the check. One clause
goes: "which is what the ticket's severity note does not cover" is a remark
about #163's text rather than about this code.

## `:538`, left alone

`An invariant, not a Package condition (ADR-0015)` is the form *Code comments*
gives verbatim. ADR 0015's *Consequences* asks each `stopifnot()` site to
establish that it is unreachable from the public interface, and why this one is
-- the two walks that hand a quosure here map `static_call_args()`'s arguments
one to one, and the ones that change an argument count are named `across()` and
`pick()` calls -- is what only this site can say.

## One sub-threshold paragraph, cut with its block

`:246` is in `:238`'s block and under the scan's seven-line threshold, so #273
has not measured it. "Identity here stays syntactic" is the amendment's
"identity is still syntactic", and the `get()` example is *Boundary for callable
identity*. Cut for the reason #332 cut `:152` and `:170`: a verbatim ADR copy
beside a paragraph trimmed for holding one is the defect left standing. Cutting
it moves nothing the scan reports.

Two are left, and each for a stated reason:

- `:266` (5 lines) -- "A head is unwrapped only down to a name ... `(\"sum\")(1)`
  is not a call to `sum`" is the amendment's *Where the head unwrapping stops*.
  It heads a different function, so it is outside the block this branch rewrote.
- `:419` (8 lines) -- cites no ADR, which is #273's own scope boundary.

## The count

**28 paragraphs / 237 lines** at `origin/main` -> **26 / 222**. `R/utils.R` goes
from four hits to two, both category 2.

## Checks

- `lintr::lint_package()` after `pkgload::load_all(\".\")`: no lints.
- `testthat::test_local()`: green, no failures, no skips, no warnings.

Comments only, no roxygen, so `man/`, `NAMESPACE`, and `README.md` are unaffected.

Refs #273