### PR TITLE
Order a one-occurrence Grouping plan on a lazy backend

### DIFF
--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -369,6 +369,21 @@ order_margin_result <- function(operation, result, execution) {
     length(operation$plan$dimensions) == 0L || !is.null(sort_id)
   )
 
+  staged_id <- if (identical(sort_id, operation$set_id_name)) {
+    NULL
+  } else {
+    sort_id
+  }
+
+  # A staged identifier the key does not read is dropped before the ordering
+  # rather than after it, so that the projection adds no query level for dbplyr
+  # to discard the `ORDER BY` from (ADR 0018).
+  if (!is.null(staged_id) && !margin_order_reads_set_id(operation$plan)) {
+    result <- dplyr::select(result, -dplyr::all_of(staged_id))
+    sort_id <- NULL
+    staged_id <- NULL
+  }
+
   terms <- margin_order_terms(
     plan = operation$plan,
     sort = operation$sort,
@@ -377,11 +392,8 @@ order_margin_result <- function(operation, result, execution) {
   if (length(terms) > 0L) {
     result <- dplyr::arrange(result, !!!terms)
   }
-  if (
-    !is.null(sort_id) &&
-      !identical(sort_id, operation$set_id_name)
-  ) {
-    result <- dplyr::select(result, -dplyr::all_of(sort_id))
+  if (!is.null(staged_id)) {
+    result <- dplyr::select(result, -dplyr::all_of(staged_id))
   }
   forget_margin_window_order(result, backend = operation$backend)
 }
@@ -442,10 +454,17 @@ margin_order_terms <- function(plan, sort, sort_id) {
     )
   }
 
-  if (!is.null(sort_id)) {
+  if (!is.null(sort_id) && margin_order_reads_set_id(plan)) {
     terms <- c(terms, list(margin_column_pronoun(sort_id)))
   }
   terms
+}
+
+# Whether the key reads the Grouping set identifier. A plan holding one
+# occurrence gives every row the same one, so neither a Grouping bit nor the
+# tiebreak has anything to order by (ADR 0018).
+margin_order_reads_set_id <- function(plan) {
+  length(plan$set_ids) > 1L
 }
 
 # One column's missingness term. Written as a comparison rather than as the

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -369,33 +369,37 @@ order_margin_result <- function(operation, result, execution) {
     length(operation$plan$dimensions) == 0L || !is.null(sort_id)
   )
 
-  staged_id <- if (identical(sort_id, operation$set_id_name)) {
-    NULL
-  } else {
-    sort_id
-  }
+  # The identifier the key reads, and `NULL` where it reads none (ADR 0018).
+  # Both the terms and the position of the projection below derive from this
+  # one variable, so no term can name a column the projection has taken away.
+  key_id <- if (length(operation$plan$set_ids) > 1L) sort_id else NULL
+  staged_id <- margin_staged_sort_identifier(operation, sort_id)
 
   # A staged identifier the key does not read is dropped before the ordering
-  # rather than after it, so that the projection adds no query level for dbplyr
-  # to discard the `ORDER BY` from (ADR 0018).
-  if (!is.null(staged_id) && !margin_order_reads_set_id(operation$plan)) {
+  # rather than after it (ADR 0018).
+  if (!is.null(staged_id) && is.null(key_id)) {
     result <- dplyr::select(result, -dplyr::all_of(staged_id))
-    sort_id <- NULL
-    staged_id <- NULL
   }
 
   terms <- margin_order_terms(
     plan = operation$plan,
     sort = operation$sort,
-    sort_id = sort_id
+    sort_id = key_id
   )
   if (length(terms) > 0L) {
     result <- dplyr::arrange(result, !!!terms)
   }
-  if (!is.null(staged_id)) {
+  if (!is.null(staged_id) && !is.null(key_id)) {
     result <- dplyr::select(result, -dplyr::all_of(staged_id))
   }
   forget_margin_window_order(result, backend = operation$backend)
+}
+
+# The Grouping set identifier the finalizer drops again: the one an executor
+# staged for the order alone. An identifier the caller asked for with `.id` is
+# the result's own column and is never dropped.
+margin_staged_sort_identifier <- function(operation, sort_id) {
+  if (identical(sort_id, operation$set_id_name)) NULL else sort_id
 }
 
 # Where a backend records a window ordering, `arrange()` has written the key
@@ -454,17 +458,10 @@ margin_order_terms <- function(plan, sort, sort_id) {
     )
   }
 
-  if (!is.null(sort_id) && margin_order_reads_set_id(plan)) {
+  if (!is.null(sort_id)) {
     terms <- c(terms, list(margin_column_pronoun(sort_id)))
   }
   terms
-}
-
-# Whether the key reads the Grouping set identifier. A plan holding one
-# occurrence gives every row the same one, so neither a Grouping bit nor the
-# tiebreak has anything to order by (ADR 0018).
-margin_order_reads_set_id <- function(plan) {
-  length(plan$set_ids) > 1L
 }
 
 # One column's missingness term. Written as a comparison rather than as the

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -345,3 +345,37 @@ leaves the `ORDER BY` alone, so the rendered SQL is what it was and
 `records_window_order` capability, and not from the class of the finalized
 result — ADR 0014's rule, for its reason. A local result and a dtplyr step
 record no window ordering to clear, and the nesting verbs admit only those.
+
+## Amendment: the projection that drops an unread identifier runs first
+
+The amendments above place the staged identifier in the `FROM` clause of the
+query carrying the `ORDER BY`, and rely on the `UNION ALL` or the aggregate
+query to put it there. A plan holding one grouping-set occurrence has neither:
+the portable adapter returns its single branch uncombined, so the identifier is
+a literal the same query computes, and the projection that drops it wraps that
+query and takes the ordering with it. `expand_with_margins()` reached this on
+every dbplyr backend, and `summarize_with_margins()` on every backend without
+native `GROUPING SETS` (#339).
+
+**Such a plan does not read the identifier at all.** Every dimension is in the
+same set as every other row's, so each Grouping bit is constant — the condition
+the key already omits a bit term on — and the tiebreak orders by a column with
+one value. The key is then the fixed keys and the dimensions alone.
+
+**So the projection runs before the ordering whenever the key does not read the
+identifier.** Nothing is left to drop afterwards, the `ORDER BY` is the
+outermost one by construction, and no query level exists for dbplyr to discard
+it from. Where the key does read the identifier the order of the two is
+unchanged, and so is every plan holding two or more occurrences.
+
+Two consequences are worth recording.
+
+*The tiebreak is omitted rather than emitted over a constant.* `.id` naming the
+identifier on a one-occurrence plan therefore drops it from the key too, which
+is the same statement the paragraph above makes about `.id` on a plan with no
+observable difference to break: one occurrence is one such plan.
+
+*Which adapter runs is still decided before any of this.* The identifier is
+allocated after that choice, so a one-occurrence plan that ran on the native
+path still runs there and still stages the column; what changes is only where
+the projection dropping it sits.

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -531,6 +531,17 @@ margin_order_single_set_specs <- function() {
         grouping_set(dplyr::all_of("region"))
       ),
       .duplicates = "drop"
+    ),
+    # One occurrence holding two dimensions. Each Grouping bit is constant for
+    # the same reason a single dimension's is, and neither reaches the key.
+    two_dimensions = rlang::exprs(
+      .grouping = grouping_spec(dplyr::all_of(c("region", "store")))
+    ),
+    # A fixed key alongside the dimension, which contributes its own terms and
+    # no Grouping bit.
+    by_and_grouping = rlang::exprs(
+      .by = dplyr::all_of("store"),
+      .grouping = grouping_spec(dplyr::all_of("region"))
     )
   )
 }
@@ -600,12 +611,57 @@ test_that("a one-occurrence plan keeps its native plan and its order", {
     expect_match(sql, "GROUP BY GROUPING SETS", fixed = TRUE, info = name)
     expect_false(grepl("UNION ALL", sql, fixed = TRUE), info = name)
     expect_match(sql, "ORDER BY", fixed = TRUE, info = name)
-    expect_identical(
-      as.character(dplyr::tbl_vars(query)),
-      c("region", "units"),
+    # The native adapter stages its identifier inside the aggregate query, so
+    # the order costs the result no column here either.
+    expect_false(
+      any(grepl(
+        "..marginplyr_sort_",
+        as.character(dplyr::tbl_vars(query)),
+        fixed = TRUE
+      )),
       info = name
     )
   }
+})
+
+test_that("`.id` on a one-occurrence plan leaves the key what it was", {
+  skip_if_no_sqlite_simulation()
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_sqlite()
+  )
+  summarized <- function(...) {
+    summarize_with_margins(
+      remote,
+      units = sum(units, na.rm = TRUE),
+      .grouping = grouping_spec(dplyr::all_of("region")),
+      .sort = "last",
+      ...
+    )
+  }
+  order_by <- function(query) {
+    sub(".*ORDER BY", "", dbplyr::sql_render(query))
+  }
+
+  identified <- summarized(.id = "set")
+  expect_identical(
+    as.character(dplyr::tbl_vars(identified)),
+    c("region", "set", "units")
+  )
+  # The identifier the caller asked for is the result's own column, so nothing
+  # is dropped after the ordering. The key is the same one either way, the
+  # tiebreak having nothing to break.
+  expect_identical(order_by(identified), order_by(summarized()))
+
+  local <- summarize_with_margins(
+    margin_order_data(),
+    units = sum(units, na.rm = TRUE),
+    .grouping = grouping_spec(dplyr::all_of("region")),
+    .id = "set",
+    .sort = "last"
+  )
+  expect_identical(local$region, c("East", "West"))
+  expect_identical(local$set, c(1L, 1L))
 })
 
 test_that("`.sort = \"none\"` records no order on a one-occurrence plan", {
@@ -618,17 +674,48 @@ test_that("`.sort = \"none\"` records no order on a one-occurrence plan", {
 
   for (name in names(specs)) {
     arguments <- specs[[name]]
-    query <- rlang::inject(summarize_with_margins(
-      remote,
-      units = sum(units, na.rm = TRUE),
-      !!!arguments,
-      .sort = "none"
-    ))
-    expect_false(
-      grepl("ORDER BY", dbplyr::sql_render(query), fixed = TRUE),
-      info = name
+    queries <- list(
+      summary = rlang::inject(summarize_with_margins(
+        remote,
+        units = sum(units, na.rm = TRUE),
+        !!!arguments,
+        .sort = "none"
+      )),
+      expansion = rlang::inject(expand_with_margins(
+        remote,
+        !!!arguments,
+        .sort = "none"
+      ))
     )
+    for (verb in names(queries)) {
+      expect_false(
+        grepl("ORDER BY", dbplyr::sql_render(queries[[verb]]), fixed = TRUE),
+        info = paste(name, verb)
+      )
+    }
   }
+})
+
+test_that("`.sort = \"none\"` clears no window ordering", {
+  remote <- dbplyr::window_order(
+    dbplyr::tbl_lazy(margin_order_data(), con = dbplyr::simulate_postgres()),
+    region
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = grouping_spec(region),
+    .sort = "none"
+  )
+  # Asking for no order reaches neither the ordering nor the clearing that
+  # follows it, so a window ordering the input carried is still what a window
+  # function written over the result orders by. Its complement is the test
+  # named "a Margin order leaves no window ordering to inherit".
+  windowed <- suppressWarnings(
+    dbplyr::sql_render(dplyr::mutate(query, running = cumsum(units)))
+  )
+  expect_match(windowed, "OVER (ORDER BY", fixed = TRUE)
 })
 
 # The live backend contracts follow.
@@ -740,19 +827,33 @@ expect_margin_order_agrees <- function(as_input) {
       },
       columns = c("year", "units")
     ),
+    # One occurrence holding two dimensions, which is the shape a `rollup()`
+    # scenario comes closest to and still does not reach.
+    single_set_dimensions = list(
+      data = margin_order_data(),
+      run = function(input) {
+        summarize_with_margins(
+          input,
+          units = sum(units, na.rm = TRUE),
+          .grouping = grouping_spec(dplyr::all_of(c("region", "store"))),
+          .sort = "last"
+        )
+      },
+      columns = c("region", "store", "units")
+    ),
     # Expansion always takes the portable path, so a one-occurrence plan is
     # where it lost its order on every dbplyr backend rather than on the ones
     # without native `GROUPING SETS`.
     single_set_expansion = list(
-      data = margin_order_missing_data(),
+      data = margin_order_data(),
       run = function(input) {
         expand_with_margins(
           input,
-          .grouping = grouping_sets(grouping_set(dplyr::all_of("region"))),
+          .grouping = grouping_spec(dplyr::all_of(c("region", "store"))),
           .sort = "last"
         )
       },
-      columns = c("region", "units")
+      columns = c("region", "store", "units")
     )
   )
 

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -506,6 +506,131 @@ test_that("a fixed key sorts its missing values last", {
   expect_identical(result$units, c(4, 4, 1, 1, 2, 2))
 })
 
+# Every spelling that compiles to a plan holding one grouping-set occurrence.
+# The bug they shared was not in any of them: a one-occurrence plan makes every
+# Grouping bit constant, so the key reads no Grouping set identifier, and the
+# projection that dropped the staged one ran after the ordering and took the
+# `ORDER BY` with it (#339).
+#
+# Expressions rather than values, because `.by` and `.grouping` are evaluated
+# by the verb and neither survives being computed here. The dimension is
+# selected by name for the reason the helper below gives: `codetools` reads
+# this closure and cannot follow a bare symbol standing for a column.
+margin_order_single_set_specs <- function() {
+  list(
+    by_only = rlang::exprs(.by = dplyr::all_of("region")),
+    grouping_spec = rlang::exprs(
+      .grouping = grouping_spec(dplyr::all_of("region"))
+    ),
+    grouping_sets = rlang::exprs(
+      .grouping = grouping_sets(grouping_set(dplyr::all_of("region")))
+    ),
+    duplicates_dropped = rlang::exprs(
+      .grouping = grouping_sets(
+        grouping_set(dplyr::all_of("region")),
+        grouping_set(dplyr::all_of("region"))
+      ),
+      .duplicates = "drop"
+    )
+  )
+}
+
+test_that("a one-occurrence plan carries its `ORDER BY` on a lazy backend", {
+  skip_if_no_sqlite_simulation()
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_sqlite()
+  )
+  specs <- margin_order_single_set_specs()
+
+  for (name in names(specs)) {
+    arguments <- specs[[name]]
+    queries <- list(
+      summary = rlang::inject(summarize_with_margins(
+        remote,
+        units = sum(units, na.rm = TRUE),
+        !!!arguments,
+        .sort = "last"
+      )),
+      expansion = rlang::inject(expand_with_margins(
+        remote,
+        !!!arguments,
+        .sort = "last"
+      ))
+    )
+
+    for (verb in names(queries)) {
+      query <- queries[[verb]]
+      sql <- dbplyr::sql_render(query)
+      info <- paste(name, verb)
+      expect_match(sql, "ORDER BY", fixed = TRUE, info = info)
+      # The key reads no Grouping set identifier here, so the staged column is
+      # dropped before the ordering and reaches no query level at all.
+      expect_false(
+        grepl("..marginplyr_sort_", sql, fixed = TRUE),
+        info = info
+      )
+      expect_false(
+        any(grepl(
+          "..marginplyr_sort_",
+          as.character(dplyr::tbl_vars(query)),
+          fixed = TRUE
+        )),
+        info = info
+      )
+    }
+  }
+})
+
+test_that("a one-occurrence plan keeps its native plan and its order", {
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_postgres()
+  )
+  specs <- margin_order_single_set_specs()
+
+  for (name in names(specs)) {
+    query <- rlang::inject(summarize_with_margins(
+      remote,
+      units = sum(units, na.rm = TRUE),
+      !!!specs[[name]],
+      .sort = "last"
+    ))
+    sql <- dbplyr::sql_render(query)
+    expect_match(sql, "GROUP BY GROUPING SETS", fixed = TRUE, info = name)
+    expect_false(grepl("UNION ALL", sql, fixed = TRUE), info = name)
+    expect_match(sql, "ORDER BY", fixed = TRUE, info = name)
+    expect_identical(
+      as.character(dplyr::tbl_vars(query)),
+      c("region", "units"),
+      info = name
+    )
+  }
+})
+
+test_that("`.sort = \"none\"` records no order on a one-occurrence plan", {
+  skip_if_no_sqlite_simulation()
+  remote <- dbplyr::tbl_lazy(
+    margin_order_data(),
+    con = dbplyr::simulate_sqlite()
+  )
+  specs <- margin_order_single_set_specs()
+
+  for (name in names(specs)) {
+    arguments <- specs[[name]]
+    query <- rlang::inject(summarize_with_margins(
+      remote,
+      units = sum(units, na.rm = TRUE),
+      !!!arguments,
+      .sort = "none"
+    ))
+    expect_false(
+      grepl("ORDER BY", dbplyr::sql_render(query), fixed = TRUE),
+      info = name
+    )
+  }
+})
+
 # The live backend contracts follow.
 #
 # Everything above proves the order against a local data frame or against a
@@ -528,6 +653,12 @@ test_that("a fixed key sorts its missing values last", {
 # representation of it; the name is a parameter because the SQL backends need a
 # distinct table per scenario.
 #
+# A scenario runs a verb rather than always `summarize_with_margins()`, because
+# a one-occurrence plan reaches the same finalization from both verbs and #339
+# broke it on the expansion of every dbplyr backend. Every one-occurrence
+# scenario keys its rows uniquely, so the comparison is a comparison of order:
+# the key leaves ties among rows a database is free to return either way.
+#
 # The dimensions are selected by name rather than as bare symbols, which the
 # tests above can write because `test_that()` passes a block rather than defines
 # a closure. `codetools` reads the closures below and cannot follow an NSE
@@ -538,7 +669,7 @@ expect_margin_order_agrees <- function(as_input) {
     # A rollup over two dimensions: subtotals with the rows they summarize.
     rollup = list(
       data = margin_order_data(),
-      summarize = function(input) {
+      run = function(input) {
         summarize_with_margins(
           input,
           units = sum(units, na.rm = TRUE),
@@ -552,7 +683,7 @@ expect_margin_order_agrees <- function(as_input) {
     # `.margin_label = NULL`, and the Grouping bit is what separates them.
     missing = list(
       data = margin_order_missing_data(),
-      summarize = function(input) {
+      run = function(input) {
         summarize_with_margins(
           input,
           units = sum(units, na.rm = TRUE),
@@ -567,7 +698,7 @@ expect_margin_order_agrees <- function(as_input) {
     # thing standing between it and the dialect's own default.
     fixed_key = list(
       data = margin_order_by_missing_data(),
-      summarize = function(input) {
+      run = function(input) {
         summarize_with_margins(
           input,
           units = sum(units, na.rm = TRUE),
@@ -577,15 +708,64 @@ expect_margin_order_agrees <- function(as_input) {
         )
       },
       columns = c("year", "region", "units")
+    ),
+    # A plan holding one grouping-set occurrence, which every Grouping bit is
+    # constant over: the order is the fixed key's and the dimension's alone.
+    # The staged Grouping set identifier is dropped before the ordering there,
+    # and dropping it afterwards is what cost the result its outermost
+    # `ORDER BY` (#339).
+    single_set = list(
+      data = margin_order_missing_data(),
+      run = function(input) {
+        summarize_with_margins(
+          input,
+          units = sum(units, na.rm = TRUE),
+          .grouping = grouping_sets(grouping_set(dplyr::all_of("region"))),
+          .sort = "last"
+        )
+      },
+      columns = c("region", "units")
+    ),
+    # The everyday one-occurrence plan: `.by` with no grouping specification at
+    # all, so the key holds no dimension term either.
+    single_set_by = list(
+      data = margin_order_by_missing_data(),
+      run = function(input) {
+        summarize_with_margins(
+          input,
+          units = sum(units, na.rm = TRUE),
+          .by = dplyr::all_of("year"),
+          .sort = "last"
+        )
+      },
+      columns = c("year", "units")
+    ),
+    # Expansion always takes the portable path, so a one-occurrence plan is
+    # where it lost its order on every dbplyr backend rather than on the ones
+    # without native `GROUPING SETS`.
+    single_set_expansion = list(
+      data = margin_order_missing_data(),
+      run = function(input) {
+        expand_with_margins(
+          input,
+          .grouping = grouping_sets(grouping_set(dplyr::all_of("region"))),
+          .sort = "last"
+        )
+      },
+      columns = c("region", "units")
     )
   )
 
   for (name in names(scenarios)) {
     scenario <- scenarios[[name]]
-    local <- scenario$summarize(scenario$data)
-    remote <- dplyr::collect(
-      scenario$summarize(as_input(scenario$data, paste0("margin_order_", name)))
+    local <- scenario$run(scenario$data)
+    query <- scenario$run(
+      as_input(scenario$data, paste0("margin_order_", name))
     )
+    # dbplyr reports a dropped `ORDER BY` as a warning naming `arrange()`, a
+    # verb the caller never wrote, so a backend that stops carrying the order
+    # is caught here as well as by the rows below (#339).
+    remote <- expect_no_warning(dplyr::collect(query))
     for (column in scenario$columns) {
       expect_identical(
         remote[[column]],


### PR DESCRIPTION
Closes #339.

## What changed

A Grouping plan holding exactly one grouping-set occurrence lost its outermost `ORDER BY` on a lazy backend. The staged Grouping set identifier is a column the same query computes there, so the projection that dropped it after the ordering wrapped that query, and dbplyr discarded the ordering — surfacing as `ORDER BY is ignored in subqueries without LIMIT`, naming an `arrange()` the caller never wrote.

Such a plan reads no identifier at all: every Grouping bit is constant over one occurrence, and the tiebreak orders by a column with one value. `margin_order_terms()` now omits the tiebreak on those plans, and `order_margin_result()` runs the projection before the ordering whenever the key does not read the identifier, so no query level is added after the `ORDER BY`.

Plans holding two or more occurrences are unchanged, and which adapter runs is still decided before the identifier is allocated — a one-occurrence plan that ran on the native `GROUPING SETS` path still runs there.

ADR 0018 gains an amendment recording the refinement to its "resolvable in the `FROM` clause" rule.

## Tests

- `expect_margin_order_agrees()` gains three one-occurrence scenarios — a `grouping_sets(grouping_set(x))` summary, a `.by`-only summary, and an expansion — and now asserts that collecting raises no warning. Its existing scenarios are all `rollup()` plans, which is why every backend job passed.
- Rendered-SQL tests cover every spelling that compiles to one occurrence (`.by` alone, `grouping_spec()`, `grouping_sets(grouping_set())`, `.duplicates = "drop"`) for both verbs on the portable path, the native plan on the PostgreSQL simulator, and `.sort = "none"` recording no order.

Local: `testthat::test_local()` 5750 pass, 0 fail, 0 skip; `lintr::lint_package()` clean; `verify-suite-coverage.R` exits 0.