### PR TITLE
Terminate the readers that restart on a pair holding the empty argument

### DIFF
--- a/R/contextual-helpers.R
+++ b/R/contextual-helpers.R
@@ -214,8 +214,14 @@ is_any_static_spelling_call <- function(expr, families) {
 # may have left empty -- an `across()` written `across(units, )` reaches here
 # with R's missing marker, and assigning that to a local raises
 # `missingArgError` on the next read of it (#174).
+#
+# What stops the recursion is the guard rather than the branches below it, so
+# the guard is `is_parenthesized()`: the same argument may be a pair wrapping
+# the empty one, `unparenthesized_value()` stops at such a pair rather than
+# unwrapping to it, and under `is_redundant_parens()` this restarted on the
+# node it was called with (#349).
 static_spelling_reference_name <- function(expr, family) {
-  if (is_redundant_parens(expr)) {
+  if (is_parenthesized(expr)) {
     return(static_spelling_reference_name(
       unparenthesized_value(expr),
       family

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -556,10 +556,18 @@ rewrite_across_selection <- function(expr,
   if (identical(call_name, "across")) {
     parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
     if (!is.null(parsed$names)) {
-      call_args[[parsed$names_index]] <- rlang::eval_tidy(
-        parsed$names,
-        env = env
+      # A template that does not evaluate is left as the caller wrote it, so
+      # dplyr raises the condition their own argument produces rather than this
+      # frame raising it first (ADR 0015). The two reads of `.names` and
+      # `.unpack` above answer a failure the same way, with the value they use
+      # when the argument is absent; here the value is the argument itself.
+      template <- tryCatch(
+        list(rlang::eval_tidy(parsed$names, env = env)),
+        error = function(cnd) NULL
       )
+      if (!is.null(template)) {
+        call_args[[parsed$names_index]] <- template[[1L]]
+      }
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1113,7 +1113,13 @@ static_character_value <- function(expr) {
   # one are read through as they are everywhere else: `get(("share"))` names
   # what `get("share")` names. Read by recursion rather than by rebinding
   # `expr`, which is an argument a `c()` above may have left empty (#174).
-  if (is_redundant_parens(expr)) {
+  #
+  # `is_parenthesized()` and not `is_redundant_parens()`, because that argument
+  # may also be a pair wrapping the empty one. `unparenthesized_value()` stops
+  # at such a pair rather than unwrapping to it, so the weaker test restarted
+  # this reader on the node it was called with, and `get(())` exhausted the
+  # evaluation stack before dplyr saw the call (#349).
+  if (is_parenthesized(expr)) {
     return(static_character_value(unparenthesized_value(expr)))
   }
   if (is.character(expr)) {

--- a/tests/testthat/helper-namespace-walk.R
+++ b/tests/testthat/helper-namespace-walk.R
@@ -19,7 +19,8 @@
 # - `test-query-policy.R`, ADR 0020's rule about which functions reach an
 #   execution entry point, and the capability table read out of the source;
 # - `test-utils.R`, that no walk over a call's arguments binds one to a name,
-#   in either the `for` spelling or the `<-` spelling;
+#   in either the `for` spelling or the `<-` spelling, and that no reader
+#   restarts on a pair of parentheses it cannot shrink;
 # - `helper-diagnostic-sites.R`, for the two diagnostics gates it serves.
 #
 # That list is a courtesy and not the record: `test-namespace-walk.R` derives

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2653,11 +2653,27 @@ test_that("a pair holding nothing in an expression evaluates as dplyr does", {
   # A bare call argument and an `across()` `.fns` reach the reference-name read
   # the share walk takes; `get()` reaches the reader of a statically known
   # string, with no share helper and no `across()` anywhere in the expression.
-  # Each of these is sent to dplyr as the caller wrote it, so dplyr's answer is
-  # the whole answer.
+  # `.names` and `.unpack` are read by evaluating them, which is a third way to
+  # reach the pair and the one that raises before any walk sees it. Each of
+  # these is sent to dplyr as the caller wrote it, so dplyr's answer is the
+  # whole answer.
   expressions <- list(
     bare = rlang::call2("sum", empty),
     fns = rlang::call2("across", quote(value), empty, .ns = "dplyr"),
+    names = rlang::call2(
+      "across",
+      quote(value),
+      quote(sum),
+      .names = empty,
+      .ns = "dplyr"
+    ),
+    unpack = rlang::call2(
+      "across",
+      quote(value),
+      quote(sum),
+      .unpack = empty,
+      .ns = "dplyr"
+    ),
     named = rlang::call2("get", empty),
     nested = rlang::call2("sum", rlang::call2("get", empty))
   )

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2633,6 +2633,92 @@ test_that("a pair of parentheses holding nothing is the empty argument", {
   )
 })
 
+test_that("a pair holding nothing in an expression evaluates as dplyr does", {
+  # The pair the test above refuses as a whole argument, one level in: `z = ()`
+  # is a summary argument the verb answers for itself (#340), while `z =
+  # sum(())` is an expression the caller wrote and dplyr evaluates. The readers
+  # that see through a pair before it is sent restart on what it wraps, and
+  # `unparenthesized_value()` stops at a pair holding nothing rather than
+  # unwrapping to it -- so a reader restarting under `is_redundant_parens()`
+  # re-entered on the node it was called with and never terminated, and the
+  # caller was answered with a stack overflow catchable by no class they would
+  # write (#349). `test-utils.R` holds the gate over the readers; these are the
+  # positions a caller reaches them from.
+  #
+  # dplyr is the oracle, as it is for an omitted argument above.
+  data <- data.frame(region = c("East", "East", "West"), value = c(1, 3, 6))
+  parens <- function(expr) as.call(list(as.name("("), expr))
+  empty <- parens(rlang::missing_arg())
+
+  # A bare call argument and an `across()` `.fns` reach the reference-name read
+  # the share walk takes; `get()` reaches the reader of a statically known
+  # string, with no share helper and no `across()` anywhere in the expression.
+  # Each of these is sent to dplyr as the caller wrote it, so dplyr's answer is
+  # the whole answer.
+  expressions <- list(
+    bare = rlang::call2("sum", empty),
+    fns = rlang::call2("across", quote(value), empty, .ns = "dplyr"),
+    named = rlang::call2("get", empty),
+    nested = rlang::call2("sum", rlang::call2("get", empty))
+  )
+
+  for (index in seq_along(expressions)) {
+    expression <- expressions[[index]]
+    baseline <- expect_error(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(z = !!expression, .groups = "drop")
+    )
+    error <- expect_error(
+      summarize_with_margins(
+        data,
+        z = !!expression,
+        .grouping = rollup(region)
+      )
+    )
+    expect_identical(class(error), class(baseline))
+    expect_identical(conditionMessage(error), conditionMessage(baseline))
+  }
+
+  # An `across()` selection is the one position dplyr is not the whole oracle
+  # for, and the pair inherits that rather than introducing it: a Margin verb
+  # resolves the selection itself, before the call is sent, so a selection that
+  # cannot be resolved is answered by the condition the selection produces and
+  # not by the one dplyr wraps around it. `across(nope, sum)` answers vctrs's
+  # subscript condition here and an `rlang_error` under dplyr, and has since
+  # the rewrite existed. What the pair owes is the cause, which is what dplyr
+  # reports underneath its own wrapper.
+  selection <- rlang::call2("across", empty, quote(sum), .ns = "dplyr")
+  baseline <- expect_error(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(z = !!selection, .groups = "drop")
+  )
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      z = !!selection,
+      .grouping = rollup(region)
+    )
+  )
+  expect_false(inherits(error, "stackOverflowError"))
+  expect_match(
+    conditionMessage(baseline),
+    conditionMessage(error),
+    fixed = TRUE
+  )
+
+  # And the refusal is the point: read as an omitted selection the pair would
+  # select every column and return a result, which is the answer dplyr does not
+  # give. `parse_across_arguments()` reports it supplied because it is -- a
+  # caller wrote a node there -- and the resolution below is what refuses it.
+  expect_identical(
+    parse_across_arguments(selection)$cols,
+    empty,
+    ignore_attr = TRUE
+  )
+})
+
 test_that("`parse_across_arguments()` answers an empty argument as omitted", {
   # The seam every `across()` path reads, and the one place that has to know
   # about the empty argument: each field below answers what it answers for an

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -414,6 +414,145 @@ test_that("the assignment scan detects the shape it is written to forbid", {
   expect_false(binds_call_parts_by_assign(quote(sum(value[]))))
 })
 
+# The third gate over the same namespace, and the one that reads a reader
+# rather than a walk over a call's parts. A pair of parentheses is read through
+# by restarting on what it wraps, and `unparenthesized_value()` stops at a pair
+# holding R's empty argument rather than unwrapping to it -- so a restart
+# guarded by `is_redundant_parens()` re-enters on the node it was called with
+# and never terminates. `is_parenthesized()` is the guard that cannot: it asks
+# whether unwrapping answers a different node, which is `FALSE` for exactly the
+# pair the peeler stops at.
+#
+# Scanned rather than listed, for the reason the gates above are. Two readers
+# were written under the weaker guard and both recursed without bound, one
+# reached from a share expression and one from a summary holding no share
+# helper at all (#349) -- so a list would be a list the third reader is not on.
+#
+# What it matches is the combination and not either half. Both readers in the
+# pair vocabulary -- `unparenthesized_call()` and `unparenthesized_name()` --
+# test `is_redundant_parens()` and read the peeler beside it, and both are
+# correct, because what they do with the answer is bind it and return: no
+# re-entry, so no node to shrink. Handing it to another call is the re-entry,
+# and `captured_call_parts()` tests the pair without reading the peeler at all.
+reads_unparenthesized_value <- function(node, index) {
+  part <- node[[index]]
+  is.call(part) && identical(part[[1L]], quote(unparenthesized_value))
+}
+
+# Whether a body hands what the peeler answers straight to another call, which
+# is the shape of a reader restarting on the unwrapped node. An assignment is
+# not one: `spelled <- unparenthesized_value(expr)` is the binding both readers
+# in the pair vocabulary make, and what follows it re-enters nothing.
+hands_on_unparenthesized_value <- function(expr) {
+  found <- FALSE
+  visit_calls(expr, function(node) {
+    head <- node[[1L]]
+    passes_on <- !identical(head, quote(unparenthesized_value)) &&
+      !identical(head, quote(`<-`)) &&
+      !identical(head, quote(`=`))
+    if (!passes_on) {
+      return(invisible(NULL))
+    }
+    # By subscript, since a scanned body may hold an empty argument of its own.
+    for (index in seq_along(node)[-1L]) {
+      if (reads_unparenthesized_value(node, index)) {
+        found <<- TRUE
+      }
+    }
+  })
+  found
+}
+
+tests_redundant_parens <- function(expr) {
+  found <- FALSE
+  visit_calls(expr, function(node) {
+    if (identical(node[[1L]], quote(is_redundant_parens))) {
+      found <<- TRUE
+    }
+  })
+  found
+}
+
+restarts_on_an_unshrunk_pair <- function(expr) {
+  tests_redundant_parens(expr) && hands_on_unparenthesized_value(expr)
+}
+
+test_that("no reader restarts on a pair of parentheses it cannot shrink", {
+  ns <- asNamespace("marginplyr")
+  functions <- namespace_functions(ns)
+  # The scan iterates over this set, so a set that arrived empty is a set that
+  # passes.
+  expect_true("unparenthesized_value" %in% functions)
+
+  expect_equal(
+    walks_matching(restarts_on_an_unshrunk_pair, functions, ns),
+    character(),
+    info = paste(
+      "Guard the restart with `is_parenthesized()` instead --",
+      "it answers `FALSE` for the pair `unparenthesized_value()` stops at,",
+      "so the reader cannot re-enter on the node it was called with."
+    )
+  )
+})
+
+test_that("the restart scan detects the shape it is written to forbid", {
+  # Asserted before the scan's verdict means anything, for the reason the two
+  # gates above assert their own: a scan that stopped matching reports exactly
+  # what a clean package reports.
+  offending <- function(expr) {
+    if (is_redundant_parens(expr)) {
+      return(offending(unparenthesized_value(expr)))
+    }
+    expr
+  }
+  # The same restart one call deeper, and one written as a plain statement
+  # rather than a `return()`: neither is a shape a reader may be written in.
+  nested <- function(expr) {
+    if (TRUE) {
+      lapply(seq_len(2L), function(i) {
+        if (is_redundant_parens(expr)) {
+          nested(unparenthesized_value(expr))
+        }
+      })
+    }
+  }
+  # Correct, and the two shapes the gate must not name: the pair vocabulary's
+  # own readers, which bind the peeler's answer and return without re-entering,
+  # and a reader that restarts under the guard that answers `FALSE` for the
+  # pair the peeler stops at.
+  compliant_binding <- function(expr) {
+    if (!is_redundant_parens(expr)) {
+      return(expr)
+    }
+    spelled <- unparenthesized_value(expr)
+    if (is_nameable_call(spelled)) {
+      return(spelled)
+    }
+    expr
+  }
+  compliant_restart <- function(expr) {
+    if (is_parenthesized(expr)) {
+      return(compliant_restart(unparenthesized_value(expr)))
+    }
+    expr
+  }
+  compliant_test <- function(expr) {
+    if (is_redundant_parens(expr)) {
+      return(NULL)
+    }
+    expr
+  }
+
+  expect_true(restarts_on_an_unshrunk_pair(body(offending)))
+  expect_true(restarts_on_an_unshrunk_pair(body(nested)))
+  expect_false(restarts_on_an_unshrunk_pair(body(compliant_binding)))
+  expect_false(restarts_on_an_unshrunk_pair(body(compliant_restart)))
+  expect_false(restarts_on_an_unshrunk_pair(body(compliant_test)))
+  # An empty argument in the scanned code must not abort the scan, which is the
+  # bug the gates in this file exist for.
+  expect_false(restarts_on_an_unshrunk_pair(quote(sum(value[]))))
+})
+
 test_that("every shared reader answers an empty call part", {
   # The scans above forbid binding a call part to a local; this is the same
   # rule read from the other end, at the readers a walk hands one to. An empty

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -168,19 +168,20 @@ is_call_arguments <- function(expr, locals) {
     (is.symbol(expr) && as.character(expr) %in% locals)
 }
 
-# The scan both gates below are, once the predicate is taken out of it: of the
-# functions a namespace binds, the names of those whose body the predicate
-# matches. Every predicate handed to it here matches a walk, which is what the
-# name says; what it returns is a set of names, named rather than counted so a
-# failure says which walk to rewrite.
+# The scan all three gates below are, once the predicate is taken out of it: of
+# the functions a namespace binds, the names of those whose body the predicate
+# matches. Every predicate handed to it here matches a walk over an expression,
+# which is what the name says; what it returns is a set of names, named rather
+# than counted so a failure says which walk to rewrite.
 #
 # The predicate is the only thing it takes for itself. The two it deliberately
 # does not take are the witness and the message: each gate's witness names what
 # that gate reads -- `static_call_args` for the `for` scan,
-# `parse_across_arguments` for the `<-` scan -- and each remedy is written for
-# its own spelling, so an argument for either would exist only to be different,
-# and would make the two look interchangeable. They stay in the `test_that()`
-# block that means them.
+# `parse_across_arguments` for the `<-` scan, `unparenthesized_value` for the
+# restart scan -- and each remedy is written for its own spelling, so an
+# argument for either would exist only to be different, and would make the
+# three look interchangeable. They stay in the `test_that()` block that means
+# them.
 #
 # The enumeration and the namespace come from the caller rather than from
 # defaults here. A gate then asserts its witness against the very set this
@@ -190,10 +191,10 @@ is_call_arguments <- function(expr, locals) {
 #
 # Local to this source rather than in `helper-namespace-walk.R`: that file
 # exists because testthat gives each test file its own environment, so one
-# file's gate cannot see a reader another defined, and both gates here are in
-# one file. The other scan of this shape, in `test-grouping-plan.R`, decides by
-# deparsing rather than by walking and says so where it stands, so a shared home
-# would be a home for one caller.
+# file's gate cannot see a reader another defined, and all three gates here are
+# in one file. The other scan of this shape, in `test-grouping-plan.R`, decides
+# by deparsing rather than by walking and says so where it stands, so a shared
+# home would be a home for one caller.
 walks_matching <- function(predicate, functions, ns) {
   matched <- vapply(
     functions,
@@ -414,14 +415,13 @@ test_that("the assignment scan detects the shape it is written to forbid", {
   expect_false(binds_call_parts_by_assign(quote(sum(value[]))))
 })
 
-# The third gate over the same namespace, and the one that reads a reader
-# rather than a walk over a call's parts. A pair of parentheses is read through
-# by restarting on what it wraps, and `unparenthesized_value()` stops at a pair
-# holding R's empty argument rather than unwrapping to it -- so a restart
-# guarded by `is_redundant_parens()` re-enters on the node it was called with
-# and never terminates. `is_parenthesized()` is the guard that cannot: it asks
-# whether unwrapping answers a different node, which is `FALSE` for exactly the
-# pair the peeler stops at.
+# The third gate over the same namespace, and the one whose subject is a walk
+# over an expression rather than over a call's parts. A pair of parentheses is
+# read through by restarting on what it wraps, and `unparenthesized_value()`
+# stops at a pair holding R's empty argument rather than unwrapping to it -- so
+# a restart guarded by `is_redundant_parens()` re-enters on the node it was
+# called with and never terminates. `is_parenthesized()` is the guard that
+# cannot, for the reason its own header gives.
 #
 # Scanned rather than listed, for the reason the gates above are. Two readers
 # were written under the weaker guard and both recursed without bound, one
@@ -434,47 +434,49 @@ test_that("the assignment scan detects the shape it is written to forbid", {
 # correct, because what they do with the answer is bind it and return: no
 # re-entry, so no node to shrink. Handing it to another call is the re-entry,
 # and `captured_call_parts()` tests the pair without reading the peeler at all.
-reads_unparenthesized_value <- function(node, index) {
-  part <- node[[index]]
-  is.call(part) && identical(part[[1L]], quote(unparenthesized_value))
-}
-
-# Whether a body hands what the peeler answers straight to another call, which
-# is the shape of a reader restarting on the unwrapped node. An assignment is
-# not one: `spelled <- unparenthesized_value(expr)` is the binding both readers
-# in the pair vocabulary make, and what follows it re-enters nothing.
-hands_on_unparenthesized_value <- function(expr) {
-  found <- FALSE
+#
+# The two halves are found in one pass rather than in a pass each, so the
+# combination is read off one traversal of the body.
+#
+# By subscript throughout, since a scanned body holds exactly the code that may
+# carry an empty argument -- and a `switch()` fallthrough branch in one is the
+# shape that carries it here.
+restarts_on_an_unshrunk_pair <- function(expr) {
+  tests_pair <- FALSE
+  hands_on_value <- FALSE
   visit_calls(expr, function(node) {
-    head <- node[[1L]]
-    passes_on <- !identical(head, quote(unparenthesized_value)) &&
-      !identical(head, quote(`<-`)) &&
-      !identical(head, quote(`=`))
-    if (!passes_on) {
+    # The written-out spelling beside the named one, since a guard is a guard
+    # however it is spelled and the hazard is what it answers. `R/` holds only
+    # the named spelling today, which is what makes the other one worth
+    # matching: a reader written tomorrow reaches for whichever it remembers.
+    if (
+      identical(node[[1L]], quote(is_redundant_parens)) ||
+        identical(node[[1L]], quote(rlang::is_call)) &&
+          length(node) >= 3L && identical(node[[3L]], "(")
+    ) {
+      tests_pair <<- TRUE
+    }
+    # An assignment is not a re-entry: `spelled <- unparenthesized_value(expr)`
+    # is the binding both readers in the pair vocabulary make, and what follows
+    # it re-enters nothing. Nor is the peeler's own nesting, `unparenthesized_
+    # value(unparenthesized_value(x))`, which shrinks whatever it can shrink.
+    if (
+      identical(node[[1L]], quote(unparenthesized_value)) ||
+        identical(node[[1L]], quote(`<-`)) ||
+        identical(node[[1L]], quote(`=`))
+    ) {
       return(invisible(NULL))
     }
-    # By subscript, since a scanned body may hold an empty argument of its own.
     for (index in seq_along(node)[-1L]) {
-      if (reads_unparenthesized_value(node, index)) {
-        found <<- TRUE
+      if (
+        is.call(node[[index]]) &&
+          identical(node[[index]][[1L]], quote(unparenthesized_value))
+      ) {
+        hands_on_value <<- TRUE
       }
     }
   })
-  found
-}
-
-tests_redundant_parens <- function(expr) {
-  found <- FALSE
-  visit_calls(expr, function(node) {
-    if (identical(node[[1L]], quote(is_redundant_parens))) {
-      found <<- TRUE
-    }
-  })
-  found
-}
-
-restarts_on_an_unshrunk_pair <- function(expr) {
-  tests_redundant_parens(expr) && hands_on_unparenthesized_value(expr)
+  tests_pair && hands_on_value
 }
 
 test_that("no reader restarts on a pair of parentheses it cannot shrink", {
@@ -543,8 +545,17 @@ test_that("the restart scan detects the shape it is written to forbid", {
     expr
   }
 
+  # And the guard written out rather than named, which is the same guard.
+  inline <- function(expr) {
+    if (rlang::is_call(expr, "(") && length(expr) == 2L) {
+      return(inline(unparenthesized_value(expr)))
+    }
+    expr
+  }
+
   expect_true(restarts_on_an_unshrunk_pair(body(offending)))
   expect_true(restarts_on_an_unshrunk_pair(body(nested)))
+  expect_true(restarts_on_an_unshrunk_pair(body(inline)))
   expect_false(restarts_on_an_unshrunk_pair(body(compliant_binding)))
   expect_false(restarts_on_an_unshrunk_pair(body(compliant_restart)))
   expect_false(restarts_on_an_unshrunk_pair(body(compliant_test)))
@@ -575,6 +586,43 @@ test_that("every shared reader answers an empty call part", {
   expect_null(static_callee_name(parts[[2L]]))
   expect_false(is_parenthesized(parts[[2L]]))
   expect_identical(expression_data_symbols(parts[[2L]]), character())
+})
+
+test_that("every shared reader answers a pair holding an empty call part", {
+  # The positive half of the gate above, and what establishes termination for
+  # each reader rather than for the one #349 found: the gate refuses the shape
+  # a non-terminating restart has, and this calls every reader that reads
+  # through a pair with the node a restart cannot shrink. A reader that
+  # recursed on it would exhaust the evaluation stack here rather than answer.
+  #
+  # The parser rejects `f(())`, so the pair is constructed. Read by subscript
+  # for the reason the readers themselves are.
+  pair <- as.call(list(as.name("("), rlang::missing_arg()))
+
+  # The pair vocabulary answers what the pair is, which is what every reader
+  # below acts on: not something unwrapping shrinks, and a pair wrapping
+  # nothing to read.
+  expect_false(is_parenthesized(pair))
+  expect_true(wraps_empty_argument(pair))
+  expect_identical(unparenthesized_value(pair), pair)
+  expect_identical(unparenthesized_call(pair), pair)
+  expect_identical(unparenthesized_name(pair), pair)
+
+  # The readers that restart on what a pair wraps, and the two spelling reads
+  # that unwrap before their shape test. Each answers the pair as it answers
+  # any other node it does not recognize.
+  expect_identical(static_call_name(pair), "(")
+  expect_null(static_call_ns(pair))
+  expect_null(static_spelling_name(pair, "selection"))
+  expect_null(static_spelling_reference_name(pair, "share"))
+  expect_null(static_character_value(pair))
+  expect_null(static_callee_name(pair))
+  expect_null(share_expression_kind(pair))
+  expect_identical(expression_data_symbols(pair), character())
+  expect_identical(
+    statement_reads_and_bound(pair, character()),
+    list(reads = character(), bound = character())
+  )
 })
 
 test_that("lazy-table assertions use the package condition seam", {


### PR DESCRIPTION
Closes #349.

## What was wrong

`unparenthesized_value()` stops at a pair of parentheses wrapping R's empty argument rather than unwrapping to it — a documented contract, since a pair holding nothing wraps no value to read and unwrapping would put R's missing marker where a local could bind it. It therefore answers the node it was given.

Two readers restarted on that answer under an `is_redundant_parens()` guard, which is true again on re-entry:

- `static_spelling_reference_name()`, reached from the share walk;
- `static_character_value()`, reached from the walk over a statically known string — **with no share helper and no `across()` anywhere in the expression**, so `z = get(())` reached it too. The issue named one reader; the branch found the second.

Both recursed without bound. The caller was answered with an `expressionStackOverflowError`, which is catchable by no class they would write and names nothing they wrote, where dplyr answers `argument 1 is empty`.

Only an injection or a constructed call spells the pair, since the parser rejects `f(())`.

A third position had a different cause and the same symptom. `across(value, sum, .names = ())` terminated once the guards were fixed and then raised a bare `simpleError` from marginplyr's own frame: the read of `.names` in the selection rewrite was the one of three `eval_tidy()` calls with no fallback, so the template was evaluated here instead of by dplyr. Found by the review of the first commit, not by the issue.

## The fix

Both readers guard with `is_parenthesized()` — "whether unwrapping answers a different node, which is what a reader that restarts on what the parentheses wrap has to know before it restarts". It is `FALSE` for exactly the pair the peeler stops at, so the restart cannot repeat. This is the guard the three readers that already restart correctly use, and `grouping_arg_spec()`'s comment cites the rule *while naming `static_spelling_reference_name()` as following it* — which it did not.

An unevaluable `.names` template keeps the argument the caller wrote, as the reads of `.names` and `.unpack` beside it keep the value they use for an absent argument, so the caller sees the condition their own argument produces (ADR 0015).

## What holds the rule

Two halves, because they establish different things.

A **structural gate** in `tests/testthat/test-utils.R` refuses the shape: a body that tests for a pair — named as `is_redundant_parens()` or written out — and hands the peeler's answer to another call, which is the re-entry. It names both readers before the fix and neither after. Scanned rather than listed, for the reason the two gates beside it are: two readers were already written this way, so a list would be a list the third is not on.

A **companion test** calls every reader that reads through a pair with the node a restart cannot shrink. That is where one that recursed would exhaust the stack rather than answer, and it is what establishes termination for the readers already here rather than only for a reader written tomorrow.

What neither can see is a restart on a peeler other than `unparenthesized_value()`: `unparenthesized_name()` answers its input for a pair wrapping anything but a name, so a restart on it under `is_parenthesized()` would not terminate. No reader is written that way, and the companion test is what says so for each reader that exists.

## Where dplyr is the oracle, and where it is not

Six of the seven positions answer with dplyr's own condition, class and message identical:

| expression | before | after |
|---|---|---|
| `sum(())` | `expressionStackOverflowError` | dplyr's `rlang_error`, identical |
| `dplyr::across(value, ())` — `.fns` | `expressionStackOverflowError` | dplyr's `rlang_error`, identical |
| `dplyr::across(value, sum, .names = ())` | `expressionStackOverflowError` | dplyr's `rlang_error`, identical |
| `dplyr::across(value, sum, .unpack = ())` | `expressionStackOverflowError` | dplyr's `rlang_error`, identical |
| `get(())` | `expressionStackOverflowError` | dplyr's `rlang_error`, identical |
| `sum(get(()))` | `expressionStackOverflowError` | dplyr's `rlang_error`, identical |
| `dplyr::across((), sum)` — `.cols` | `expressionStackOverflowError` | the cause dplyr reports, unwrapped |

**The `across()` *selection* is the one position dplyr is not the whole oracle for, and it is a deviation from the issue's first acceptance criterion that this branch is not the right place to close.** A Margin verb resolves a selection itself before the call is sent, so a selection that cannot be resolved is answered by the condition the selection produces and not by the one dplyr wraps around it. That is not specific to the empty pair — no selection error matches dplyr's class here:

| selection | dplyr | marginplyr, on this branch and before it |
|---|---|---|
| `across(nope, sum)` | `rlang_error` | `vctrs_error_subscript_oob` |
| `across(1:99, sum)` | `rlang_error` | `vctrs_error_subscript_oob` |
| `across((), sum)` | `rlang_error` | `simpleError` from tidyselect's `env_has()` |

The three differ from each other as well as from dplyr, because each is whatever tidyselect raises for that selection. Meeting the criterion literally would mean changing how every selection error in the package is reported, which is a contract change and not a termination fix.

The test holds the pair to what its neighbours are held to: it terminates, and it carries the cause dplyr reports underneath its own wrapper. It also asserts the pair is **not** read as an omitted selection — read as omitted it would have selected every column and returned a result where dplyr raises, which is the failure the issue's fourth criterion is about.

## Checks

`lintr::lint_package()` clean; full suite green with no failures and no skips; `verify-context-budget.R` and `verify-verifier-invocation.R` pass. No roxygen touched, so `man/` is unchanged.