### PR TITLE
Keep a repeated warning one report past a caller's pointer line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,14 +178,13 @@
   wrote, and an error blames the Margin verb you called rather than an internal
   summary. A warning every grouping set raises is reported once and says how
   many further grouping sets raised it, in place of one identical warning per
-  set — `2^k` of them for a `cube()` of `k` dimensions — while warnings that
-  differ from each other are still reported one by one. That holds whatever
-  your own warning text says, including a diagnostic of yours that spells the
-  line dplyr writes to point at `dplyr::last_dplyr_warnings()`. Only that
-  context changes: the class, the diagnostic, and the cause you receive are
-  the ones raised. A lazy input is unaffected, because its summary
-  expressions run when you collect the result rather than while the verb runs
-  (#141, #108).
+  set — `2^k` of them for a `cube()` of `k` dimensions — including a warning
+  whose own text spells the line dplyr writes to point at
+  `dplyr::last_dplyr_warnings()`, while warnings that differ from each other
+  are still reported one by one. Only that context changes: the class, the
+  diagnostic, and the cause you receive are the ones raised. A lazy input is
+  unaffected, because its summary expressions run when you collect the result
+  rather than while the verb runs (#141, #108).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/NEWS.md
+++ b/NEWS.md
@@ -179,10 +179,13 @@
   summary. A warning every grouping set raises is reported once and says how
   many further grouping sets raised it, in place of one identical warning per
   set — `2^k` of them for a `cube()` of `k` dimensions — while warnings that
-  differ from each other are still reported one by one. Only that context
-  changes: the class, the diagnostic, and the cause you receive are the ones
-  raised. A lazy input is unaffected, because its summary expressions run when
-  you collect the result rather than while the verb runs (#141, #108).
+  differ from each other are still reported one by one. That holds whatever
+  your own warning text says, including a diagnostic of yours that spells the
+  line dplyr writes to point at `dplyr::last_dplyr_warnings()`. Only that
+  context changes: the class, the diagnostic, and the cause you receive are
+  the ones raised. A lazy input is unaffected, because its summary
+  expressions run when you collect the result rather than while the verb runs
+  (#141, #108).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -197,7 +197,7 @@ buffer_branch_warning <- function(cnd, conditions, restatements) {
 # line at column zero exactly as it renders a bullet. So the header is what
 # precedes the first bullet, a grouping-value bullet is one written before the
 # `Caused by` line that introduces the caller's own diagnostic, and the pointer
-# at the store is looked for only in a message whose header said there was more
+# at the store is the last line of a message whose header said there was more
 # than one warning to point at.
 #
 # Each part is matched as the line it was written as -- `message_line_runs()`
@@ -221,12 +221,20 @@ branch_warning_identity <- function(cnd) {
   cause <- match(TRUE, grepl("^Caused by ", written))
   removed <- rep(FALSE, length(runs))
 
-  aggregated <- !is.na(first_bullet) &&
-    first_bullet > 1L &&
-    grepl(
-      "^There (were|was) [0-9]+ warnings? in ",
-      paste(written[seq_len(first_bullet - 1L)], collapse = " ")
-    )
+  header <- if (is.na(first_bullet) || first_bullet == 1L) {
+    ""
+  } else {
+    paste(written[seq_len(first_bullet - 1L)], collapse = " ")
+  }
+  # The header's own count, kept rather than only tested for: it is what says
+  # whether dplyr appended a pointer, having nothing to point at where it
+  # reported one warning. `regmatches()` returns the whole match ahead of the
+  # groups, so the count is the third element.
+  counted <- regmatches(
+    header,
+    regexec("^There (were|was) ([0-9]+) warnings? in ", header)
+  )[[1L]]
+  aggregated <- length(counted) > 0L
   if (aggregated) {
     removed[seq_len(first_bullet - 1L)] <- TRUE
   }
@@ -234,18 +242,23 @@ branch_warning_identity <- function(cnd) {
     removed <- removed |
       (grepl("^[i\u2139] In group ", written) & seq_along(written) < cause)
   }
-  # The pointer runs to the end of the message, so everything after it goes
-  # with it. Its backticks are optional because cli writes the call as an
-  # `x-r-run` hyperlink where the terminal takes one, and the backticks are what
-  # the link replaces -- so removing the escapes is necessary for this line and
-  # not sufficient (#217). That widens what a caller's own diagnostic can be
-  # mistaken for by exactly one spelling, which is the direction this reading is
-  # already chosen to fail in.
-  pointer <- which(
-    grepl("^[i\u2139] Run `?dplyr::last_dplyr_warnings\\(\\)`?", written)
-  )
-  if (aggregated && length(pointer) > 0L) {
-    removed[seq(max(pointer), length(runs))] <- TRUE
+  # The pointer dplyr appends is the last line, and it appends one only where
+  # the header counted more than one warning to point at. A caller's own
+  # diagnostic can spell that line anywhere in the message, and reading one as
+  # dplyr's splits the identity of a single warning: the branch that raised it
+  # once loses the tail that the branch that raised it twice keeps (#341). Its
+  # backticks are optional because cli writes the call as an `x-r-run` hyperlink
+  # where the terminal takes one, and the backticks are what the link replaces
+  # -- so removing the escapes is necessary for this line and not sufficient
+  # (#217).
+  appended <- aggregated &&
+    as.integer(counted[[3L]]) > 1L &&
+    grepl(
+      "^[i\u2139] Run `?dplyr::last_dplyr_warnings\\(\\)`?",
+      written[[length(written)]]
+    )
+  if (appended) {
+    removed[[length(runs)]] <- TRUE
   }
 
   paste(

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -226,15 +226,18 @@ branch_warning_identity <- function(cnd) {
   } else {
     paste(written[seq_len(first_bullet - 1L)], collapse = " ")
   }
-  # The header's own count, kept rather than only tested for: it is what says
-  # whether dplyr appended a pointer, having nothing to point at where it
-  # reported one warning. `regmatches()` returns the whole match ahead of the
-  # groups, so the count is the third element.
-  counted <- regmatches(
+  header_match <- regmatches(
     header,
     regexec("^There (were|was) ([0-9]+) warnings? in ", header)
   )[[1L]]
-  aggregated <- length(counted) > 0L
+  aggregated <- length(header_match) > 0L
+  # `regmatches()` returns the whole match ahead of the two groups, so the
+  # count is the third element.
+  warning_count <- if (aggregated) {
+    as.integer(header_match[[3L]])
+  } else {
+    NA_integer_
+  }
   if (aggregated) {
     removed[seq_len(first_bullet - 1L)] <- TRUE
   }
@@ -242,23 +245,19 @@ branch_warning_identity <- function(cnd) {
     removed <- removed |
       (grepl("^[i\u2139] In group ", written) & seq_along(written) < cause)
   }
-  # The pointer dplyr appends is the last line, and it appends one only where
-  # the header counted more than one warning to point at. A caller's own
-  # diagnostic can spell that line anywhere in the message, and reading one as
-  # dplyr's splits the identity of a single warning: the branch that raised it
-  # once loses the tail that the branch that raised it twice keeps (#341). Its
-  # backticks are optional because cli writes the call as an `x-r-run` hyperlink
-  # where the terminal takes one, and the backticks are what the link replaces
-  # -- so removing the escapes is necessary for this line and not sufficient
-  # (#217).
+  # The pointer's backticks are optional because cli writes the call as an
+  # `x-r-run` hyperlink where the terminal takes one, and the backticks are what
+  # the link replaces -- so removing the escapes is necessary for this line and
+  # not sufficient (#217).
+  last <- length(written)
   appended <- aggregated &&
-    as.integer(counted[[3L]]) > 1L &&
+    warning_count > 1L &&
     grepl(
       "^[i\u2139] Run `?dplyr::last_dplyr_warnings\\(\\)`?",
-      written[[length(written)]]
+      written[[last]]
     )
   if (appended) {
-    removed[[length(runs)]] <- TRUE
+    removed[[last]] <- TRUE
   }
 
   paste(

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -517,6 +517,25 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
   )
 })
 
+# dplyr appends its pointer only at the end of a message whose header said there
+# was more than one warning, and a caller's own text may spell that line too.
+# The plan below raises one warning in a branch of two groups, where dplyr
+# appends the pointer, and in a branch of one, where it appends none -- so a
+# removal that reads the caller's line as dplyr's computes a different identity
+# in each and reports the warning twice (#341). Nothing else in the suite
+# reaches this: the pair above differ, so they are two reports either way.
+test_that("a caller's own pointer line does not split one warning", {
+  text <- "bad value\ni Run `dplyr::last_dplyr_warnings()` tail"
+  warnings <- collect_warnings(summarize_branch_diagnostics(text, text))
+
+  expect_length(warnings, 1L)
+  message <- conditionMessage(warnings[[1L]])
+  expect_match(message, "1 further grouping set", fixed = TRUE)
+  # The caller's line is no part of what the identity removes, so the report
+  # still carries it.
+  expect_match(message, "last_dplyr_warnings()` tail", fixed = TRUE)
+})
+
 # ADR 0022's contract for a restated line, asserted line by line rather than in
 # aggregate. `expect_rendering_markers()` above says only that some marker
 # survived somewhere, which a message that had lost the styling on one other

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -526,14 +526,23 @@ test_that("a marker inside a value or a diagnostic decides nothing", {
 # reaches this: the pair above differ, so they are two reports either way.
 test_that("a caller's own pointer line does not split one warning", {
   text <- "bad value\ni Run `dplyr::last_dplyr_warnings()` tail"
-  warnings <- collect_warnings(summarize_branch_diagnostics(text, text))
+  collected <- warnings_under_every_rendering(
+    summarize_branch_diagnostics(text, text)
+  )
 
-  expect_length(warnings, 1L)
-  message <- conditionMessage(warnings[[1L]])
-  expect_match(message, "1 further grouping set", fixed = TRUE)
+  expect_rendering_markers(collected)
+  expect_identical(lengths(collected), for_every_rendering(1L))
+  expect_identical(
+    reported_contains(collected, "1 further grouping set"),
+    for_every_rendering(TRUE)
+  )
   # The caller's line is no part of what the identity removes, so the report
-  # still carries it.
-  expect_match(message, "last_dplyr_warnings()` tail", fixed = TRUE)
+  # still carries its tail. The word alone is what every width can be asked
+  # for: the line it sits on wraps at the narrow ones.
+  expect_identical(
+    reported_contains(collected, "tail"),
+    for_every_rendering(TRUE)
+  )
 })
 
 # ADR 0022's contract for a restated line, asserted line by line rather than in


### PR DESCRIPTION
Closes #341.

`branch_warning_identity()` looked for dplyr's pointer at `last_dplyr_warnings()`
anywhere in the rendered message. dplyr appends one only at the end of a message
whose header counted more than one warning, so a line the caller's own warning
text spelled was read as dplyr's — and the two branches of a `rollup()` then
computed different identities for one warning, reporting it twice.

The removal now reads the count out of the header it already matches, and takes
the last written line only where that count is more than one.

`tests/testthat/test-execution-conditions.R` pins it with a warning whose text
carries the pointer line; nothing in the suite reached this before. The pair of
distinct diagnostics that both spell the pointer line is still two reports.