### PR TITLE
Fix dtplyr ordered-factor expansion

### DIFF
--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -382,11 +382,23 @@ label_margin_branch <- function(.data,
       dplyr::across(dplyr::all_of(labelled_as_character), as.character)
     )
   }
+  # dtplyr renders a scalar overwrite as data.table `:=`. On a multi-row factor
+  # column, data.table recycles it without replacing the column class, leaving
+  # an ordered factor opposite the character branch at `funion()`. A full-size
+  # value replaces the column so factor restoration remains after the union.
+  dtplyr_factor_cols <- if (inherits(.data, "dtplyr_step")) {
+    vapply(factor_info, function(info) info$col, character(1))
+  } else {
+    character()
+  }
   values <- lapply(
     omitted,
     function(col) {
       label <- margin_labels[[col]]
       if (!is_missing_margin_label(label)) {
+        if (col %in% dtplyr_factor_cols) {
+          return(rlang::expr(rep(!!label, dplyr::n())))
+        }
         return(label)
       }
       value <- prototypes[[col]]

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -455,6 +455,57 @@ test_that("dtplyr applies mixed named labels lazily and restores factors", {
   expect_true(all(is.na(result$second[result$id == 1L])))
 })
 
+test_that("dtplyr expansion verbs restore ordered factor dimensions", {
+  skip_if_suggest_absent("dtplyr")
+  # Two rows are load-bearing: data.table replaces a one-row factor column but
+  # recycles a scalar assignment into a multi-row one without replacing it.
+  data <- data.frame(
+    group = ordered(c("small", "large"), levels = c("small", "large")),
+    value = 1:2
+  )
+  source <- dtplyr::lazy_dt(data)
+  lazy <- list(
+    expand_with_margins = expand_with_margins(
+      source,
+      .grouping = rollup(group),
+      .margin_label = "(all)",
+      .margin_label_position = "first"
+    ),
+    nest_with_margins = nest_with_margins(
+      source,
+      .grouping = rollup(group),
+      .margin_label = "(all)",
+      .margin_label_position = "first"
+    )
+  )
+
+  results <- lapply(names(lazy), function(verb) {
+    expect_s3_class(lazy[[verb]], "dtplyr_step")
+    dplyr::collect(lazy[[verb]])
+  })
+  names(results) <- names(lazy)
+  results$nest_by_with_margins <- nest_by_with_margins(
+    source,
+    .grouping = rollup(group),
+    .margin_label = "(all)",
+    .margin_label_position = "first"
+  )
+
+  for (verb in names(results)) {
+    result <- results[[verb]]
+    expect_true(is.ordered(result$group), info = verb)
+    expect_identical(
+      levels(result$group),
+      c("(all)", "small", "large"),
+      info = verb
+    )
+    expect_setequal(
+      as.character(result$group),
+      c("small", "large", "(all)")
+    )
+  }
+})
+
 test_that("Arrow applies mixed named labels lazily with typed missing values", {
   skip_if_suggest_absent("arrow")
   data <- data.frame(


### PR DESCRIPTION
## Summary

- replace omitted factor dimensions with full-length label values on dtplyr branches so data.table changes the column type before `funion()`
- keep factor reconstruction after the portable union, preserving ordered status, source level order, and Margin-label position
- cover `expand_with_margins()`, `nest_with_margins()`, and `nest_by_with_margins()` through their public interfaces

## Testing

- `Rscript -e 'testthat::test_dir("tests/testthat", filter = "^(margin-label|expand-operation|nest-operation|factor)$", load_package = "source", stop_on_failure = TRUE)'`
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); print(lintr::lint_package())'`
- `Rscript .github/scripts/verify-context-budget.R`
- `git diff --check`

Closes #354
