### PR TITLE
Cite ADR 0008 in check_ambiguous_nested_name()'s header (#336)

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -450,23 +450,18 @@ nested_arg_expr <- function(arg) {
 # is followed here for what a caller could stop holding rather than for what one
 # arrives with.
 #
-# A binding that raises when it is read is not a specification, so the
-# selection reading stands where it raises, and so does an object carrying the
-# class with no kind to read -- an atomic vector given the class offers no
-# field to read at all, which `grouping_spec_kind()` answers with `NULL`, and
-# a list without the field answers `NULL` too, neither of which is a kind this
-# position could admit. Both that reading and the classification below are the
-# guard's own, so the two cannot disagree about what a kind is or about what one
-# is readable off. The evaluation's catch and the read's are narrow in what they
-# decide and not in what they swallow: everything they hide is a failure to
-# produce a specification of an admitted kind, which is a specification reading
-# that is not available. That is where the ADR-0015 line falls too, because
-# nothing here is deciding what such an object is -- a list carrying the class
-# and no kind, bound to a name nothing shadows, still reaches
-# `validate_grouping_spec_early()` and is refused in its own words. So does an
-# atomic vector carrying it, since #262 stopped that guard reading a field
-# before it had established the object can be read: what a colliding name
-# withholds here is a Package condition in either shape, not an untyped one.
+# A specification reading this site cannot complete is not a reading the
+# position has, so the selection reading stands -- for a binding that raises
+# when it is read, and for an object whose kind the shared readers answer
+# `NULL` for (ADR 0008).
+#
+# The evaluation catch is this site's own, and the ADR-0015 line falls across
+# it where `grouping_spec_kind()`'s header above puts it for the read's:
+# nothing here decides what such an object is. Declining costs the object no
+# diagnostic either, since the same one bound to a name nothing shadows is read
+# as a specification and refused by `validate_grouping_spec_early()` as a
+# Package condition (ADR 0008, *the condition class of a specification the
+# guard could not read*).
 #
 # `rule` is the parent's own, which the caller already holds because it
 # validates nested arguments with it; deriving it again here would be the same

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -455,14 +455,6 @@ nested_arg_expr <- function(arg) {
 # when it is read, and for an object whose kind the shared readers answer
 # `NULL` for (ADR 0008).
 #
-# The evaluation catch is this site's own, and the ADR-0015 line falls across
-# it where `grouping_spec_kind()`'s header above puts it for the read's:
-# nothing here decides what such an object is. Declining costs the object no
-# diagnostic either, since the same one bound to a name nothing shadows is read
-# as a specification and refused by `validate_grouping_spec_early()` as a
-# Package condition (ADR 0008, *the condition class of a specification the
-# guard could not read*).
-#
 # `rule` is the parent's own, which the caller already holds because it
 # validates nested arguments with it; deriving it again here would be the same
 # lookup twice. It is derived from the parent's kind, so the pair handed to the


### PR DESCRIPTION
Closes #336.

`check_ambiguous_nested_name()`'s header carried a 17-line paragraph that #272
left in place. #272 read the whole block against ADR 0026, which is the ADR its
own Problem section was about; ADR 0008 was never in its frame, and #273
excludes the block's line range on the ground that #272 owns it — which is no
longer true, #272 being closed. The paragraph's sentences turned out to be
ADR 0008's.

## What was deleted, and where each sentence lives

| The sentence | Where the argument lives |
|---|---|
| a binding that raises when it is read leaves the selection reading standing | ADR 0008, *The nested-name site* — a section written about this call site |
| an object carrying the class with no kind to read does too | the same sentence there: "a kind it cannot classify is not a kind the position admits" |
| the atomic-vector and missing-field mechanism | `grouping_spec_kind()`'s own header, above in this file |
| the two readings cannot disagree about what a kind is | ADR 0008, *Where the classification is made* |
| both catches are narrow in what they decide and not in what they swallow | `grouping_spec_kind()`'s header, which makes the claim about both catches and names this function while doing it |
| `#262` stopped the guard reading a field before it had established the object can be read | ADR 0008, *Amendment: the condition class of a specification the guard could not read* |

The `#262` clause is the one the ticket asked about specifically: it cited the
issue rather than the ADR section that holds the decision, so an amendment to
that section left the paragraph standing and nothing compared the two. It now
cites the section.

## What is left

Four lines, and what they carry is this site's: that the selection reading
stands wherever a specification reading cannot be completed here -- for a
binding that raises when it is read, and for an object whose kind the shared
readers answer `NULL` for -- with ADR 0008 named as where that decision lives.

A first attempt kept a second paragraph on the evaluation catch and the ADR-0015
line. The review found it false for the raising-binding shape and a second copy
of what `grouping_spec_kind()`'s header already holds for this catch by name, so
it was deleted rather than rewritten. The review record comment on this PR has
both findings and their answers.

## Neither ADR gains a sentence

Every deleted sentence was checked against ADR 0008 and ADR 0026 rather than
assumed to be there, and each was present. The one claim neither holds — that a
list carrying the class but no `type` field answers `NULL` from `$` rather than
raising — is base R's semantics and not a decision of this package's, and the
retained sentence covers it by naming the answer rather than the mechanism.

## Verification

- `lintr::lint_package()` under `pkgload::load_all()` — no lints.
- Full test suite under `pkgload::load_all()` — green.
- `Rscript .github/scripts/verify-context-budget.R` — passes.
- No behaviour changes: the diff is comments only, and no generated file moves.
