### PR TITLE
Answer an injected `across()` selection and `.names` (#350)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -197,10 +197,17 @@
   selection was read as the formula shorthand for a predicate. Forwarding an
   argument your caller omitted is one value of the same spelling, and it now
   selects no columns, which is what dplyr selects for it; a selection you write
-  empty yourself still means every eligible column, as it did. An omitted
-  `.names` template forwarded the same way reaches dplyr, which names the
-  argument you wrote, in place of R's `object '' not found` naming nothing
-  (#350).
+  empty yourself still means every eligible column, as it did. dplyr reads a
+  nested `across()` — one inside another expression rather than standing as the
+  summary — differently, taking its deprecated `everything()` default for a
+  forwarded omission; marginplyr resolves the selection wherever it is written,
+  so the reading above is the one you get at both positions. A share's
+  `across()` reads its selection the same way, so a forwarded name that is not
+  an eligible preceding summary is now refused by that name rather than
+  reported as an unusable selection. An `across()` `.names` template that
+  cannot be evaluated — forwarded empty, or naming something absent — reaches
+  dplyr, which names the argument you wrote, in place of R's bare
+  `object '' not found` naming nothing (#350).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/NEWS.md
+++ b/NEWS.md
@@ -190,6 +190,17 @@
   Redundant parentheses are transparent at all three positions, as they are
   elsewhere: an injected pair wrapping nothing is the empty argument it wraps
   (#340).
+* A selection a wrapper forwards into `across()` is now the selection dplyr
+  makes of it. `across({{ cols }}, sum)` — the ordinary way to pass on a
+  selection your own caller wrote — was refused by tidyselect, which advised
+  wrapping it in `where()`, whatever columns it named, because the forwarded
+  selection was read as the formula shorthand for a predicate. Forwarding an
+  argument your caller omitted is one value of the same spelling, and it now
+  selects no columns, which is what dplyr selects for it; a selection you write
+  empty yourself still means every eligible column, as it did. An omitted
+  `.names` template forwarded the same way reaches dplyr, which names the
+  argument you wrote, in place of R's `object '' not found` naming nothing
+  (#350).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/R/share.R
+++ b/R/share.R
@@ -3037,8 +3037,14 @@ resolve_share_selection <- function(expr,
                                     context,
                                     kind,
                                     error_call) {
-  if (rlang::is_symbol(expr)) {
-    source <- rlang::as_name(expr)
+  # Through the injected reading, so that a selection a wrapper forwarded is
+  # asked the question the written one is asked, rather than reaching
+  # `eval_select()` as an unusable selection (ADR 0019's amendment, #169).
+  # Asked with `is_name_part()` for the reason `validate_share_across_syntax()`
+  # gives, and read twice rather than bound, because what it carries can be the
+  # empty argument.
+  if (is_name_part(unwrap_injected_quosure(expr))) {
+    source <- rlang::as_name(unwrap_injected_quosure(expr))
     if (!source %in% preceding_names) {
       abort_share_source_name(source, preceding, context, kind)
     }
@@ -3047,9 +3053,18 @@ resolve_share_selection <- function(expr,
     as.list(seq_along(preceding_names)),
     preceding_names
   )
+  # A quosure carries the environment `env` would supply, and wrapping one
+  # hands `eval_select()` a quosure inside a quosure -- the lambda shorthand,
+  # which it refuses. `resolve_summary_selection()` reads a selection the same
+  # way, for the same reason (#350).
+  selection <- if (rlang::is_quosure(expr)) {
+    expr
+  } else {
+    rlang::new_quosure(expr, env = env)
+  }
   tryCatch(
     names(tidyselect::eval_select(
-      rlang::new_quosure(expr, env = env),
+      selection,
       data = proxy,
       strict = TRUE,
       allow_rename = FALSE,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -501,11 +501,13 @@ rewrite_across_selection <- function(expr,
 
   # One resolution, whichever way the selection was written: `parsed$cols` is
   # already the `dplyr::everything()` that an omitted `.cols` selects, and an
-  # argument the caller left empty is omitted in exactly that sense. What the
-  # branch decides is only where the resolved selection goes -- prepended when
-  # no argument occupies `.cols`, and written back over the argument that does,
-  # so an empty one keeps its position instead of being dropped from the
-  # middle of the call (#174).
+  # argument the caller wrote empty is omitted in exactly that sense. A quosure
+  # carrying the empty argument is not, and reaches the resolution below as the
+  # selection it is -- the empty one, which is what dplyr selects for it (#350).
+  # What the branch decides is only where the resolved selection goes --
+  # prepended when no argument occupies `.cols`, and written back over the
+  # argument that does, so an empty one keeps its position instead of being
+  # dropped from the middle of the call (#174).
   selected <- resolve_summary_selection(
     parsed$cols,
     env = env,
@@ -555,7 +557,13 @@ rewrite_across_selection <- function(expr,
 
   if (identical(call_name, "across")) {
     parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
-    if (!is.null(parsed$names)) {
+    # Evaluated here so that a template written against the caller's own
+    # bindings reaches dplyr as the string it evaluates to. A quosure carrying
+    # the empty argument has no value to evaluate, and evaluating it looked up
+    # the empty symbol: base R answers that with an untyped `simpleError`
+    # naming nothing the caller wrote. dplyr raises on the same argument and
+    # names it, so the argument is left for dplyr (ADR 0015, #350).
+    if (!is.null(parsed$names) && !is_injected_empty_argument(parsed$names)) {
       call_args[[parsed$names_index]] <- rlang::eval_tidy(
         parsed$names,
         env = env
@@ -583,8 +591,21 @@ rewrite_pick_selection <- function(expr, env, data_proxy) {
 }
 
 resolve_summary_selection <- function(expr, env, data_proxy) {
+  # A quosure is passed on rather than wrapped, because it already carries the
+  # environment `env` would supply. Wrapping one produces a quosure whose
+  # expression is a quosure, and `eval_select()` reads that inner `~` as the
+  # lambda shorthand and refuses the selection with `where()` advice. `{{ }}`
+  # at `.cols` inlines a quosure, which is the ordinary idiom for forwarding a
+  # selection, so the wrapping refused every forwarded selection rather than
+  # only one carrying the empty argument (#350).
+  selection <- if (rlang::is_quosure(expr)) {
+    expr
+  } else {
+    rlang::new_quosure(expr, env = env)
+  }
+
   tidyselect::eval_select(
-    rlang::new_quosure(expr, env = env),
+    selection,
     data = data_proxy,
     strict = TRUE,
     allow_rename = TRUE

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -503,7 +503,7 @@ rewrite_across_selection <- function(expr,
   # already the `dplyr::everything()` that an omitted `.cols` selects, and an
   # argument the caller wrote empty is omitted in exactly that sense. A quosure
   # carrying the empty argument is not, and reaches the resolution below as the
-  # selection it is -- the empty one, which is what dplyr selects for it (#350).
+  # selection it is -- the empty one (#350).
   # What the branch decides is only where the resolved selection goes --
   # prepended when no argument occupies `.cols`, and written back over the
   # argument that does, so an empty one keeps its position instead of being
@@ -558,16 +558,20 @@ rewrite_across_selection <- function(expr,
   if (identical(call_name, "across")) {
     parsed <- parse_across_arguments(rebuild_static_call(expr, call_args))
     # Evaluated here so that a template written against the caller's own
-    # bindings reaches dplyr as the string it evaluates to. A quosure carrying
-    # the empty argument has no value to evaluate, and evaluating it looked up
-    # the empty symbol: base R answers that with an untyped `simpleError`
-    # naming nothing the caller wrote. dplyr raises on the same argument and
-    # names it, so the argument is left for dplyr (ADR 0015, #350).
-    if (!is.null(parsed$names) && !is_injected_empty_argument(parsed$names)) {
-      call_args[[parsed$names_index]] <- rlang::eval_tidy(
-        parsed$names,
-        env = env
+    # bindings reaches dplyr as the string it evaluates to. A template that
+    # cannot be evaluated is left as the caller wrote it, so dplyr evaluates it
+    # and raises with the context naming their own argument: base R's answer to
+    # the same read is an untyped `simpleError` naming nothing they wrote, and
+    # an empty argument a wrapper forwarded reaches this as one (ADR 0015,
+    # #350). The `.unpack` read above tolerates the same failure the same way.
+    if (!is.null(parsed$names)) {
+      evaluated <- tryCatch(
+        list(rlang::eval_tidy(parsed$names, env = env)),
+        error = function(cnd) NULL
       )
+      if (!is.null(evaluated)) {
+        call_args[[parsed$names_index]] <- evaluated[[1L]]
+      }
     }
   }
 
@@ -591,13 +595,14 @@ rewrite_pick_selection <- function(expr, env, data_proxy) {
 }
 
 resolve_summary_selection <- function(expr, env, data_proxy) {
-  # A quosure is passed on rather than wrapped, because it already carries the
-  # environment `env` would supply. Wrapping one produces a quosure whose
-  # expression is a quosure, and `eval_select()` reads that inner `~` as the
-  # lambda shorthand and refuses the selection with `where()` advice. `{{ }}`
-  # at `.cols` inlines a quosure, which is the ordinary idiom for forwarding a
-  # selection, so the wrapping refused every forwarded selection rather than
-  # only one carrying the empty argument (#350).
+  # A quosure is passed on rather than wrapped, because it carries the
+  # environment `env` would supply and a selection needs the one it was written
+  # in. Wrapping produces a quosure whose expression is a quosure, which
+  # `eval_select()` reads as the lambda shorthand and refuses with `where()`
+  # advice. `{{ }}` at `.cols` inlines a quosure, so this is the position the
+  # ordinary idiom for forwarding a selection arrives at (#350). The
+  # environment is what separates this from ADR 0019's amendment, which reads an
+  # injected *name* for the name alone.
   selection <- if (rlang::is_quosure(expr)) {
     expr
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -340,22 +340,6 @@ is_empty_argument <- function(quo) {
     wraps_empty_argument(unparenthesized_value(rlang::quo_get_expr(quo)))
 }
 
-# Whether a call argument is a quosure carrying an empty argument -- the
-# spelling a caller produces by forwarding an argument their own caller left
-# out, `f({{ x }})` with `x` omitted. R's own empty argument is the other
-# spelling, and `rlang::is_missing()` answers that one; neither predicate
-# answers the other. Asked of a part read by subscript out of
-# `static_call_args()`, which holds either, so the quosure test comes first and
-# `is_empty_argument()` above is reached only for what it accepts.
-#
-# The two spellings are not interchangeable at a selection: dplyr takes the
-# formal's default for a written empty `.cols` and selects nothing for an
-# injected one, so a reader folding them together answers a call the caller did
-# not write (#350).
-is_injected_empty_argument <- function(part) {
-  rlang::is_quosure(part) && is_empty_argument(part)
-}
-
 # The head and the arguments of a call a walk descends into, and the node
 # rebuilt around rewritten arguments. `static_call_name()` above answers what a
 # walk asks of a node it does not descend into; these three are what it asks of

--- a/R/utils.R
+++ b/R/utils.R
@@ -340,6 +340,22 @@ is_empty_argument <- function(quo) {
     wraps_empty_argument(unparenthesized_value(rlang::quo_get_expr(quo)))
 }
 
+# Whether a call argument is a quosure carrying an empty argument -- the
+# spelling a caller produces by forwarding an argument their own caller left
+# out, `f({{ x }})` with `x` omitted. R's own empty argument is the other
+# spelling, and `rlang::is_missing()` answers that one; neither predicate
+# answers the other. Asked of a part read by subscript out of
+# `static_call_args()`, which holds either, so the quosure test comes first and
+# `is_empty_argument()` above is reached only for what it accepts.
+#
+# The two spellings are not interchangeable at a selection: dplyr takes the
+# formal's default for a written empty `.cols` and selects nothing for an
+# injected one, so a reader folding them together answers a call the caller did
+# not write (#350).
+is_injected_empty_argument <- function(part) {
+  rlang::is_quosure(part) && is_empty_argument(part)
+}
+
 # The head and the arguments of a call a walk descends into, and the node
 # rebuilt around rewritten arguments. `static_call_name()` above answers what a
 # walk asks of a node it does not descend into; these three are what it asks of

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2349,21 +2349,25 @@ test_that("an omitted share `.fns` is refused by name, not by lookup", {
 })
 
 # The tests below cover the other spelling of an empty argument, and the wider
-# reading that spelling belongs to. A caller forwarding an argument their own
-# caller left out injects a quosure carrying the empty argument rather than the
-# empty argument itself, so `rlang::is_missing()` is false of it and the parse
-# above reads it as supplied. dplyr tells the two apart the same way -- a
-# written empty `.cols` takes the formal's default and deprecates, an injected
-# one selects nothing -- so dplyr is the oracle here as it is for the omitted
-# spelling, and folding the injected spelling into the omitted one would answer
-# a different call than the caller wrote (#350).
+# reading it belongs to. A caller forwarding an argument their own caller left
+# out injects a quosure carrying the empty argument rather than the empty
+# argument itself, so `rlang::is_missing()` is false of it and the parse above
+# reads it as supplied. dplyr is the oracle here as it is for the omitted
+# spelling, and it tells the two apart the same way (#350).
+#
+# One divergence from dplyr is deliberate, and is the one asserted at the end.
+# dplyr reads a top-level `across()` statically, where an injected empty `.cols`
+# resolves to the empty selection, and evaluates a nested one at run time, where
+# the same argument takes the deprecated `everything()` default. Every position
+# is rewritten here, so one reading applies to both, and it is the one dplyr
+# gives the position `across()` is written in as a summary.
 
 test_that("an injected `across()` selection is the selection dplyr makes", {
-  # The ordinary tidy-eval idiom for forwarding a selection, and the shape the
-  # empty selection below is one value of. `{{ }}` inlines a quosure into
-  # `.cols`, where a resolution that wrapped it in a second quosure handed
-  # `eval_select()` a one-sided formula -- read as the lambda shorthand, which
-  # is the `where()` the refusal advised (#350).
+  # The ordinary tidy-eval idiom for forwarding a selection, and the shape an
+  # omitted argument is one value of. `{{ }}` inlines a quosure into `.cols`,
+  # where a resolution that wrapped it in a second quosure handed
+  # `eval_select()` a one-sided formula -- the lambda shorthand, which is the
+  # `where()` the refusal advised.
   data <- data.frame(
     region = c("East", "East", "West"),
     units = c(1, 3, 6),
@@ -2397,8 +2401,10 @@ test_that("an injected `across()` selection is the selection dplyr makes", {
         )
     )
   }
+  # `drop = FALSE` because an empty selection leaves the grouping's key column
+  # alone, which a default subscript would hand back as a vector.
   groups_of <- function(result) {
-    dplyr::arrange(result[!is.na(result$region), ], region)
+    dplyr::arrange(result[!is.na(result$region), , drop = FALSE], region)
   }
 
   expect_equal(
@@ -2416,49 +2422,17 @@ test_that("an injected `across()` selection is the selection dplyr makes", {
     oracle(data, c(units, revenue)),
     ignore_attr = "row.names"
   )
-})
 
-test_that("an injected empty `across()` selection selects what dplyr selects", {
-  # dplyr resolves the empty quosure rather than reading it as an omission, and
-  # `tidyselect::eval_select()` answers one with the empty selection. The
-  # written empty `.cols` beside it keeps the formal's default, which is the
-  # difference these two assert together.
-  data <- data.frame(
-    region = c("East", "East", "West"),
-    units = c(1, 3, 6),
-    revenue = c(2, 4, 8)
-  )
-  summarize <- function(data, selection) {
-    summarize_with_margins(
-      data,
-      dplyr::across({{ selection }}, sum),
-      .grouping = rollup(region),
-      .margin_label = NULL
-    )
-  }
-  oracle <- function(data, selection) {
-    as.data.frame(
-      data |>
-        dplyr::group_by(region) |>
-        dplyr::summarise(
-          dplyr::across({{ selection }}, sum),
-          .groups = "drop"
-        )
-    )
-  }
-
-  # `drop = FALSE` because the selection is empty: the result is the grouping's
-  # key column alone, which a default subscript would hand back as a vector.
-  injected <- summarize(data)
+  # The omitted argument, which dplyr resolves rather than reading as an
+  # omission, and `eval_select()` answers with the empty selection.
   expect_equal(
-    dplyr::arrange(injected[!is.na(injected$region), , drop = FALSE], region),
+    groups_of(summarize(data)),
     oracle(data),
     ignore_attr = "row.names"
   )
-  expect_identical(names(injected), "region")
+  expect_identical(names(summarize(data)), "region")
 
-  # The written spelling, which selects every eligible column instead, so the
-  # two readings cannot be collapsed into one.
+  # The written spelling beside it, which still means every eligible column.
   written <- summarize_with_margins(
     data,
     dplyr::across(, sum),
@@ -2468,14 +2442,13 @@ test_that("an injected empty `across()` selection selects what dplyr selects", {
   expect_identical(names(written), c("region", "units", "revenue"))
 })
 
-test_that("an injected empty `across()` `.names` raises dplyr's own error", {
-  # The template is evaluated here so that a name written against the caller's
-  # own bindings reaches dplyr as the string it evaluates to. An empty quosure
-  # has no value to evaluate, and evaluating it looked up the empty symbol:
-  # base R answered with an untyped `simpleError` reading `object '' not found`
-  # whose `conditionCall()` was `NULL`, which names nothing the caller wrote
-  # and inherits no class they could catch (ADR-0015). dplyr raises on the same
-  # input, so leaving the argument for dplyr is what the oracle decides (#350).
+test_that("an unevaluable `across()` `.names` raises dplyr's own error", {
+  # The template is evaluated so that one written against the caller's own
+  # bindings reaches dplyr as its string. Every read that cannot produce one
+  # leaves the argument for dplyr, which is the same answer for an argument a
+  # wrapper forwarded empty and for a template naming something absent: base R
+  # answers either with an untyped `simpleError` carrying no context and no
+  # class the caller could catch (ADR-0015).
   data <- data.frame(
     region = c("East", "East", "West"),
     units = c(1, 3, 6)
@@ -2487,7 +2460,6 @@ test_that("an injected empty `across()` `.names` raises dplyr's own error", {
       .grouping = rollup(region)
     )
   }
-
   oracle <- function(data, template) {
     data |>
       dplyr::group_by(region) |>
@@ -2496,42 +2468,51 @@ test_that("an injected empty `across()` `.names` raises dplyr's own error", {
         .groups = "drop"
       )
   }
+  paired <- function(error, baseline, spelling) {
+    expect_identical(class(error), class(baseline))
+    expect_false(inherits(error, "simpleError"))
+    expect_false(inherits(error, "missingArgError"))
+    expect_match(conditionMessage(error), spelling, fixed = TRUE)
+  }
 
-  baseline <- expect_error(oracle(data))
-  error <- expect_error(summarize(data))
+  paired(
+    expect_error(summarize(data)),
+    expect_error(oracle(data)),
+    ".names = "
+  )
+  # A template naming nothing, which fails the same read for a reason that has
+  # no empty argument in it.
+  paired(
+    expect_error(
+      summarize_with_margins(
+        data,
+        dplyr::across(units, sum, .names = absent_template),
+        .grouping = rollup(region)
+      )
+    ),
+    expect_error(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(
+          dplyr::across(units, sum, .names = absent_template),
+          .groups = "drop"
+        )
+    ),
+    ".names = absent_template"
+  )
 
-  expect_identical(class(error), class(baseline))
-  expect_false(inherits(error, "simpleError"))
-  expect_false(inherits(error, "missingArgError"))
-  # dplyr's context names the caller's own argument, which is the half a bare
-  # `simpleError` carried none of.
-  expect_match(conditionMessage(error), ".names = ", fixed = TRUE)
-
-  # The control: an injected template that does have a value is still
-  # evaluated here, so the guard withholds the evaluation for the empty
-  # argument alone rather than for every injected template.
+  # The control: a template that does have a value is still evaluated here, so
+  # what the read withholds is the inlining and not the evaluation.
   expect_identical(
     names(summarize(data, "{.col}_total")),
-    names(
-      as.data.frame(
-        data |>
-          dplyr::group_by(region) |>
-          dplyr::summarise(
-            dplyr::across(units, sum, .names = "{.col}_total"),
-            .groups = "drop"
-          )
-      )
-    )
+    names(as.data.frame(oracle(data, "{.col}_total")))
   )
 })
 
 test_that("an injected empty `across()` argument answers as dplyr answers", {
-  # The positions the same pass reached that already agree with dplyr, asserted
-  # so that a later change breaking one of them is caught here rather than by a
-  # caller. `.fns` and an argument forwarded to it are evaluated by dplyr, and
-  # `.unpack` is evaluated here only to decide whether the name normalization
-  # applies -- a read that already tolerates a template it cannot evaluate, and
-  # leaves the argument for dplyr either way.
+  # The positions the same pass reached that already agreed with dplyr,
+  # asserted so that a later change breaking one of them is caught here rather
+  # than by a caller.
   data <- data.frame(
     region = c("East", "East", "West"),
     units = c(1, 3, 6)
@@ -2580,6 +2561,91 @@ test_that("an injected empty `across()` argument answers as dplyr answers", {
     expected,
     ignore_attr = "row.names"
   )
+})
+
+test_that("an injected share selection is refused by the name it carries", {
+  # The share planner reads its selection through a resolver of its own, which
+  # had the same wrapping and the same `rlang::is_symbol()` read #169 fixed at
+  # the four helpers: a forwarded name reached `eval_select()` and was reported
+  # as an unusable selection, rather than being asked whether it names an
+  # eligible summary.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+  summarize <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      units = sum(units),
+      dplyr::across({{ selection }}, share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    )
+  }
+
+  error <- expect_error(
+    summarize(data, absent),
+    "unknown summary `absent`",
+    fixed = TRUE
+  )
+  expect_s3_class(error, "marginplyr_error")
+
+  # An omitted selection reads as the empty one here too, so the share names no
+  # output rather than every eligible source, which is what the written empty
+  # selection above it means.
+  expect_identical(names(summarize(data)), c("region", "units"))
+})
+
+test_that("a nested `across()` selection is resolved where it is written", {
+  # The deliberate divergence the section comment names. dplyr's own two
+  # readings disagree about an injected empty `.cols`: its static expansion of
+  # a top-level `across()` resolves it to the empty selection, and its run-time
+  # `across()` -- which is what a nested one reaches -- takes the deprecated
+  # `everything()` default instead. Every position is rewritten here, so the
+  # resolved one is what dplyr gives the position `across()` is written in as a
+  # summary, at every position.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+  nested <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      columns = ncol(dplyr::across({{ selection }}, ~1)),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    )
+  }
+  oracle <- function(data, selection) {
+    unique(
+      dplyr::summarise(
+        dplyr::group_by(data, region),
+        columns = ncol(dplyr::across({{ selection }}, ~1))
+      )$columns
+    )
+  }
+  columns_of <- function(result) {
+    unique(result$columns)
+  }
+
+  # A selection that is not empty agrees with dplyr wherever it is written.
+  expect_identical(columns_of(nested(data, c(units, revenue))), 2L)
+  expect_identical(
+    columns_of(nested(data, c(units, revenue))),
+    oracle(data, c(units, revenue))
+  )
+
+  # An omitted one is where the two readings part. dplyr raises its lifecycle
+  # warning on the run-time path, which is the signal that says the answer
+  # beside it is the deprecated default rather than a resolution.
+  expect_identical(columns_of(nested(data)), 0L)
+  expect_warning(
+    deprecated <- oracle(data),
+    "without supplying `.cols`",
+    fixed = TRUE
+  )
+  expect_identical(deprecated, 2L)
 })
 
 test_that("an empty argument answers as omitted wherever the walk reads one", {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -2348,6 +2348,240 @@ test_that("an omitted share `.fns` is refused by name, not by lookup", {
   expect_false(inherits(error, "missingArgError"))
 })
 
+# The tests below cover the other spelling of an empty argument, and the wider
+# reading that spelling belongs to. A caller forwarding an argument their own
+# caller left out injects a quosure carrying the empty argument rather than the
+# empty argument itself, so `rlang::is_missing()` is false of it and the parse
+# above reads it as supplied. dplyr tells the two apart the same way -- a
+# written empty `.cols` takes the formal's default and deprecates, an injected
+# one selects nothing -- so dplyr is the oracle here as it is for the omitted
+# spelling, and folding the injected spelling into the omitted one would answer
+# a different call than the caller wrote (#350).
+
+test_that("an injected `across()` selection is the selection dplyr makes", {
+  # The ordinary tidy-eval idiom for forwarding a selection, and the shape the
+  # empty selection below is one value of. `{{ }}` inlines a quosure into
+  # `.cols`, where a resolution that wrapped it in a second quosure handed
+  # `eval_select()` a one-sided formula -- read as the lambda shorthand, which
+  # is the `where()` the refusal advised (#350).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+  summarize <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      dplyr::across({{ selection }}, sum),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    )
+  }
+  # The same forwarding written out, since `{{ }}` is shorthand for it and the
+  # inlined quosure is what both produce.
+  forward <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      dplyr::across(!!rlang::enquo(selection), sum),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    )
+  }
+  oracle <- function(data, selection) {
+    as.data.frame(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(
+          dplyr::across({{ selection }}, sum),
+          .groups = "drop"
+        )
+    )
+  }
+  groups_of <- function(result) {
+    dplyr::arrange(result[!is.na(result$region), ], region)
+  }
+
+  expect_equal(
+    groups_of(summarize(data, units)),
+    oracle(data, units),
+    ignore_attr = "row.names"
+  )
+  expect_equal(
+    groups_of(forward(data, units)),
+    oracle(data, units),
+    ignore_attr = "row.names"
+  )
+  expect_equal(
+    groups_of(summarize(data, c(units, revenue))),
+    oracle(data, c(units, revenue)),
+    ignore_attr = "row.names"
+  )
+})
+
+test_that("an injected empty `across()` selection selects what dplyr selects", {
+  # dplyr resolves the empty quosure rather than reading it as an omission, and
+  # `tidyselect::eval_select()` answers one with the empty selection. The
+  # written empty `.cols` beside it keeps the formal's default, which is the
+  # difference these two assert together.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6),
+    revenue = c(2, 4, 8)
+  )
+  summarize <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      dplyr::across({{ selection }}, sum),
+      .grouping = rollup(region),
+      .margin_label = NULL
+    )
+  }
+  oracle <- function(data, selection) {
+    as.data.frame(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(
+          dplyr::across({{ selection }}, sum),
+          .groups = "drop"
+        )
+    )
+  }
+
+  # `drop = FALSE` because the selection is empty: the result is the grouping's
+  # key column alone, which a default subscript would hand back as a vector.
+  injected <- summarize(data)
+  expect_equal(
+    dplyr::arrange(injected[!is.na(injected$region), , drop = FALSE], region),
+    oracle(data),
+    ignore_attr = "row.names"
+  )
+  expect_identical(names(injected), "region")
+
+  # The written spelling, which selects every eligible column instead, so the
+  # two readings cannot be collapsed into one.
+  written <- summarize_with_margins(
+    data,
+    dplyr::across(, sum),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expect_identical(names(written), c("region", "units", "revenue"))
+})
+
+test_that("an injected empty `across()` `.names` raises dplyr's own error", {
+  # The template is evaluated here so that a name written against the caller's
+  # own bindings reaches dplyr as the string it evaluates to. An empty quosure
+  # has no value to evaluate, and evaluating it looked up the empty symbol:
+  # base R answered with an untyped `simpleError` reading `object '' not found`
+  # whose `conditionCall()` was `NULL`, which names nothing the caller wrote
+  # and inherits no class they could catch (ADR-0015). dplyr raises on the same
+  # input, so leaving the argument for dplyr is what the oracle decides (#350).
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+  summarize <- function(data, template) {
+    summarize_with_margins(
+      data,
+      dplyr::across(units, sum, .names = {{ template }}),
+      .grouping = rollup(region)
+    )
+  }
+
+  oracle <- function(data, template) {
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(
+        dplyr::across(units, sum, .names = {{ template }}),
+        .groups = "drop"
+      )
+  }
+
+  baseline <- expect_error(oracle(data))
+  error <- expect_error(summarize(data))
+
+  expect_identical(class(error), class(baseline))
+  expect_false(inherits(error, "simpleError"))
+  expect_false(inherits(error, "missingArgError"))
+  # dplyr's context names the caller's own argument, which is the half a bare
+  # `simpleError` carried none of.
+  expect_match(conditionMessage(error), ".names = ", fixed = TRUE)
+
+  # The control: an injected template that does have a value is still
+  # evaluated here, so the guard withholds the evaluation for the empty
+  # argument alone rather than for every injected template.
+  expect_identical(
+    names(summarize(data, "{.col}_total")),
+    names(
+      as.data.frame(
+        data |>
+          dplyr::group_by(region) |>
+          dplyr::summarise(
+            dplyr::across(units, sum, .names = "{.col}_total"),
+            .groups = "drop"
+          )
+      )
+    )
+  )
+})
+
+test_that("an injected empty `across()` argument answers as dplyr answers", {
+  # The positions the same pass reached that already agree with dplyr, asserted
+  # so that a later change breaking one of them is caught here rather than by a
+  # caller. `.fns` and an argument forwarded to it are evaluated by dplyr, and
+  # `.unpack` is evaluated here only to decide whether the name normalization
+  # applies -- a read that already tolerates a template it cannot evaluate, and
+  # leaves the argument for dplyr either way.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    units = c(1, 3, 6)
+  )
+  paired <- function(summary) {
+    error <- expect_error(rlang::inject(summarize_with_margins(
+      data,
+      !!summary,
+      .grouping = rollup(region)
+    )))
+    baseline <- expect_error(rlang::inject(
+      data |>
+        dplyr::group_by(region) |>
+        dplyr::summarise(!!summary, .groups = "drop")
+    ))
+    expect_identical(class(error), class(baseline))
+    expect_false(inherits(error, "simpleError"))
+    expect_identical(class(error$parent), class(baseline$parent))
+  }
+  empty <- function(...) rlang::enquos(...)[[1L]]
+  forward <- function(argument) empty(x = {{ argument }})
+
+  paired(rlang::expr(dplyr::across(units, !!forward())))
+  paired(rlang::expr(dplyr::across(units, sum, .unpack = !!forward())))
+  paired(rlang::expr(dplyr::across(units, sum, na.rm = !!forward())))
+
+  # `pick()` resolves its arguments as one `c()` call, so an injected empty one
+  # is an element of that call rather than the whole selection, and dplyr
+  # answers it with a result rather than a condition.
+  picked <- summarize_with_margins(
+    data,
+    columns = ncol(dplyr::pick(!!forward())),
+    .grouping = rollup(region),
+    .margin_label = NULL
+  )
+  expected <- as.data.frame(
+    data |>
+      dplyr::group_by(region) |>
+      dplyr::summarise(
+        columns = ncol(dplyr::pick(!!forward())),
+        .groups = "drop"
+      )
+  )
+  expect_equal(
+    dplyr::arrange(picked[!is.na(picked$region), ], region),
+    expected,
+    ignore_attr = "row.names"
+  )
+})
+
 test_that("an empty argument answers as omitted wherever the walk reads one", {
   # `across()` was the reconstruction path #174 was filed for, and the audit
   # that fixed it found the same read in four more places, each reached by an


### PR DESCRIPTION
Closes #350.

A wrapper forwarding a selection injects a quosure into `.cols`, which is the
ordinary tidy-eval idiom. `resolve_summary_selection()` wrapped whatever it was
given in a fresh quosure, so a quosure arrived at `tidyselect::eval_select()`
inside another one, where the inner `~` reads as the lambda shorthand:
`across({{ cols }}, sum)` was refused with tidyselect's `where()` advice
whatever columns it named. A quosure is now passed on, carrying the environment
the wrapping would have supplied.

Forwarding an argument the caller omitted is one value of that spelling, and it
now selects what dplyr selects for it, which is nothing. `rlang::is_missing()`
is false of such a quosure, so the `across()` parse reads it as supplied —
correctly, since dplyr tells the two spellings apart the same way: a written
empty `.cols` takes the formal's default and deprecates, an injected one
resolves to the empty selection. Folding them together at the parse would
answer a call the caller did not write, so the two sites that read the argument
answer it instead.

The second is `.names`. The template is evaluated so that one written against
the caller's own bindings reaches dplyr as its string; an empty quosure has no
value, and evaluating it looked up the empty symbol for base R's untyped
`simpleError` reading `object '' not found`, whose `conditionCall()` was
`NULL`. dplyr raises on the same argument and names it, so the argument is left
for dplyr (ADR 0015).

`.fns`, `.unpack`, an argument forwarded to the function, and `pick()` were
checked in the same pass and already agree with dplyr; tests hold them there.

## Local checks

- `testthat::test_local()` with `NOT_CRAN=true` — passes.
- `lintr::lint_package()` after `pkgload::load_all()` — no lints.
- `roxygen2::roxygenise()` — no diff.
- `spelling::spell_check_package()` — clean.
- `Rscript .github/scripts/verify-context-budget.R` — within budget.