### PR TITLE
Settle a formula and the `.data$name` pronoun from the names (#346)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -163,8 +163,10 @@
   selection carrying `where()` still resolves against your input's column
   types, including one written under `/`. It reaches two more spellings: a
   formula, which tidyselect refuses on sight whatever it wraps, and the
-  `.data$name` pronoun, whose name your input either holds or does not.
-  `.data[[name]]` is unchanged and still resolves against your input.
+  `.data` pronoun, whose name your input either holds or does not. Where you
+  have turned a deprecation into an error with
+  `options(lifecycle_verbosity = "error")`, the deprecation `.data` carries in
+  a selection is now raised before the query too.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/NEWS.md
+++ b/NEWS.md
@@ -161,7 +161,10 @@
   on a backend that needs one, so on a disconnected or slow connection you
   were handed the connection's failure instead of the column diagnostic. A
   selection carrying `where()` still resolves against your input's column
-  types, including one written under `/`.
+  types, including one written under `/`. It reaches two more spellings: a
+  formula, which tidyselect refuses on sight whatever it wraps, and the
+  `.data$name` pronoun, whose name your input either holds or does not.
+  `.data[[name]]` is unchanged and still resolves against your input.
 * Every error marginplyr raises for a correctable call now inherits the
   `"marginplyr_error"` class, so `tryCatch(marginplyr_error = )` catches them
   all. It is the only promised class; narrower subclasses and message wording

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -190,12 +190,15 @@ prepare_grouping_plan <- function(.data,
         # them is what keeps this pass invisible but for the failure it exists
         # to raise; `one_of()` is where that is observable.
         #
-        # A deprecation warning is the one kind suppressing is not enough for,
-        # and the option is what covers it. lifecycle signals one once per
-        # session, so a pass that signals it and muffles it spends the only
-        # signal the caller had coming and the canonical pass then reports
-        # nothing -- less than the second pass reports, where every other
-        # warning here is more. `.data$region` is where that is observable.
+        # A deprecation warning is the one kind suppressing is not enough for.
+        # lifecycle signals one once per session, so a pass that signals it
+        # and muffles it spends the only signal the caller had coming and the
+        # canonical pass then reports nothing. The option withholds the signal
+        # instead of hiding it; `.data$region` is where that is observable.
+        #
+        # `"error"` is the one verbosity it does not replace, because under it
+        # the deprecation is a failure the names decide and quieting it would
+        # put the read below in front of it (ADR 0005).
         rlang::with_options(
           suppressWarnings(compile_grouping_spec(
             grouping_spec,
@@ -206,7 +209,7 @@ prepare_grouping_plan <- function(.data,
             duplicates_choices = duplicates_choices,
             preflight = preflight
           )),
-          lifecycle_verbosity = "quiet"
+          lifecycle_verbosity = discarded_pass_verbosity()
         )
       }
       data_proxy <- grouping_selection_proxy(data, backend = backend)
@@ -378,13 +381,9 @@ is_name_only_expr <- function(expr, env, data_vars) {
   if (call_name %in% selection_refused_operators()) {
     return(TRUE)
   }
-  # `.data$region` is settled by the names, tidyselect's walk having a `.data`
-  # branch that looks up the name written here. `.data[[...]]` is not read:
-  # its subscript is no name this reader can see, and `FALSE` resolves the
-  # selection against the snapshot, which is correct however the shape reads.
-  # Asked after the name, so a pair of parentheses around the whole pronoun is
-  # already off it.
-  if (identical(call_name, "$") && is_data_pronoun_column(expr)) {
+  # The `.data` pronoun. Asked after the name, so a pair of parentheses around
+  # the whole pronoun is already off it.
+  if (call_name %in% c("$", "[[") && is_data_pronoun(expr)) {
     return(TRUE)
   }
   if (!call_name %in% c(selection_walk_operators(), "(")) {
@@ -401,17 +400,32 @@ is_name_only_expr <- function(expr, env, data_vars) {
   ))
 }
 
-# Whether this `$` call is the `.data$name` pronoun naming one column
-# literally, which is the half of the pronoun the names settle. The caller
-# holds that the call is named `$`. The operand is compared with the `.data`
-# symbol as written rather than through a redundant pair, because tidyselect
-# refuses `(.data)$region` -- reading through the pair here would answer for a
-# spelling it rejects, which is where ADR 0019's reading stops.
-is_data_pronoun_column <- function(expr) {
+# Whether this call reads the `.data` pronoun, which the caller holds is named
+# `$` or `[[`. Both halves are settled by the column names: `$` looks up the
+# symbol beside it and `[[` a constant subscript, and tidyselect refuses every
+# other spelling under the pronoun on sight -- a subscript that is not
+# constant, one that is no string, a `$` whose right side is no symbol. So the
+# subject is the pronoun rather than the two shapes of subscript, and #346's
+# premise that `.data[[var]]` costs a read is measured in
+# `investigation/what-the-data-pronoun-settles-in-a-selection.md`.
+#
+# The operand is compared with the `.data` symbol as written rather than
+# through a redundant pair: tidyselect refuses `(.data)$region`, so reading
+# through the pair here would answer for a spelling it rejects.
+is_data_pronoun <- function(expr) {
   parts <- static_call_args(expr)
-  length(parts) == 2L &&
-    identical(parts[[1L]], quote(.data)) &&
-    is_name_part(parts[[2L]])
+  length(parts) == 2L && identical(parts[[1L]], quote(.data))
+}
+
+# The lifecycle verbosity the discarded name-only pass runs under. The caller's
+# own value is kept where it makes a deprecation an error, since that error is
+# one the names decide.
+discarded_pass_verbosity <- function() {
+  verbosity <- getOption("lifecycle_verbosity")
+  if (identical(verbosity, "error")) {
+    return(verbosity)
+  }
+  "quiet"
 }
 
 is_name_only_selection <- function(arg, data_vars) {

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -189,15 +189,25 @@ prepare_grouping_plan <- function(.data,
         # the canonical pass signals again from the same names. Suppressing
         # them is what keeps this pass invisible but for the failure it exists
         # to raise; `one_of()` is where that is observable.
-        suppressWarnings(compile_grouping_spec(
-          grouping_spec,
-          data_vars = data_vars,
-          data_proxy = grouping_name_proxy(data_vars),
-          .by = if (is.null(by)) character() else by,
-          .duplicates = .duplicates,
-          duplicates_choices = duplicates_choices,
-          preflight = preflight
-        ))
+        #
+        # A deprecation warning is the one kind suppressing is not enough for,
+        # and the option is what covers it. lifecycle signals one once per
+        # session, so a pass that signals it and muffles it spends the only
+        # signal the caller had coming and the canonical pass then reports
+        # nothing -- less than the second pass reports, where every other
+        # warning here is more. `.data$region` is where that is observable.
+        rlang::with_options(
+          suppressWarnings(compile_grouping_spec(
+            grouping_spec,
+            data_vars = data_vars,
+            data_proxy = grouping_name_proxy(data_vars),
+            .by = if (is.null(by)) character() else by,
+            .duplicates = .duplicates,
+            duplicates_choices = duplicates_choices,
+            preflight = preflight
+          )),
+          lifecycle_verbosity = "quiet"
+        )
       }
       data_proxy <- grouping_selection_proxy(data, backend = backend)
       if (is.null(by)) {
@@ -334,6 +344,19 @@ is_name_only_expr <- function(expr, env, data_vars) {
     return(is.atomic(expr))
   }
 
+  # tidyselect refuses a formula in a selection on sight, in `stop_formula()`,
+  # whatever it wraps, so the refusal depends on no column type. It is read
+  # from the shape rather than joined to `selection_refused_operators()`
+  # because `is_nameable_call()` declines a call to `~`, so the name that set
+  # is consulted by is never read (ADR 0019, #163).
+  #
+  # A quosure is a call to `~` too, and is excluded: tidyselect evaluates one
+  # rather than refusing it, so what settles a quosure is the expression it
+  # carries, which this reader does not open.
+  if (rlang::is_call(expr, "~") && !rlang::is_quosure(expr)) {
+    return(TRUE)
+  }
+
   # A language object that is no call -- an expression vector, a pairlist --
   # answers `NULL` here, which the next line already turns into the `FALSE` a
   # guard would have returned.
@@ -355,6 +378,15 @@ is_name_only_expr <- function(expr, env, data_vars) {
   if (call_name %in% selection_refused_operators()) {
     return(TRUE)
   }
+  # `.data$region` is settled by the names, tidyselect's walk having a `.data`
+  # branch that looks up the name written here. `.data[[...]]` is not read:
+  # its subscript is no name this reader can see, and `FALSE` resolves the
+  # selection against the snapshot, which is correct however the shape reads.
+  # Asked after the name, so a pair of parentheses around the whole pronoun is
+  # already off it.
+  if (identical(call_name, "$") && is_data_pronoun_column(expr)) {
+    return(TRUE)
+  }
   if (!call_name %in% c(selection_walk_operators(), "(")) {
     return(FALSE)
   }
@@ -367,6 +399,19 @@ is_name_only_expr <- function(expr, env, data_vars) {
     env = env,
     data_vars = data_vars
   ))
+}
+
+# Whether this `$` call is the `.data$name` pronoun naming one column
+# literally, which is the half of the pronoun the names settle. The caller
+# holds that the call is named `$`. The operand is compared with the `.data`
+# symbol as written rather than through a redundant pair, because tidyselect
+# refuses `(.data)$region` -- reading through the pair here would answer for a
+# spelling it rejects, which is where ADR 0019's reading stops.
+is_data_pronoun_column <- function(expr) {
+  parts <- static_call_args(expr)
+  length(parts) == 2L &&
+    identical(parts[[1L]], quote(.data)) &&
+    is_name_part(parts[[2L]])
 }
 
 is_name_only_selection <- function(arg, data_vars) {

--- a/investigation/what-the-data-pronoun-settles-in-a-selection.md
+++ b/investigation/what-the-data-pronoun-settles-in-a-selection.md
@@ -1,0 +1,65 @@
+# What the `.data` pronoun settles in a tidyselect selection
+
+Investigated: 2026-08-31
+
+#346 asked for `is_name_only_expr()` to settle `.data$x` from the column names
+and drew a boundary at the pronoun's other half:
+
+> It is narrower than it looks: `.data$x` with a literal name is settled, while
+> `.data[[var]]` is not, so whatever reads this has to tell a symbol
+> right-hand side from an expression one.
+
+That premise is what this note measures. It does not hold: every spelling under
+the pronoun is settled by the names, so the reader the issue asked for would
+have declined half of its own subject.
+
+Measured against tidyselect 1.2.1, dplyr 1.2.1, R 4.6.1, through
+`tidyselect::eval_select()` on `grouping_name_proxy(c("region", "area",
+"value"))` — the list of positions marginplyr resolves a name-only selection
+against — with the subscript variable `v <- "region"` bound in the quosure's
+environment.
+
+| selection | result |
+|---|---|
+| `.data$region` | selects `region` |
+| `.data[["region"]]` | selects `region` |
+| `.data[[v]]` | error: The subscript of `.data[[subscript]]` must be a constant. |
+| `.data[[toupper(v)]]` | error: same |
+| `.data[[c("a", "b")]]` | error: same |
+| `.data[[1]]` | error: Must subset the data pronoun with a string, not the number 1 |
+| `.data[[NULL]]` | error: Must subset the data pronoun with a string, not `NULL` |
+| `` `$`(.data, "region") `` | error: The RHS of `.data$rhs` must be a symbol. |
+| `(.data)$region` | error: object '.data' not found |
+| `.data$region$sub` | error: object '.data' not found |
+
+So the subscript never reaches the data. A constant string is a name lookup; a
+subscript that is not a constant, or is no string, is refused before anything
+is walked, exactly as `*` and `^` are. Both are answers the column names
+decide, which is the question `is_name_only_expr()` asks.
+
+Two of the errors are about the pronoun's *operand* rather than its subscript,
+and they are why the reader compares that operand with the `.data` symbol as
+written rather than through a redundant pair or a second `$`.
+
+## What differs by position, and what does not
+
+`dplyr::select(d, .data[[v]])` selects `region` while
+`tidyselect::eval_select(quo(.data[[v]]), d)` raises the constant-subscript
+error, which reads like a positional difference in the pronoun. It is not one:
+`select()` wraps its arguments as `c(!!!quos)`, so what tidyselect walks is a
+`c()` call holding a *quosure*, and a quosure node is evaluated whole rather
+than walked as a `[[` node. Confirmed by writing the same shape without
+`select()`: `c(.data[[v]])` with `.data[[v]]` written as a bare call raises the
+constant-subscript error, so it is the quosure and not the `c()` that changes
+the answer.
+
+marginplyr passes each argument's own quosure to `eval_select()`, so the
+pronoun is the quosure's expression and is walked as a `[[` node. The
+`select()` reading is not reachable from there, and an injected quosure is
+answered `FALSE` by `is_name_only_expr()` for its own reason.
+
+## Where this landed
+
+`is_data_pronoun()` in `R/grouping-plan.R` takes both halves, and the header
+there is authoritative for the decision. This note is the evidence and is not
+maintained: it says what tidyselect 1.2.1 did on the date above.

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2066,6 +2066,31 @@ test_that("the name-only reader answers what the names settle", {
 
   # `where()` is the one helper that reads column data.
   expect_false(name_only(quote(where(is.numeric))))
+
+  # tidyselect refuses a formula on sight, whatever it wraps, so the operand
+  # decides nothing here either -- and a redundant pair is walked down to one.
+  expect_true(name_only(quote(~c(region))))
+  expect_true(name_only(quote(~ where(is.numeric))))
+  expect_true(name_only(quote((~c(region)))))
+  expect_true(name_only(quote(c(region, ~absent))))
+  # A quosure is a `~` call as well, and is not refused: tidyselect evaluates
+  # one, so what settles it is the expression it carries and this reader does
+  # not open one.
+  expect_false(name_only(rlang::quo(region)))
+
+  # `.data$region` is a name tidyselect's `.data` branch looks up.
+  expect_true(name_only(quote(.data$region)))
+  expect_true(name_only(quote(c(.data$region, area))))
+  expect_true(name_only(quote((.data$region))))
+  # The operand is the `.data` symbol as written: tidyselect refuses
+  # `(.data)$region`, so the pair is not read through here.
+  expect_false(name_only(quote((.data)$region)))
+  # A subscript is no name this reads, so the pronoun's other half is left to
+  # the snapshot.
+  expect_false(name_only(quote(.data[["region"]])))
+  expect_false(name_only(quote(.data$region$sub)))
+  # `$` on anything else is what it always was.
+  expect_false(name_only(quote(other$region)))
 })
 
 test_that("a selection the names settle is refused before the typed snapshot", {
@@ -2128,6 +2153,36 @@ test_that("a selection the names settle is refused before the typed snapshot", {
     pattern = "vector of column names"
   )
 
+  # A formula is refused by `stop_formula()` before anything under it is
+  # walked, so it is settled by the names for the same reason a refused
+  # operator is -- reached from the shape, the name of a `~` call being one no
+  # reader here takes (#346).
+  for (grouping in list(
+    quote(grouping_set(~c(region))),
+    quote(rollup(~c(region)))
+  )) {
+    refuse(
+      rlang::call2("inspect_grouping", quote(data), .grouping = grouping),
+      class = "rlang_error",
+      pattern = "Formula shorthand"
+    )
+  }
+
+  # The `.data` pronoun names a column, so a name it does not hold is a
+  # failure the names decide. The spelling is deprecated in a selection, and
+  # the warning saying so is what the test below counts; here it is the
+  # ordering that is under test, so it is muffled rather than counted.
+  for (grouping in list(
+    quote(grouping_set(.data$absent)),
+    quote(rollup(.data$absent))
+  )) {
+    suppressWarnings(refuse(
+      rlang::call2("inspect_grouping", quote(data), .grouping = grouping),
+      class = "rlang_error_data_pronoun_not_found",
+      pattern = "absent"
+    ))
+  }
+
   # `.by` reaches the same reader, and its keys are resolved before the read.
   refuse(
     quote(inspect_grouping(
@@ -2147,6 +2202,20 @@ test_that("a selection the names settle is refused before the typed snapshot", {
     class = "rlang_error",
     pattern = "vector of column names"
   )
+  refuse(
+    quote(inspect_grouping(data, .grouping = rollup(region), .by = ~c(area))),
+    class = "rlang_error",
+    pattern = "Formula shorthand"
+  )
+  suppressWarnings(refuse(
+    quote(inspect_grouping(
+      data,
+      .grouping = rollup(region),
+      .by = .data$absent
+    )),
+    class = "rlang_error_data_pronoun_not_found",
+    pattern = "absent"
+  ))
 
   # The other half of the rule: a selection carrying a predicate is not
   # settled by names, and still resolves against the snapshot.
@@ -2194,6 +2263,33 @@ test_that("the discarded name-only pass reports nothing the second does not", {
       data,
       .grouping = rollup(area),
       .by = tidyselect::one_of(c("region", "absent"))
+    ))),
+    1L
+  )
+
+  # A deprecation warning is the case suppressing alone gets wrong, and
+  # `.data$region` is where it is observable: lifecycle signals one once per
+  # session, so a discarded pass that signals and muffles it leaves the
+  # canonical pass with nothing to report. The option the pass sets is what
+  # keeps the count at one rather than zero. `lifecycle_verbosity` is fixed
+  # here so the count is this call's and not the session's (#346).
+  rlang::local_options(lifecycle_verbosity = "warning")
+  for (grouping in list(
+    quote(grouping_set(.data$region)),
+    quote(rollup(.data$region))
+  )) {
+    expect_identical(
+      count_warnings(
+        rlang::call2("inspect_grouping", quote(data), .grouping = grouping)
+      ),
+      1L
+    )
+  }
+  expect_identical(
+    count_warnings(quote(inspect_grouping(
+      data,
+      .grouping = rollup(area),
+      .by = .data$region
     ))),
     1L
   )

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2078,19 +2078,24 @@ test_that("the name-only reader answers what the names settle", {
   # not open one.
   expect_false(name_only(rlang::quo(region)))
 
-  # `.data$region` is a name tidyselect's `.data` branch looks up.
+  # Both halves of the `.data` pronoun: `$` looks up the symbol beside it,
+  # `[[` a constant subscript, and tidyselect refuses on sight every other
+  # spelling under it -- a subscript that is not constant, one that is no
+  # string, a `$` whose right side is no symbol.
   expect_true(name_only(quote(.data$region)))
   expect_true(name_only(quote(c(.data$region, area))))
   expect_true(name_only(quote((.data$region))))
+  expect_true(name_only(quote(.data[["region"]])))
+  expect_true(name_only(quote(.data[[var]])))
+  expect_true(name_only(rlang::call2("$", quote(.data), "region")))
   # The operand is the `.data` symbol as written: tidyselect refuses
   # `(.data)$region`, so the pair is not read through here.
   expect_false(name_only(quote((.data)$region)))
-  # A subscript is no name this reads, so the pronoun's other half is left to
-  # the snapshot.
-  expect_false(name_only(quote(.data[["region"]])))
+  # A pronoun read is one `$`, so a second one is not the pronoun.
   expect_false(name_only(quote(.data$region$sub)))
-  # `$` on anything else is what it always was.
+  # `$` and `[[` on anything else are what they always were.
   expect_false(name_only(quote(other$region)))
+  expect_false(name_only(quote(other[["region"]])))
 })
 
 test_that("a selection the names settle is refused before the typed snapshot", {
@@ -2169,12 +2174,15 @@ test_that("a selection the names settle is refused before the typed snapshot", {
   }
 
   # The `.data` pronoun names a column, so a name it does not hold is a
-  # failure the names decide. The spelling is deprecated in a selection, and
-  # the warning saying so is what the test below counts; here it is the
-  # ordering that is under test, so it is muffled rather than counted.
+  # failure the names decide -- through either half of it. The spelling is
+  # deprecated in a selection, and the warning saying so is what the test
+  # below counts; here it is the ordering that is under test, so it is muffled
+  # rather than counted.
   for (grouping in list(
     quote(grouping_set(.data$absent)),
-    quote(rollup(.data$absent))
+    quote(rollup(.data$absent)),
+    quote(grouping_set(.data[["absent"]])),
+    quote(rollup(.data[["absent"]]))
   )) {
     suppressWarnings(refuse(
       rlang::call2("inspect_grouping", quote(data), .grouping = grouping),
@@ -2267,12 +2275,10 @@ test_that("the discarded name-only pass reports nothing the second does not", {
     1L
   )
 
-  # A deprecation warning is the case suppressing alone gets wrong, and
-  # `.data$region` is where it is observable: lifecycle signals one once per
-  # session, so a discarded pass that signals and muffles it leaves the
-  # canonical pass with nothing to report. The option the pass sets is what
-  # keeps the count at one rather than zero. `lifecycle_verbosity` is fixed
-  # here so the count is this call's and not the session's (#346).
+  # `.data$region` is deprecated in a selection, so it warns from both passes
+  # where lifecycle is asked to warn every time. `lifecycle_verbosity` is
+  # fixed here because the option is otherwise the session's, and a count this
+  # test did not fix is one an earlier test decides (#346).
   rlang::local_options(lifecycle_verbosity = "warning")
   for (grouping in list(
     quote(grouping_set(.data$region)),
@@ -2293,6 +2299,79 @@ test_that("the discarded name-only pass reports nothing the second does not", {
     ))),
     1L
   )
+})
+
+test_that("the discarded pass withholds a deprecation, not muffles it", {
+  # The count above cannot see what this asserts. lifecycle signals a
+  # deprecation once per session, so the pass that muffles what it signals
+  # spends the caller's only signal and the canonical pass then reports
+  # nothing -- and pinning `lifecycle_verbosity` to make a count repeatable is
+  # exactly the mode where that spend cannot happen. What the two passes run
+  # under is the observable that holds either way (#346).
+  data <- data.frame(region = "East", area = "North", value = 1)
+  compile <- compile_grouping_spec
+  seen <- character()
+  local_mocked_bindings(
+    compile_grouping_spec = function(...) {
+      verbosity <- getOption("lifecycle_verbosity")
+      seen <<- c(seen, if (is.null(verbosity)) NA_character_ else verbosity)
+      compile(...)
+    }
+  )
+
+  # Two passes run for a plan the names settle, and only the discarded one is
+  # withheld: the canonical pass runs under whatever the caller set.
+  rlang::local_options(lifecycle_verbosity = NULL)
+  inspect_grouping(data, .grouping = rollup(region))
+  expect_identical(seen, c("quiet", NA_character_))
+
+  seen <- character()
+  rlang::local_options(lifecycle_verbosity = "warning")
+  inspect_grouping(data, .grouping = rollup(region))
+  expect_identical(seen, c("quiet", "warning"))
+
+  # `"error"` is the caller's own, kept through the discarded pass, because
+  # under it the deprecation is a failure the names decide and withholding it
+  # would send the read first (ADR 0005).
+  seen <- character()
+  rlang::local_options(lifecycle_verbosity = "error")
+  inspect_grouping(data, .grouping = rollup(region))
+  expect_identical(seen, c("error", "error"))
+})
+
+test_that("a deprecation that is an error precedes the read", {
+  # The other half of the rule above, counted where every ordering in this
+  # file is: `.data$region` under `lifecycle_verbosity = "error"` fails on the
+  # deprecation, and that failure the names decide is raised before the
+  # snapshot (#346).
+  data <- data.frame(region = "East", area = "North", value = 1)
+  reads <- 0L
+  local_mocked_bindings(
+    grouping_selection_proxy = function(.data, ...) {
+      reads <<- reads + 1L
+      .data
+    }
+  )
+  rlang::local_options(lifecycle_verbosity = "error")
+  for (grouping in list(
+    quote(grouping_set(.data$region)),
+    quote(rollup(.data$region))
+  )) {
+    reads <- 0L
+    expect_error(
+      rlang::eval_tidy(
+        rlang::call2("inspect_grouping", quote(data), .grouping = grouping)
+      ),
+      class = "lifecycle_error_deprecated"
+    )
+    expect_identical(reads, 0L)
+  }
+  reads <- 0L
+  expect_error(
+    inspect_grouping(data, .grouping = rollup(area), .by = .data$region),
+    class = "lifecycle_error_deprecated"
+  )
+  expect_identical(reads, 0L)
 })
 
 test_that("duplicate grouping sets have explicit policies", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -900,18 +900,30 @@ test_that("every analysis that names a call reads a formula as a `~` call", {
   )
 
   # A formula names no output columns, is no share helper call, no `across()`
-  # call, no name-only selection, and no grouping helper -- whatever sits on
-  # its right-hand side. Each of these answered for that right-hand side.
+  # call, and no grouping helper -- whatever sits on its right-hand side. Each
+  # of these answered for that right-hand side.
   expect_identical(
     known_data_frame_output_names(quote(~ dplyr::pick(value)), env, proxy),
     character()
   )
   expect_null(share_helper_call_kind(quote(~ share_of_total(units))))
   expect_false(is_across_call(quote(~ dplyr::across(value, mean))))
-  expect_false(
+  expect_null(grouping_helper_name(quote(~ grouping_id(region))))
+
+  # `is_name_only_expr()` answers a formula too, and its answer is the
+  # formula's rather than its right-hand side's: tidyselect refuses one on
+  # sight, so both of these are settled by the names while the right-hand
+  # sides answer `TRUE` and `FALSE` (#346).
+  expect_true(
     is_name_only_expr(quote(~c(region)), env = env, data_vars = "region")
   )
-  expect_null(grouping_helper_name(quote(~ grouping_id(region))))
+  expect_true(
+    is_name_only_expr(
+      quote(~ where(is.numeric)),
+      env = env,
+      data_vars = "region"
+    )
+  )
 
   # The predicate search still finds `where()`, from the parts rather than
   # from a misread name, and answers a bare-symbol right-hand side instead of


### PR DESCRIPTION
Closes #346.

`is_name_only_expr()` answers whether tidyselect settles an expression from the
column names alone, so a failure the names decide is raised before typed
metadata is acquired (ADR 0005). #342 closed three shapes; this closes the two
it could not reach.

## A formula

tidyselect refuses one in a selection on sight, in `stop_formula()`, whatever
it wraps, so the refusal depends on no column type. `"~"` cannot join
`selection_refused_operators()`: `is_nameable_call()` declines a call to `~`
(ADR 0019, #163), so the name that set is consulted by is never read. The
shape is read directly, before the name is taken. A quosure is a `~` call too
and is excluded — tidyselect evaluates one rather than refusing it.

## `.data$name`

Settled by the names: tidyselect's walk has a `.data` branch that looks up the
name written in the call. The reader takes the `$` call whose left operand is
the `.data` symbol *as written* — tidyselect refuses `(.data)$region`, so the
pair is not read through there — and whose right operand is a symbol.
`.data[[...]]` is not read, and `FALSE` for it resolves against the snapshot.

## The warning that had to be kept

`.data$x` is deprecated in a selection and lifecycle signals that once per
session. The discarded name-only pass muffles what it signals, so settling
`.data$region` made the pass spend the caller's only signal and the canonical
pass report nothing — less than the second pass reports, where the pass's rule
had only ever been that it reports no *more*. `lifecycle_verbosity = "quiet"`
over the discarded pass fixes the signalling rather than the display; every
other warning is still suppressed.

## Read counts

| call | before | after |
|---|---|---|
| `grouping_set(~c(region))` | 1 | 0 |
| `rollup(~c(region))` | 1 | 0 |
| `.by = ~c(region)` | 1 | 0 |
| `grouping_set(.data$absent)` | 1 | 0 |
| `rollup(.data$absent)` | 1 | 0 |
| `.by = .data$absent` | 1 | 0 |
| `rollup(everything() / where(is.numeric))` | 1 | 1 |
| `grouping_set(.data[["absent"]])` | 1 | 1 |

Local: full `testthat` suite green with `NOT_CRAN=true`, `lintr::lint_package()`
clean.