### PR TITLE
Stage a share without the caller's own call (#357)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -208,6 +208,16 @@
   cannot be evaluated — forwarded empty, naming something absent, or a pair of
   parentheses holding nothing — reaches dplyr, which names the argument you
   wrote, in place of R's bare error naming nothing (#349, #350).
+* A selection or a source your wrapper forwards into a share now reaches the
+  share it names. `across({{ cols }}, share_of_total)` and
+  `share_of_total({{ col }})` — with the `!!rlang::enquo()` and
+  `!!rlang::ensym()` spellings of each — reported `object 'cols' not found`,
+  naming your own wrapper's argument in place of the summary you wrote: the
+  check marginplyr wraps around a share's source carried your call back into
+  the summary, where dplyr defused it a second time and expanded the
+  forwarding where that argument is not bound. The check carries no call
+  there now, and a share's conditions still name the call you wrote,
+  forwarding and all (#357).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were

--- a/R/share.R
+++ b/R/share.R
@@ -970,6 +970,15 @@ wraps_share_sources_in_summary <- function(backend_kind) {
   backend_kind %in% c("local", "dtplyr")
 }
 
+# The dots with each share's source expression wrapped in the check that
+# applies the eligible-type and cardinality rules to it. Only dtplyr is given
+# the caller's call here, and as text: its checks raise at `collect()`, after
+# the verb call has returned, so nothing else can supply one. A local check
+# raises inside the verb call, where `with_margin_error_call()` sets the call
+# -- and staging one into the expression is worse than redundant there,
+# because `dplyr::summarise()` defuses the staged dot a second time and
+# expands whatever injection the caller's own spelling holds, in a mask where
+# their wrapper's formal is not bound (#357).
 wrap_share_sources <- function(dots,
                                cardinality,
                                call,
@@ -1019,8 +1028,7 @@ wrap_share_sources <- function(dots,
         share_private_call("check_share_across"),
         expr,
         share_outputs = share_outputs,
-        share_kinds = share_kinds,
-        call = rlang::call2("quote", call)
+        share_kinds = share_kinds
       )
     } else {
       check <- checks[[1L]]
@@ -1035,11 +1043,7 @@ wrap_share_sources <- function(dots,
         share_output = check$share_output,
         source_summary = check$source_summary,
         share_kind = check$share_kind,
-        !!!if (is_dtplyr) {
-          list(call_text = share_call_text(call))
-        } else {
-          list(call = rlang::call2("quote", call))
-        }
+        !!!if (is_dtplyr) list(call_text = share_call_text(call))
       )
     }
     dots[[position]] <- rlang::new_quosure(
@@ -1282,24 +1286,27 @@ share_private_call <- function(name) {
   )
 }
 
-check_share_across <- function(value, share_outputs, share_kinds, call) {
+check_share_across <- function(value, share_outputs, share_kinds) {
   for (source_summary in names(share_outputs)) {
     check_share_scalar(
       value[[source_summary]],
       share_output = share_outputs[[source_summary]],
       source_summary = source_summary,
-      share_kind = share_kinds[[source_summary]],
-      call = call
+      share_kind = share_kinds[[source_summary]]
     )
   }
   value
 }
 
+# The rules a share's source must satisfy, applied to one value. `call` is
+# dtplyr's alone: only its check raises after the verb call has returned, so
+# only it has to name the call itself. Everywhere else this raises inside the
+# operation, which names it.
 check_share_scalar <- function(value,
                                share_output,
                                source_summary,
                                share_kind,
-                               call) {
+                               call = NULL) {
   if (length(value) != 1L) {
     abort_marginplyr(
       c(

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -2006,6 +2006,61 @@ test_that("dtplyr Total shares match local results", {
   expect_equal(sum(unpartitioned$revenue_share), 2)
 })
 
+# The two backends below answer an injected share selection today, and for
+# reasons that are not the local backend's: dtplyr carries the caller's call as
+# text, which no second defusal reads, and a lazy backend wraps no source in the
+# summary at all. Neither reason is stated where it could be read off the
+# result, so a change to either would be reported by nothing (#357).
+test_that("dtplyr answers an injected share `across()` selection", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.frame(group = c("x", "y"), units = c(1, 3))
+  summarize <- function(source, selection) {
+    summarize_with_margins(
+      source,
+      units = sum(units),
+      dplyr::across({{ selection }}, share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+
+  expected <- summarize(data, units)
+  result <- dplyr::collect(summarize(dtplyr::lazy_dt(data), units))
+
+  expect_equal(as.data.frame(result), as.data.frame(expected))
+  expect_equal(result$units_share, c(0.25, 0.75, 1))
+})
+
+test_that("DuckDB answers an injected share `across()` selection", {
+  skip_if_suggest_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- data.frame(group = c("x", "y"), units = c(1, 3))
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "injected_share_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source, selection) {
+    summarize_with_margins(
+      source,
+      units = sum(units),
+      dplyr::across({{ selection }}, share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+
+  expected <- summarize(data, units)
+  result <- dplyr::collect(summarize(remote, units)) |>
+    dplyr::arrange(group)
+
+  expect_equal(as.data.frame(result), as.data.frame(expected))
+  expect_equal(result$units_share, c(0.25, 0.75, 1))
+})
+
 test_that("dtplyr rejects ineligible Total-share sources on collection", {
   skip_if_suggest_absent("dtplyr")
   step <- dtplyr::lazy_dt(data.frame(group = c("x", "y"), value = 1:2))

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -1990,6 +1990,175 @@ test_that("Total shares expand through across and integer sources", {
   expect_type(result$units_of_total, "double")
 })
 
+# A wrapper forwarding a selection or a source into a share is the ordinary
+# tidy-eval idiom, and the three spellings below are the ones it is written in.
+# What lost them is stated where it was answered, in `wrap_share_sources()`'s
+# header (#357). These two are over the summaries, because a summary is what
+# the caller was denied; the call a share's condition reports is the test after
+# them.
+test_that("an injected share `across()` selection computes what it names", {
+  data <- data.frame(group = c("x", "y"), units = c(1, 3), revenue = c(10, 30))
+
+  written <- summarize_with_margins(
+    data,
+    dplyr::across(c(units, revenue), sum),
+    dplyr::across(
+      c(units, revenue),
+      share_of_total,
+      .names = "{.col}_share"
+    ),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  )
+
+  curly <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      dplyr::across(c(units, revenue), sum),
+      dplyr::across({{ selection }}, share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+  quosure <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      dplyr::across(c(units, revenue), sum),
+      dplyr::across(
+        !!rlang::enquo(selection),
+        share_of_total,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+
+  expect_identical(curly(data, c(units, revenue)), written)
+  expect_identical(quosure(data, c(units, revenue)), written)
+
+  # `rlang::ensym()` carries a bare symbol and no quosure, so it selects one
+  # column and is compared against the written spelling of that selection.
+  one_written <- summarize_with_margins(
+    data,
+    dplyr::across(c(units, revenue), sum),
+    dplyr::across(units, share_of_total, .names = "{.col}_share"),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  )
+  symbol <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      dplyr::across(c(units, revenue), sum),
+      dplyr::across(
+        !!rlang::ensym(selection),
+        share_of_total,
+        .names = "{.col}_share"
+      ),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+
+  expect_identical(symbol(data, units), one_written)
+})
+
+test_that("an injected direct share source computes what it names", {
+  data <- data.frame(group = c("x", "y"), value = c(1, 3))
+
+  written <- summarize_with_margins(
+    data,
+    total = sum(value),
+    whole = share_of_total(total),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  )
+
+  curly <- function(data, source) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      whole = share_of_total({{ source }}),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+  quosure <- function(data, source) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      whole = share_of_total(!!rlang::enquo(source)),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+  symbol <- function(data, source) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      whole = share_of_total(!!rlang::ensym(source)),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+  }
+
+  expect_identical(curly(data, total), written)
+  expect_identical(quosure(data, total), written)
+  expect_identical(symbol(data, total), written)
+})
+
+# What the staging stopped carrying, `with_margin_error_call()` supplies: a
+# Package condition raised inside the verb call takes its call from the
+# operation rather than from the expression handed to dplyr. This is the whole
+# reason the staged call could be removed, so it is asserted as the call itself
+# and not as its name -- including for a caller whose call holds an injection,
+# where the spelling quoted back is the one they wrote (ADR 0024).
+test_that("a share condition reports the caller's own call, injected or not", {
+  data <- data.frame(group = c("x", "y"), value = c(1, 3))
+
+  written <- function(data) {
+    summarize_with_margins(
+      data,
+      total = c(min(value), max(value)),
+      whole = share_of_total(total),
+      .grouping = rollup(group)
+    )
+  }
+  written_error <- expect_error(
+    written(data),
+    class = "marginplyr_share_cardinality_error"
+  )
+  # Bound before the comparison rather than written into it: `expect_*()`
+  # defuses its arguments, which is the second defusal this test is about.
+  written_call <- quote(summarize_with_margins(
+    data,
+    total = c(min(value), max(value)),
+    whole = share_of_total(total),
+    .grouping = rollup(group)
+  ))
+  expect_identical(conditionCall(written_error), written_call)
+
+  injected <- function(data, selection) {
+    summarize_with_margins(
+      data,
+      total = c(min(value), max(value)),
+      dplyr::across({{ selection }}, share_of_total, .names = "{.col}_share"),
+      .grouping = rollup(group)
+    )
+  }
+  injected_error <- expect_error(
+    injected(data, total),
+    class = "marginplyr_share_cardinality_error"
+  )
+  injected_call <- quote(summarize_with_margins(
+    data,
+    total = c(min(value), max(value)),
+    dplyr::across({{ selection }}, share_of_total, .names = "{.col}_share"),
+    .grouping = rollup(group)
+  ))
+  expect_identical(conditionCall(injected_error), injected_call)
+})
+
 test_that("Total-share staging avoids adversarial user-name collisions", {
   # The fixed-key stand-in a Total share joins on when `.by` is empty is the
   # one internal name Parent shares never allocate.


### PR DESCRIPTION
Closes #357.

A wrapper forwarding a selection or a source into a share is the ordinary tidy-eval idiom, and every spelling of it failed on the local backend. The share staging wrapped each source expression in a check carrying the caller's own verb call as `quote(<call>)` — which still holds `{{ selection }}` or `!!rlang::ensym(...)` unexpanded — and `dplyr::summarise()` defuses the staged dot a second time, expanding the injection in a mask where the wrapper's formal is not bound.

The call is removed rather than re-encoded. On the local backend it decides nothing: replacing it with a sentinel and running all four local paths reports the caller's verb call every time, never the sentinel, because `with_margin_error_call()` already sets `$call` on any Package condition raised inside the operation. The same sentinel on the dtplyr path does surface — a dtplyr share raises at `collect()`, after the verb call has returned — so there the call still travels with the expression, as text.

`check_share_across()` therefore loses its `call` argument outright; `check_share_scalar()` keeps one defaulting to `NULL`, supplied by `check_dtplyr_share_source()`, which is its one caller that has to name a call itself.

## Tests

- Local: an injected share `across()` selection and an injected direct share source, each over `{{ }}`, `!!rlang::enquo()`, and `!!rlang::ensym()`, compared against the written spelling.
- Local: the whole call a share's condition reports, for a plain wrapper and for one whose call holds the injection — this is what makes the removal safe rather than merely green.
- dtplyr and DuckDB: an injected share `across()`. Both passed before this change, for reasons that are not the local backend's; nothing else would report a change to either.

`lintr::lint_package()` clean, full suite green with `NOT_CRAN=true`.

## Not in this PR

The dtplyr `str2lang(call_text)` failure filed as #360 — a caller call holding an inlined object does not survive the deparse round trip. Different cause, not fixed here.