### PR TITLE
Name .sort where the README's first output is read (#367)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -54,11 +54,10 @@ january_sales |>
 The result is one regular data frame—not three reports that you have to build
 and combine yourself.
 
-Row order is unspecified. The arrangement above happens to follow the input's
-own row order, so the same call on the same data shuffled reads differently.
-`.sort` asks for a Margin order, which puts each subtotal with the rows it
-summarizes, and `arrange()` gives any other presentation order. [Put each
-subtotal with the rows it
+Row order is unspecified: the same call on the same data in a different order
+can arrange the result differently. `.sort` asks for a Margin order, which puts
+each subtotal with the rows it summarizes, and `arrange()` gives any other
+presentation order. [Put each subtotal with the rows it
 summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html) shows
 `.sort` at work and what it does not promise.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -54,6 +54,14 @@ january_sales |>
 The result is one regular data frame—not three reports that you have to build
 and combine yourself.
 
+Row order is unspecified. The arrangement above happens to follow the input's
+own row order, so the same call on the same data shuffled reads differently.
+`.sort` asks for a Margin order, which puts each subtotal with the rows it
+summarizes, and `arrange()` gives any other presentation order. [Put each
+subtotal with the rows it
+summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html) shows
+`.sort` at work and what it does not promise.
+
 - Works with local data frames and lazy `dbplyr` tables.
 
 - Uses native `GROUP BY GROUPING SETS` on DuckDB and PostgreSQL.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ january_sales |>
 The result is one regular data frame—not three reports that you have to
 build and combine yourself.
 
+Row order is unspecified. The arrangement above happens to follow the
+input’s own row order, so the same call on the same data shuffled reads
+differently. `.sort` asks for a Margin order, which puts each subtotal
+with the rows it summarizes, and `arrange()` gives any other
+presentation order. [Put each subtotal with the rows it
+summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html)
+shows `.sort` at work and what it does not promise.
+
 - Works with local data frames and lazy `dbplyr` tables.
 
 - Uses native `GROUP BY GROUPING SETS` on DuckDB and PostgreSQL.

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ january_sales |>
 The result is one regular data frame—not three reports that you have to
 build and combine yourself.
 
-Row order is unspecified. The arrangement above happens to follow the
-input’s own row order, so the same call on the same data shuffled reads
-differently. `.sort` asks for a Margin order, which puts each subtotal
-with the rows it summarizes, and `arrange()` gives any other
-presentation order. [Put each subtotal with the rows it
+Row order is unspecified: the same call on the same data in a different
+order can arrange the result differently. `.sort` asks for a Margin
+order, which puts each subtotal with the rows it summarizes, and
+`arrange()` gives any other presentation order. [Put each subtotal with
+the rows it
 summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html)
 shows `.sort` at work and what it does not promise.
 


### PR DESCRIPTION
Closes #367.

The README's headline block prints detail rows, then subtotals, then the grand
total, and says nothing about how they got there. Within a reporting level that
arrangement is the input's own row order, so the same call on the same data
shuffled reads differently.

`.sort` is what asks for an order, and it appeared nowhere in either half of the
README. The reference, Get Started, and the recipes vignette all state the rule;
the page with the widest reach was the one that left a reader no reason to look
for it.

The added sentence states what those pages state and cites the recipes section
that shows it. The headline call keeps its arguments: `.sort = "last"` does not
produce the block the README shows — it puts each subtotal directly beneath the
rows it summarizes — so passing it would change the first output a reader sees
in exchange for a longer first call. That was the decision the issue named as
the one worth making.

`README.md` is regenerated from `README.Rmd` against the installed working tree
and pandoc 3.10.1, the version `document.yaml` pins. Its diff is the prose and
nothing else; every output block is byte-identical.