### PR TITLE
Read an empty argument inside a selection as tidyselect reads one (#351)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,10 @@ function. A spelling the position does not recognize is never
 evaluated to find out, because a selection such as `starts_with("re")` has no
 meaning outside a selection context. An argument the caller left empty gets
 neither reading, and is refused naming the constructor and the position; a
-trailing comma is not one, because R captures no argument for it. Both
+trailing comma is not one, because R captures no argument for it. That refusal
+reaches the position and not what a selection written there contains: an empty
+argument inside such a selection leaves the position filled, and is read as
+tidyselect reads one. Both
 readings claim one argument at once: a bare name that is a column of the
 input and is also bound, in the caller's environment, to a specification of a
 kind the position admits — which kinds those are varies by constructor. How

--- a/NEWS.md
+++ b/NEWS.md
@@ -189,7 +189,12 @@
   get from omitting it, which is what writing `.grouping = ` already means.
   Redundant parentheses are transparent at all three positions, as they are
   elsewhere: an injected pair wrapping nothing is the empty argument it wraps
-  (#340).
+  (#340). An empty argument one level further down — inside a selection, as in
+  `.by = c(, region)` or `rollup(c(, grade))` — is read as tidyselect reads
+  one, which under `c()` is to select nothing for it, in place of the same
+  `attempt to use zero-length variable name`. The refusal above reaches a
+  constructor argument's own position and not a selection written there, so
+  `rollup(, grade)` is still refused (#351).
 * A selection a wrapper forwards into `across()` is now the selection dplyr
   makes of it. `across({{ cols }}, sum)` — the ordinary way to pass on a
   selection your own caller wrote — was refused by tidyselect, which advised

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -349,25 +349,9 @@ selection_refused_operators <- function() {
 # hold `env` as the expression's own environment and `data_vars` as the input's
 # column names, which is the pair the symbol branch decides from.
 is_name_only_expr <- function(expr, env, data_vars) {
-  # R's empty argument, answered before anything asks what the part names --
-  # it is a symbol whose name is `""`, so the branch below would put that name
-  # to `rlang::env_has()`, which raises for a zero-length variable name
-  # (#351). This is the site `is_name_part()`'s header names: the rule is
-  # satisfied by answering the empty argument outright rather than by
-  # declining it.
-  #
-  # `TRUE` is what the contract above gives it. tidyselect settles an empty
-  # part from the names in both directions -- it drops one under `c()` and
-  # fails on one under every other walk operator, as `dplyr::select()` does --
-  # and `investigation/an-empty-argument-under-a-selection-walk.md` measures
-  # which per operator. A selection written at a Grouping specification
-  # argument reaches here too, and `CONTEXT.md`'s *Nested specification
-  # position* holds why that is not the empty constructor argument
-  # `preflight_grouping_spec()` refuses.
-  if (rlang::is_missing(expr)) {
-    return(TRUE)
-  }
-  if (is.symbol(expr)) {
+  # `is_name_part()` rather than `rlang::is_symbol()`, for the reason its
+  # header gives: a part read by subscript may be R's empty argument.
+  if (is_name_part(expr)) {
     name <- as.character(expr)
     return(
       name %in% data_vars ||
@@ -377,6 +361,16 @@ is_name_only_expr <- function(expr, env, data_vars) {
           inherit = TRUE
         )
     )
+  }
+  # The empty argument the branch above declined. tidyselect settles one from
+  # the names too, which is what `TRUE` claims here;
+  # `investigation/an-empty-argument-under-a-selection-walk.md` measures what
+  # it settles it as, per operator. A selection written at a Grouping
+  # specification argument reaches this reader as well, and `CONTEXT.md`'s
+  # *Nested specification position* holds why that is not the empty argument
+  # `preflight_grouping_spec()` refuses (#351).
+  if (rlang::is_missing(expr)) {
+    return(TRUE)
   }
   if (!is.language(expr)) {
     return(is.atomic(expr))

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -349,6 +349,24 @@ selection_refused_operators <- function() {
 # hold `env` as the expression's own environment and `data_vars` as the input's
 # column names, which is the pair the symbol branch decides from.
 is_name_only_expr <- function(expr, env, data_vars) {
+  # R's empty argument, answered before anything asks what the part names --
+  # it is a symbol whose name is `""`, so the branch below would put that name
+  # to `rlang::env_has()`, which raises for a zero-length variable name
+  # (#351). This is the site `is_name_part()`'s header names: the rule is
+  # satisfied by answering the empty argument outright rather than by
+  # declining it.
+  #
+  # `TRUE` is what the contract above gives it. tidyselect settles an empty
+  # part from the names in both directions -- it drops one under `c()` and
+  # fails on one under every other walk operator, as `dplyr::select()` does --
+  # and `investigation/an-empty-argument-under-a-selection-walk.md` measures
+  # which per operator. A selection written at a Grouping specification
+  # argument reaches here too, and `CONTEXT.md`'s *Nested specification
+  # position* holds why that is not the empty constructor argument
+  # `preflight_grouping_spec()` refuses.
+  if (rlang::is_missing(expr)) {
+    return(TRUE)
+  }
   if (is.symbol(expr)) {
     name <- as.character(expr)
     return(

--- a/R/utils.R
+++ b/R/utils.R
@@ -419,6 +419,11 @@ static_call_args <- function(expr) {
 # binding, or an output called `""`, which nothing the caller wrote can be
 # (#174). Asked of a part read by subscript, never of one bound to a name,
 # which is the rule above.
+#
+# `is_name_only_expr()` is the one site that satisfies the rule without asking
+# this: it has an answer for the empty argument rather than only a reading to
+# decline, so it returns that answer first and the symbol branch below it
+# never sees one (#351).
 is_name_part <- function(part) {
   !rlang::is_missing(part) && rlang::is_symbol(part)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -419,11 +419,6 @@ static_call_args <- function(expr) {
 # binding, or an output called `""`, which nothing the caller wrote can be
 # (#174). Asked of a part read by subscript, never of one bound to a name,
 # which is the rule above.
-#
-# `is_name_only_expr()` is the one site that satisfies the rule without asking
-# this: it has an answer for the empty argument rather than only a reading to
-# decline, so it returns that answer first and the symbol branch below it
-# never sees one (#351).
 is_name_part <- function(part) {
   !rlang::is_missing(part) && rlang::is_symbol(part)
 }

--- a/investigation/an-empty-argument-under-a-selection-walk.md
+++ b/investigation/an-empty-argument-under-a-selection-walk.md
@@ -1,0 +1,72 @@
+# An empty argument under a selection walk
+
+Investigated: 2026-09-01
+
+Measured while deciding what `is_name_only_expr()` should answer for R's empty
+argument (#351). That reader read a name off every symbol, and the empty
+argument is a symbol whose name is `""`, so `rlang::env_has()` raised `attempt
+to use zero-length variable name` for any selection carrying one. Answering it
+as tidyselect answers it required knowing what tidyselect does with such a
+part, which is not documented in `language.Rd` or anywhere else read here.
+
+## Environment
+
+| Component | Version |
+|---|---|
+| R | 4.6.1 |
+| tidyselect | 1.2.1 |
+| rlang | 1.3.0 |
+| vctrs | 0.7.3 |
+| dplyr | 1.2.1 |
+
+## What tidyselect does, per operator
+
+`tidyselect::eval_select()` over a two-column frame, one empty operand per
+call. The operators are those `selection_walk_operators()` names plus `(`,
+and two leaf helpers for contrast.
+
+| expression | result |
+|---|---|
+| `c(, region)` | selects `region` |
+| `c(region, )` | selects `region` |
+| `c(region, , grade)` | selects `region`, `grade` |
+| `-( )` | `simpleError`: attempt to use zero-length variable name |
+| `!( )` | `simpleError`: attempt to use zero-length variable name |
+| `\|(, region)` | `simpleError`: attempt to use zero-length variable name |
+| `/(, region)` | `simpleError`: attempt to use zero-length variable name |
+| `( )` | `simpleError`: attempt to use zero-length variable name |
+| `:(, region)` | `missingArgError`: argument "expr" is missing |
+| `&(region, )` | `missingArgError`: argument "y" is missing |
+| `all_of( )` | `rlang_error`: argument "x" is missing |
+| `starts_with( )` | `rlang_error`: argument "match" is missing |
+
+`c()` is the only operator that drops the part. Under every other one
+tidyselect fails, and under five of them with the same untyped message
+marginplyr was producing on its own account — so a caller who reached that
+message through `-( )` was seeing tidyselect's failure either way, while one
+who reached it through `c(, region)` was seeing a selection tidyselect would
+have accepted.
+
+Both halves are settled by the column names: no branch above reads a column's
+data, so a reader answering `TRUE` for the part hands tidyselect a question
+the names decide, which is the contract `is_name_only_expr()` states.
+
+Only the three `c()` rows are spellings R parses. The rest were built with
+`as.call()`, and the empty argument was written as `rlang::missing_arg()` at
+each use rather than bound to a local, because reading such a local raises
+`missingArgError` naming the local (#168, #174) — which happened once while
+building this table.
+
+## The same measurement through `dplyr::summarise()`
+
+`dplyr::summarise(d, n = n(), .by = <expr>)` was measured for the `c()` rows
+and agrees with `eval_select()`: `c(, region)`, `c(region, )`, and
+`c(region, , grade)` group by the named columns. `dplyr::select()` reproduces
+the failures for the rest, so the non-`c()` rows are not a marginplyr
+divergence to close.
+
+## What was not measured
+
+Why `c()` differs was not traced into tidyselect's `eval_c()`. The finding
+here is the behaviour rather than its mechanism, and the behaviour is what the
+reader's answer rests on.

--- a/investigation/an-empty-argument-under-a-selection-walk.md
+++ b/investigation/an-empty-argument-under-a-selection-walk.md
@@ -41,15 +41,13 @@ and two leaf helpers for contrast.
 | `starts_with( )` | `rlang_error`: argument "match" is missing |
 
 `c()` is the only operator that drops the part. Under every other one
-tidyselect fails, and under five of them with the same untyped message
-marginplyr was producing on its own account — so a caller who reached that
-message through `-( )` was seeing tidyselect's failure either way, while one
-who reached it through `c(, region)` was seeing a selection tidyselect would
-have accepted.
+tidyselect fails, and under five of them with `attempt to use zero-length
+variable name`, which is base R's message for reading a symbol whose name is
+`""` rather than a diagnostic tidyselect wrote.
 
-Both halves are settled by the column names: no branch above reads a column's
-data, so a reader answering `TRUE` for the part hands tidyselect a question
-the names decide, which is the contract `is_name_only_expr()` states.
+Neither outcome reads a column's data. Every row was measured twice — over a
+frame whose columns hold values, and over a named list of column positions
+carrying none — and the two agreed on all twelve.
 
 Only the three `c()` rows are spellings R parses. The rest were built with
 `as.call()`, and the empty argument was written as `rlang::missing_arg()` at
@@ -62,11 +60,9 @@ building this table.
 `dplyr::summarise(d, n = n(), .by = <expr>)` was measured for the `c()` rows
 and agrees with `eval_select()`: `c(, region)`, `c(region, )`, and
 `c(region, , grade)` group by the named columns. `dplyr::select()` reproduces
-the failures for the rest, so the non-`c()` rows are not a marginplyr
-divergence to close.
+every failure in the table, so no row of it belongs to `.by` in particular.
 
 ## What was not measured
 
-Why `c()` differs was not traced into tidyselect's `eval_c()`. The finding
-here is the behaviour rather than its mechanism, and the behaviour is what the
-reader's answer rests on.
+Why `c()` differs was not traced into tidyselect's `eval_c()`. What was
+established here is the behaviour and not its mechanism.

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -849,6 +849,41 @@ verbs_taking <- function(arg) {
   )
 }
 
+# One wrapper per verb, forwarding both arguments with `{{ }}`. File level
+# because two tests below put different expressions through the same six
+# verbs; a second copy could disagree with the derivation above while this
+# one still matched it.
+forwarded_verbs <- list(
+  summarize_with_margins = function(data, by, grouping) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      .by = {{ by }},
+      .grouping = {{ grouping }}
+    )
+  },
+  summarise_with_margins = function(data, by, grouping) {
+    summarise_with_margins(
+      data,
+      total = sum(value),
+      .by = {{ by }},
+      .grouping = {{ grouping }}
+    )
+  },
+  expand_with_margins = function(data, by, grouping) {
+    expand_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+  },
+  nest_with_margins = function(data, by, grouping) {
+    nest_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+  },
+  nest_by_with_margins = function(data, by, grouping) {
+    nest_by_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+  },
+  inspect_grouping = function(data, by, grouping) {
+    inspect_grouping(data, .by = {{ by }}, .grouping = {{ grouping }})
+  }
+)
+
 # The two verb arguments injection can leave empty, and neither is the `.by = `
 # above: R matches a named formal's empty argument to that formal's default,
 # while `{{ }}` splices R's missing marker into the quosure. Only the second
@@ -870,42 +905,11 @@ test_that("a forwarded empty `.by` or `.grouping` is the argument absent", {
     region = c("East", "East", "West"),
     value = c(1, 3, 6)
   )
-  forwarded <- list(
-    summarize_with_margins = function(data, by, grouping) {
-      summarize_with_margins(
-        data,
-        total = sum(value),
-        .by = {{ by }},
-        .grouping = {{ grouping }}
-      )
-    },
-    summarise_with_margins = function(data, by, grouping) {
-      summarise_with_margins(
-        data,
-        total = sum(value),
-        .by = {{ by }},
-        .grouping = {{ grouping }}
-      )
-    },
-    expand_with_margins = function(data, by, grouping) {
-      expand_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
-    },
-    nest_with_margins = function(data, by, grouping) {
-      nest_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
-    },
-    nest_by_with_margins = function(data, by, grouping) {
-      nest_by_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
-    },
-    inspect_grouping = function(data, by, grouping) {
-      inspect_grouping(data, .by = {{ by }}, .grouping = {{ grouping }})
-    }
-  )
+  expect_setequal(names(forwarded_verbs), verbs_taking(".by"))
+  expect_setequal(names(forwarded_verbs), verbs_taking(".grouping"))
 
-  expect_setequal(names(forwarded), verbs_taking(".by"))
-  expect_setequal(names(forwarded), verbs_taking(".grouping"))
-
-  for (name in names(forwarded)) {
-    verb <- forwarded[[name]]
+  for (name in names(forwarded_verbs)) {
+    verb <- forwarded_verbs[[name]]
     expect_identical(
       verb(data, grouping = rollup(region)),
       verb(data, NULL, rollup(region)),
@@ -922,7 +926,7 @@ test_that("a forwarded empty `.by` or `.grouping` is the argument absent", {
   # arrives, so what the guard answers is the empty argument and not every
   # injected one.
   expect_identical(
-    forwarded$inspect_grouping(data, NULL, rollup(region)),
+    forwarded_verbs$inspect_grouping(data, NULL, rollup(region)),
     inspect_grouping(data, .grouping = rollup(region))
   )
 })
@@ -966,55 +970,27 @@ test_that("an empty argument inside a `.by` selection selects nothing", {
     grade = c("a", "b", "a"),
     value = c(1, 3, 6)
   )
-  forwarded <- list(
-    summarize_with_margins = function(data, by) {
-      summarize_with_margins(
-        data,
-        total = sum(value),
-        .by = {{ by }},
-        .grouping = rollup(grade)
-      )
-    },
-    summarise_with_margins = function(data, by) {
-      summarise_with_margins(
-        data,
-        total = sum(value),
-        .by = {{ by }},
-        .grouping = rollup(grade)
-      )
-    },
-    expand_with_margins = function(data, by) {
-      expand_with_margins(data, .by = {{ by }}, .grouping = rollup(grade))
-    },
-    nest_with_margins = function(data, by) {
-      nest_with_margins(data, .by = {{ by }}, .grouping = rollup(grade))
-    },
-    nest_by_with_margins = function(data, by) {
-      nest_by_with_margins(data, .by = {{ by }}, .grouping = rollup(grade))
-    },
-    inspect_grouping = function(data, by) {
-      inspect_grouping(data, .by = {{ by }}, .grouping = rollup(grade))
-    }
-  )
-  expect_setequal(names(forwarded), verbs_taking(".by"))
 
-  for (name in names(forwarded)) {
-    verb <- forwarded[[name]]
-    expect_identical(verb(data, c(, region)), verb(data, region), info = name)
-    expect_identical(verb(data, c(region, )), verb(data, region), info = name)
+  for (name in names(forwarded_verbs)) {
+    verb <- forwarded_verbs[[name]]
     expect_identical(
-      verb(data, c(region, , tier)),
-      verb(data, c(region, tier)),
+      verb(data, c(, region), rollup(grade)),
+      verb(data, region, rollup(grade)),
+      info = name
+    )
+    expect_identical(
+      verb(data, c(region, ), rollup(grade)),
+      verb(data, region, rollup(grade)),
+      info = name
+    )
+    expect_identical(
+      verb(data, c(region, , tier), rollup(grade)),
+      verb(data, c(region, tier), rollup(grade)),
       info = name
     )
   }
 })
 
-# The same reader serves a Grouping specification argument, so a selection
-# written at one carries the part to the same place. What this settles is the
-# boundary against the refusal of an empty constructor argument: that refusal
-# is about the argument's own position, which `c(, grade)` does not leave
-# empty. `CONTEXT.md`'s *Nested specification position* holds the decision.
 test_that("an empty argument inside a specification's selection reads too", {
   data <- data.frame(
     region = c("East", "East", "West"),
@@ -1040,28 +1016,38 @@ test_that("an empty argument inside a specification's selection reads too", {
   )
 })
 
-# `c()` is the only walk operator that drops the part. Under the rest,
-# tidyselect raises for it, and so does `dplyr::select()` -- this package's
-# reading is not what makes those fail. So what is asserted is that nothing
-# here refuses the selection before tidyselect is reached, and not the
-# message, which is tidyselect's and moves with its version;
-# `investigation/an-empty-argument-under-a-selection-walk.md` measures the
-# message per operator on the version it was measured against.
+# What this asserts is that nothing here refuses the selection before
+# tidyselect is reached -- and not the message, which is tidyselect's and
+# moves with its version.
+# `investigation/an-empty-argument-under-a-selection-walk.md` measures it.
 #
-# Constructed, because `-()` and `|(, region)` are not spellings R parses.
+# Constructed, because none of these is a spelling R parses.
 test_that("an empty operand under another walk operator is tidyselect's", {
   data <- data.frame(region = c("East", "West"), value = c(1, 6))
-  operators <- c("-", "!", "|", "/")
+  # The shapes that note measured, minus `( )`: a pair holding the empty
+  # argument is the whole argument left empty, which `is_empty_argument()`
+  # answers before this reader is reached (#340).
+  operands <- list(
+    as.call(list(as.name("-"), rlang::missing_arg())),
+    as.call(list(as.name("!"), rlang::missing_arg())),
+    as.call(list(as.name("|"), rlang::missing_arg(), quote(region))),
+    as.call(list(as.name("/"), rlang::missing_arg(), quote(region))),
+    as.call(list(as.name(":"), rlang::missing_arg(), quote(region))),
+    as.call(list(as.name("&"), quote(region), rlang::missing_arg()))
+  )
 
-  for (index in seq_along(operators)) {
-    operand <- as.call(list(
-      as.name(operators[[index]]),
-      rlang::missing_arg()
-    ))
+  for (index in seq_along(operands)) {
     error <- expect_error(
-      inspect_grouping(data, .by = !!operand, .grouping = rollup(region))
+      inspect_grouping(
+        data,
+        .by = !!operands[[index]],
+        .grouping = rollup(region)
+      )
     )
-    expect_false(inherits(error, "marginplyr_error"), info = operators[[index]])
+    expect_false(
+      inherits(error, "marginplyr_error"),
+      info = deparse1(operands[[index]])
+    )
   }
 })
 

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -948,6 +948,123 @@ test_that("a forwarded empty `.by` is still an argument the caller supplied", {
   )
 })
 
+# The empty argument one level down from the verb's argument. The argument is
+# a selection that names a column, so `is_empty_argument()` is never asked and
+# `is_name_only_expr()` read the part -- where the empty argument is a symbol
+# whose name is `""` and `rlang::env_has()` raised for a zero-length variable
+# name (#351). #340's answer above is a different position and is unchanged.
+#
+# Answered as tidyselect answers it, which under `c()` is to select nothing
+# for the part. Every position, since the walk reads every part, and every
+# verb the derivation names rather than a list that could miss one.
+test_that("an empty argument inside a `.by` selection selects nothing", {
+  # `tier` is here so that the interior position has a second fixed key to sit
+  # beside, without the selection reaching the column `.grouping` takes.
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    tier = c("x", "y", "x"),
+    grade = c("a", "b", "a"),
+    value = c(1, 3, 6)
+  )
+  forwarded <- list(
+    summarize_with_margins = function(data, by) {
+      summarize_with_margins(
+        data,
+        total = sum(value),
+        .by = {{ by }},
+        .grouping = rollup(grade)
+      )
+    },
+    summarise_with_margins = function(data, by) {
+      summarise_with_margins(
+        data,
+        total = sum(value),
+        .by = {{ by }},
+        .grouping = rollup(grade)
+      )
+    },
+    expand_with_margins = function(data, by) {
+      expand_with_margins(data, .by = {{ by }}, .grouping = rollup(grade))
+    },
+    nest_with_margins = function(data, by) {
+      nest_with_margins(data, .by = {{ by }}, .grouping = rollup(grade))
+    },
+    nest_by_with_margins = function(data, by) {
+      nest_by_with_margins(data, .by = {{ by }}, .grouping = rollup(grade))
+    },
+    inspect_grouping = function(data, by) {
+      inspect_grouping(data, .by = {{ by }}, .grouping = rollup(grade))
+    }
+  )
+  expect_setequal(names(forwarded), verbs_taking(".by"))
+
+  for (name in names(forwarded)) {
+    verb <- forwarded[[name]]
+    expect_identical(verb(data, c(, region)), verb(data, region), info = name)
+    expect_identical(verb(data, c(region, )), verb(data, region), info = name)
+    expect_identical(
+      verb(data, c(region, , tier)),
+      verb(data, c(region, tier)),
+      info = name
+    )
+  }
+})
+
+# The same reader serves a Grouping specification argument, so a selection
+# written at one carries the part to the same place. What this settles is the
+# boundary against the refusal of an empty constructor argument: that refusal
+# is about the argument's own position, which `c(, grade)` does not leave
+# empty. `CONTEXT.md`'s *Nested specification position* holds the decision.
+test_that("an empty argument inside a specification's selection reads too", {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    grade = c("a", "b", "a"),
+    value = c(1, 3, 6)
+  )
+  expect_identical(
+    inspect_grouping(data, .grouping = rollup(c(, grade))),
+    inspect_grouping(data, .grouping = rollup(grade))
+  )
+  expect_identical(
+    inspect_grouping(data, .grouping = rollup(c(grade, ))),
+    inspect_grouping(data, .grouping = rollup(grade))
+  )
+  # One level in, where the constructor holding the selection is the inner
+  # one -- the frame the refusal above would have named.
+  expect_identical(
+    inspect_grouping(
+      data,
+      .grouping = grouping_sets(grouping_set(c(, region)))
+    ),
+    inspect_grouping(data, .grouping = grouping_sets(grouping_set(region)))
+  )
+})
+
+# `c()` is the only walk operator that drops the part. Under the rest,
+# tidyselect raises for it, and so does `dplyr::select()` -- this package's
+# reading is not what makes those fail. So what is asserted is that nothing
+# here refuses the selection before tidyselect is reached, and not the
+# message, which is tidyselect's and moves with its version;
+# `investigation/an-empty-argument-under-a-selection-walk.md` measures the
+# message per operator on the version it was measured against.
+#
+# Constructed, because `-()` and `|(, region)` are not spellings R parses.
+test_that("an empty operand under another walk operator is tidyselect's", {
+  data <- data.frame(region = c("East", "West"), value = c(1, 6))
+  operators <- c("-", "!", "|", "/")
+
+  for (index in seq_along(operators)) {
+    operand <- as.call(list(
+      as.name(operators[[index]]),
+      rlang::missing_arg()
+    ))
+    error <- expect_error(
+      inspect_grouping(data, .by = !!operand, .grouping = rollup(region))
+    )
+    expect_false(inherits(error, "marginplyr_error"), info = operators[[index]])
+  }
+})
+
 # The other reader of a kind nothing has validated, and the one where the
 # guards' answer is not the answer: this site declines rather than refuses, so
 # what a method could take from it was a compiled call rather than a diagnostic

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -932,6 +932,45 @@ test_that("every analysis that names a call reads a formula as a `~` call", {
   expect_false(contains_selection_predicate(quote(~.x)))
 })
 
+# R's empty argument is a symbol whose name is `""`, and this reader answered a
+# symbol by reading that name: `rlang::env_has()` raises `attempt to use
+# zero-length variable name`, an untyped condition naming nothing the caller
+# wrote (#351). It arrives as a part of a selection rather than as a whole
+# argument, so `is_empty_argument()` is never asked about it.
+#
+# `TRUE` is the answer the header's contract already gives: the column names
+# settle it, as a selection under `c()` and as tidyselect's own failure under
+# every other walk operator. Which of the two a caller reaches is measured per
+# operator in `investigation/an-empty-argument-under-a-selection-walk.md`.
+test_that("the name-only reader answers R's empty argument", {
+  env <- rlang::current_env()
+
+  # The part on its own, which is what the walk below hands the reader.
+  expect_true(
+    is_name_only_expr(rlang::missing_arg(), env = env, data_vars = "region")
+  )
+
+  # And reached through a walk, in all three positions a selection can hold
+  # one. Written rather than constructed: R's parser keeps the empty argument
+  # in each, unlike the `f((), x)` the refusal of an empty constructor
+  # argument has to build.
+  written <- list(
+    quote(c(, region)),
+    quote(c(region, )),
+    quote(c(region, , grade))
+  )
+  for (index in seq_along(written)) {
+    expect_true(
+      is_name_only_expr(
+        written[[index]],
+        env = env,
+        data_vars = c("region", "grade")
+      ),
+      info = deparse(written[[index]])
+    )
+  }
+})
+
 test_that("a formula in a summary expression evaluates instead of aborting", {
   # `derived = purrr::map_dbl(v, ~.x)` is the realistic spelling of this. purrr
   # is neither an Import nor a Suggest of this package, so it is written here

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -932,28 +932,25 @@ test_that("every analysis that names a call reads a formula as a `~` call", {
   expect_false(contains_selection_predicate(quote(~.x)))
 })
 
-# R's empty argument is a symbol whose name is `""`, and this reader answered a
-# symbol by reading that name: `rlang::env_has()` raises `attempt to use
-# zero-length variable name`, an untyped condition naming nothing the caller
-# wrote (#351). It arrives as a part of a selection rather than as a whole
-# argument, so `is_empty_argument()` is never asked about it.
+# The reader answered a symbol by reading its name, and R's empty argument is
+# one whose name is `""` -- so `rlang::env_has()` raised for a zero-length
+# variable name (#351). It arrives as a part of a selection rather than as a
+# whole argument, so `is_empty_argument()` is never asked about it.
 #
-# `TRUE` is the answer the header's contract already gives: the column names
-# settle it, as a selection under `c()` and as tidyselect's own failure under
-# every other walk operator. Which of the two a caller reaches is measured per
-# operator in `investigation/an-empty-argument-under-a-selection-walk.md`.
+# `TRUE` is what the reader's own contract gives it;
+# `investigation/an-empty-argument-under-a-selection-walk.md` measures what
+# tidyselect then settles such a part as, per operator.
 test_that("the name-only reader answers R's empty argument", {
   env <- rlang::current_env()
 
-  # The part on its own, which is what the walk below hands the reader.
+  # The part on its own, which is what a walk hands the reader.
   expect_true(
     is_name_only_expr(rlang::missing_arg(), env = env, data_vars = "region")
   )
 
-  # And reached through a walk, in all three positions a selection can hold
-  # one. Written rather than constructed: R's parser keeps the empty argument
-  # in each, unlike the `f((), x)` the refusal of an empty constructor
-  # argument has to build.
+  # Written spellings, in all three positions a selection can hold one. R's
+  # parser keeps the empty argument in each, unlike the `f((), x)` the refusal
+  # of an empty constructor argument has to build.
   written <- list(
     quote(c(, region)),
     quote(c(region, )),
@@ -966,7 +963,30 @@ test_that("the name-only reader answers R's empty argument", {
         env = env,
         data_vars = c("region", "grade")
       ),
-      info = deparse(written[[index]])
+      info = deparse1(written[[index]])
+    )
+  }
+
+  # And every other operator a walk descends into, asked of the reader rather
+  # than through a verb: what it must not do is raise, whatever tidyselect
+  # goes on to do with the part.
+  constructed <- list(
+    as.call(list(as.name("-"), rlang::missing_arg())),
+    as.call(list(as.name("!"), rlang::missing_arg())),
+    as.call(list(as.name("("), rlang::missing_arg())),
+    as.call(list(as.name("|"), rlang::missing_arg(), quote(region))),
+    as.call(list(as.name("/"), rlang::missing_arg(), quote(region))),
+    as.call(list(as.name(":"), rlang::missing_arg(), quote(region))),
+    as.call(list(as.name("&"), quote(region), rlang::missing_arg()))
+  )
+  for (index in seq_along(constructed)) {
+    expect_true(
+      is_name_only_expr(
+        constructed[[index]],
+        env = env,
+        data_vars = "region"
+      ),
+      info = deparse1(constructed[[index]])
     )
   }
 })


### PR DESCRIPTION
Closes #351.

`is_name_only_expr()` read a name off every symbol, and R's empty argument is a symbol whose name is `""`, so `rlang::env_has()` raised `attempt to use zero-length variable name` for any selection carrying one. Reproduced on `main` for `.by = c(, region)`, `c(region, )`, `c(region, , grade)`, and for the same selection written at a Grouping specification argument — `rollup(c(, grade))`. All three spellings parse, so none needed injection to reach the reader.

This was the last site in the package reading a name off a symbol without first asking whether the part names anything; every other one already goes through `is_name_part()`.

## What the reader answers

`TRUE`, which is what its contract already gives an empty part: the column names settle it in both directions. tidyselect drops one under `c()` and fails on one under every other walk operator, exactly as `dplyr::select()` does, and neither branch reads a column's data. `investigation/an-empty-argument-under-a-selection-walk.md` measures which per operator, and records that the non-`c()` failures are tidyselect's rather than a divergence to close.

Refusing an empty part with a Package condition was weighed and rejected: it would make this package stricter than dplyr for shapes dplyr accepts, and would break the reported case.

## The boundary it settles for `.grouping`

`CONTEXT.md`'s *Nested specification position* now says that the refusal of an empty constructor argument reaches the argument's own position and not what a selection written there contains. So `rollup(, grade)` is refused, unchanged, and `rollup(c(, grade))` is not. Its existing test passes unmodified, which is what carries that half.

## Tests

- `is_name_only_expr()` answered directly for the part and through a walk in all three positions.
- End to end over every verb `verbs_taking(".by")` derives — six, not the five the issue body says; it undercounts `inspect_grouping()`.
- `rollup(c(, grade))`, `rollup(c(grade, ))`, and one nested `grouping_sets(grouping_set(c(, region)))`.
- For `-`, `!`, `|`, and `/` carrying an empty operand, that no `marginplyr_error` is raised. The message is tidyselect's and version-dependent, so it is not snapshotted here; the note holds it with the versions it was measured on.

Full suite: 6114 passing, 0 failures, 0 skips. `lintr::lint_package()` clean. Context budget unchanged (`CONTEXT.md` is not in the always-loaded closure).

No `man/`, `NAMESPACE`, or `README.md` change — nothing exported or documented changed.