### PR TITLE
Refuse an empty summary, and select no columns for an empty .by

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -171,16 +171,18 @@
   an ordinary space. Errors from your summary expressions, tidyselect, dplyr,
   or a backend keep their original class, diagnostic, and cause, and so do
   internal invariant checks that no change to the call can avoid.
-* An argument you leave empty is now answered by marginplyr or by dplyr, never
-  by an internal name. A summary written `z = ` — or forwarded by a wrapper
+* An argument you leave empty is now answered by name, in place of R's own
+  missing-argument error. A summary written `z = ` — or forwarded by a wrapper
   whose own caller omitted the column it passes on — is refused as an empty
-  summary named `z`, in place of `argument "expr" is missing, with no default`,
-  and an unnamed empty argument is dropped wherever it sits, as
-  `dplyr::summarise()` drops one. An empty `.by` forwarded the same way selects
-  no columns, as it does in dplyr, in place of `attempt to use zero-length
-  variable name`; it is still an argument you supplied, so grouped input
-  carrying one is refused as it was. An empty argument inside a Grouping
-  specification constructor keeps the refusal it already had (#340).
+  summary named `z`, where it used to report `argument "expr" is missing, with
+  no default`; an unnamed one is refused as `..1`, the name dplyr gives it. A
+  trailing comma is not an empty argument, here as in a Grouping specification
+  constructor, because R captures no argument for one. An empty `.by` forwarded
+  the same way selects no columns, as it does in dplyr, in place of `attempt to
+  use zero-length variable name`; it is still an argument you supplied, so
+  grouped input carrying one is refused as it was. An empty `.grouping` is the
+  plan you get from omitting it, which is what writing `.grouping = ` already
+  means (#340).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/NEWS.md
+++ b/NEWS.md
@@ -175,14 +175,16 @@
   missing-argument error. A summary written `z = ` — or forwarded by a wrapper
   whose own caller omitted the column it passes on — is refused as an empty
   summary named `z`, where it used to report `argument "expr" is missing, with
-  no default`; an unnamed one is refused as `..1`, the name dplyr gives it. A
-  trailing comma is not an empty argument, here as in a Grouping specification
-  constructor, because R captures no argument for one. An empty `.by` forwarded
-  the same way selects no columns, as it does in dplyr, in place of `attempt to
-  use zero-length variable name`; it is still an argument you supplied, so
-  grouped input carrying one is refused as it was. An empty `.grouping` is the
-  plan you get from omitting it, which is what writing `.grouping = ` already
-  means (#340).
+  no default`; an unnamed one is refused as `..1`. A trailing comma is not an
+  empty argument, here as in a Grouping specification constructor, because no
+  argument is captured for one. An empty `.by` forwarded the same way selects
+  no columns, as it does in dplyr, in place of `attempt to use zero-length
+  variable name`; it is still an argument you supplied, so grouped input
+  carrying one is refused as it was. An empty `.grouping` is the plan you get
+  from omitting it, which is what writing `.grouping = ` already means.
+  Redundant parentheses are transparent here as they are elsewhere, so `(` with
+  nothing inside it is the empty argument it wraps at each of these positions
+  (#340).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/NEWS.md
+++ b/NEWS.md
@@ -175,15 +175,15 @@
   missing-argument error. A summary written `z = ` — or forwarded by a wrapper
   whose own caller omitted the column it passes on — is refused as an empty
   summary named `z`, where it used to report `argument "expr" is missing, with
-  no default`; an unnamed one is refused as `..1`. A trailing comma is not an
-  empty argument, here as in a Grouping specification constructor, because no
-  argument is captured for one. An empty `.by` forwarded the same way selects
-  no columns, as it does in dplyr, in place of `attempt to use zero-length
-  variable name`; it is still an argument you supplied, so grouped input
-  carrying one is refused as it was. An empty `.grouping` is the plan you get
-  from omitting it, which is what writing `.grouping = ` already means.
-  Redundant parentheses are transparent here as they are elsewhere, so `(` with
-  nothing inside it is the empty argument it wraps at each of these positions
+  no default`; an unnamed one is refused by its position, the first being
+  `..1`. A trailing comma is not an empty argument, here as in a Grouping
+  specification constructor, because no argument is captured for one. An empty
+  `.by` selects no columns, as it does in dplyr, in place of `attempt to use
+  zero-length variable name`; it is still an argument you supplied, so grouped
+  input carrying one is refused as it was. An empty `.grouping` is the plan you
+  get from omitting it, which is what writing `.grouping = ` already means.
+  Redundant parentheses are transparent at all three positions, as they are
+  elsewhere: an injected pair wrapping nothing is the empty argument it wraps
   (#340).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that

--- a/NEWS.md
+++ b/NEWS.md
@@ -171,6 +171,16 @@
   an ordinary space. Errors from your summary expressions, tidyselect, dplyr,
   or a backend keep their original class, diagnostic, and cause, and so do
   internal invariant checks that no change to the call can avoid.
+* An argument you leave empty is now answered by marginplyr or by dplyr, never
+  by an internal name. A summary written `z = ` — or forwarded by a wrapper
+  whose own caller omitted the column it passes on — is refused as an empty
+  summary named `z`, in place of `argument "expr" is missing, with no default`,
+  and an unnamed empty argument is dropped wherever it sits, as
+  `dplyr::summarise()` drops one. An empty `.by` forwarded the same way selects
+  no columns, as it does in dplyr, in place of `attempt to use zero-length
+  variable name`; it is still an argument you supplied, so grouped input
+  carrying one is refused as it was. An empty argument inside a Grouping
+  specification constructor keeps the refusal it already had (#340).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -426,10 +426,6 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
     # frame holding what the diagnostic names: the constructor and the
     # argument's position (#261). Which spellings count as empty, and why the
     # question is put to the quosure, are `is_empty_argument()`'s.
-    #
-    # Unrefused, such an argument reaches `is_name_only_expr()`, where the
-    # empty argument is a symbol whose name is `""` and `rlang::env_has()`
-    # raises an untyped condition for a zero-length variable name.
     if (is_empty_argument(arg)) {
       abort_empty_grouping_arg(rule$constructor, i)
     }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -106,7 +106,17 @@ resolve_fixed_keys <- function(by_quo, group_vars, data_vars) {
     # input and cannot rename one.
     return(group_vars)
   }
-  if (rlang::quo_is_null(by_quo)) {
+  # An empty `.by` selects no columns, which is `dplyr`'s answer to the same
+  # input -- what a wrapper forwards when its own caller omitted the column it
+  # passes on. Asked here because `is_name_only_selection()` below binds no
+  # local but reads the expression: R's empty argument is a symbol whose name
+  # is `""`, and `rlang::env_has()` raises an untyped condition for a
+  # zero-length variable name (#340).
+  #
+  # It is asked after `normalize_grouping_input()` has refused a grouped input
+  # carrying any `.by`, so the two readings dplyr takes of an empty one are
+  # both kept: supplied for that refusal, and no columns here.
+  if (rlang::quo_is_null(by_quo) || rlang::quo_is_missing(by_quo)) {
     return(character())
   }
   if (!is_name_only_selection(by_quo, data_vars)) {

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -446,11 +446,9 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 }
 
 # The spelling a nested position reads an argument by: the caller's expression
-# with its redundant parentheses removed (#178, #259). It answers the pair
-# wrapping R's empty argument rather than unwrapping to the marker
-# (#168, #174), which is the shape `is_empty_argument()` reads to refuse one
-# (#261). Every caller here runs downstream of that refusal and is handed no
-# empty argument at all.
+# with its redundant parentheses removed (#178, #259). Every caller here runs
+# downstream of `preflight_grouping_spec()`'s refusal of an empty argument
+# (#261) and is handed none.
 nested_arg_expr <- function(arg) {
   unparenthesized_value(rlang::quo_get_expr(arg))
 }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -106,16 +106,14 @@ resolve_fixed_keys <- function(by_quo, group_vars, data_vars) {
     # input and cannot rename one.
     return(group_vars)
   }
-  # An empty `.by` selects no columns, which is `dplyr`'s answer to the same
-  # input -- what a wrapper forwards when its own caller omitted the column it
-  # passes on. Asked here because `is_name_only_selection()` below binds no
-  # local but reads the expression: R's empty argument is a symbol whose name
-  # is `""`, and `rlang::env_has()` raises an untyped condition for a
-  # zero-length variable name (#340).
+  # An empty `.by` selects no columns, which is dplyr's answer to it. Asked
+  # before `is_name_only_selection()` below, which reads the expression rather
+  # than binding it: the empty argument is a symbol whose name is `""`, and
+  # `rlang::env_has()` raises for a zero-length variable name (#340).
   #
-  # It is asked after `normalize_grouping_input()` has refused a grouped input
-  # carrying any `.by`, so the two readings dplyr takes of an empty one are
-  # both kept: supplied for that refusal, and no columns here.
+  # `normalize_grouping_input()` has already refused a grouped input carrying
+  # any `.by`, which keeps dplyr's other reading of an empty one: supplied
+  # there, no columns here.
   if (rlang::quo_is_null(by_quo) || rlang::quo_is_missing(by_quo)) {
     return(character())
   }
@@ -167,7 +165,16 @@ prepare_grouping_plan <- function(.data,
 
   with_margin_error_call(
     {
-      grouping_spec <- rlang::eval_tidy(grouping_quo)
+      # An empty `.grouping` is the argument left absent, which is what
+      # `.grouping = ` already means: R matches a named formal's empty argument
+      # to that formal's default. Only injection carries the missing marker
+      # this far, and `rlang::eval_tidy()` evaluates it -- `object '' not
+      # found`, naming nothing the caller wrote (#340).
+      grouping_spec <- if (rlang::quo_is_missing(grouping_quo)) {
+        NULL
+      } else {
+        rlang::eval_tidy(grouping_quo)
+      }
       validate_grouping_spec_early(grouping_spec)
       if (!is.null(validate_grouping)) {
         validate_grouping(grouping_spec)

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -114,7 +114,7 @@ resolve_fixed_keys <- function(by_quo, group_vars, data_vars) {
   # `normalize_grouping_input()` has already refused a grouped input carrying
   # any `.by`, which keeps dplyr's other reading of an empty one: supplied
   # there, no columns here.
-  if (rlang::quo_is_null(by_quo) || rlang::quo_is_missing(by_quo)) {
+  if (rlang::quo_is_null(by_quo) || is_empty_argument(by_quo)) {
     return(character())
   }
   if (!is_name_only_selection(by_quo, data_vars)) {
@@ -170,7 +170,7 @@ prepare_grouping_plan <- function(.data,
       # to that formal's default. Only injection carries the missing marker
       # this far, and `rlang::eval_tidy()` evaluates it -- `object '' not
       # found`, naming nothing the caller wrote (#340).
-      grouping_spec <- if (rlang::quo_is_missing(grouping_quo)) {
+      grouping_spec <- if (is_empty_argument(grouping_quo)) {
         NULL
       } else {
         rlang::eval_tidy(grouping_quo)
@@ -422,24 +422,15 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   args <- vector("list", length(grouping_spec$args))
   for (i in seq_along(grouping_spec$args)) {
     arg <- grouping_spec$args[[i]]
-    # The first test is asked of the quosure, which is an object like any
-    # other, and before anything reads the expression out of it -- the rule
-    # `R/utils.R` states for every reader a walk asks first (#168, #174). The
-    # refusal is here rather than in the reader below because this is the frame
-    # holding what the diagnostic names: the constructor and the argument's
-    # position (#261).
+    # The refusal is here rather than in the reader below because this is the
+    # frame holding what the diagnostic names: the constructor and the
+    # argument's position (#261). Which spellings count as empty, and why the
+    # question is put to the quosure, are `is_empty_argument()`'s.
     #
-    # The second is the same argument written inside redundant parentheses,
-    # which every other reading here sees through (#178, #259) and which this
-    # one has to see through for the same reason: `(` is the identity function,
-    # so the pair wraps nothing to read either. Only an injection or a
-    # constructed call spells it, since the parser rejects `f((), x)`.
-    # Unrefused it reaches `is_name_only_expr()`, where the empty argument is a
-    # symbol whose name is `""` and `rlang::env_has()` raises an untyped
-    # condition for a zero-length variable name.
-    if (
-      rlang::quo_is_missing(arg) || wraps_empty_argument(nested_arg_expr(arg))
-    ) {
+    # Unrefused, such an argument reaches `is_name_only_expr()`, where the
+    # empty argument is a symbol whose name is `""` and `rlang::env_has()`
+    # raises an untyped condition for a zero-length variable name.
+    if (is_empty_argument(arg)) {
       abort_empty_grouping_arg(rule$constructor, i)
     }
     nested <- grouping_arg_spec(arg, data_vars)
@@ -461,9 +452,9 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 # The spelling a nested position reads an argument by: the caller's expression
 # with its redundant parentheses removed (#178, #259). It answers the pair
 # wrapping R's empty argument rather than unwrapping to the marker
-# (#168, #174), and that pair is what `preflight_grouping_spec()` reads to
-# refuse an empty argument (#261). Every other caller runs downstream of that
-# refusal and is handed no empty argument at all.
+# (#168, #174), which is the shape `is_empty_argument()` reads to refuse one
+# (#261). Every caller here runs downstream of that refusal and is handed no
+# empty argument at all.
 nested_arg_expr <- function(arg) {
   unparenthesized_value(rlang::quo_get_expr(arg))
 }

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -816,12 +816,7 @@ summarize_with_margins <- function(.data,
                                    .id = NULL,
                                    .sort = c("none", "last", "first")) {
   call <- rlang::current_call()
-  # `.ignore_empty = "all"` is `dplyr::summarise()`'s own reading of an empty
-  # argument: an unnamed one is dropped wherever it sits, and a named one is
-  # kept for `check_empty_summaries()` to refuse (#340). The default,
-  # `"trailing"`, kept a leading or interior unnamed one and carried R's
-  # missing marker into every reader downstream.
-  dots <- rlang::enquos(..., .ignore_empty = "all")
+  dots <- rlang::enquos(...)
   grouping_quo <- rlang::enquo(.grouping)
   by_quo <- rlang::enquo(.by)
 
@@ -839,10 +834,11 @@ summarize_with_margins <- function(.data,
         .id = .id
       )
       assert_logical_scalar(.check_share_source)
-      # Ahead of every reading of a summary expression, including the two
-      # below: an empty argument is refused rather than bound to a local.
-      check_empty_summaries(dots)
       check_option_named_summaries(dots)
+      # Ahead of the two readings of a summary expression below, and after the
+      # one check that reads only names: an empty argument is refused rather
+      # than bound to a local.
+      check_empty_summaries(dots)
       check_summary_context_helpers(dots)
       preflight_shares(dots)
     },

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -816,7 +816,12 @@ summarize_with_margins <- function(.data,
                                    .id = NULL,
                                    .sort = c("none", "last", "first")) {
   call <- rlang::current_call()
-  dots <- rlang::enquos(...)
+  # `.ignore_empty = "all"` is `dplyr::summarise()`'s own reading of an empty
+  # argument: an unnamed one is dropped wherever it sits, and a named one is
+  # kept for `check_empty_summaries()` to refuse (#340). The default,
+  # `"trailing"`, kept a leading or interior unnamed one and carried R's
+  # missing marker into every reader downstream.
+  dots <- rlang::enquos(..., .ignore_empty = "all")
   grouping_quo <- rlang::enquo(.grouping)
   by_quo <- rlang::enquo(.by)
 
@@ -834,6 +839,9 @@ summarize_with_margins <- function(.data,
         .id = .id
       )
       assert_logical_scalar(.check_share_source)
+      # Ahead of every reading of a summary expression, including the two
+      # below: an empty argument is refused rather than bound to a local.
+      check_empty_summaries(dots)
       check_option_named_summaries(dots)
       check_summary_context_helpers(dots)
       preflight_shares(dots)

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -134,17 +134,17 @@ check_option_named_summaries <- function(dots) {
 
 # The refusal every reader of a summary expression holds. R's empty argument is
 # a marker, and a reader that binds it to a local raises `missingArgError` on
-# the next read of that local -- `R/share.R` holds four such readers, so the
+# the next read of that local -- several below and in `R/share.R` do, so the
 # guard runs ahead of all of them rather than inside one (#340).
 #
 # Every empty argument `rlang::enquos(...)` captures is refused, named or not,
 # including one spliced in. What it captures no argument for is a trailing
 # comma, which keeps the reading `grouping_set(region, )` already has.
 #
-# An unnamed one is named `..n`, which is how dplyr refers to it and what
-# `name_unnamed_by_position()` below spells.
+# An unnamed one is named `..n`, the numbering
+# `name_unnamed_by_position()` below already spells.
 check_empty_summaries <- function(dots) {
-  empty <- vapply(dots, rlang::quo_is_missing, logical(1), USE.NAMES = FALSE)
+  empty <- vapply(dots, is_empty_argument, logical(1), USE.NAMES = FALSE)
   if (!any(empty)) {
     return(invisible(NULL))
   }
@@ -796,9 +796,11 @@ known_across_function_names <- function(parsed) {
   name_unnamed_by_position(fns_names, "")
 }
 
-# Both callers name the unnamed entries of an argument list by position, which
+# Every caller names the unnamed entries of an argument list by position, which
 # is how dplyr refers to them: an argument forwarded through `across()`'s `...`
-# is `..n`, and an unnamed `.fns` list entry takes its index. The replacement
+# is `..n`, and an unnamed `.fns` list entry takes its index. An empty summary
+# `check_empty_summaries()` refuses is named the same way, so what the caller
+# reads is one numbering rather than one per site. The replacement
 # has to be indexed by the same positions that select it. Building it over the
 # whole list instead makes the two sides differ in length whenever any entry is
 # named, so base R recycles -- warning from a call that otherwise succeeds --

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -1,36 +1,3 @@
-# The refusal every later reader of a summary expression holds. An empty
-# argument is R's missing marker, and a reader that binds it to a local raises
-# `missingArgError` on the next read of that local -- `preflight_shares()` is
-# the first of four in `R/share.R` alone, so the guard runs ahead of all of
-# them rather than inside one (#340).
-#
-# Only a named argument reaches here. `summarize_with_margins()` captures `...`
-# with `.ignore_empty = "all"`, which drops an unnamed empty argument wherever
-# it sits, exactly as `dplyr::summarise()` does with the same input.
-#
-# The first one the caller wrote is the one answered, which is the rule
-# `check_option_named_summaries()` below reads its own candidates in.
-check_empty_summaries <- function(dots) {
-  dot_names <- names(dots)
-  if (is.null(dot_names)) {
-    return(invisible(NULL))
-  }
-  empty <- vapply(dots, rlang::quo_is_missing, logical(1), USE.NAMES = FALSE)
-  if (!any(empty)) {
-    return(invisible(NULL))
-  }
-
-  # Read only from the cli template below, which `codetools` cannot follow
-  # into.
-  name <- dot_names[[which(empty)[[1L]]]] # nolint: object_usage_linter.
-  # `{.arg}` rather than `{.var}`: the caller wrote this as an argument name,
-  # and the refusal is what stops it becoming a column.
-  abort_marginplyr(c(
-    "Summary {.arg {name}} is empty.",
-    i = "Remove the summary, or write the expression it computes."
-  ))
-}
-
 # Options the verb once had. A caller following older material writes them as
 # if they were still arguments, and `...` would otherwise accept the value as
 # an ordinary summary and return a constant column. Each entry carries its own
@@ -163,6 +130,38 @@ check_option_named_summaries <- function(dots) {
     ))
   }
   invisible(NULL)
+}
+
+# The refusal every reader of a summary expression holds. R's empty argument is
+# a marker, and a reader that binds it to a local raises `missingArgError` on
+# the next read of that local -- `R/share.R` holds four such readers, so the
+# guard runs ahead of all of them rather than inside one (#340).
+#
+# Every empty argument `rlang::enquos(...)` captures is refused, named or not,
+# including one spliced in. What it captures no argument for is a trailing
+# comma, which keeps the reading `grouping_set(region, )` already has.
+#
+# An unnamed one is named `..n`, which is how dplyr refers to it and what
+# `name_unnamed_by_position()` below spells.
+check_empty_summaries <- function(dots) {
+  empty <- vapply(dots, rlang::quo_is_missing, logical(1), USE.NAMES = FALSE)
+  if (!any(empty)) {
+    return(invisible(NULL))
+  }
+
+  # The first one the caller wrote, which is the order
+  # `check_option_named_summaries()` above answers its own candidates in.
+  #
+  # `name` is read from the cli template below and nowhere else, which
+  # `codetools` cannot follow into.
+  labels <- name_unnamed_by_position(rlang::names2(dots), "..")
+  name <- labels[[which(empty)[[1L]]]] # nolint: object_usage_linter.
+  # `{.arg}` rather than `{.var}`: the caller wrote this as an argument name,
+  # and the refusal is what stops it becoming a column.
+  abort_marginplyr(c(
+    "Summary {.arg {name}} is empty.",
+    i = "Remove the summary, or write the expression it computes."
+  ))
 }
 
 check_summary_context_helpers <- function(dots) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -1,3 +1,36 @@
+# The refusal every later reader of a summary expression holds. An empty
+# argument is R's missing marker, and a reader that binds it to a local raises
+# `missingArgError` on the next read of that local -- `preflight_shares()` is
+# the first of four in `R/share.R` alone, so the guard runs ahead of all of
+# them rather than inside one (#340).
+#
+# Only a named argument reaches here. `summarize_with_margins()` captures `...`
+# with `.ignore_empty = "all"`, which drops an unnamed empty argument wherever
+# it sits, exactly as `dplyr::summarise()` does with the same input.
+#
+# The first one the caller wrote is the one answered, which is the rule
+# `check_option_named_summaries()` below reads its own candidates in.
+check_empty_summaries <- function(dots) {
+  dot_names <- names(dots)
+  if (is.null(dot_names)) {
+    return(invisible(NULL))
+  }
+  empty <- vapply(dots, rlang::quo_is_missing, logical(1), USE.NAMES = FALSE)
+  if (!any(empty)) {
+    return(invisible(NULL))
+  }
+
+  # Read only from the cli template below, which `codetools` cannot follow
+  # into.
+  name <- dot_names[[which(empty)[[1L]]]] # nolint: object_usage_linter.
+  # `{.arg}` rather than `{.var}`: the caller wrote this as an argument name,
+  # and the refusal is what stops it becoming a column.
+  abort_marginplyr(c(
+    "Summary {.arg {name}} is empty.",
+    i = "Remove the summary, or write the expression it computes."
+  ))
+}
+
 # Options the verb once had. A caller following older material writes them as
 # if they were still arguments, and `...` would otherwise accept the value as
 # an ordinary summary and return a constant column. Each entry carries its own

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -141,8 +141,8 @@ check_option_named_summaries <- function(dots) {
 # including one spliced in. What it captures no argument for is a trailing
 # comma, which keeps the reading `grouping_set(region, )` already has.
 #
-# An unnamed one is named `..n`, the numbering
-# `name_unnamed_by_position()` below already spells.
+# An unnamed one is named `..n`, the numbering `name_unnamed_by_position()`
+# below already spells.
 check_empty_summaries <- function(dots) {
   empty <- vapply(dots, is_empty_argument, logical(1), USE.NAMES = FALSE)
   if (!any(empty)) {
@@ -800,8 +800,8 @@ known_across_function_names <- function(parsed) {
 # is how dplyr refers to them: an argument forwarded through `across()`'s `...`
 # is `..n`, and an unnamed `.fns` list entry takes its index. An empty summary
 # `check_empty_summaries()` refuses is named the same way, so what the caller
-# reads is one numbering rather than one per site. The replacement
-# has to be indexed by the same positions that select it. Building it over the
+# reads is one numbering rather than one per site. The replacement has to be
+# indexed by the same positions that select it. Building it over the
 # whole list instead makes the two sides differ in length whenever any entry is
 # named, so base R recycles -- warning from a call that otherwise succeeds --
 # and numbers the survivors by their position among the unnamed entries rather

--- a/R/utils.R
+++ b/R/utils.R
@@ -334,10 +334,7 @@ wraps_empty_argument <- function(expr) {
 # `f((), x)`.
 #
 # Asked of the quosure, before anything reads the expression out of it, which
-# is the rule above for every reader a walk asks first (#168, #174). Every
-# position a caller can leave empty asks this one question, so a position that
-# starts seeing through one spelling and not the other is not reachable from
-# here (#340).
+# is the rule above for every reader a walk asks first (#168, #174).
 is_empty_argument <- function(quo) {
   rlang::quo_is_missing(quo) ||
     wraps_empty_argument(unparenthesized_value(rlang::quo_get_expr(quo)))

--- a/R/utils.R
+++ b/R/utils.R
@@ -325,6 +325,24 @@ wraps_empty_argument <- function(expr) {
   is_redundant_parens(expr) && rlang::is_missing(expr[[2L]])
 }
 
+# Whether a caller left this argument empty, in either spelling R gives them:
+# the empty argument itself, or the same argument inside redundant
+# parentheses. The second is read through for the reason every other reading
+# reads through a pair (#178, #259, ADR 0019) -- `(` is the identity function,
+# so a pair wrapping the empty argument wraps nothing to read either. Only an
+# injection or a constructed call spells it, since the parser rejects
+# `f((), x)`.
+#
+# Asked of the quosure, before anything reads the expression out of it, which
+# is the rule above for every reader a walk asks first (#168, #174). Every
+# position a caller can leave empty asks this one question, so a position that
+# starts seeing through one spelling and not the other is not reachable from
+# here (#340).
+is_empty_argument <- function(quo) {
+  rlang::quo_is_missing(quo) ||
+    wraps_empty_argument(unparenthesized_value(rlang::quo_get_expr(quo)))
+}
+
 # The head and the arguments of a call a walk descends into, and the node
 # rebuilt around rewritten arguments. `static_call_name()` above answers what a
 # walk asks of a node it does not descend into; these three are what it asks of

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -948,7 +948,6 @@ test_that("a forwarded empty `.by` is still an argument the caller supplied", {
   )
 })
 
-
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so
 # what a method could take from it was a compiled call rather than a diagnostic

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -834,8 +834,11 @@ test_that("the empty spellings that already had a reading keep it", {
 })
 
 # Every exported verb taking the argument named, derived from the signatures so
-# that a sixth arrives below as a wrapper a list is missing rather than as a
-# position nothing covers.
+# that a seventh arrives below as a wrapper a list is missing rather than as a
+# position nothing covers. The six it answers today are the same six for both
+# arguments, `summarise_with_margins()` included: the derivation reads exports
+# rather than function objects, so a synonym that stopped being one would show
+# as an entry the list no longer covers.
 verbs_taking <- function(arg) {
   Filter(
     function(name) {
@@ -846,58 +849,82 @@ verbs_taking <- function(arg) {
   )
 }
 
-# The other empty argument a verb takes, and not the `.by = ` above: R matches
-# a named formal's empty argument to that formal's default, while `{{ }}`
-# splices R's missing marker into the quosure. Only the second reaches
-# `resolve_fixed_keys()` carrying one (#340).
-test_that("a forwarded empty `.by` selects no columns on every verb", {
+# The two verb arguments injection can leave empty, and neither is the `.by = `
+# above: R matches a named formal's empty argument to that formal's default,
+# while `{{ }}` splices R's missing marker into the quosure. Only the second
+# reaches the verb carrying one (#340).
+#
+# They fail by different mechanisms and are answered on one path each, which is
+# why one table of wrappers covers both. An empty `.by` reached
+# `resolve_fixed_keys()`, where `is_name_only_selection()` read it and
+# `rlang::env_has()` raised for a zero-length variable name. Nothing binds
+# `.grouping`'s expression at all, so `rlang::eval_tidy()` evaluated the empty
+# symbol and raised `object '' not found`.
+#
+# What each is answered with is the argument supplied as absent: no columns
+# selected, which is dplyr's own answer to an empty `.by`, and the plan
+# omitting `.grouping` gives, which is what writing `.grouping = ` already
+# means.
+test_that("a forwarded empty `.by` or `.grouping` is the argument absent", {
   data <- data.frame(
     region = c("East", "East", "West"),
     value = c(1, 3, 6)
   )
-  # `.by = NULL` is the same call with the argument supplied as absent, so each
-  # pair asserts dplyr's own answer to an empty `.by`: no columns selected.
   forwarded <- list(
-    summarize_with_margins = function(data, by) {
+    summarize_with_margins = function(data, by, grouping) {
       summarize_with_margins(
         data,
         total = sum(value),
         .by = {{ by }},
-        .grouping = rollup(region)
+        .grouping = {{ grouping }}
       )
     },
-    expand_with_margins = function(data, by) {
-      expand_with_margins(data, .by = {{ by }}, .grouping = rollup(region))
-    },
-    nest_with_margins = function(data, by) {
-      nest_with_margins(data, .by = {{ by }}, .grouping = rollup(region))
-    },
-    nest_by_with_margins = function(data, by) {
-      nest_by_with_margins(data, .by = {{ by }}, .grouping = rollup(region))
-    },
-    inspect_grouping = function(data, by) {
-      inspect_grouping(data, .by = {{ by }}, .grouping = rollup(region))
-    },
-    # The spelling synonym, which is the same function under a second export.
-    # It is here because the derivation below reads exports rather than
-    # function objects, and a synonym that stopped being one would show as an
-    # entry this list no longer covers.
-    summarise_with_margins = function(data, by) {
+    summarise_with_margins = function(data, by, grouping) {
       summarise_with_margins(
         data,
         total = sum(value),
         .by = {{ by }},
-        .grouping = rollup(region)
+        .grouping = {{ grouping }}
       )
+    },
+    expand_with_margins = function(data, by, grouping) {
+      expand_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+    },
+    nest_with_margins = function(data, by, grouping) {
+      nest_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+    },
+    nest_by_with_margins = function(data, by, grouping) {
+      nest_by_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+    },
+    inspect_grouping = function(data, by, grouping) {
+      inspect_grouping(data, .by = {{ by }}, .grouping = {{ grouping }})
     }
   )
 
   expect_setequal(names(forwarded), verbs_taking(".by"))
+  expect_setequal(names(forwarded), verbs_taking(".grouping"))
 
   for (name in names(forwarded)) {
     verb <- forwarded[[name]]
-    expect_identical(verb(data), verb(data, NULL), info = name)
+    expect_identical(
+      verb(data, grouping = rollup(region)),
+      verb(data, NULL, rollup(region)),
+      info = name
+    )
+    expect_identical(
+      verb(data, by = NULL),
+      verb(data, NULL, NULL),
+      info = name
+    )
   }
+
+  # The other half, once: a specification the wrapper does forward still
+  # arrives, so what the guard answers is the empty argument and not every
+  # injected one.
+  expect_identical(
+    forwarded$inspect_grouping(data, NULL, rollup(region)),
+    inspect_grouping(data, .grouping = rollup(region))
+  )
 })
 
 test_that("a forwarded empty `.by` is still an argument the caller supplied", {
@@ -921,62 +948,6 @@ test_that("a forwarded empty `.by` is still an argument the caller supplied", {
   )
 })
 
-# The third verb argument injection can leave empty, and the one that fails by
-# a different mechanism: nothing binds `.grouping`'s expression, so
-# `rlang::eval_tidy()` evaluated the empty symbol and raised `object '' not
-# found`. What it is answered with is the reading `.grouping = ` already has,
-# because R matches a named formal's empty argument to that formal's default
-# (#340).
-test_that("a forwarded empty `.grouping` is the plan omitting it gives", {
-  data <- data.frame(
-    region = c("East", "East", "West"),
-    value = c(1, 3, 6)
-  )
-  # The same six verbs the `.by` test covers, for the same reason: both
-  # arguments are read once, on the path all of them reach.
-  forwarded <- list(
-    summarize_with_margins = function(data, grouping) {
-      summarize_with_margins(
-        data,
-        total = sum(value),
-        .grouping = {{ grouping }}
-      )
-    },
-    summarise_with_margins = function(data, grouping) {
-      summarise_with_margins(
-        data,
-        total = sum(value),
-        .grouping = {{ grouping }}
-      )
-    },
-    expand_with_margins = function(data, grouping) {
-      expand_with_margins(data, .grouping = {{ grouping }})
-    },
-    nest_with_margins = function(data, grouping) {
-      nest_with_margins(data, .grouping = {{ grouping }})
-    },
-    nest_by_with_margins = function(data, grouping) {
-      nest_by_with_margins(data, .grouping = {{ grouping }})
-    },
-    inspect_grouping = function(data, grouping) {
-      inspect_grouping(data, .grouping = {{ grouping }})
-    }
-  )
-  expect_setequal(names(forwarded), verbs_taking(".grouping"))
-
-  for (name in names(forwarded)) {
-    verb <- forwarded[[name]]
-    expect_identical(verb(data), verb(data, NULL), info = name)
-  }
-
-  # The other half, once: a specification the wrapper does forward still
-  # arrives, so what the guard answers is the empty argument and not every
-  # injected one.
-  expect_identical(
-    forwarded$inspect_grouping(data, rollup(region)),
-    inspect_grouping(data, .grouping = rollup(region))
-  )
-})
 
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -833,6 +833,94 @@ test_that("the empty spellings that already had a reading keep it", {
   )
 })
 
+# The other empty argument a verb takes, and not the `.by = ` above: R matches
+# a named formal's empty argument to that formal's default, while `{{ }}`
+# splices R's missing marker into the quosure. Only the second reaches
+# `resolve_fixed_keys()` carrying one, where `is_name_only_selection()` read it
+# as a symbol whose name is `""` and `rlang::env_has()` raised an untyped
+# condition for a zero-length variable name (#340).
+test_that("a forwarded empty `.by` selects no columns on every verb", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  # `.by = NULL` is the same call with the argument supplied as absent, so each
+  # pair asserts dplyr's own answer to an empty `.by`: no columns selected.
+  forwarded <- list(
+    summarize_with_margins = function(data, by) {
+      summarize_with_margins(
+        data,
+        total = sum(value),
+        .by = {{ by }},
+        .grouping = rollup(region)
+      )
+    },
+    expand_with_margins = function(data, by) {
+      expand_with_margins(data, .by = {{ by }}, .grouping = rollup(region))
+    },
+    nest_with_margins = function(data, by) {
+      nest_with_margins(data, .by = {{ by }}, .grouping = rollup(region))
+    },
+    nest_by_with_margins = function(data, by) {
+      nest_by_with_margins(data, .by = {{ by }}, .grouping = rollup(region))
+    },
+    inspect_grouping = function(data, by) {
+      inspect_grouping(data, .by = {{ by }}, .grouping = rollup(region))
+    },
+    # The spelling synonym, which is the same function under a second export.
+    # It is here because the derivation below reads exports rather than
+    # function objects, and a synonym that stopped being one would show as an
+    # entry this list no longer covers.
+    summarise_with_margins = function(data, by) {
+      summarise_with_margins(
+        data,
+        total = sum(value),
+        .by = {{ by }},
+        .grouping = rollup(region)
+      )
+    }
+  )
+
+  # Derived from the exported signatures rather than listed, so a sixth verb
+  # taking `.by` arrives here as a wrapper this list is missing rather than as
+  # a position nothing covers.
+  exports <- getNamespaceExports("marginplyr")
+  by_verbs <- Filter(
+    function(name) {
+      object <- getExportedValue("marginplyr", name)
+      is.function(object) && ".by" %in% names(formals(object))
+    },
+    exports
+  )
+  expect_setequal(names(forwarded), by_verbs)
+
+  for (name in names(forwarded)) {
+    verb <- forwarded[[name]]
+    expect_identical(verb(data), verb(data, NULL), info = name)
+  }
+})
+
+test_that("a forwarded empty `.by` is still an argument the caller supplied", {
+  # The other half of dplyr's reading, which is unchanged: an empty `.by`
+  # selects no columns, but it is supplied, so a grouped input is refused
+  # exactly as `.by = region` would be.
+  data <- dplyr::group_by(
+    data.frame(region = c("East", "East", "West"), value = c(1, 3, 6)),
+    region
+  )
+  forwarded <- function(data, by) {
+    inspect_grouping(data, .by = {{ by }}, .grouping = rollup(region))
+  }
+
+  error <- expect_error(forwarded(data))
+  expect_s3_class(error, "marginplyr_error")
+  expect_match(
+    conditionMessage(error),
+    "Can't supply `.by` when `.data` is grouped.",
+    fixed = TRUE
+  )
+})
+
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so
 # what a method could take from it was a compiled call rather than a diagnostic

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -921,6 +921,28 @@ test_that("a forwarded empty `.by` is still an argument the caller supplied", {
   )
 })
 
+# The third verb argument injection can leave empty, and the one that fails by
+# a different mechanism: nothing binds `.grouping`'s expression, so
+# `rlang::eval_tidy()` evaluated the empty symbol and raised `object '' not
+# found`. What it is answered with is the reading `.grouping = ` already has,
+# because R matches a named formal's empty argument to that formal's default
+# (#340).
+test_that("a forwarded empty `.grouping` is the plan omitting it gives", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    value = c(1, 3, 6)
+  )
+  forwarded <- function(data, grouping) {
+    inspect_grouping(data, .grouping = {{ grouping }})
+  }
+
+  expect_identical(forwarded(data), inspect_grouping(data))
+  expect_identical(
+    forwarded(data, rollup(region)),
+    inspect_grouping(data, .grouping = rollup(region))
+  )
+})
+
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so
 # what a method could take from it was a compiled call rather than a diagnostic

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -836,9 +836,7 @@ test_that("the empty spellings that already had a reading keep it", {
 # The other empty argument a verb takes, and not the `.by = ` above: R matches
 # a named formal's empty argument to that formal's default, while `{{ }}`
 # splices R's missing marker into the quosure. Only the second reaches
-# `resolve_fixed_keys()` carrying one, where `is_name_only_selection()` read it
-# as a symbol whose name is `""` and `rlang::env_has()` raised an untyped
-# condition for a zero-length variable name (#340).
+# `resolve_fixed_keys()` carrying one (#340).
 test_that("a forwarded empty `.by` selects no columns on every verb", {
   data <- data.frame(
     region = c("East", "East", "West"),

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -833,6 +833,19 @@ test_that("the empty spellings that already had a reading keep it", {
   )
 })
 
+# Every exported verb taking the argument named, derived from the signatures so
+# that a sixth arrives below as a wrapper a list is missing rather than as a
+# position nothing covers.
+verbs_taking <- function(arg) {
+  Filter(
+    function(name) {
+      object <- getExportedValue("marginplyr", name)
+      is.function(object) && arg %in% names(formals(object))
+    },
+    getNamespaceExports("marginplyr")
+  )
+}
+
 # The other empty argument a verb takes, and not the `.by = ` above: R matches
 # a named formal's empty argument to that formal's default, while `{{ }}`
 # splices R's missing marker into the quosure. Only the second reaches
@@ -879,18 +892,7 @@ test_that("a forwarded empty `.by` selects no columns on every verb", {
     }
   )
 
-  # Derived from the exported signatures rather than listed, so a sixth verb
-  # taking `.by` arrives here as a wrapper this list is missing rather than as
-  # a position nothing covers.
-  exports <- getNamespaceExports("marginplyr")
-  by_verbs <- Filter(
-    function(name) {
-      object <- getExportedValue("marginplyr", name)
-      is.function(object) && ".by" %in% names(formals(object))
-    },
-    exports
-  )
-  expect_setequal(names(forwarded), by_verbs)
+  expect_setequal(names(forwarded), verbs_taking(".by"))
 
   for (name in names(forwarded)) {
     verb <- forwarded[[name]]
@@ -930,13 +932,48 @@ test_that("a forwarded empty `.grouping` is the plan omitting it gives", {
     region = c("East", "East", "West"),
     value = c(1, 3, 6)
   )
-  forwarded <- function(data, grouping) {
-    inspect_grouping(data, .grouping = {{ grouping }})
+  # The same six verbs the `.by` test covers, for the same reason: both
+  # arguments are read once, on the path all of them reach.
+  forwarded <- list(
+    summarize_with_margins = function(data, grouping) {
+      summarize_with_margins(
+        data,
+        total = sum(value),
+        .grouping = {{ grouping }}
+      )
+    },
+    summarise_with_margins = function(data, grouping) {
+      summarise_with_margins(
+        data,
+        total = sum(value),
+        .grouping = {{ grouping }}
+      )
+    },
+    expand_with_margins = function(data, grouping) {
+      expand_with_margins(data, .grouping = {{ grouping }})
+    },
+    nest_with_margins = function(data, grouping) {
+      nest_with_margins(data, .grouping = {{ grouping }})
+    },
+    nest_by_with_margins = function(data, grouping) {
+      nest_by_with_margins(data, .grouping = {{ grouping }})
+    },
+    inspect_grouping = function(data, grouping) {
+      inspect_grouping(data, .grouping = {{ grouping }})
+    }
+  )
+  expect_setequal(names(forwarded), verbs_taking(".grouping"))
+
+  for (name in names(forwarded)) {
+    verb <- forwarded[[name]]
+    expect_identical(verb(data), verb(data, NULL), info = name)
   }
 
-  expect_identical(forwarded(data), inspect_grouping(data))
+  # The other half, once: a specification the wrapper does forward still
+  # arrives, so what the guard answers is the empty argument and not every
+  # injected one.
   expect_identical(
-    forwarded(data, rollup(region)),
+    forwarded$inspect_grouping(data, rollup(region)),
     inspect_grouping(data, .grouping = rollup(region))
   )
 })

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2451,6 +2451,15 @@ test_that("an empty argument outside `across()` evaluates as dplyr evaluates", {
   )
 })
 
+# The two tests below read one builder, so the refusal they pin is one message
+# rather than two spellings of it.
+empty_summary_message <- function(name) {
+  paste0(
+    "Summary `", name, "` is empty.\n",
+    "i Remove the summary, or write the expression it computes."
+  )
+}
+
 test_that("a summary argument the caller left empty is refused by name", {
   # The two spellings that leave a summary empty: the plain typo, and the
   # tidy-eval idiom a wrapper forwards a column its own caller omitted with.
@@ -2474,13 +2483,7 @@ test_that("a summary argument the caller left empty is refused by name", {
     # Asserted in full rather than matched, because what #340 found was not a
     # missing refusal but a diagnostic naming `expr`, the local
     # `preflight_shares()` bound the missing marker to.
-    expect_identical(
-      conditionMessage(error),
-      paste0(
-        "Summary `z` is empty.\n",
-        "i Remove the summary, or write the expression it computes."
-      )
-    )
+    expect_identical(conditionMessage(error), empty_summary_message("z"))
     # The call the caller wrote, not the reader that found the empty argument.
     expect_identical(conditionCall(error)[[1L]], quote(summarize_with_margins))
   }
@@ -2492,15 +2495,10 @@ test_that("an unnamed empty summary argument is refused by its position", {
   # whether it carries a name or not. Each raised `missingArgError` from the
   # first reader that bound it (#340).
   #
-  # `..n` is the name the refusal gives an unnamed argument, which is how dplyr
-  # refers to one and what `name_unnamed_by_position()` already spells.
+  # `..n` is the name the refusal gives an unnamed argument, the numbering
+  # `name_unnamed_by_position()` already spells for every other unnamed
+  # argument this package names.
   data <- data.frame(region = c("East", "East", "West"), value = c(1, 3, 6))
-  empty_summary_message <- function(name) {
-    paste0(
-      "Summary `", name, "` is empty.\n",
-      "i Remove the summary, or write the expression it computes."
-    )
-  }
 
   shapes <- list(
     leading = list(
@@ -2565,6 +2563,61 @@ test_that("an unnamed empty summary argument is refused by its position", {
       total = sum(value),
       .grouping = rollup(region)
     )
+  )
+})
+
+test_that("a pair of parentheses holding nothing is the empty argument", {
+  # `(` is the identity function, so a pair wrapping R's empty argument wraps
+  # nothing to read either -- the reading every other position takes of a
+  # redundant pair (#178, #259, ADR 0019), and the one a Grouping specification
+  # constructor has taken since #259. The parser rejects `f(())`, so a
+  # constructed call is how the pair is spelled at all.
+  data <- data.frame(region = c("East", "East", "West"), value = c(1, 3, 6))
+  parens <- function(expr) as.call(list(as.name("("), expr))
+  empty <- parens(rlang::missing_arg())
+
+  # A summary is refused as the unwrapped argument is. Unrefused, this pair
+  # reached the share preflight and recursed without bound.
+  named <- expect_error(summarize_with_margins(
+    data,
+    z = !!empty,
+    .grouping = rollup(region)
+  ))
+  expect_s3_class(named, "marginplyr_error")
+  expect_identical(conditionMessage(named), empty_summary_message("z"))
+
+  unnamed <- expect_error(summarize_with_margins(
+    data,
+    !!empty,
+    total = sum(value),
+    .grouping = rollup(region)
+  ))
+  expect_s3_class(unnamed, "marginplyr_error")
+  expect_identical(conditionMessage(unnamed), empty_summary_message("..1"))
+
+  # `.by` and `.grouping` answer it as they answer the unwrapped argument: no
+  # columns, and the plan omitting the argument gives.
+  expect_identical(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      .by = !!empty,
+      .grouping = rollup(region)
+    ),
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      .grouping = rollup(region)
+    )
+  )
+  expect_identical(
+    inspect_grouping(data, .grouping = !!empty),
+    inspect_grouping(data)
+  )
+  # Two pairs deep, since what reads through them unwraps until it stops.
+  expect_identical(
+    inspect_grouping(data, .grouping = !!parens(empty)),
+    inspect_grouping(data)
   )
 })
 

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2451,6 +2451,75 @@ test_that("an empty argument outside `across()` evaluates as dplyr evaluates", {
   )
 })
 
+test_that("a summary argument the caller left empty is refused by name", {
+  # The two spellings that leave a summary empty: the plain typo, and the
+  # tidy-eval idiom a wrapper forwards a column its own caller omitted with.
+  # Both reach the verb as the same quosure, so the refusal names what they
+  # share -- the summary the caller wrote (#340).
+  data <- data.frame(region = c("East", "West"), value = c(1, 6))
+  forwarded <- function(data, column) {
+    summarize_with_margins(data, z = {{ column }}, .grouping = rollup(region))
+  }
+
+  errors <- list(
+    written = expect_error(
+      summarize_with_margins(data, z = , .grouping = rollup(region))
+    ),
+    injected = expect_error(forwarded(data))
+  )
+
+  for (error in errors) {
+    expect_s3_class(error, "marginplyr_error")
+    expect_false(inherits(error, "missingArgError"))
+    # Asserted in full rather than matched, because what #340 found was not a
+    # missing refusal but a diagnostic naming `expr`, the local
+    # `preflight_shares()` bound the missing marker to.
+    expect_identical(
+      conditionMessage(error),
+      paste0(
+        "Summary `z` is empty.\n",
+        "i Remove the summary, or write the expression it computes."
+      )
+    )
+    # The call the caller wrote, not the reader that found the empty argument.
+    expect_identical(conditionCall(error)[[1L]], quote(summarize_with_margins))
+  }
+})
+
+test_that("an unnamed empty summary argument is dropped as dplyr drops one", {
+  # dplyr is the oracle again. It captures `...` with `.ignore_empty = "all"`,
+  # which keeps a named empty argument for the refusal above and drops an
+  # unnamed one wherever it sits. Only a trailing one was dropped here, so a
+  # leading one reached `preflight_shares()` and raised `missingArgError`
+  # (#340).
+  data <- data.frame(region = c("East", "East", "West"), value = c(1, 3, 6))
+
+  expected <- summarize_with_margins(
+    data,
+    total = sum(value),
+    .grouping = rollup(region)
+  )
+  leading <- summarize_with_margins(
+    data,
+    ,
+    total = sum(value),
+    .grouping = rollup(region)
+  )
+  trailing <- summarize_with_margins(
+    data,
+    total = sum(value),
+    ,
+    .grouping = rollup(region)
+  )
+
+  expect_identical(leading, expected)
+  expect_identical(trailing, expected)
+  expect_identical(
+    names(dplyr::summarise(data, , total = sum(value))),
+    "total"
+  )
+})
+
 test_that("`parse_across_arguments()` answers an empty argument as omitted", {
   # The seam every `across()` path reads, and the one place that has to know
   # about the empty argument: each field below answers what it answers for an

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2486,37 +2486,85 @@ test_that("a summary argument the caller left empty is refused by name", {
   }
 })
 
-test_that("an unnamed empty summary argument is dropped as dplyr drops one", {
-  # dplyr is the oracle again. It captures `...` with `.ignore_empty = "all"`,
-  # which keeps a named empty argument for the refusal above and drops an
-  # unnamed one wherever it sits. Only a trailing one was dropped here, so a
-  # leading one reached `preflight_shares()` and raised `missingArgError`
-  # (#340).
+test_that("an unnamed empty summary argument is refused by its position", {
+  # The other spellings an empty summary reaches the verb by. A leading or
+  # interior one is written; a spliced one is built, and survives capture
+  # whether it carries a name or not. Each raised `missingArgError` from the
+  # first reader that bound it (#340).
+  #
+  # `..n` is the name the refusal gives an unnamed argument, which is how dplyr
+  # refers to one and what `name_unnamed_by_position()` already spells.
   data <- data.frame(region = c("East", "East", "West"), value = c(1, 3, 6))
+  empty_summary_message <- function(name) {
+    paste0(
+      "Summary `", name, "` is empty.\n",
+      "i Remove the summary, or write the expression it computes."
+    )
+  }
 
-  expected <- summarize_with_margins(
-    data,
-    total = sum(value),
-    .grouping = rollup(region)
-  )
-  leading <- summarize_with_margins(
-    data,
-    ,
-    total = sum(value),
-    .grouping = rollup(region)
-  )
-  trailing <- summarize_with_margins(
-    data,
-    total = sum(value),
-    ,
-    .grouping = rollup(region)
+  shapes <- list(
+    leading = list(
+      error = expect_error(summarize_with_margins(
+        data,
+        ,
+        total = sum(value),
+        .grouping = rollup(region)
+      )),
+      name = "..1"
+    ),
+    interior = list(
+      error = expect_error(summarize_with_margins(
+        data,
+        total = sum(value),
+        ,
+        rows = dplyr::n(),
+        .grouping = rollup(region)
+      )),
+      name = "..2"
+    ),
+    spliced = list(
+      error = expect_error(summarize_with_margins(
+        data,
+        !!!list(rlang::missing_arg()),
+        total = sum(value),
+        .grouping = rollup(region)
+      )),
+      name = "..1"
+    ),
+    spliced_named = list(
+      error = expect_error(summarize_with_margins(
+        data,
+        !!!list(z = rlang::missing_arg()),
+        .grouping = rollup(region)
+      )),
+      name = "z"
+    )
   )
 
-  expect_identical(leading, expected)
-  expect_identical(trailing, expected)
+  for (shape in shapes) {
+    expect_s3_class(shape$error, "marginplyr_error")
+    expect_false(inherits(shape$error, "missingArgError"))
+    expect_identical(
+      conditionMessage(shape$error),
+      empty_summary_message(shape$name)
+    )
+  }
+
+  # A trailing comma is not an empty argument, here as in a Grouping
+  # specification constructor: `rlang::enquos(...)` captures no argument for
+  # one, so the refusal above cannot reach it and must not start reaching it.
   expect_identical(
-    names(dplyr::summarise(data, , total = sum(value))),
-    "total"
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      ,
+      .grouping = rollup(region)
+    ),
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      .grouping = rollup(region)
+    )
   )
 })
 

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -63,6 +63,28 @@ test_that("every removed option answers its near misses the same way", {
   )
 })
 
+# The order the two checks over `...` run in, which nothing else pins. An
+# option-shaped name is answered by the option guidance whether or not the
+# caller left it empty, so `check_empty_summaries()` runs after
+# `check_option_named_summaries()` rather than before it (#340). Moving it back
+# ahead leaves every other test in the suite green and changes only the message
+# below.
+test_that("a removed option left empty is still answered as a removed one", {
+  expect_error(
+    summarize_with_margins(
+      admission_data(),
+      .groups = ,
+      s = sum(v),
+      .grouping = rollup(g)
+    ),
+    paste0(
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.\n",
+      "i Margin-summary results are always ungrouped\\."
+    ),
+    class = "marginplyr_error"
+  )
+})
+
 test_that("the synonym answers removed options identically", {
   # `summarise_with_margins()` is the same object, but the option names are read
   # from formals and the messages name one spelling, so the synonym is where a

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -10,8 +10,7 @@ admission_data <- function() {
   data.frame(g = c("a", "a", "b"), v = c(1, 2, 3))
 }
 
-# The guidance the one removed option carries, read by every test asserting a
-# refusal that carries it.
+# The guidance the one removed option carries.
 removed_groups_guidance <- "\ni Margin-summary results are always ungrouped\\."
 
 # Two tests stood here, `a removed option is reported instead of summarized`

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -10,6 +10,10 @@ admission_data <- function() {
   data.frame(g = c("a", "a", "b"), v = c(1, 2, 3))
 }
 
+# The guidance the one removed option carries, read by every test asserting a
+# refusal that carries it.
+removed_groups_guidance <- "\ni Margin-summary results are always ungrouped\\."
+
 # Two tests stood here, `a removed option is reported instead of summarized`
 # and `a near miss on a removed option names what the caller wrote`. Both were
 # written against `.sort`, which ADR 0018 returned as a live argument: a name
@@ -33,8 +37,6 @@ test_that("every removed option answers its near misses the same way", {
   # patterns below read across it. That is what keeps them assertions about one
   # message rather than two: the guidance is asserted where the refusal that
   # carries it is, not merely somewhere in the corpus.
-  guidance <- "\ni Margin-summary results are always ungrouped\\."
-
   expect_error(
     summarize_with_margins(
       admission_data(),
@@ -43,7 +45,8 @@ test_that("every removed option answers its near misses the same way", {
       .groups = "drop"
     ),
     paste0(
-      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.", guidance
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.",
+      removed_groups_guidance
     ),
     class = "marginplyr_error"
   )
@@ -57,7 +60,7 @@ test_that("every removed option answers its near misses the same way", {
     ),
     paste0(
       "`\\.groupss` is not an argument.+neither is the `\\.groups` it ",
-      "resembles\\.", guidance
+      "resembles\\.", removed_groups_guidance
     ),
     class = "marginplyr_error"
   )
@@ -78,8 +81,8 @@ test_that("a removed option left empty is still answered as a removed one", {
       .grouping = rollup(g)
     ),
     paste0(
-      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.\n",
-      "i Margin-summary results are always ungrouped\\."
+      "`summarize_with_margins\\(\\)` has no `\\.groups` argument\\.",
+      removed_groups_guidance
     ),
     class = "marginplyr_error"
   )


### PR DESCRIPTION
Closes #340.

Two positions answered a caller who left an argument empty with R's own untyped error: a summary in `...` raised `argument "expr" is missing, with no default` from `preflight_shares()`, and an empty `.by` raised `attempt to use zero-length variable name` from `is_name_only_selection()`. A third, found by the review, raised `object '' not found`.

- `check_empty_summaries()` refuses every empty argument `rlang::enquos(...)` captures, ahead of every reader that would bind one. An unnamed one is named `..n`, as dplyr names it. A trailing comma is not an empty argument, because R captures no argument for one — the reading a Grouping specification constructor has had since #261.
- `resolve_fixed_keys()` answers an empty `.by` with no fixed keys, as dplyr answers the same input. The grouped-input refusal runs first and still treats it as an argument the caller supplied.
- `prepare_grouping_plan()` answers an empty `.grouping` with the plan omitting it gives, which is what writing `.grouping = ` already means. This is one position past the two #340 enumerates: nothing binds `.grouping`'s expression, so the audit the issue was written from did not reach it.

The refusal an empty argument gets inside a Grouping specification constructor is untouched, trailing comma included.