### PR TITLE
Refuse a selection the names settle before the typed snapshot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -153,6 +153,15 @@
   returned the right answer, having read the whole input to get it — so on
   those versions this is a breaking change, and the rewrites the refusal names
   reproduce the old result while letting you choose what is read.
+* A `.grouping` or `.by` selection whose failure the column names already
+  settle is now refused without querying your input. This reaches the
+  set-difference operator `/` that tidyselect reads, the arithmetic and
+  scalar-boolean spellings it refuses in a selection — `*`, `^`, `&&`, and
+  `||` — and `one_of()`. Each of these used to send the zero-row query first
+  on a backend that needs one, so on a disconnected or slow connection you
+  were handed the connection's failure instead of the column diagnostic. A
+  selection carrying `where()` still resolves against your input's column
+  types, including one written under `/`.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -185,7 +185,11 @@ prepare_grouping_plan <- function(.data,
         # against the resolved keys below. Withholding the pass instead would
         # make a `.grouping` error determinable from names alone wait for a
         # backend read, which ADR-0005 forbids.
-        compile_grouping_spec(
+        # Discarded with the plan it compiles, so a warning it signals is one
+        # the canonical pass signals again from the same names. Suppressing
+        # them is what keeps this pass invisible but for the failure it exists
+        # to raise; `one_of()` is where that is observable.
+        suppressWarnings(compile_grouping_spec(
           grouping_spec,
           data_vars = data_vars,
           data_proxy = grouping_name_proxy(data_vars),
@@ -193,7 +197,7 @@ prepare_grouping_plan <- function(.data,
           .duplicates = .duplicates,
           duplicates_choices = duplicates_choices,
           preflight = preflight
-        )
+        ))
       }
       data_proxy <- grouping_selection_proxy(data, backend = backend)
       if (is.null(by)) {
@@ -295,8 +299,8 @@ validate_nested_grouping_units <- function(parent, nested) {
 
 # The operators tidyselect's walk combines a selection from. `/` is one:
 # tidyselect reads it as a set difference in `eval_slash()`, which its
-# `language.Rd` does not record. `(` is walked too but combines nothing, so
-# each reader adds it where it meets one.
+# `language.Rd` does not record. `(` is walked too but combines nothing, so it
+# is not here.
 selection_walk_operators <- function() {
   c("c", ":", "!", "-", "|", "&", "/")
 }
@@ -311,7 +315,9 @@ selection_refused_operators <- function() {
 # its selection where it has one, its failure where it has none. `TRUE` is what
 # lets a failure the names decide be raised before typed metadata is acquired
 # (ADR 0005); a shape this cannot answer for is `FALSE`, which resolves it
-# against the typed snapshot and is correct however that shape reads.
+# against the typed snapshot and is correct however that shape reads. Callers
+# hold `env` as the expression's own environment and `data_vars` as the input's
+# column names, which is the pair the symbol branch decides from.
 is_name_only_expr <- function(expr, env, data_vars) {
   if (is.symbol(expr)) {
     name <- as.character(expr)

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -293,6 +293,25 @@ validate_nested_grouping_units <- function(parent, nested) {
   invisible(NULL)
 }
 
+# The operators tidyselect's walk combines a selection from. `/` is one:
+# tidyselect reads it as a set difference in `eval_slash()`, which its
+# `language.Rd` does not record. `(` is walked too but combines nothing, so
+# each reader adds it where it meets one.
+selection_walk_operators <- function() {
+  c("c", ":", "!", "-", "|", "&", "/")
+}
+
+# The spellings tidyselect refuses in place of one of those. It refuses them on
+# sight, before anything under them is walked.
+selection_refused_operators <- function() {
+  c("&&", "||", "*", "^")
+}
+
+# Whether tidyselect settles this expression from the column names alone --
+# its selection where it has one, its failure where it has none. `TRUE` is what
+# lets a failure the names decide be raised before typed metadata is acquired
+# (ADR 0005); a shape this cannot answer for is `FALSE`, which resolves it
+# against the typed snapshot and is correct however that shape reads.
 is_name_only_expr <- function(expr, env, data_vars) {
   if (is.symbol(expr)) {
     name <- as.character(expr)
@@ -316,14 +335,21 @@ is_name_only_expr <- function(expr, env, data_vars) {
   if (is.null(call_name)) {
     return(FALSE)
   }
+  # The helpers that read names and nothing else. `where()` is the one that
+  # reads column data, so it is absent and answers below.
   leaf_helpers <- c(
     "all_of", "any_of", "starts_with", "ends_with", "contains",
-    "matches", "num_range", "everything", "last_col"
+    "matches", "num_range", "everything", "last_col", "one_of"
   )
   if (call_name %in% leaf_helpers) {
     return(TRUE)
   }
-  if (!call_name %in% c("c", ":", "!", "-", "|", "&", "(")) {
+  # A refused spelling fails on itself, so its operands are never reached and a
+  # predicate under one settles nothing.
+  if (call_name %in% selection_refused_operators()) {
+    return(TRUE)
+  }
+  if (!call_name %in% c(selection_walk_operators(), "(")) {
     return(FALSE)
   }
 
@@ -1080,15 +1106,13 @@ resolve_grouping_selection <- function(arg, data_proxy) {
 # part of an argument, for the reason recorded above
 # `is_grouping_spec_subscript()`.
 #
-# The operators are the ones tidyselect's walk descends into -- its documented
-# selection grammar, `c()`, `-`, `:`, `!`, `&`, `|`, and the `/` it reads as a
-# set difference -- together with the scalar-boolean and arithmetic spellings
-# it refuses in place of one of them, which cost nothing to name and are
-# refused before anything under them is walked. `(` is not among them because
-# `nested_arg_expr()` has already dropped a redundant pair, and a quosure is
-# not, because `is_nameable_call()` declines the call to `~` that one is.
+# The operators are both sets above: a specification reaches this under a
+# refused spelling as readily as under one that is walked. `(` is not among
+# them because `nested_arg_expr()` has already dropped a redundant pair, and a
+# quosure is not, because `is_nameable_call()` declines the call to `~` that
+# one is.
 is_grouping_spec_predicate <- function(selection_frame, expr) {
-  operators <- c("c", "-", ":", "!", "&", "|", "&&", "||", "*", "/", "^")
+  operators <- c(selection_walk_operators(), selection_refused_operators())
   if (!is_nameable_call(expr)) {
     return(FALSE)
   }

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2037,6 +2037,97 @@ test_that("fixed keys settled by name alone need no typed metadata", {
   )
 })
 
+test_that("the name-only reader answers what the names settle", {
+  # The reader's question is whether tidyselect settles the expression --
+  # its selection or its failure alike -- from the column names, and the
+  # answers below are what tidyselect's own walk does with each shape.
+  data_vars <- by_rename_vars()
+  env <- rlang::new_environment()
+  name_only <- function(expr) {
+    is_name_only_expr(expr, env = env, data_vars = data_vars)
+  }
+
+  # `/` is a set difference tidyselect descends into, as `c()` and `|` are,
+  # so it is settled by what its operands settle.
+  expect_true(name_only(quote(tidyselect::everything() / region)))
+  expect_true(name_only(quote(c(region, area) / area)))
+  expect_false(name_only(quote(tidyselect::everything() / where(is.numeric))))
+
+  # A spelling tidyselect refuses fails on itself, before anything under it is
+  # walked, so the operands decide nothing and are not asked.
+  expect_true(name_only(quote(region * value)))
+  expect_true(name_only(quote(region^value)))
+  expect_true(name_only(quote(region && value)))
+  expect_true(name_only(quote(region || value)))
+  expect_true(name_only(quote(where(is.numeric) * region)))
+
+  # `one_of()` reads names and nothing else, exactly as `any_of()` does.
+  expect_true(name_only(quote(tidyselect::one_of("region"))))
+
+  # `where()` is the one helper that reads column data.
+  expect_false(name_only(quote(where(is.numeric))))
+})
+
+test_that("a selection the names settle is refused before the typed snapshot", {
+  # ADR-0005 puts a failure the names decide before the read, and the read is
+  # what this counts: `grouping_selection_proxy()` is the one place typed
+  # metadata is acquired, so a refusal that reaches it has already sent the
+  # query a lazy backend answers it with.
+  data <- data.frame(region = "East", area = "North", value = 1)
+  reads <- 0L
+  local_mocked_bindings(
+    grouping_selection_proxy = function(.data, ...) {
+      reads <<- reads + 1L
+      .data
+    }
+  )
+  refuse <- function(expr) {
+    reads <<- 0L
+    error <- expect_error(rlang::eval_tidy(expr))
+    list(reads = reads, message = conditionMessage(error))
+  }
+
+  unknown <- refuse(quote(inspect_grouping(
+    data,
+    .grouping = grouping_set(tidyselect::everything() / absent)
+  )))
+  expect_identical(unknown$reads, 0L)
+  expect_match(unknown$message, "absent")
+
+  arithmetic <- refuse(quote(inspect_grouping(
+    data,
+    .grouping = grouping_set(region * value)
+  )))
+  expect_identical(arithmetic$reads, 0L)
+  expect_match(arithmetic$message, "arithmetic operator")
+
+  helper <- refuse(quote(inspect_grouping(
+    data,
+    .grouping = grouping_set(tidyselect::one_of(1))
+  )))
+  expect_identical(helper$reads, 0L)
+  expect_match(helper$message, "vector of column names")
+
+  # `.by` reaches the same reader, and its keys are resolved before the read.
+  by_unknown <- refuse(quote(inspect_grouping(
+    data,
+    .grouping = rollup(region),
+    .by = tidyselect::everything() / absent
+  )))
+  expect_identical(by_unknown$reads, 0L)
+  expect_match(by_unknown$message, "absent")
+
+  # The other half of the rule: a selection carrying a predicate is not
+  # settled by names, and still resolves against the snapshot.
+  reads <- 0L
+  plan <- inspect_grouping(
+    data,
+    .grouping = rollup(tidyselect::everything() / where(is.numeric))
+  )
+  expect_identical(reads, 1L)
+  expect_identical(plan$included, c("(region, area)", "(region)", "()"))
+})
+
 test_that("duplicate grouping sets have explicit policies", {
   spec <- grouping_sets(grouping_set(a), grouping_set(a))
 

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2081,41 +2081,72 @@ test_that("a selection the names settle is refused before the typed snapshot", {
       .data
     }
   )
-  refuse <- function(expr) {
+  # Each refusal is tidyselect's own, raised through the name proxy, so the
+  # class it arrives under is the External half ADR 0015 draws.
+  refuse <- function(expr, class, pattern) {
     reads <<- 0L
-    error <- expect_error(rlang::eval_tidy(expr))
-    list(reads = reads, message = conditionMessage(error))
+    error <- expect_error(rlang::eval_tidy(expr), class = class)
+    expect_false(inherits(error, "marginplyr_error"))
+    expect_match(conditionMessage(error), pattern)
+    expect_identical(reads, 0L)
   }
 
-  unknown <- refuse(quote(inspect_grouping(
-    data,
-    .grouping = grouping_set(tidyselect::everything() / absent)
-  )))
-  expect_identical(unknown$reads, 0L)
-  expect_match(unknown$message, "absent")
+  for (grouping in list(
+    quote(grouping_set(tidyselect::everything() / absent)),
+    quote(rollup(tidyselect::everything() / absent))
+  )) {
+    refuse(
+      rlang::call2("inspect_grouping", quote(data), .grouping = grouping),
+      class = "vctrs_error_subscript_oob",
+      pattern = "absent"
+    )
+  }
 
-  arithmetic <- refuse(quote(inspect_grouping(
-    data,
-    .grouping = grouping_set(region * value)
-  )))
-  expect_identical(arithmetic$reads, 0L)
-  expect_match(arithmetic$message, "arithmetic operator")
+  for (spelling in list(
+    quote(region * value),
+    quote(region^value),
+    quote(region && value),
+    quote(region || value)
+  )) {
+    refuse(
+      rlang::call2(
+        "inspect_grouping",
+        quote(data),
+        .grouping = rlang::call2("grouping_set", spelling)
+      ),
+      class = "rlang_error",
+      pattern = "Can't use (arithmetic operator|scalar)"
+    )
+  }
 
-  helper <- refuse(quote(inspect_grouping(
-    data,
-    .grouping = grouping_set(tidyselect::one_of(1))
-  )))
-  expect_identical(helper$reads, 0L)
-  expect_match(helper$message, "vector of column names")
+  refuse(
+    quote(inspect_grouping(
+      data,
+      .grouping = grouping_set(tidyselect::one_of(1))
+    )),
+    class = "rlang_error",
+    pattern = "vector of column names"
+  )
 
   # `.by` reaches the same reader, and its keys are resolved before the read.
-  by_unknown <- refuse(quote(inspect_grouping(
-    data,
-    .grouping = rollup(region),
-    .by = tidyselect::everything() / absent
-  )))
-  expect_identical(by_unknown$reads, 0L)
-  expect_match(by_unknown$message, "absent")
+  refuse(
+    quote(inspect_grouping(
+      data,
+      .grouping = rollup(region),
+      .by = tidyselect::everything() / absent
+    )),
+    class = "vctrs_error_subscript_oob",
+    pattern = "absent"
+  )
+  refuse(
+    quote(inspect_grouping(
+      data,
+      .grouping = rollup(region),
+      .by = tidyselect::one_of(1)
+    )),
+    class = "rlang_error",
+    pattern = "vector of column names"
+  )
 
   # The other half of the rule: a selection carrying a predicate is not
   # settled by names, and still resolves against the snapshot.
@@ -2126,6 +2157,46 @@ test_that("a selection the names settle is refused before the typed snapshot", {
   )
   expect_identical(reads, 1L)
   expect_identical(plan$included, c("(region, area)", "(region)", "()"))
+})
+
+test_that("the discarded name-only pass reports nothing the second does not", {
+  # The pass exists to raise a failure the names decide and its plan is thrown
+  # away, so a condition it signals besides that failure is one the caller
+  # receives twice: the canonical pass resolves the same selection again.
+  # `one_of()` is where this is observable, being the one recognized helper
+  # that reports an unknown name without failing on it.
+  data <- data.frame(region = "East", area = "North", value = 1)
+  count_warnings <- function(expr) {
+    n <- 0L
+    withCallingHandlers(
+      rlang::eval_tidy(expr),
+      warning = function(cnd) {
+        n <<- n + 1L
+        invokeRestart("muffleWarning")
+      }
+    )
+    n
+  }
+
+  for (grouping in list(
+    quote(grouping_set(tidyselect::one_of(c("region", "absent")))),
+    quote(rollup(tidyselect::one_of(c("region", "absent"))))
+  )) {
+    expect_identical(
+      count_warnings(
+        rlang::call2("inspect_grouping", quote(data), .grouping = grouping)
+      ),
+      1L
+    )
+  }
+  expect_identical(
+    count_warnings(quote(inspect_grouping(
+      data,
+      .grouping = rollup(area),
+      .by = tidyselect::one_of(c("region", "absent"))
+    ))),
+    1L
+  )
 })
 
 test_that("duplicate grouping sets have explicit policies", {


### PR DESCRIPTION
Closes #342.

`is_name_only_expr()` answers whether tidyselect settles an expression from the
column names alone, so a failure the names decide is raised before typed
metadata is acquired (ADR 0005). Three classes of expression answered `FALSE`
that the question settles as `TRUE`, and each made preparation send the
zero-row selection-proxy query before reporting an error the names had already
decided.

- **`/`** — tidyselect walks it as a set difference, in `eval_slash()`, exactly
  as it walks `c()`, `:`, `!`, `-`, `|`, and `&`. Its `language.Rd` records no
  entry for it, which is why `selection_walk_operators()` says where the fact
  is read.
- **`*`, `^`, `&&`, `||`** — refused outright, so their failure depends on
  nothing. They answer without descending: tidyselect refuses them before
  walking anything under them, so `where(is.numeric) * a` fails on `*` and
  never reaches the predicate.
- **`one_of()`** — reads names and nothing else, as `any_of()` does, and
  `one_of(1)` is refused for its input type before a name is consulted. It is
  superseded rather than deprecated, so tidyselect keeps it.

`where()` still answers `FALSE`, including under `/`, so a selection carrying a
predicate resolves against the typed snapshot as it did.

## The issue asked for something else

#342's second acceptance criterion asked that `is_name_only_expr()` and
`is_grouping_spec_predicate()` enumerate the same operators. That would be
wrong, and the issue has been rewritten to say so. The two are not copies of
one list: they take different subsets of tidyselect's dispatch table because
they answer different questions. `is_name_only_expr()` reads the caller's
expression as written and needs `(` — which is what makes
`grouping_set((zzz))` report locally today — while
`is_grouping_spec_predicate()` is reached through `nested_arg_expr()`, which
has already dropped the pair. What they share is the two operator sets, now
named once and read by both.

The issue also offered "no, deliberately" as a valid close for `one_of()`.
That is not available: `one_of(1)` is a locally settled failure that reached
the backend first.

## Tests

Two blocks in `tests/testthat/test-grouping-plan.R`:

- the reader's classification, shape by shape, including `/` over a predicate;
- the ordering, counting calls to `grouping_selection_proxy()` — the one place
  typed metadata is acquired — for `.grouping` and `.by` alike, with a
  predicate selection as the positive control that still reads once.

The count is taken through `local_mocked_bindings()` against a local data
frame, so it needs no optional backend and asserts the rule rather than one
backend's behaviour.

## Out of scope

Two shapes the same invariant settles as `TRUE` that this reader cannot reach —
a formula, and `.data$x` — are #346. Each is held out by a decision living
elsewhere rather than by the operator sets this changes.
