### PR TITLE
Refuse a name on a grouping constructor's argument (#365)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,11 @@
   constructor and the position — `grouping_sets(, region)` reports that its
   first argument is empty — rather than reporting an internal name you never
   wrote. A trailing comma is not an empty argument, because R captures no
-  argument for it.
+  argument for it. A name on the constructor's own argument is refused too:
+  `rollup(area = region)` reports the name rather than dropping it, and so a
+  Margin verb's own argument written one pair of parentheses in —
+  `rollup(region, .by = year)` — is reported rather than taken as a second
+  dimension (#365).
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -272,6 +272,26 @@ abort_empty_grouping_arg <- function(constructor, position) {
   ))
 }
 
+# The refusal of a name R bound to a constructor's own argument. Every
+# constructor takes `...` alone, so such a name is not a selection renaming a
+# dimension -- `abort_grouping_rename()` answers that one level in -- and
+# nothing reads it: expansion takes the argument's value and the name reaches
+# no position. A Margin verb's own argument written one pair of parentheses in
+# arrives here, which is the spelling that made the position silent (#365).
+#
+# The pairs arrive alone in an `i` bullet, per ADR 0023's condition 2: how many
+# of them there are is the caller's decision.
+abort_named_grouping_arg <- function(constructor, pairs) {
+  abort_marginplyr(c(
+    "{.fun {constructor}} takes no named arguments:",
+    i = "{.code {pairs}}.",
+    i = paste0(
+      "Remove the {cli::qty(length(pairs))}name{?s}, or move a Margin verb's ",
+      "argument to the verb call."
+    )
+  ))
+}
+
 abort_empty_composite <- function() {
   abort_marginplyr(
     "An empty {.fun grouping_set} cannot be a composite dimension."
@@ -489,6 +509,10 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
 
   rule <- find_grouping_kind_rule(grouping_spec$type)
   stopifnot(!is.null(rule))
+  # Over the whole call before the loop reads any argument, so a call carrying
+  # a renaming selection as well is answered by the refusal that needs no data
+  # (ADR 0005).
+  check_named_grouping_args(grouping_spec, rule)
   name_only <- TRUE
   args <- vector("list", length(grouping_spec$args))
   for (i in seq_along(grouping_spec$args)) {
@@ -514,6 +538,25 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
     args[[i]] <- list(quo = arg, nested = nested_preflight)
   }
   list(spec = grouping_spec, args = args, name_only = name_only)
+}
+
+# Every name the caller bound to one constructor call's own arguments. The pair
+# is the caller's own text on both halves (ADR 0024), so an argument left empty
+# gives the name and nothing after the `=`, which is what was written.
+check_named_grouping_args <- function(grouping_spec, rule) {
+  arg_names <- rlang::names2(grouping_spec$args)
+  named <- nzchar(arg_names)
+  if (!any(named)) {
+    return(invisible(NULL))
+  }
+  abort_named_grouping_arg(
+    rule$constructor,
+    paste0(
+      arg_names[named],
+      " = ",
+      vapply(grouping_spec$args[named], rlang::as_label, character(1))
+    )
+  )
 }
 
 # The spelling a nested position reads an argument by: the caller's expression

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -272,15 +272,12 @@ abort_empty_grouping_arg <- function(constructor, position) {
   ))
 }
 
-# The refusal of a name R bound to a constructor's own argument. Every
-# constructor takes `...` alone, so such a name is not a selection renaming a
-# dimension -- `abort_grouping_rename()` answers that one level in -- and
-# nothing reads it: expansion takes the argument's value and the name reaches
-# no position. A Margin verb's own argument written one pair of parentheses in
-# arrives here, which is the spelling that made the position silent (#365).
-#
-# The pairs arrive alone in an `i` bullet, per ADR 0023's condition 2: how many
-# of them there are is the caller's decision.
+# The refusal of a name R bound to a constructor's own argument. Such a name is
+# not a selection renaming a dimension -- `abort_grouping_rename()` answers
+# that one level in -- and nothing reads it: expansion takes the argument's
+# value and the name reaches no position. A Margin verb's own argument written
+# one pair of parentheses in arrives here, which is the spelling that made the
+# position silent (#365).
 abort_named_grouping_arg <- function(constructor, pairs) {
   abort_marginplyr(c(
     "{.fun {constructor}} takes no named arguments:",
@@ -540,12 +537,19 @@ preflight_grouping_spec <- function(grouping_spec, data_vars) {
   list(spec = grouping_spec, args = args, name_only = name_only)
 }
 
-# Every name the caller bound to one constructor call's own arguments. The pair
-# is the caller's own text on both halves (ADR 0024), so an argument left empty
-# gives the name and nothing after the `=`, which is what was written.
+# Every name the caller bound to one constructor call's own arguments, less the
+# ones `abort_empty_grouping_arg()` speaks for. An empty argument has no
+# spelling for a pair to quote (#261), so it is left to the loop below, which
+# refuses it by position.
 check_named_grouping_args <- function(grouping_spec, rule) {
   arg_names <- rlang::names2(grouping_spec$args)
-  named <- nzchar(arg_names)
+  empty <- vapply(
+    grouping_spec$args,
+    is_empty_argument,
+    logical(1),
+    USE.NAMES = FALSE
+  )
+  named <- nzchar(arg_names) & !empty
   if (!any(named)) {
     return(invisible(NULL))
   }

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -71,9 +71,13 @@
 #'   which takes no nested Grouping specification at all. A name bound to
 #'   anything that is not a specification is a column, as it always was.
 #'
-#'   A dimension is a column of the input, so a selection cannot rename it:
-#'   `c(area = region)` is an error rather than a dimension named `area`.
-#'   Rename the result afterwards with [dplyr::rename()].
+#'   A dimension is a column of the input, so a name attached to one is
+#'   refused, whether it sits inside a selection or on the constructor's own
+#'   argument: `c(area = region)` and `rollup(area = region)` are both errors
+#'   rather than a dimension named `area`. Rename the result afterwards with
+#'   [dplyr::rename()]. A Margin verb's own argument written in a constructor
+#'   falls under that same rule, so `rollup(region, .by = year)` reports the
+#'   name instead of taking `year` as a second dimension.
 #'
 #' @return A grouping specification for use in `.grouping`.
 #' @family grouping plans and grouping identity

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -66,9 +66,13 @@ when it is bound to a \code{\link[=grouping_set]{grouping_set()}}, and never in 
 which takes no nested Grouping specification at all. A name bound to
 anything that is not a specification is a column, as it always was.
 
-A dimension is a column of the input, so a selection cannot rename it:
-\code{c(area = region)} is an error rather than a dimension named \code{area}.
-Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
+A dimension is a column of the input, so a name attached to one is
+refused, whether it sits inside a selection or on the constructor's own
+argument: \code{c(area = region)} and \code{rollup(area = region)} are both errors
+rather than a dimension named \code{area}. Rename the result afterwards with
+\code{\link[dplyr:rename]{dplyr::rename()}}. A Margin verb's own argument written in a constructor
+falls under that same rule, so \code{rollup(region, .by = year)} reports the
+name instead of taking \code{year} as a second dimension.}
 }
 \value{
 A grouping specification for use in \code{.grouping}.

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -126,6 +126,10 @@ pluralizing_coverage <- function() {
       "test-grouping-plan.R",
       "a renaming grouping selection is refused by every constructor"
     ),
+    abort_named_grouping_arg = pluralizing_test_location(
+      "test-grouping-plan.R",
+      "a name on a constructor's own argument is refused"
+    ),
     abort_observed_label_collision = rep("this file, the collision block", 2L),
     check_summary_context_helpers = pluralizing_test_location(
       "test-contextual-helpers.R",
@@ -201,7 +205,7 @@ test_that("the readings behind the coverage gate", {
   expect_false(is_call_to(quote(cli::format_inline("x")), "pluralize"))
 })
 
-# The gate. A seventeenth pluralizing site fails until it is pinned and named
+# The gate. A new pluralizing site fails until it is pinned and named
 # here, and a site that stops pluralizing fails until its entry goes -- neither
 # of which is a number anyone maintains, which is what the census this replaced
 # turned out to be.

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2815,3 +2815,89 @@ test_that("compile_grouping_spec() reads a narrowed duplicates vocabulary", {
   )
   expect_equal(dropped$sets, list("a"))
 })
+
+test_that("a name on a constructor's own argument is refused", {
+  data_vars <- c("region", "year", "value")
+
+  refuse <- function(spec) {
+    error <- expect_error(compile_grouping_spec(
+      spec,
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
+    ))
+    expect_s3_class(error, "marginplyr_error")
+    conditionMessage(error)
+  }
+
+  named_message <- function(constructor, pairs) {
+    paste0(
+      sprintf("`%s()` takes no named arguments:\n", constructor),
+      sprintf("i %s.\n", paste(sprintf("`%s`", pairs), collapse = " and ")),
+      sprintf(
+        "i Remove the %s, or move a Margin verb's argument to the verb call.",
+        if (length(pairs) == 1L) "name" else "names"
+      )
+    )
+  }
+
+  # A Margin verb's argument written one pair of parentheses in. Every
+  # constructor is covered, because the mistake is available at each of them.
+  expect_identical(
+    refuse(rollup(region, .by = year)),
+    named_message("rollup", ".by = year")
+  )
+  expect_identical(
+    refuse(cube(region, .id = "level")),
+    named_message("cube", ".id = \"level\"")
+  )
+  expect_identical(
+    refuse(grouping_set(region, .sort = "last")),
+    named_message("grouping_set", ".sort = \"last\"")
+  )
+  expect_identical(
+    refuse(grouping_sets(grouping_set(region), .duplicates = "drop")),
+    named_message("grouping_sets", ".duplicates = \"drop\"")
+  )
+  expect_identical(
+    refuse(grouping_spec(rollup(region), .keep = TRUE)),
+    named_message("grouping_spec", ".keep = TRUE")
+  )
+
+  # The same refusal answers a name that is not a verb's argument, which the
+  # renaming rule already refuses one level in.
+  expect_identical(
+    refuse(rollup(area = region)),
+    named_message("rollup", "area = region")
+  )
+  # A name on a nested specification renames no dimension, so only this
+  # refusal speaks for it.
+  expect_identical(
+    refuse(grouping_sets(s = rollup(region))),
+    named_message("grouping_sets", "s = rollup(region)")
+  )
+
+  # How many names there are is the caller's decision, so one call carrying
+  # two is one refusal (ADR 0023, condition 2).
+  expect_identical(
+    refuse(rollup(region, .by = year, .id = "level")),
+    named_message("rollup", c(".by = year", ".id = \"level\""))
+  )
+
+  # Checked for the whole call before any argument is read, so the refusal
+  # that needs no data answers a call carrying both mistakes.
+  expect_identical(
+    refuse(rollup(tidyselect::all_of(c(area = "region")), .by = year)),
+    named_message("rollup", ".by = year")
+  )
+
+  # A name repeating its own column still renames nothing and is still a
+  # selection, so the renaming rule keeps its own population.
+  expect_identical(
+    compile_grouping_spec(
+      rollup(tidyselect::all_of(c(region = "region"))),
+      data_vars,
+      duplicates_choices = margin_duplicates_choices
+    )$dimensions,
+    "region"
+  )
+})

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2901,3 +2901,37 @@ test_that("a name on a constructor's own argument is refused", {
     "region"
   )
 })
+
+test_that("a name on an empty argument is refused by position", {
+  data_vars <- c("region", "year", "value")
+
+  # An empty argument has no spelling for a pair to quote (#261), so the
+  # refusal that points by position speaks for it even when it carries a name.
+  first <- expect_error(compile_grouping_spec(
+    rollup(area = ),
+    data_vars,
+    duplicates_choices = margin_duplicates_choices
+  ))
+  expect_s3_class(first, "marginplyr_error")
+  expect_identical(
+    conditionMessage(first),
+    paste0(
+      "Argument 1 of `rollup()` is empty.\n",
+      "i Remove the comma, or write the columns that position selects."
+    )
+  )
+
+  second <- expect_error(compile_grouping_spec(
+    rollup(region, .by = ),
+    data_vars,
+    duplicates_choices = margin_duplicates_choices
+  ))
+  expect_s3_class(second, "marginplyr_error")
+  expect_identical(
+    conditionMessage(second),
+    paste0(
+      "Argument 2 of `rollup()` is empty.\n",
+      "i Remove the comma, or write the columns that position selects."
+    )
+  )
+})


### PR DESCRIPTION
Closes #365.

The grouping constructors capture `...` as quosures and never read the names R bound to those arguments. A name inside a selection is refused — `rollup(c(area = cut))` reports a renaming dimension — while the same name one level out was dropped: `rollup(area = cut)` resolved to `rollup(cut)`, and `rollup(cut, .by = color)` took `color` as a second dimension, producing a report correct for the grouping that ran with nothing saying which grouping that was.

`preflight_grouping_spec()` now refuses a named argument over the whole call before the loop reads any argument, with its own diagnostic. The design was settled on the issue; the agent brief there carries the decisions and what each rests on.