### PR TITLE
Read the last eight of #273's list, and cut four (#273)

### DIFF
--- a/R/contextual-helpers.R
+++ b/R/contextual-helpers.R
@@ -23,9 +23,9 @@
 # `test-contextual-helpers.R` asserts the laziness rather than trusting it.
 #
 # `contextual` is what ADR 0019's criterion decides, and it is not a synonym
-# for "read statically": three of the four families here are read statically
+# for "read statically": the families carrying it `FALSE` are read statically
 # and are still ordinary names. That ADR's *What the criterion decides* is
-# authoritative for which family the field is true of and why.
+# authoritative for which and why.
 static_spelling_rules <- function() {
   list(
     grouping = function() {

--- a/R/contextual-helpers.R
+++ b/R/contextual-helpers.R
@@ -2,20 +2,9 @@
 # the three families read alongside them, keyed by the family that decides what
 # recognition does. It is the one place those names and the namespaces they may
 # carry are written down, and the one place their namespace test is
-# implemented. Before #172 each reader carried a spelling and a test of its
-# own, two derived from a rules table and the rest written out, and one --
-# `where`, in `contains_selection_predicate()` -- had no namespace test at all,
-# so a spelling could be recognized by the analysis and missed by the rewrite
-# beside it. `investigation/contextual-helper-execution-mechanism.md` counts
-# and tabulates them (#172, ADR 0019).
-#
-# The language-capture primitives are the one set of names read statically and
-# deliberately kept out. `language_capture_formal()` and
-# `captured_call_parts()` (`R/utils.R`) carry `quote`, `substitute`, and
-# `expression` with a `base` namespace test of their own, and that test is not
-# this one: a capture is refused where the head names a binding the analysis
-# can see, so it answers to the calling environment where every family here
-# refuses to. Registering them would put two rules under one reader.
+# implemented. ADR 0019's *The recognized spellings live in one registry* is
+# authoritative for why one place, for what it replaced, and for the
+# language-capture primitives it keeps out.
 #
 # A family names its own spellings only where no other table already owns them.
 # `share_kind_rules()` is the authoritative description of a contextual share
@@ -34,14 +23,9 @@
 # `test-contextual-helpers.R` asserts the laziness rather than trusting it.
 #
 # `contextual` is what ADR 0019's criterion decides, and it is not a synonym
-# for "read statically". A Contextual helper's meaning arises only through
-# static rewriting, so no caller binding can change what the verb does with it.
-# The other three families are read statically and are still ordinary names: a
-# Grouping specification constructor's spelling decides only whether a nested
-# argument is evaluated at all -- which is what separates a nested
-# specification from a tidyselect selection -- and a data-frame constructor's
-# spelling is read only to predict the output names of a data-frame-valued
-# summary. Both really run whatever the name is bound to.
+# for "read statically": three of the four families here are read statically
+# and are still ordinary names. That ADR's *What the criterion decides* is
+# authoritative for which family the field is true of and why.
 static_spelling_rules <- function() {
   list(
     grouping = function() {

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -297,12 +297,9 @@ summarize_margin_branch <- function(.data,
   )
 
   # A lazy input whose branch came back local was read, and both arms of this
-  # are that one fact. Which arm depends on who did the reading (ADR 0015): an
-  # Arrow input absorbing is something the caller can rewrite, and the refusal
-  # names the rewrites; any other backend answering a lazy input with a local
-  # frame is a defect here or there, which no rewrite of their call avoids.
-  # Attributing the second to Arrow would be worse than not reporting it -- a
-  # diagnostic that misdirects, over a defect.
+  # are that one fact. Which arm depends on who did the reading, and ADR 0025's
+  # *How the refusal is raised* is authoritative for why each falls where it
+  # does.
   #
   # The second arm is also what catches a branch list that is part local and
   # part lazy, which `combine_margin_branches()` does not: a lazy-first mix is

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -271,13 +271,10 @@ abort_absorbed_summary <- function(labels) {
 # expression once per grouping set and this stops at the first.
 #
 # Over an Arrow input the guard raises the refusal rather than an internal
-# invariant (ADR 0015), although what it reports is a defect. A caller reaching
-# it can act on it, and the action is the one the refusal already names; making
-# them read a bug report instead would move the cost of marginplyr's drift onto
-# them. It has a second arm, for every other lazy backend, where that reasoning
-# inverts and an invariant is what the caller should get; the comment on the
-# guard itself is where that sits, and ADR 0025 records both. The maintainer's
-# signal is `test-query-policy.R`, which fails when a read happens at all.
+# invariant, and its second arm inverts that for every other lazy backend.
+# Which way each falls is on the guard itself, and ADR 0025 records both. The
+# maintainer's signal is `test-query-policy.R`, which fails when a read
+# happens at all.
 summarize_margin_branch <- function(.data,
                                     ...,
                                     .by,
@@ -300,13 +297,12 @@ summarize_margin_branch <- function(.data,
   )
 
   # A lazy input whose branch came back local was read, and both arms of this
-  # are that one fact. Which arm depends on who did the reading, because ADR
-  # 0015 sorts a condition by what the caller can do about it rather than by
-  # what happened: an Arrow input absorbing is something they can rewrite, and
-  # the refusal names the rewrites; any other backend answering a lazy input
-  # with a local frame is a defect here or there, which no rewrite of their
-  # call avoids. Attributing the second to Arrow would be worse than not
-  # reporting it -- a diagnostic that misdirects, over a defect.
+  # are that one fact. Which arm depends on who did the reading (ADR 0015): an
+  # Arrow input absorbing is something the caller can rewrite, and the refusal
+  # names the rewrites; any other backend answering a lazy input with a local
+  # frame is a defect here or there, which no rewrite of their call avoids.
+  # Attributing the second to Arrow would be worse than not reporting it -- a
+  # diagnostic that misdirects, over a defect.
   #
   # The second arm is also what catches a branch list that is part local and
   # part lazy, which `combine_margin_branches()` does not: a lazy-first mix is

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -266,20 +266,13 @@ abort_margin_label_collision <- function(margin_labels, found, on_collision) {
 }
 
 # Four arms across the two refusals below, rather than one template with two
-# branches inside it. Both branches choose a whole clause: the kind chooses how
-# the collision is named, and under the declared kind that clause pluralizes
-# with the subject, so one template would have to pick between two noun pairs;
-# and the subject is either the one colliding label, which is interpolated, or
-# the words standing in for several distinct ones, which is not, so `{?}`
-# cannot write both -- the arm it picks is literal text and is never re-read as
-# a template. ADR 0023's third amendment records the measurement and why a
+# branches inside it. ADR 0023's third amendment was written about this
+# refusal and is authoritative for what the arms differ by and for why a
 # branch on a count is still inside its `{?}` rule.
 #
 # What the shape costs is every element the arms share, written out in each:
 # the bullet carrying the columns four times, the noun `column{?s}` inflects
-# four times, and each remedy twice. The structural gate is what leaves no
-# cheaper spelling, since a template hoisted out of the arms is a template
-# bound elsewhere and it refuses one.
+# four times, and each remedy twice.
 #
 # `.check_margin_label = FALSE` is offered only where it is a remedy. It turns
 # off the read, and a declared collision is not found by reading, so naming it

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -388,9 +388,9 @@ order_margin_result <- function(operation, result, execution) {
 
 # Where a backend records a window ordering, `arrange()` has written the key
 # into two places and only one of them is a Margin order, so the second is
-# cleared. ADR 0018's *`arrange()` writes the key into two places* is
-# authoritative for which is which and for why clearing it takes nothing away.
-# What is left alone is the `ORDER BY`, which is where the rows' order is.
+# cleared. ADR 0018's *a lazy result carries the order and records no window
+# ordering* is authoritative for which is which, for why clearing it takes
+# nothing away, and for the `ORDER BY` it leaves alone.
 forget_margin_window_order <- function(result, backend) {
   if (!backend$records_window_order) {
     return(result)

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -386,21 +386,11 @@ order_margin_result <- function(operation, result, execution) {
   forget_margin_window_order(result, backend = operation$backend)
 }
 
-# Where a backend records a window ordering, `arrange()` has just written the
-# key into two places, and only one of them is a Margin order. ADR 0018's rule
-# -- the key must be resolvable in the `FROM` clause of the query carrying the
-# `ORDER BY` -- is what splits them. The `ORDER BY` reads the Grouping set
-# identifier out of `FROM`, so it survives the projection above dropping that
-# column; the window ordering is rewritten by that same projection and loses
-# every term naming the identifier, leaving a truncated key that orders a
-# margin row by where its label falls.
-#
-# Recording that is worse than recording nothing, and it is also unusable:
-# `compute()` replays a window ordering through `window_order()`, which takes a
-# bare column name or `desc()` of one and nothing else, so the computed terms a
-# Margin key is made of stop it and no sorted result can be materialized at all
-# (#102). Clearing it takes nothing away, because the rows still arrive in the
-# Margin order -- that is the `ORDER BY`, which this leaves alone.
+# Where a backend records a window ordering, `arrange()` has written the key
+# into two places and only one of them is a Margin order, so the second is
+# cleared. ADR 0018's *`arrange()` writes the key into two places* is
+# authoritative for which is which and for why clearing it takes nothing away.
+# What is left alone is the `ORDER BY`, which is where the rows' order is.
 forget_margin_window_order <- function(result, backend) {
   if (!backend$records_window_order) {
     return(result)


### PR DESCRIPTION
The six files with one or two hits each. **This finishes #273's list**, after
#331, #332, #333, #334, and #335.

## What each was

| site (at `origin/main`) | category | disposition |
|---|---|---|
| `R/contextual-helpers.R:1` | 1 | cut to the citation |
| `R/contextual-helpers.R:36` | 1 | cut to the citation |
| `R/factor.R:41` | 2 | left |
| `R/grouping-adapter-union.R:273` | 1 + self-copy | defers to the guard |
| `R/grouping-adapter-union.R:302` | 1 (part) | cites |
| `R/grouping-spec.R:252` | 2 | left |
| `R/margin-label.R:268` | 1 | cut to the citation |
| `R/margin-operation.R:389` | 1 | cut to the citation |

## `R/contextual-helpers.R`

Both headers are ADR 0019's. `:1` restated *The recognized spellings live in one
registry*:

> Before this decision every reader carried a spelling and a test of its own,
> and one of them -- `where`, in `contains_selection_predicate()` -- had no
> namespace test at all; `investigation/contextual-helper-execution-mechanism.md`
> tabulates them.

`:12`, the language-capture paragraph beside it, is the rest of that same
section ("Putting them under one reader would put two rules under it") and goes
with it -- same block, cites no ADR, the `R/share.R:2172` case from #334.

`:36` restated *The rule* and *What the criterion decides*, including that "a
caller who binds `tibble` gets their own function" and that the constructor gate
"decides *whether the argument is evaluated at all*".

## `R/margin-label.R:268`

ADR 0023's third amendment was written **about this refusal**, and the paragraph
restated it:

> The two arms here name different subjects -- the one colliding label, which is
> interpolated, against the words `Margin labels` standing in for several
> distinct ones, which is not -- so no single template can write both.

`:278`'s structural-gate sentence is the same amendment's and goes with it. What
stays is what the shape costs at this site: the columns bullet four times, the
noun four times, each remedy twice.

## `R/margin-operation.R:389`

ADR 0018's ***`arrange()` writes the key into two places***, both paragraphs,
down to `window_order()` accepting "a bare column name or `desc()` of one and
rejects everything else".

## `R/grouping-adapter-union.R` -- a copy of itself, not of an ADR

`:273` and `:302` are the same argument written twice, thirty lines apart in one
file, and `:273` said so: "the comment on the guard itself is where that sits".
Both also re-derived ADR 0015's predicate --

> The predicate is avoidability, not the origin of the cause.

-- as "ADR 0015 sorts a condition by what the caller can do about it rather than
by what happened". The header now defers to the guard for which way each arm
falls, and the guard cites.

This is the one shape in the ticket that is not ADR duplication. *Code comments*
reaches it the same way: the second copy reads as support for the first while
nothing compares the two.

## The two left alone

- `R/factor.R:41` -- ADR 0015's form over a call chain only this site knows: every
  Margin verb calls `validate_margin_operation()` before the
  `finalize_margin_operation()` that reaches here, so the `stopifnot()` is
  unreachable, which is what that ADR's *Consequences* asks each such site to
  establish. The ADR 0020 citation beside it says which way the declared-level
  collision falls.
- `R/grouping-spec.R:252` -- names which ADR 0008 amendment answers it and how it
  falls here (the empty string). The form the whole ticket converged on, and the
  same as `R/grouping-plan.R:912`.

## The count, corrected

**37 paragraphs / 328 lines** at `04f093f` -> **15 / 126** here.

328 is the figure at `04f093f`, which is the commit the list was taken at. Every
pull request in this ticket, this one included, wrote **324** against it. 324 is
the count at `4dab04d`, where these six branches started; the set of 37 is the
same at both. Corrected in `1a0f4a7`.

All thirty-seven have been read and decided. **What survives is not "the ones
left alone"** -- an earlier draft of this body said so and it is false. Of the
fifteen:

| | sites |
|---|---|
| byte-identical to a paragraph on the original list | `R/factor.R:41`, `R/grouping-plan.R:180`, `R/share.R:2155`, `R/summary-selections.R:718`, `R/utils.R:525` |
| never on the list -- written after `04f093f` | `R/grouping-plan.R:352`, `:911`, `:1182` |
| cut by one of the six branches and still over seven lines | the rest |

The filter is a length heuristic, and that is the honest reading of the residue:
a paragraph it still reports may be one nobody touched, one this ticket
rewrote, or one written after the list was taken, and the number alone does not
say which.

## One of the 37 recorded nowhere until now

`R/grouping-plan.R:506` at `04f093f` is the `admitted_nested_kinds()` header, and
it is on the list. `526b2c6` removed it -- **#272's** work, one commit before
these branches started -- so it is decided, and no #273 pull request said so.
Recorded here.

## The one it did not settle

`R/grouping-plan.R:453` is on the list and outside the scope, because #273
excludes its range as #272's and #272 has closed. #335's review found it
re-derives ADR 0008, which neither ticket checked it against. Filed as **#336**,
open.

## Checks

- `lintr::lint_package()` after `pkgload::load_all(".")`: no lints.
- `testthat::test_local()`: green, no failures, no skips, no warnings.

Comments only, no roxygen, so `man/`, `NAMESPACE`, and `README.md` are unaffected.

Closes #273