### PR TITLE
Write a dtplyr share's call as source it can read back (#360)

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -1399,36 +1399,55 @@ abort_share_source_type <- function(value,
 # source. The parts that fail are replaced before the call is written, rather
 # than the read being allowed to fail (#360).
 share_call_text <- function(call) {
-  text <- deparse_call_text(round_trippable_call(call))
-  # An invariant, not a Package condition (ADR 0015): `round_trippable_call()`
-  # answers every part that does not parse back, so a text that still does not
-  # is a defect here rather than something a call rewrite avoids. It is stated
-  # at the site that writes the text, inside the verb call, because the site
-  # that reads it is past the point where stopping is affordable.
-  stopifnot(!is.null(parse_call_text(text)))
+  text <- deparse_call_text(writable_call(call))
+  # An invariant, not a Package condition (ADR 0015): `writable_call()` answers
+  # every part that does not read back, so a text that still does not is a
+  # defect here. It is stated at the site that writes the text, inside the verb
+  # call, because the site that reads it is past the point where stopping is
+  # affordable.
+  stopifnot(call_text_reads_back(text))
   text
 }
 
+# One expression as the source that would write it.
 deparse_call_text <- function(expr) {
   paste(deparse(expr, width.cutoff = 500L), collapse = "\n")
 }
 
+# Whether `text` can be read back as one expression.
+#
+# Asked instead of testing `parse_call_text()` for `NULL`, because `NULL` is
+# also what the text `"NULL"` reads as. A caller's `.margin_label = NULL` is a
+# part `deparse()` writes perfectly well, and conflating the two answers put a
+# name in its place.
+call_text_reads_back <- function(text) {
+  tryCatch(
+    {
+      str2lang(text)
+      TRUE
+    },
+    error = function(cnd) FALSE
+  )
+}
+
 # The call a text stands for, or `NULL` where the text cannot be read as one.
+# The two answers are one answer at the only site that asks: a text this cannot
+# read and a text reading as `NULL` both leave the condition no call to name.
 parse_call_text <- function(text) {
   tryCatch(str2lang(text), error = function(cnd) NULL)
 }
 
-# `expr` with every part `deparse()` cannot write as source replaced by a name
-# spelling the class of what stood there. Only the parts that fail are touched,
-# which is why the test is a trial rather than a type: a `data.frame` and a
-# Grouping specification both round-trip, and replacing them would thin a call
-# that reads correctly today.
+# `expr` -- a call -- with every part `deparse()` cannot write as source
+# replaced by a name spelling the class of what stood there. Only the parts
+# that fail are touched, which is why the test is a trial rather than a type: a
+# `data.frame` and a Grouping specification both round-trip, and replacing them
+# would thin a call that reads correctly today.
 #
 # A symbol is answered before the trial. `deparse()` writes a non-syntactic
 # name bare when it is asked for one alone -- `unit count`, which does not
 # parse -- and backquotes it inside the call it is written in, so trying one on
 # its own reports a failure the text this produces does not have.
-round_trippable_call <- function(expr) {
+writable_call <- function(expr) {
   if (rlang::is_symbol(expr) || deparse_round_trips(expr)) {
     return(expr)
   }
@@ -1439,24 +1458,31 @@ round_trippable_call <- function(expr) {
       if (rlang::is_missing(expr[[position]])) {
         next
       }
-      expr[[position]] <- round_trippable_call(expr[[position]])
+      part <- writable_call(expr[[position]])
+      # `expr[[position]] <- NULL` deletes the argument rather than setting it,
+      # and `NULL` comes back from the walk only when the caller wrote one --
+      # every replacement is a name. So the argument is left where it is.
+      if (!is.null(part)) {
+        expr[[position]] <- part
+      }
     }
     if (deparse_round_trips(expr)) {
       return(expr)
     }
   }
-  unrepresentable_name(expr)
+  unwritable_name(expr)
 }
 
+# Whether `deparse()` writes `expr` as source that reads back as an expression.
 deparse_round_trips <- function(expr) {
   text <- tryCatch(deparse_call_text(expr), error = function(cnd) NULL)
-  !is.null(text) && !is.null(parse_call_text(text))
+  !is.null(text) && call_text_reads_back(text)
 }
 
-# What stands in a call for a value R cannot write as source. A name rather
-# than a string, so that the part reads as the position it occupies, and
+# What stands in a call for a value `deparse()` cannot write as source. A name
+# rather than a string, so that the part reads as the position it occupies, and
 # non-syntactic so that no caller's own spelling collides with it.
-unrepresentable_name <- function(value) {
+unwritable_name <- function(value) {
   rlang::sym(paste0("<", class(value)[[1L]], ">"))
 }
 

--- a/R/share.R
+++ b/R/share.R
@@ -1253,7 +1253,10 @@ check_dtplyr_share_source <- function(value,
     share_output = share_output,
     source_summary = source_summary,
     share_kind = share_kind,
-    call = str2lang(call_text)
+    # Read at `collect()`, where no frame above can answer a failure. A text
+    # this cannot read costs the caller the call their diagnostic names, and
+    # must not cost them the diagnostic itself (ADR 0015, #360).
+    call = parse_call_text(call_text)
   )
 }
 
@@ -1385,8 +1388,76 @@ abort_share_source_type <- function(value,
   )
 }
 
+# The caller's call as text a dtplyr share can carry to `collect()`. What it
+# returns parses: `check_dtplyr_share_source()` reads it back where nothing can
+# answer a failure.
+#
+# `deparse()` is not total over calls. `do.call()` records the evaluated
+# arguments, so a call reaching here can hold the input itself -- a
+# `data.table`, whose `.internal.selfref` externalptr `deparse()` writes as
+# `<pointer: ...>` -- or an environment, neither of which R can write as
+# source. The parts that fail are replaced before the call is written, rather
+# than the read being allowed to fail (#360).
 share_call_text <- function(call) {
-  paste(deparse(call, width.cutoff = 500L), collapse = "\n")
+  text <- deparse_call_text(round_trippable_call(call))
+  # An invariant, not a Package condition (ADR 0015): `round_trippable_call()`
+  # answers every part that does not parse back, so a text that still does not
+  # is a defect here rather than something a call rewrite avoids. It is stated
+  # at the site that writes the text, inside the verb call, because the site
+  # that reads it is past the point where stopping is affordable.
+  stopifnot(!is.null(parse_call_text(text)))
+  text
+}
+
+deparse_call_text <- function(expr) {
+  paste(deparse(expr, width.cutoff = 500L), collapse = "\n")
+}
+
+# The call a text stands for, or `NULL` where the text cannot be read as one.
+parse_call_text <- function(text) {
+  tryCatch(str2lang(text), error = function(cnd) NULL)
+}
+
+# `expr` with every part `deparse()` cannot write as source replaced by a name
+# spelling the class of what stood there. Only the parts that fail are touched,
+# which is why the test is a trial rather than a type: a `data.frame` and a
+# Grouping specification both round-trip, and replacing them would thin a call
+# that reads correctly today.
+#
+# A symbol is answered before the trial. `deparse()` writes a non-syntactic
+# name bare when it is asked for one alone -- `unit count`, which does not
+# parse -- and backquotes it inside the call it is written in, so trying one on
+# its own reports a failure the text this produces does not have.
+round_trippable_call <- function(expr) {
+  if (rlang::is_symbol(expr) || deparse_round_trips(expr)) {
+    return(expr)
+  }
+  if (rlang::is_call(expr)) {
+    for (position in seq_along(expr)) {
+      # The empty argument is not a value, and standing a name in for it would
+      # write an argument the caller did not pass (#351).
+      if (rlang::is_missing(expr[[position]])) {
+        next
+      }
+      expr[[position]] <- round_trippable_call(expr[[position]])
+    }
+    if (deparse_round_trips(expr)) {
+      return(expr)
+    }
+  }
+  unrepresentable_name(expr)
+}
+
+deparse_round_trips <- function(expr) {
+  text <- tryCatch(deparse_call_text(expr), error = function(cnd) NULL)
+  !is.null(text) && !is.null(parse_call_text(text))
+}
+
+# What stands in a call for a value R cannot write as source. A name rather
+# than a string, so that the part reads as the position it occupies, and
+# non-syntactic so that no caller's own spelling collides with it.
+unrepresentable_name <- function(value) {
+  rlang::sym(paste0("<", class(value)[[1L]], ">"))
 }
 
 analyze_ordinary_summaries <- function(dots, selection_proxy) {

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -2170,3 +2170,68 @@ test_that("Arrow rejects Total shares before constructing a query", {
   expect_identical(calls$summarize, 0L)
   expect_identical(calls$collect, 0L)
 })
+
+test_that("dtplyr reports a share against a call holding its own input", {
+  skip_if_suggest_absent("dtplyr")
+  # `do.call()` records the evaluated arguments, so the call this verb captures
+  # holds the `lazy_dt` itself. Its `.internal.selfref` externalptr is what
+  # `deparse()` cannot write as source, and the text the share carries to
+  # `collect()` used to be that unreadable deparse (#360).
+  data <- data.frame(
+    group = c("x", "x", "y"),
+    value = 1:3
+  )
+
+  query <- do.call(summarize_with_margins, list(
+    dtplyr::lazy_dt(data),
+    source = quote(range(value)),
+    share = quote(share_of_total(source)),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  ))
+
+  expect_s3_class(query, "dtplyr_step")
+  error <- expect_error(
+    dplyr::collect(query),
+    "exactly one value per grouping row"
+  )
+  expect_s3_class(error, "marginplyr_share_cardinality_error")
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(error$share_output, "share")
+  expect_identical(error$source_summary, "source")
+
+  # The input is the one part replaced. Named by its class rather than by the
+  # spelling of that class, which is dtplyr's to change.
+  input <- conditionCall(error)[[2L]]
+  expect_true(rlang::is_symbol(input))
+  expect_match(as.character(input), "^<.+>$")
+
+  # Every other argument is still the caller's own.
+  expect_identical(conditionCall(error)$source, quote(range(value)))
+  expect_identical(conditionCall(error)$share, quote(share_of_total(source)))
+})
+
+test_that("dtplyr reports an across share against the same call", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.frame(
+    group = c("x", "x", "y"),
+    value = 1:3
+  )
+
+  query <- do.call(summarize_with_margins, list(
+    dtplyr::lazy_dt(data),
+    quote(dplyr::across(value, list(flag = ~ any(.x > 0)))),
+    flag_share = quote(share_of_parent(value_flag)),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  ))
+
+  expect_s3_class(query, "dtplyr_step")
+  error <- expect_error(
+    dplyr::collect(query),
+    "plain integer or double scalar"
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(error$share_output, "flag_share")
+  expect_true(rlang::is_call(conditionCall(error)))
+})

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -2206,9 +2206,12 @@ test_that("dtplyr reports a share against a call holding its own input", {
   expect_true(rlang::is_symbol(input))
   expect_match(as.character(input), "^<.+>$")
 
-  # Every other argument is still the caller's own.
+  # Every other argument is still the caller's own, `NULL` included: it is a
+  # part `deparse()` writes, so the walk has nothing to answer it with.
   expect_identical(conditionCall(error)$source, quote(range(value)))
   expect_identical(conditionCall(error)$share, quote(share_of_total(source)))
+  expect_null(conditionCall(error)$.margin_label)
+  expect_true(".margin_label" %in% names(as.list(conditionCall(error))))
 })
 
 test_that("dtplyr reports an across share against the same call", {
@@ -2233,5 +2236,13 @@ test_that("dtplyr reports an across share against the same call", {
   )
   expect_s3_class(error, "marginplyr_error")
   expect_identical(error$share_output, "flag_share")
-  expect_true(rlang::is_call(conditionCall(error)))
+  expect_identical(error$source_summary, "value_flag")
+
+  input <- conditionCall(error)[[2L]]
+  expect_true(rlang::is_symbol(input))
+  expect_match(as.character(input), "^<.+>$")
+  expect_identical(
+    conditionCall(error)$flag_share,
+    quote(share_of_parent(value_flag))
+  )
 })

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -2719,3 +2719,76 @@ test_that("the two share refusals a verb reaches only as a second line", {
     fixed = TRUE
   )
 })
+
+test_that("a call deparse can write whole is carried through unchanged", {
+  call <- quote(summarize_with_margins(data, units = sum(units)))
+  expect_identical(
+    share_call_text(call),
+    paste(deparse(call, width.cutoff = 500L), collapse = "\n")
+  )
+})
+
+test_that("a call text replaces only the part deparse cannot write", {
+  call <- quote(summarize_with_margins(data, units = sum(units)))
+  call[[2L]] <- new.env()
+
+  expect_identical(
+    str2lang(share_call_text(call)),
+    quote(summarize_with_margins(`<environment>`, units = sum(units)))
+  )
+})
+
+test_that("a call text replaces the smallest part it can", {
+  call <- quote(summarize_with_margins(data, .grouping = rollup(region)))
+  call[[3L]][[2L]] <- new.env()
+
+  expect_identical(
+    str2lang(share_call_text(call)),
+    quote(summarize_with_margins(data, .grouping = rollup(`<environment>`)))
+  )
+})
+
+test_that("a call text names a replaced part by the class it stood for", {
+  call <- quote(summarize_with_margins(data))
+  call[[2L]] <- structure(new.env(), class = c("lazy_thing", "environment"))
+
+  expect_identical(
+    str2lang(share_call_text(call)),
+    quote(summarize_with_margins(`<lazy_thing>`))
+  )
+})
+
+test_that("a call text carries an empty argument past the walk", {
+  call <- quote(summarize_with_margins(data, , units = sum(units)))
+  call[[2L]] <- new.env()
+
+  expect_identical(
+    str2lang(share_call_text(call)),
+    quote(summarize_with_margins(`<environment>`, , units = sum(units)))
+  )
+})
+
+test_that("a call text keeps a non-syntactic name the caller wrote", {
+  call <- quote(summarize_with_margins(data, units = sum(x)))
+  call[[2L]] <- new.env()
+  call[[3L]][[2L]] <- as.name("unit count")
+
+  expect_identical(
+    str2lang(share_call_text(call)),
+    quote(summarize_with_margins(`<environment>`, units = sum(`unit count`)))
+  )
+})
+
+test_that("a dtplyr share reports no call rather than a parse error", {
+  error <- expect_error(
+    check_dtplyr_share_source(
+      c(1, 2),
+      share_output = "share",
+      source_summary = "source",
+      share_kind = "total",
+      call_text = "summarize_with_margins(<environment>)"
+    ),
+    class = "marginplyr_share_cardinality_error"
+  )
+  expect_null(conditionCall(error))
+})

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -2792,3 +2792,17 @@ test_that("a dtplyr share reports no call rather than a parse error", {
   )
   expect_null(conditionCall(error))
 })
+
+test_that("a call text keeps a `NULL` the caller wrote", {
+  # `NULL` is what an unreadable text and the text `"NULL"` both parse to, so
+  # a walk that reads the parse for its answer replaces an argument
+  # `deparse()` writes perfectly well -- and `.margin_label = NULL` is this
+  # package's own idiom.
+  call <- quote(summarize_with_margins(data, .margin_label = NULL))
+  call[[2L]] <- new.env()
+
+  expect_identical(
+    str2lang(share_call_text(call)),
+    quote(summarize_with_margins(`<environment>`, .margin_label = NULL))
+  )
+})


### PR DESCRIPTION
Closes #360.

A dtplyr share carries the caller's call to `collect()` as deparsed text and reads it back with `str2lang()`. `deparse()` is not total over calls, so a call holding the input itself — as `do.call()` records — was answered with R's own parse error in place of the share's Package condition.

The text is made total rather than the read guarded: the call is walked before it is written, and every part `deparse()` cannot write as source is replaced by a name spelling that part's class. The test is a trial rather than a type, so a `data.frame` or a Grouping specification, both of which round-trip, is left exactly as the caller wrote it.

The alternative #360 raised — carrying the call as an object — was measured and is closed: `dtplyr:::dt_squash()` raises `abort("Invalid input")` for anything that is not atomic, `NULL`, a symbol, a quosure, or a call, and descends into and rewrites a bare call object.

`.check_share_source = FALSE` did not avoid the crash, so there was no workaround short of not using `do.call()`.

## Checks

- `testthat::test_dir("tests/testthat")` under `NOT_CRAN=true`: 6165 pass, 0 fail, 0 skip
- `lintr::lint_package()` after `pkgload::load_all()`: no lints
- No roxygen, `README.Rmd`, or `DESCRIPTION` change, so nothing generated needs regenerating