### PR TITLE
Cut what ADR 0015 and 0023 own from R/grouping-plan.R (#273)

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -619,10 +619,9 @@ compile_grouping_spec_impl <- function(preflight,
   # `grouping_name_proxy(data_vars)`, this same set; and a selection column
   # names alone cannot settle, resolved against the typed snapshot, whose
   # columns are that set on every backend. A `.by` source that could invent a
-  # name is the thing that has to justify itself here — before #134 one did,
-  # and reported a column the caller never wrote. The `.by`/`.grouping` overlap
-  # check below is the opposite case and stays a Package condition: an ordinary
-  # call reaches it.
+  # name is the thing that has to justify itself here. The `.by`/`.grouping`
+  # overlap check below is the opposite case and stays a Package condition: an
+  # ordinary call reaches it.
   unknown_by <- setdiff(.by, data_vars)
   if (length(unknown_by) > 0L) {
     stop(
@@ -1034,10 +1033,8 @@ grouping_arg_spec <- function(arg, data_vars) {
 # The refused value is read from the condition rather than by evaluating the
 # quosure again to identify it: tidyselect has already evaluated it once, and
 # ADR 0008 fixes how often a caller's quosure runs. This is marginplyr's own
-# report about a position of its own, so it stays parentless, as
-# `abort_share_source_name()` does for the same reason. Every other failure is
-# an External condition and is re-raised as it arrived, with its own class,
-# diagnostic, and cause.
+# report about a position of its own, so it stays parentless, where every
+# other failure is an External condition and propagates unchanged (ADR 0015).
 #
 # A specification stored as a function is refused from the frames instead,
 # because tidyselect refuses no function: it calls one, as the predicate form
@@ -1328,19 +1325,14 @@ resolve_column_selection <- function(arg, data_proxy, on_rename) {
 
 # One caller mistake, one diagnostic: `.grouping` and `.by` refuse a renaming
 # selection for the same reason, and only the noun and the rule it states
-# differ. That difference used to be a labels list the refusal read a singular
-# or a plural noun out of; it is now two refusals, and the resolution above is
-# handed whichever one speaks for its selection.
+# differ. Two refusals rather than one, with the resolution above handed
+# whichever speaks for its selection.
 #
 # Written out rather than kept as one template with the noun interpolated,
-# because the noun is what pluralizes. `{?s}` reads the quantity beside it, so
-# a shared template would have to choose between two noun pairs, which is the
-# branch ADR 0023's `{?}` rule dissolves rather than relocates. Writing them
-# out also keeps both inside the structural gate, which reads
-# `abort_marginplyr()`'s own argument and refuses a template bound elsewhere --
-# the shape `abort_share_helper_position()` records in `R/share.R`, where what
-# two calls share is written out in each for that reason. ADR 0023's third
-# amendment names that refusal and this pair together.
+# because the noun is what pluralizes and `{?s}` reads the quantity beside it,
+# so a shared template would have to branch on it. ADR 0023's `{?}` rule is
+# what refuses that branch, and its third amendment names this pair beside
+# `R/share.R`'s helper-position refusal as what an R branch may choose instead.
 #
 # The pairs arrive alone in an `i` bullet, per ADR 0023's condition 2: how many
 # of them there are is the caller's decision.


### PR DESCRIPTION
Fifth file of #273, after #331, #332, #333, and #334.

**#273's split says `R/grouping-plan.R` (6). The scan reports eight** at
`origin/main`: `:180`, `:352`, `:453`, `:614`, `:912`, `:1034`, `:1185`, `:1335`.
Third undercount in the split, after `R/conditions.R`'s and `R/share.R`'s.

## The exclusion still holds, for a different reason

#273 says:

> `R/grouping-plan.R:364-459` is #272 and is excluded here; two of its
> paragraphs appear in the scan.

**#272 is CLOSED / COMPLETED**, by #277 and #278. The ticket's "two" is wrong in
the other direction from the undercounts above: at `04f093f` the scan hit
**three** paragraphs inside `364-459` -- `:364`, `:407`, and `:438`. #272 removed
the first two and kept the third, which is `:453` today, so one is in the scan
now. It is exactly what #272's *What must not be lost* named:

> The `#261` path ..., the `#262` catch and what it decides, `rule` being the
> parent's own and what that buys the memo -- each is a fact about this call
> site, established after ADR 0026 was written or below the level it records.

So `:453` stays, and the exclusion holds because the question was answered
rather than because it is open.

## What each was

| site | category | disposition |
|---|---|---|
| `:180` | 2 | left |
| `:352` | 2 | left |
| `:453` | 2 | left -- #272's settled residue |
| `:614` | 2, one clause 3 | clause cut |
| `:912` | 2 | left |
| `:1034` | 1 (part) | cut to the citation |
| `:1185` | 2 | left |
| `:1335` | 1 | cut to the citation |

Five untouched is the highest proportion in this ticket so far, which is what a
file #272 has already been through should look like.

## `:1034`

> Every other failure is an External condition and is re-raised as it arrived,
> with its own class, diagnostic, and cause.

against ADR 0015:

> External conditions propagate unchanged, and rethrows preserve the original
> condition rather than reclassifying it.

The contrast the site needs -- this report is marginplyr's own and stays
parentless, where everything else propagates -- now carries the citation. The
pointer to `abort_share_source_name()` goes with it, being what the citation
covers.

## `:1335`

Two of ADR 0023's rules. "The branch ADR 0023's `{?}` rule dissolves rather than
relocates" is that ADR's own sentence:

> A rule permitting an `if` where `{?}` is awkward relocates that idiom rather
> than dissolving it

And the structural gate reading `abort_marginplyr()`'s own argument, with its
pointer to `abort_share_helper_position()` in `R/share.R`, is the third instance
of a shape already removed from `R/summary-selections.R:92` (#332) and
`R/share.R:2358` (#334). ADR 0023's third amendment holds that decision and
names that refusal itself.

`:1329` goes with it -- same block, under the threshold, and "That difference
used to be a labels list the refusal read a singular or a plural noun out of" is
a record of what the code was.

## `:614`, one clause

What it establishes -- that each of the three `.by` sources binds every value to
`data_vars`, so no documented call reaches this `stop()` -- is what ADR 0015's
*Consequences* asks each such site to supply about itself, and is category 2.
"Before #134 one did, and reported a column the caller never wrote" is a past
change, and the sentence before it already states the rule for a future one.

## The five left alone

- `:180` -- the ADR-0005 citation says which way the site falls; unresolved fixed
  keys standing in as none, and the two checks made again against the resolved
  keys, are in no ADR.
- `:352` and `:912` -- contract plus citation. `:912` names *which two
  amendments* of ADR 0008 answer it, which is the form this ticket has been
  converging on across five files.
- `:1185` -- what is not forced and why: an unforced binding, an active binding,
  and `...`. Only this site knows it.
- `:453` -- above.

## A finding this branch does not answer: #336

#335's Spec axis was pointed at `:453` to test the exclusion rather than accept
it, and found that the paragraph re-derives **ADR 0008** -- an ADR neither ticket
checked it against. `:458-460` against ADR 0008:340-342, and `:453-454` against
ADR 0008's *The nested-name site*, a section written about this exact call site.

It is not answered here. `:453` is inside the range #273 excludes by name, and
*Answering a review* asks a finding a branch's Acceptance does not reach to
become a ticket rather than prose. Filed as #336, with what the review found and
why two passes missed it: #272 compared the block against ADR 0026 only, and
#273 excludes it because #272 owned it -- which stopped being true when #272
closed.

## The count

**22 paragraphs / 188 lines** at `origin/main` -> **20 / 171**.
`R/grouping-plan.R` goes from eight hits to six, all six deliberate.

## Checks

- `lintr::lint_package()` after `pkgload::load_all(".")`: no lints. The two
  over-80 lines in this file are pre-existing and outside every hunk.
- `testthat::test_local()`: green, no failures, no skips, no warnings.

Comments only, no roxygen, so `man/`, `NAMESPACE`, and `README.md` are unaffected.

Refs #273