### PR TITLE
Scope the factor-preservation claim to the backends that restore factors

### DIFF
--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -239,11 +239,27 @@
 #' attributes a result must carry after the Margin operation, as with any
 #' dplyr pipeline.
 #'
-#' Factor and ordered-factor columns are the one exception, because
-#' marginplyr decomposes them to insert `.margin_label` and rebuilds them
-#' itself. Their levels and ordering are preserved; see *Display labels and
-#' grouping identity*. Classed columns such as [Date] and [POSIXct], including
-#' its `tzone`, are carried through by dplyr and vctrs unchanged.
+#' Factor and ordered-factor columns are the one exception, on the backends
+#' whose factors marginplyr can rebuild: local data frames, `dtplyr`, and
+#' DuckDB. There it decomposes them to insert `.margin_label` and rebuilds
+#' them itself, so their levels and ordering are preserved; see *Display
+#' labels and grouping identity*. On DuckDB it is the levels alone: an `ENUM`
+#' carries no ordered flag, so an ordered factor is already unordered when
+#' marginplyr reads the column and unordered is what it rebuilds.
+#'
+#' Arrow is the one backend that can hold a factor without marginplyr being
+#' able to rebuild one, because the schema a dimension's prototype is read
+#' from carries a dictionary column with no levels in it. A non-missing
+#' `.margin_label` there converts the dimension to character as it does any
+#' ordinary dimension, so the levels and the ordered status are gone and a
+#' Margin order sorts the dimension by its values; plain
+#' [dplyr::summarize()] over the same table keeps the dictionary type, so
+#' this is marginplyr's loss rather than Arrow's. `NA_character_` and `NULL`
+#' insert no label and so convert nothing. A SQL backend other than DuckDB
+#' reaches none of this, storing a factor as text before marginplyr sees it.
+#'
+#' Classed columns such as [Date] and [POSIXct], including its `tzone`, are
+#' carried through by dplyr and vctrs unchanged.
 #'
 #' @section Grouping set identifiers:
 #' When `.id` names an output column, each result row receives the one-based
@@ -293,7 +309,8 @@
 #' differ.
 #'
 #' Factor and ordered-factor dimensions sort by their restored levels rather
-#' than by their rendering. `.margin_label_position` positions a synthetic
+#' than by their rendering, on the backends that restore them; see *Result
+#' class and attributes*. `.margin_label_position` positions a synthetic
 #' factor level and never a row: it changes `levels()` and nothing else, so the
 #' two options stay independent and no combination of them is wrong.
 #'
@@ -451,11 +468,13 @@
 #' are names from `.by`.
 #'
 #' Non-missing labels convert ordinary grouping dimensions to character. A
-#' factor or ordered factor is reconstructed after the Margin operation,
-#' preserving ordered status and placing a new synthetic level last by default
-#' or first when `.margin_label_position = "first"`. A label equal to any
-#' declared level, used or unused, is rejected before any grouping set is
-#' built, whatever `.check_margin_label` says: see that argument above.
+#' factor or ordered factor is reconstructed after the Margin operation where
+#' the backend allows it -- see *Result class and attributes*, which owns that
+#' condition -- preserving ordered status and placing a new synthetic level
+#' last by default or first when `.margin_label_position = "first"`. A label
+#' equal to any declared level, used or unused, is rejected before any
+#' grouping set is built, whatever `.check_margin_label` says: see that
+#' argument above.
 #' Reconstruction preserves the distinction between an observation that uses a
 #' factor NA level and an actually missing factor code.
 #'

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -237,11 +237,27 @@ the vctrs rules for combining bare vectors do with them. Attach the
 attributes a result must carry after the Margin operation, as with any
 dplyr pipeline.
 
-Factor and ordered-factor columns are the one exception, because
-marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
-itself. Their levels and ordering are preserved; see \emph{Display labels and
-grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
-its \code{tzone}, are carried through by dplyr and vctrs unchanged.
+Factor and ordered-factor columns are the one exception, on the backends
+whose factors marginplyr can rebuild: local data frames, \code{dtplyr}, and
+DuckDB. There it decomposes them to insert \code{.margin_label} and rebuilds
+them itself, so their levels and ordering are preserved; see \emph{Display
+labels and grouping identity}. On DuckDB it is the levels alone: an \code{ENUM}
+carries no ordered flag, so an ordered factor is already unordered when
+marginplyr reads the column and unordered is what it rebuilds.
+
+Arrow is the one backend that can hold a factor without marginplyr being
+able to rebuild one, because the schema a dimension's prototype is read
+from carries a dictionary column with no levels in it. A non-missing
+\code{.margin_label} there converts the dimension to character as it does any
+ordinary dimension, so the levels and the ordered status are gone and a
+Margin order sorts the dimension by its values; plain
+\code{\link[dplyr:summarize]{dplyr::summarize()}} over the same table keeps the dictionary type, so
+this is marginplyr's loss rather than Arrow's. \code{NA_character_} and \code{NULL}
+insert no label and so convert nothing. A SQL backend other than DuckDB
+reaches none of this, storing a factor as text before marginplyr sees it.
+
+Classed columns such as \link{Date} and \link{POSIXct}, including its \code{tzone}, are
+carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{
@@ -294,7 +310,8 @@ alike, but they are separated by position, because their Grouping bits
 differ.
 
 Factor and ordered-factor dimensions sort by their restored levels rather
-than by their rendering. \code{.margin_label_position} positions a synthetic
+than by their rendering, on the backends that restore them; see \emph{Result
+class and attributes}. \code{.margin_label_position} positions a synthetic
 factor level and never a row: it changes \code{levels()} and nothing else, so the
 two options stay independent and no combination of them is wrong.
 
@@ -335,11 +352,13 @@ exactly once; missing, unknown, duplicate, and empty names are rejected, as
 are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
-factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing a new synthetic level last by default
-or first when \code{.margin_label_position = "first"}. A label equal to any
-declared level, used or unused, is rejected before any grouping set is
-built, whatever \code{.check_margin_label} says: see that argument above.
+factor or ordered factor is reconstructed after the Margin operation where
+the backend allows it -- see \emph{Result class and attributes}, which owns that
+condition -- preserving ordered status and placing a new synthetic level
+last by default or first when \code{.margin_label_position = "first"}. A label
+equal to any declared level, used or unused, is rejected before any
+grouping set is built, whatever \code{.check_margin_label} says: see that
+argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -236,11 +236,27 @@ the vctrs rules for combining bare vectors do with them. Attach the
 attributes a result must carry after the Margin operation, as with any
 dplyr pipeline.
 
-Factor and ordered-factor columns are the one exception, because
-marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
-itself. Their levels and ordering are preserved; see \emph{Display labels and
-grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
-its \code{tzone}, are carried through by dplyr and vctrs unchanged.
+Factor and ordered-factor columns are the one exception, on the backends
+whose factors marginplyr can rebuild: local data frames, \code{dtplyr}, and
+DuckDB. There it decomposes them to insert \code{.margin_label} and rebuilds
+them itself, so their levels and ordering are preserved; see \emph{Display
+labels and grouping identity}. On DuckDB it is the levels alone: an \code{ENUM}
+carries no ordered flag, so an ordered factor is already unordered when
+marginplyr reads the column and unordered is what it rebuilds.
+
+Arrow is the one backend that can hold a factor without marginplyr being
+able to rebuild one, because the schema a dimension's prototype is read
+from carries a dictionary column with no levels in it. A non-missing
+\code{.margin_label} there converts the dimension to character as it does any
+ordinary dimension, so the levels and the ordered status are gone and a
+Margin order sorts the dimension by its values; plain
+\code{\link[dplyr:summarize]{dplyr::summarize()}} over the same table keeps the dictionary type, so
+this is marginplyr's loss rather than Arrow's. \code{NA_character_} and \code{NULL}
+insert no label and so convert nothing. A SQL backend other than DuckDB
+reaches none of this, storing a factor as text before marginplyr sees it.
+
+Classed columns such as \link{Date} and \link{POSIXct}, including its \code{tzone}, are
+carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{
@@ -293,7 +309,8 @@ alike, but they are separated by position, because their Grouping bits
 differ.
 
 Factor and ordered-factor dimensions sort by their restored levels rather
-than by their rendering. \code{.margin_label_position} positions a synthetic
+than by their rendering, on the backends that restore them; see \emph{Result
+class and attributes}. \code{.margin_label_position} positions a synthetic
 factor level and never a row: it changes \code{levels()} and nothing else, so the
 two options stay independent and no combination of them is wrong.
 
@@ -334,11 +351,13 @@ exactly once; missing, unknown, duplicate, and empty names are rejected, as
 are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
-factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing a new synthetic level last by default
-or first when \code{.margin_label_position = "first"}. A label equal to any
-declared level, used or unused, is rejected before any grouping set is
-built, whatever \code{.check_margin_label} says: see that argument above.
+factor or ordered factor is reconstructed after the Margin operation where
+the backend allows it -- see \emph{Result class and attributes}, which owns that
+condition -- preserving ordered status and placing a new synthetic level
+last by default or first when \code{.margin_label_position = "first"}. A label
+equal to any declared level, used or unused, is rejected before any
+grouping set is built, whatever \code{.check_margin_label} says: see that
+argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -282,11 +282,27 @@ the vctrs rules for combining bare vectors do with them. Attach the
 attributes a result must carry after the Margin operation, as with any
 dplyr pipeline.
 
-Factor and ordered-factor columns are the one exception, because
-marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
-itself. Their levels and ordering are preserved; see \emph{Display labels and
-grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
-its \code{tzone}, are carried through by dplyr and vctrs unchanged.
+Factor and ordered-factor columns are the one exception, on the backends
+whose factors marginplyr can rebuild: local data frames, \code{dtplyr}, and
+DuckDB. There it decomposes them to insert \code{.margin_label} and rebuilds
+them itself, so their levels and ordering are preserved; see \emph{Display
+labels and grouping identity}. On DuckDB it is the levels alone: an \code{ENUM}
+carries no ordered flag, so an ordered factor is already unordered when
+marginplyr reads the column and unordered is what it rebuilds.
+
+Arrow is the one backend that can hold a factor without marginplyr being
+able to rebuild one, because the schema a dimension's prototype is read
+from carries a dictionary column with no levels in it. A non-missing
+\code{.margin_label} there converts the dimension to character as it does any
+ordinary dimension, so the levels and the ordered status are gone and a
+Margin order sorts the dimension by its values; plain
+\code{\link[dplyr:summarize]{dplyr::summarize()}} over the same table keeps the dictionary type, so
+this is marginplyr's loss rather than Arrow's. \code{NA_character_} and \code{NULL}
+insert no label and so convert nothing. A SQL backend other than DuckDB
+reaches none of this, storing a factor as text before marginplyr sees it.
+
+Classed columns such as \link{Date} and \link{POSIXct}, including its \code{tzone}, are
+carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{
@@ -339,7 +355,8 @@ alike, but they are separated by position, because their Grouping bits
 differ.
 
 Factor and ordered-factor dimensions sort by their restored levels rather
-than by their rendering. \code{.margin_label_position} positions a synthetic
+than by their rendering, on the backends that restore them; see \emph{Result
+class and attributes}. \code{.margin_label_position} positions a synthetic
 factor level and never a row: it changes \code{levels()} and nothing else, so the
 two options stay independent and no combination of them is wrong.
 
@@ -380,11 +397,13 @@ exactly once; missing, unknown, duplicate, and empty names are rejected, as
 are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
-factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing a new synthetic level last by default
-or first when \code{.margin_label_position = "first"}. A label equal to any
-declared level, used or unused, is rejected before any grouping set is
-built, whatever \code{.check_margin_label} says: see that argument above.
+factor or ordered factor is reconstructed after the Margin operation where
+the backend allows it -- see \emph{Result class and attributes}, which owns that
+condition -- preserving ordered status and placing a new synthetic level
+last by default or first when \code{.margin_label_position = "first"}. A label
+equal to any declared level, used or unused, is rejected before any
+grouping set is built, whatever \code{.check_margin_label} says: see that
+argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -291,11 +291,27 @@ the vctrs rules for combining bare vectors do with them. Attach the
 attributes a result must carry after the Margin operation, as with any
 dplyr pipeline.
 
-Factor and ordered-factor columns are the one exception, because
-marginplyr decomposes them to insert \code{.margin_label} and rebuilds them
-itself. Their levels and ordering are preserved; see \emph{Display labels and
-grouping identity}. Classed columns such as \link{Date} and \link{POSIXct}, including
-its \code{tzone}, are carried through by dplyr and vctrs unchanged.
+Factor and ordered-factor columns are the one exception, on the backends
+whose factors marginplyr can rebuild: local data frames, \code{dtplyr}, and
+DuckDB. There it decomposes them to insert \code{.margin_label} and rebuilds
+them itself, so their levels and ordering are preserved; see \emph{Display
+labels and grouping identity}. On DuckDB it is the levels alone: an \code{ENUM}
+carries no ordered flag, so an ordered factor is already unordered when
+marginplyr reads the column and unordered is what it rebuilds.
+
+Arrow is the one backend that can hold a factor without marginplyr being
+able to rebuild one, because the schema a dimension's prototype is read
+from carries a dictionary column with no levels in it. A non-missing
+\code{.margin_label} there converts the dimension to character as it does any
+ordinary dimension, so the levels and the ordered status are gone and a
+Margin order sorts the dimension by its values; plain
+\code{\link[dplyr:summarize]{dplyr::summarize()}} over the same table keeps the dictionary type, so
+this is marginplyr's loss rather than Arrow's. \code{NA_character_} and \code{NULL}
+insert no label and so convert nothing. A SQL backend other than DuckDB
+reaches none of this, storing a factor as text before marginplyr sees it.
+
+Classed columns such as \link{Date} and \link{POSIXct}, including its \code{tzone}, are
+carried through by dplyr and vctrs unchanged.
 }
 
 \section{Grouping set identifiers}{
@@ -348,7 +364,8 @@ alike, but they are separated by position, because their Grouping bits
 differ.
 
 Factor and ordered-factor dimensions sort by their restored levels rather
-than by their rendering. \code{.margin_label_position} positions a synthetic
+than by their rendering, on the backends that restore them; see \emph{Result
+class and attributes}. \code{.margin_label_position} positions a synthetic
 factor level and never a row: it changes \code{levels()} and nothing else, so the
 two options stay independent and no combination of them is wrong.
 
@@ -510,11 +527,13 @@ exactly once; missing, unknown, duplicate, and empty names are rejected, as
 are names from \code{.by}.
 
 Non-missing labels convert ordinary grouping dimensions to character. A
-factor or ordered factor is reconstructed after the Margin operation,
-preserving ordered status and placing a new synthetic level last by default
-or first when \code{.margin_label_position = "first"}. A label equal to any
-declared level, used or unused, is rejected before any grouping set is
-built, whatever \code{.check_margin_label} says: see that argument above.
+factor or ordered factor is reconstructed after the Margin operation where
+the backend allows it -- see \emph{Result class and attributes}, which owns that
+condition -- preserving ordered status and placing a new synthetic level
+last by default or first when \code{.margin_label_position = "first"}. A label
+equal to any declared level, used or unused, is rejected before any
+grouping set is built, whatever \code{.check_margin_label} says: see that
+argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 


### PR DESCRIPTION
Closes #343.

*Result class and attributes* claimed without qualification that a factor
dimension's levels and ordering survive a Margin operation, and
`expand_with_margins()` and the nesting verbs inherit the section as written.
On Arrow the claim is false under the default Margin label: `can_restore_factors`
is false there, so the dimension comes back as character ordered by its values,
while plain `dplyr::summarize()` over the same table keeps the dictionary type.

The section now names the three backends `backend_capabilities()` grants
restoration to — local data frames, `dtplyr`, DuckDB — says what Arrow returns
instead and why the schema a prototype is read from cannot supply levels, notes
that `NA_character_`/`NULL` insert no label and convert nothing, and says a SQL
backend other than DuckDB never held a factor to lose.

The Margin label contract and the Margin order key now cite that condition
rather than restating it, so one section owns it.

`man/` regenerated in the same commit. Lint, spelling, the context budget, and
the full suite under `NOT_CRAN=true` are green locally.