### PR TITLE
Read the plan's dimensions for a bare grouping_id() (#366)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,18 @@
   `rollup(region, .by = year)` — is reported rather than taken as a second
   dimension (#365).
 * Added contextual `grouping_bit()` and `grouping_id()` summary helpers.
+  `grouping_id()` written with no columns reads every `.grouping` column of the
+  resolved plan, in plan order, which is the order `inspect_grouping()` reports:
+  a bare `grouping_id()` is `inspect_grouping()$grouping_id` for the Grouping
+  set the row came from, as `.id` is `set_id` for its occurrence. Retyping the
+  columns is still accepted, and is how a subset of them or an order other than
+  the plan's is encoded, but a retyped list is a copy of a specification written
+  in the same call: widening `rollup(cut, color)` to
+  `rollup(cut, color, clarity)` renumbered the levels while
+  `grouping_id(cut, color)` went on returning a two-bit mask (#366). Columns
+  fixed by `.by` are not part of the default, each contributing a bit that is
+  always zero. A plan with no dimensions gives `0L`, and one past the 31-column
+  cap is refused as a written call of that width is.
 * Added the contextual `share_of_parent()` summary helper, which divides a
   preceding numeric scalar summary by the same measure one `rollup()` level
   up, partitioned by the fixed `.by` keys. Local data frames, dbplyr, and

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -13,8 +13,7 @@
 #' the resolved plan, in plan order. That is the order [inspect_grouping()]
 #' reports, so a bare [grouping_id()] equals that function's `grouping_id` for
 #' the grouping set the row came from. Columns fixed by `.by` are not part of
-#' that default: each belongs to every grouping set, so it would widen the
-#' mask by a bit that is always zero.
+#' that default.
 #'
 #' The `_bit` suffix emphasizes the `0`/`1` result and deliberately avoids
 #' masking [base::grouping()], an unrelated function that returns a permutation
@@ -243,12 +242,8 @@ grouping_helper_vars <- function(args, helper, plan) {
   if (identical(helper, "grouping_bit") && length(carried) != 1L) {
     abort_marginplyr("{.fun grouping_bit} requires exactly one column.")
   }
-  # `grouping_id()` written with no columns reads the plan's dimensions, in
-  # plan order, which is the order `inspect_grouping()` reports its own
-  # `grouping_id` in -- so a bare call and that column agree for one resolved
-  # plan, as `.id` and `set_id` do (ADR 0009). The plan's `.by` is left out:
-  # a `.by` column belongs to every Grouping set, so carrying it would widen
-  # the mask by a bit that is always zero and spend one of the 31 (#366).
+  # A call naming no columns falls to the plan's dimensions, in plan order,
+  # and not to its `.by` (ADR 0009).
   #
   # Written back as symbols rather than returned, so the column cap below stays
   # at one site. Every other check between here and it passes by construction:

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -7,8 +7,14 @@
 #' [grouping_bit()] corresponds to SQL `GROUPING(x)`: it returns `1L` when
 #' `x` is absent from the grouping set and `0L` otherwise.
 #' [grouping_id()] combines those flags as a bit mask; its last argument is
-#' the least-significant bit. It accepts between 1 and 31 distinct grouping
-#' columns.
+#' the least-significant bit. It accepts up to 31 distinct grouping columns.
+#'
+#' Written with no columns, [grouping_id()] reads every `.grouping` column of
+#' the resolved plan, in plan order. That is the order [inspect_grouping()]
+#' reports, so a bare [grouping_id()] equals that function's `grouping_id` for
+#' the grouping set the row came from. Columns fixed by `.by` are not part of
+#' that default: each belongs to every grouping set, so it would widen the
+#' mask by a bit that is always zero.
 #'
 #' The `_bit` suffix emphasizes the `0`/`1` result and deliberately avoids
 #' masking [base::grouping()], an unrelated function that returns a permutation
@@ -66,7 +72,8 @@
 #' would be.
 #'
 #' @param x A bare grouping column.
-#' @param ... Bare grouping columns.
+#' @param ... Bare grouping columns. Passing none reads every `.grouping`
+#'   column of the resolved plan.
 #'
 #' @return A grouping flag or identifier when used inside
 #'   [summarize_with_margins()]. Local data frames and `dtplyr` steps return R
@@ -101,7 +108,7 @@
 #'   .data = dplyr::filter(retail_sales, year == 2026L, month == "Jan"),
 #'   revenue = sum(revenue),
 #'   store_is_total = grouping_bit(store),
-#'   level = grouping_id(region, store),
+#'   level = grouping_id(),
 #'   .grouping = rollup(region, store),
 #'   .margin_label = NULL
 #' )
@@ -236,8 +243,18 @@ grouping_helper_vars <- function(args, helper, plan) {
   if (identical(helper, "grouping_bit") && length(carried) != 1L) {
     abort_marginplyr("{.fun grouping_bit} requires exactly one column.")
   }
+  # `grouping_id()` written with no columns reads the plan's dimensions, in
+  # plan order, which is the order `inspect_grouping()` reports its own
+  # `grouping_id` in -- so a bare call and that column agree for one resolved
+  # plan, as `.id` and `set_id` do (ADR 0009). The plan's `.by` is left out:
+  # a `.by` column belongs to every Grouping set, so carrying it would widen
+  # the mask by a bit that is always zero and spend one of the 31 (#366).
+  #
+  # Written back as symbols rather than returned, so the column cap below stays
+  # at one site. Every other check between here and it passes by construction:
+  # `plan$dimensions` holds distinct names drawn from `allowed`.
   if (identical(helper, "grouping_id") && length(carried) == 0L) {
-    abort_marginplyr("{.fun grouping_id} requires at least one column.")
+    carried <- lapply(plan$dimensions, rlang::sym)
   }
 
   # The compound question, asked here even though the check above has already
@@ -332,6 +349,14 @@ grouping_sql_expr <- function(var, con) {
 }
 
 grouping_id_sql_expr <- function(vars, con) {
+  if (length(vars) == 0L) {
+    # A plan with no dimensions reaches this adapter over its `.by` columns
+    # alone, and has no `GROUPING()` term for the mask to be built from: the
+    # reduction below would have nothing to reduce and would answer `NULL`.
+    # The literal is the constant the local path computes for that plan.
+    return(dbplyr::sql_glue2(con, "{0L}"))
+  }
+
   terms <- lapply(
     seq_along(vars),
     function(i) {

--- a/design/adr/0009-distinguish-grouping-set-identifiers-from-grouping-identifiers.md
+++ b/design/adr/0009-distinguish-grouping-set-identifiers-from-grouping-identifiers.md
@@ -77,3 +77,45 @@ remains stable only within one ordered plan.
 
 `inspect_grouping()`'s guaranteed Grouping-plan order is likewise unchanged,
 and is still not the same thing as a Margin order.
+
+## Amendment: the second correspondence, between a bare `grouping_id()` and `inspect_grouping()$grouping_id`
+
+This ADR fixes one correspondence: given the same resolved `.by`,
+`.grouping`, and `.duplicates`, `inspect_grouping()$set_id` is exactly the
+value a Margin verb's `.id` produces. `grouping_id()` had no counterpart to it,
+because the columns it encoded were whatever the caller retyped rather than
+anything the plan decided. A caller who wanted the plan's own mask wrote the
+`.grouping` columns a second time, in the same call, and a later edit to
+`.grouping` renumbered the levels while the retyped list kept returning the
+older mask (#366).
+
+`grouping_id()` written with no columns now reads every Grouping dimension of
+the resolved plan, in plan order. That gives the second correspondence: a bare
+`grouping_id()` is exactly `inspect_grouping()$grouping_id` for the Grouping
+set the row came from, as `.id` is exactly `set_id` for its occurrence. The
+retyped spelling is unchanged and remains the way to encode a subset of the
+dimensions, or to fix an order other than the plan's.
+
+Fixed `.by` columns are excluded from that default. A `.by` column belongs to
+every Grouping set, so it contributes a zero bit wherever it appears, and
+leading zero bits leave the value alone — the exclusion is observable only at
+the 31-column cap, which is where it earns itself: a plan of 31 dimensions
+beside a fixed column is one the default can encode. Passing a `.by` column
+explicitly is still accepted and still contributes its zero bit.
+
+Two edges follow the plan rather than the caller. A plan with no dimensions
+gives `0L`, which is what `inspect_grouping()` reports for it. A plan of more
+than 31 dimensions is refused with the same at-most-31 diagnostic the written
+spelling raises; `inspect_grouping()` reports `NA_integer_` there and the bare
+call deliberately does not adopt that, a silently-`NA` identifier being the
+failure this default exists to remove.
+
+What this ADR decides is unaffected. A Grouping set identifier is still stable
+only within one ordered Grouping plan and still separates duplicate
+occurrences; a Grouping identifier is still stable for one absence pattern and
+may still be non-consecutive. A bare `grouping_id()` is a Grouping identifier
+and inherits both properties — it cannot tell duplicate occurrences apart, and
+a `rollup()` plan still skips identifier 2.
+
+`grouping_bit()` is unchanged. It asks about one named column, so no-argument
+has no reading for it, and it keeps refusing a call that names none.

--- a/man/grouping_bit.Rd
+++ b/man/grouping_bit.Rd
@@ -42,8 +42,7 @@ Written with no columns, \code{\link[=grouping_id]{grouping_id()}} reads every \
 the resolved plan, in plan order. That is the order \code{\link[=inspect_grouping]{inspect_grouping()}}
 reports, so a bare \code{\link[=grouping_id]{grouping_id()}} equals that function's \code{grouping_id} for
 the grouping set the row came from. Columns fixed by \code{.by} are not part of
-that default: each belongs to every grouping set, so it would widen the
-mask by a bit that is always zero.
+that default.
 
 The \verb{_bit} suffix emphasizes the \code{0}/\code{1} result and deliberately avoids
 masking \code{\link[base:grouping]{base::grouping()}}, an unrelated function that returns a permutation

--- a/man/grouping_bit.Rd
+++ b/man/grouping_bit.Rd
@@ -12,7 +12,8 @@ grouping_id(...)
 \arguments{
 \item{x}{A bare grouping column.}
 
-\item{...}{Bare grouping columns.}
+\item{...}{Bare grouping columns. Passing none reads every \code{.grouping}
+column of the resolved plan.}
 }
 \value{
 A grouping flag or identifier when used inside
@@ -35,8 +36,14 @@ grouping set from ordinary missing values in the source data.
 \code{\link[=grouping_bit]{grouping_bit()}} corresponds to SQL \code{GROUPING(x)}: it returns \code{1L} when
 \code{x} is absent from the grouping set and \code{0L} otherwise.
 \code{\link[=grouping_id]{grouping_id()}} combines those flags as a bit mask; its last argument is
-the least-significant bit. It accepts between 1 and 31 distinct grouping
-columns.
+the least-significant bit. It accepts up to 31 distinct grouping columns.
+
+Written with no columns, \code{\link[=grouping_id]{grouping_id()}} reads every \code{.grouping} column of
+the resolved plan, in plan order. That is the order \code{\link[=inspect_grouping]{inspect_grouping()}}
+reports, so a bare \code{\link[=grouping_id]{grouping_id()}} equals that function's \code{grouping_id} for
+the grouping set the row came from. Columns fixed by \code{.by} are not part of
+that default: each belongs to every grouping set, so it would widen the
+mask by a bit that is always zero.
 
 The \verb{_bit} suffix emphasizes the \code{0}/\code{1} result and deliberately avoids
 masking \code{\link[base:grouping]{base::grouping()}}, an unrelated function that returns a permutation
@@ -113,7 +120,7 @@ summarize_with_margins(
   .data = dplyr::filter(retail_sales, year == 2026L, month == "Jan"),
   revenue = sum(revenue),
   store_is_total = grouping_bit(store),
-  level = grouping_id(region, store),
+  level = grouping_id(),
   .grouping = rollup(region, store),
   .margin_label = NULL
 )

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -1728,6 +1728,89 @@ test_that("native SQL omits display flags when labels are disabled", {
   expect_identical(dplyr::group_vars(query), character())
 })
 
+# The bare `grouping_id()` of #366 resolves before either adapter runs, so the
+# native path is asserted against the retyped spelling rather than against a
+# transcription of the SQL: what the default has to produce is the same query.
+test_that("a bare grouping_id() renders the native SQL of the retyped call", {
+  remote <- dbplyr::tbl_lazy(
+    data.frame(a = "x", b = "u", value = 1),
+    con = dbplyr::simulate_postgres()
+  )
+  query <- function(gid) {
+    summarize_with_margins(
+      remote,
+      n = dplyr::n(),
+      gid = !!gid,
+      .grouping = rollup(a, b),
+      .margin_label = NULL
+    )
+  }
+
+  bare <- dbplyr::sql_render(query(quote(grouping_id())))
+  written <- dbplyr::sql_render(query(quote(grouping_id(a, b))))
+
+  expect_identical(bare, written)
+  expect_match(bare, "GROUPING(\"a\")", fixed = TRUE)
+  expect_match(bare, "GROUPING(\"b\")", fixed = TRUE)
+})
+
+# A plan with no dimensions still reaches the native adapter -- `GROUP BY
+# GROUPING SETS` over the `.by` columns alone -- where the mask has no
+# `GROUPING()` term to build from and has to be written as the literal the
+# local path computes.
+test_that("a bare grouping_id() renders a literal for a dimensionless plan", {
+  remote <- dbplyr::tbl_lazy(
+    data.frame(a = "x", value = 1),
+    con = dbplyr::simulate_postgres()
+  )
+  query <- summarize_with_margins(
+    remote,
+    n = dplyr::n(),
+    gid = grouping_id(),
+    .by = a
+  )
+  sql <- dbplyr::sql_render(query)
+
+  expect_match(sql, "GROUP BY GROUPING SETS", fixed = TRUE)
+  expect_false(grepl("GROUPING(\"", sql, fixed = TRUE))
+  expect_match(sql, "0 AS \"gid\"", fixed = TRUE)
+})
+
+test_that("DuckDB collects the same bare grouping_id() the local path gives", {
+  skip_if_suggest_absent("duckdb", "DBI")
+
+  data <- data.frame(
+    a = c("x", "x", "y"),
+    b = c("u", "v", "u"),
+    value = 1:3
+  )
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "bare_grouping_id",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+
+  collected <- dplyr::collect(summarize_with_margins(
+    remote,
+    total = sum(value),
+    gid = grouping_id(),
+    .grouping = rollup(a, b)
+  ))
+  local <- summarize_with_margins(
+    data,
+    total = sum(value),
+    gid = grouping_id(),
+    .grouping = rollup(a, b)
+  )
+
+  expect_setequal(as.integer(collected$gid), local$gid)
+  expect_identical(sort(unique(as.integer(collected$gid))), c(0L, 1L, 3L))
+})
+
 test_that("native SQL reports incompatible dbplyr query representations", {
   registerS3method(
     "sql_build",

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -502,10 +502,6 @@ test_that("a bare grouping_id() reads the plan's own dimensions", {
   expect_setequal(unique(result$bare), c(0L, 1L, 3L))
 })
 
-# The default is the plan's dimensions and not its `.by`. A `.by` column
-# belongs to every Grouping set, so it always contributes a zero bit, and a
-# leading zero leaves the number alone -- the exclusion is observable at the
-# column cap, which is where it is asserted below.
 test_that("a bare grouping_id() equals inspect_grouping()$grouping_id", {
   data <- data.frame(
     k = c("f", "f", "g"),
@@ -514,44 +510,27 @@ test_that("a bare grouping_id() equals inspect_grouping()$grouping_id", {
     value = 1:3
   )
 
-  expect_plan_correspondence <- function(result, plan) {
+  # ADR 0009 states the correspondence for one resolved `.by` and `.grouping`,
+  # so one specification is injected into both calls rather than written twice.
+  expect_plan_correspondence <- function(grouping, by = rlang::quo(NULL)) {
+    result <- summarize_with_margins(
+      data,
+      total = sum(value),
+      gid = grouping_id(),
+      .id = "sid",
+      .by = !!by,
+      .grouping = !!grouping
+    )
+    plan <- inspect_grouping(data, .by = !!by, .grouping = !!grouping)
     expect_identical(
       result$gid,
       plan$grouping_id[match(result$sid, plan$set_id)]
     )
   }
 
-  expect_plan_correspondence(
-    summarize_with_margins(
-      data,
-      total = sum(value),
-      gid = grouping_id(),
-      .id = "sid",
-      .grouping = rollup(a, b)
-    ),
-    inspect_grouping(data, .grouping = rollup(a, b))
-  )
-  expect_plan_correspondence(
-    summarize_with_margins(
-      data,
-      total = sum(value),
-      gid = grouping_id(),
-      .id = "sid",
-      .grouping = cube(a, b)
-    ),
-    inspect_grouping(data, .grouping = cube(a, b))
-  )
-  expect_plan_correspondence(
-    summarize_with_margins(
-      data,
-      total = sum(value),
-      gid = grouping_id(),
-      .id = "sid",
-      .by = k,
-      .grouping = rollup(a, b)
-    ),
-    inspect_grouping(data, .by = k, .grouping = rollup(a, b))
-  )
+  expect_plan_correspondence(rlang::quo(rollup(a, b)))
+  expect_plan_correspondence(rlang::quo(cube(a, b)))
+  expect_plan_correspondence(rlang::quo(rollup(a, b)), rlang::quo(k))
 })
 
 test_that("a bare grouping_id() is zero where the plan has no dimensions", {
@@ -599,7 +578,7 @@ test_that("a bare grouping_id() follows an edit to .grouping", {
   expect_identical(max(three$gid), 7L)
 })
 
-test_that("a bare grouping_id() leaves every written-argument refusal", {
+test_that("written arguments to grouping_id() are refused as before", {
   data <- data.frame(a = 1, b = 1)
 
   expect_error(
@@ -628,11 +607,6 @@ test_that("a bare grouping_id() leaves every written-argument refusal", {
   )
 })
 
-# The one place the `.by` exclusion is observable: 31 dimensions beside a fixed
-# column is a plan the bare call can encode, and would not be if `.by` were
-# carried. `inspect_grouping()` reports `NA_integer_` beyond the cap and the
-# bare call does not adopt that -- a silently-`NA` identifier is what this
-# default exists to remove.
 test_that("a bare grouping_id() reaches the column cap on dimensions alone", {
   dimension_data <- function(n) {
     data <- as.data.frame(stats::setNames(
@@ -643,7 +617,7 @@ test_that("a bare grouping_id() reaches the column cap on dimensions alone", {
     data$value <- 1
     data
   }
-  one_set <- function(n) {
+  single_grouping_set <- function(n) {
     rlang::call2(
       "grouping_sets",
       rlang::call2("grouping_set", !!!rlang::syms(paste0("c", seq_len(n))))
@@ -654,7 +628,7 @@ test_that("a bare grouping_id() reaches the column cap on dimensions alone", {
     dimension_data(31L),
     gid = grouping_id(),
     .by = k,
-    .grouping = !!one_set(31L)
+    .grouping = !!single_grouping_set(31L)
   )
   expect_identical(fixed$gid, 0L)
 
@@ -662,7 +636,7 @@ test_that("a bare grouping_id() reaches the column cap on dimensions alone", {
     summarize_with_margins(
       dimension_data(32L),
       gid = grouping_id(),
-      .grouping = !!one_set(32L)
+      .grouping = !!single_grouping_set(32L)
     ),
     "at most 31 columns"
   )

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -477,6 +477,198 @@ test_that("grouping helpers validate their context and columns", {
   expect_setequal(qualified$bit, c(0L, 1L))
 })
 
+# `grouping_id()` written with no columns reads the Grouping plan's own
+# dimensions, in plan order (#366). The retyped spelling stays legal and is
+# what these compare against: the default is the same columns in the same
+# order, so the two calls are the same value and not merely the same shape.
+test_that("a bare grouping_id() reads the plan's own dimensions", {
+  data <- data.frame(
+    k = "f",
+    a = c("x", "x", "y"),
+    b = c("u", "v", "u"),
+    value = 1:3
+  )
+
+  result <- summarize_with_margins(
+    data,
+    total = sum(value),
+    bare = grouping_id(),
+    written = grouping_id(a, b),
+    .by = k,
+    .grouping = rollup(a, b)
+  )
+
+  expect_identical(result$bare, result$written)
+  expect_setequal(unique(result$bare), c(0L, 1L, 3L))
+})
+
+# The default is the plan's dimensions and not its `.by`. A `.by` column
+# belongs to every Grouping set, so it always contributes a zero bit, and a
+# leading zero leaves the number alone -- the exclusion is observable at the
+# column cap, which is where it is asserted below.
+test_that("a bare grouping_id() equals inspect_grouping()$grouping_id", {
+  data <- data.frame(
+    k = c("f", "f", "g"),
+    a = c("x", "x", "y"),
+    b = c("u", "v", "u"),
+    value = 1:3
+  )
+
+  expect_plan_correspondence <- function(result, plan) {
+    expect_identical(
+      result$gid,
+      plan$grouping_id[match(result$sid, plan$set_id)]
+    )
+  }
+
+  expect_plan_correspondence(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      gid = grouping_id(),
+      .id = "sid",
+      .grouping = rollup(a, b)
+    ),
+    inspect_grouping(data, .grouping = rollup(a, b))
+  )
+  expect_plan_correspondence(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      gid = grouping_id(),
+      .id = "sid",
+      .grouping = cube(a, b)
+    ),
+    inspect_grouping(data, .grouping = cube(a, b))
+  )
+  expect_plan_correspondence(
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      gid = grouping_id(),
+      .id = "sid",
+      .by = k,
+      .grouping = rollup(a, b)
+    ),
+    inspect_grouping(data, .by = k, .grouping = rollup(a, b))
+  )
+})
+
+test_that("a bare grouping_id() is zero where the plan has no dimensions", {
+  data <- data.frame(k = c("f", "g"), value = 1:2)
+
+  by_only <- summarize_with_margins(
+    data,
+    total = sum(value),
+    gid = grouping_id(),
+    .by = k
+  )
+  expect_identical(by_only$gid, c(0L, 0L))
+
+  empty_set <- summarize_with_margins(
+    data,
+    total = sum(value),
+    gid = grouping_id(),
+    .grouping = grouping_set()
+  )
+  expect_identical(empty_set$gid, 0L)
+})
+
+# Editing `.grouping` is what the retyped spelling could not follow, so the
+# bare call is asserted against an edit rather than against one plan only.
+test_that("a bare grouping_id() follows an edit to .grouping", {
+  data <- data.frame(
+    a = c("x", "y"),
+    b = c("u", "u"),
+    c = c("p", "p"),
+    value = 1:2
+  )
+
+  two <- summarize_with_margins(
+    data,
+    gid = grouping_id(),
+    .grouping = rollup(a, b)
+  )
+  three <- summarize_with_margins(
+    data,
+    gid = grouping_id(),
+    .grouping = rollup(a, b, c)
+  )
+
+  expect_identical(max(two$gid), 3L)
+  expect_identical(max(three$gid), 7L)
+})
+
+test_that("a bare grouping_id() leaves every written-argument refusal", {
+  data <- data.frame(a = 1, b = 1)
+
+  expect_error(
+    summarize_with_margins(data, bad = grouping_bit(), .grouping = rollup(a)),
+    "exactly one column"
+  )
+  expect_error(
+    summarize_with_margins(data, bad = grouping_id(, ), .grouping = rollup(a)),
+    "only accepts bare grouping columns"
+  )
+  expect_error(
+    summarize_with_margins(data, bad = grouping_id(1), .grouping = rollup(a)),
+    "only accepts bare grouping columns"
+  )
+  expect_error(
+    summarize_with_margins(
+      data,
+      bad = grouping_id(a, a),
+      .grouping = rollup(a)
+    ),
+    "duplicate columns"
+  )
+  expect_error(
+    summarize_with_margins(data, bad = grouping_id(b), .grouping = rollup(a)),
+    "not part of"
+  )
+})
+
+# The one place the `.by` exclusion is observable: 31 dimensions beside a fixed
+# column is a plan the bare call can encode, and would not be if `.by` were
+# carried. `inspect_grouping()` reports `NA_integer_` beyond the cap and the
+# bare call does not adopt that -- a silently-`NA` identifier is what this
+# default exists to remove.
+test_that("a bare grouping_id() reaches the column cap on dimensions alone", {
+  dimension_data <- function(n) {
+    data <- as.data.frame(stats::setNames(
+      rep(list("x"), n),
+      paste0("c", seq_len(n))
+    ))
+    data$k <- "f"
+    data$value <- 1
+    data
+  }
+  one_set <- function(n) {
+    rlang::call2(
+      "grouping_sets",
+      rlang::call2("grouping_set", !!!rlang::syms(paste0("c", seq_len(n))))
+    )
+  }
+
+  fixed <- summarize_with_margins(
+    dimension_data(31L),
+    gid = grouping_id(),
+    .by = k,
+    .grouping = !!one_set(31L)
+  )
+  expect_identical(fixed$gid, 0L)
+
+  capped <- expect_error(
+    summarize_with_margins(
+      dimension_data(32L),
+      gid = grouping_id(),
+      .grouping = !!one_set(32L)
+    ),
+    "at most 31 columns"
+  )
+  expect_s3_class(capped, "marginplyr_error")
+})
+
 test_that("expand and nest verbs consume the same grouping plan", {
   data <- data.frame(a = c("x", "x", "y"), b = c("u", "v", "u"), x = 1:3)
 


### PR DESCRIPTION
Closes #366.

`grouping_id()` written with no columns now reads every Grouping dimension of the resolved plan, in plan order — the order `inspect_grouping()` reports — so a bare call equals `inspect_grouping()$grouping_id` for the row's Grouping set. Fixed `.by` columns are excluded; a plan with no dimensions gives `0L`; a plan past the 31-column cap keeps the existing refusal. `grouping_bit()` is unchanged.

ADR 0009 carries the amendment. Review record to follow.