### PR TITLE
Spell a per-dimension NULL Margin label (#371)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,12 +73,14 @@ factor level.
 _Avoid_: Total value, missing-value replacement
 
 **Margin label collision**:
-A grouping dimension holding, as one of its own values, the Margin label
-chosen for it — so that a margin row and a row of the source data cannot be
-told apart by that column. A collision is *declared* when the colliding value
-is a factor level, which the column's type records, and *observed* when it
-appears only among the column's values.
-_Avoid_: Duplicate label, ambiguous margin
+A grouping dimension holding, as one of its own values, the non-missing Margin
+label chosen for it — so that a margin row and a row of the source data cannot
+be told apart by that column. A collision is *declared* when the colliding
+value is a factor level, which the column's type records, and *observed* when
+it appears only among the column's values. A typed-missing Margin label is not
+a collision: it displays as missing wherever the column already holds missing
+values, and a Grouping bit or Grouping identifier is what tells the two apart.
+_Avoid_: Duplicate label, ambiguous margin, typed-missing ambiguity
 
 **Margin order**:
 The row order a Margin operation produces when it is asked to order its

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,7 +80,7 @@ value is a factor level, which the column's type records, and *observed* when
 it appears only among the column's values. A typed-missing Margin label is not
 a collision: it displays as missing wherever the column already holds missing
 values, and a Grouping bit or Grouping identifier is what tells the two apart.
-_Avoid_: Duplicate label, ambiguous margin, typed-missing ambiguity
+_Avoid_: Duplicate label, ambiguous margin
 
 **Margin order**:
 The row order a Margin operation produces when it is asked to order its

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -1,18 +1,16 @@
-# The Margin label as one shape: `NULL`, an unnamed character scalar, or a
-# named list holding one label per dimension. A named character vector is the
-# shorthand for a list with no `NULL` element and is converted to one here, so
-# nothing downstream carries two spellings of the same argument.
-#
-# The list exists because `c()` drops a `NULL` element before this is reached,
-# which left a per-dimension `NULL` unwritable while both halves of the
-# collision check rested on one (ADR 0012).
+# The Margin label a caller wrote, as the shape the rest of the operation
+# reads: `NULL`, an unnamed character scalar, or a named list of per-dimension
+# labels. A named character vector is converted to that list here, so the two
+# named spellings are one downstream (ADR 0012).
 normalize_margin_label <- function(.margin_label) {
   if (is.null(.margin_label)) {
     return(NULL)
   }
   # An unnamed list is not the list form: its elements name no dimension, and
-  # a caller who meant one label wrote the scalar.
-  is_label_list <- is.list(.margin_label) && !is.null(names(.margin_label))
+  # a caller who meant one label wrote the scalar. Bare, because a one-row
+  # data frame is otherwise a named list whose columns pass as labels.
+  is_label_list <- rlang::is_bare_list(.margin_label) &&
+    !is.null(names(.margin_label))
   if (!is_label_list &&
         (!is.character(.margin_label) || length(.margin_label) == 0L)) {
     abort_marginplyr(paste0(
@@ -48,8 +46,6 @@ normalize_margin_label <- function(.margin_label) {
 
 # Each element of a named-list `.margin_label` is one dimension's label, so it
 # is what an unnamed scalar may be, plus the `NULL` the list exists to carry.
-# The offending names travel in an `i` bullet because how many of them arrive
-# is the caller's decision (ADR 0023).
 validate_margin_label_elements <- function(.margin_label) {
   bad <- vapply(
     .margin_label,
@@ -171,8 +167,8 @@ validate_margin_label <- function(.data,
           "{cli::qty(length(na_level_cols))}column{?s}:"
         ),
         i = "{.var {na_level_cols}}.",
-        # A bare `NULL` is the whole of `.margin_label`, so it is a remedy
-        # only where there is one dimension; the list is one either way.
+        # The list spelling, because a bare `NULL` is the whole of
+        # `.margin_label` and so is not one dimension's answer (ADR 0012).
         i = paste0(
           "Use {.code NULL} in a named-list {.arg .margin_label} for a ",
           "typed-missing Margin label while preserving the NA level."
@@ -238,9 +234,7 @@ check_observed_label_collision <- function(data,
   # A factor dimension states its values in its levels, and a label equal to
   # one of them was rejected above, so reading its column could only find a
   # value the levels do not contain. A typed-missing label is not a collision
-  # (ADR 0012): it displays as missing wherever the column already holds
-  # missing values, which is the result `NULL` has always been allowed to
-  # produce, so neither spelling of it selects a column.
+  # (ADR 0012), so neither spelling of one selects a column either.
   read_cols <- Filter(
     function(col) {
       !is_missing_margin_label(margin_labels[[col]]) && !(col %in% factor_cols)

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -1,11 +1,23 @@
+# The Margin label as one shape: `NULL`, an unnamed character scalar, or a
+# named list holding one label per dimension. A named character vector is the
+# shorthand for a list with no `NULL` element and is converted to one here, so
+# nothing downstream carries two spellings of the same argument.
+#
+# The list exists because `c()` drops a `NULL` element before this is reached,
+# which left a per-dimension `NULL` unwritable while both halves of the
+# collision check rested on one (ADR 0012).
 normalize_margin_label <- function(.margin_label) {
   if (is.null(.margin_label)) {
     return(NULL)
   }
-  if (!is.character(.margin_label) || length(.margin_label) == 0L) {
+  # An unnamed list is not the list form: its elements name no dimension, and
+  # a caller who meant one label wrote the scalar.
+  is_label_list <- is.list(.margin_label) && !is.null(names(.margin_label))
+  if (!is_label_list &&
+        (!is.character(.margin_label) || length(.margin_label) == 0L)) {
     abort_marginplyr(paste0(
       "{.arg .margin_label} must be {.code NULL}, an unnamed character ",
-      "scalar, or a named character vector."
+      "scalar, or a named character vector or list."
     ))
   }
   label_names <- names(.margin_label)
@@ -27,7 +39,39 @@ normalize_margin_label <- function(.margin_label) {
   if (anyDuplicated(label_names)) {
     abort_marginplyr("{.arg .margin_label} names must not be duplicated.")
   }
-  .margin_label
+  if (is_label_list) {
+    validate_margin_label_elements(.margin_label)
+    return(.margin_label)
+  }
+  as.list(.margin_label)
+}
+
+# Each element of a named-list `.margin_label` is one dimension's label, so it
+# is what an unnamed scalar may be, plus the `NULL` the list exists to carry.
+# The offending names travel in an `i` bullet because how many of them arrive
+# is the caller's decision (ADR 0023).
+validate_margin_label_elements <- function(.margin_label) {
+  bad <- vapply(
+    .margin_label,
+    function(label) {
+      !is.null(label) && !(is.character(label) && length(label) == 1L)
+    },
+    logical(1)
+  )
+  if (!any(bad)) {
+    return(invisible(NULL))
+  }
+  # Read only from the cli template below, which codetools cannot see.
+  # nolint start: object_usage_linter.
+  bad_names <- names(.margin_label)[bad]
+  # nolint end
+  abort_marginplyr(c(
+    paste0(
+      "{.arg .margin_label} list elements must each be {.code NULL} or a ",
+      "character scalar:"
+    ),
+    i = "{.var {bad_names}}."
+  ))
 }
 
 resolve_margin_labels <- function(.margin_label, dimensions) {
@@ -127,9 +171,11 @@ validate_margin_label <- function(.data,
           "{cli::qty(length(na_level_cols))}column{?s}:"
         ),
         i = "{.var {na_level_cols}}.",
+        # A bare `NULL` is the whole of `.margin_label`, so it is a remedy
+        # only where there is one dimension; the list is one either way.
         i = paste0(
-          "Use {.code NULL} for a typed-missing Margin label while ",
-          "preserving the NA level."
+          "Use {.code NULL} in a named-list {.arg .margin_label} for a ",
+          "typed-missing Margin label while preserving the NA level."
         )
       ))
     }
@@ -191,12 +237,13 @@ check_observed_label_collision <- function(data,
   factor_cols <- vapply(factor_info, function(info) info$col, character(1))
   # A factor dimension states its values in its levels, and a label equal to
   # one of them was rejected above, so reading its column could only find a
-  # value the levels do not contain. A missing label is the exception: whether
-  # the column holds a missing value is not something the levels record.
+  # value the levels do not contain. A typed-missing label is not a collision
+  # (ADR 0012): it displays as missing wherever the column already holds
+  # missing values, which is the result `NULL` has always been allowed to
+  # produce, so neither spelling of it selects a column.
   read_cols <- Filter(
     function(col) {
-      label <- margin_labels[[col]]
-      !is.null(label) && !(col %in% factor_cols && !is.na(label))
+      !is_missing_margin_label(margin_labels[[col]]) && !(col %in% factor_cols)
     },
     col_names
   )
@@ -212,14 +259,14 @@ check_observed_label_collision <- function(data,
     function(col) {
       margin_label <- margin_labels[[col]]
       column <- rlang::sym(col)
-      condition <- if (is.na(margin_label)) {
-        rlang::expr(is.na(!!column))
-      } else {
-        rlang::expr(as.character(!!column) == !!margin_label)
-      }
       rlang::expr(
         sum(
-          dplyr::if_else(!!condition, 1L, 0L, missing = 0L),
+          dplyr::if_else(
+            as.character(!!column) == !!margin_label,
+            1L,
+            0L,
+            missing = 0L
+          ),
           na.rm = TRUE
         )
       )

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -27,10 +27,12 @@
 #'   way; see [grouping_set()].
 #' @param .margin_label A display label for dimensions omitted from a grouping
 #'   set. An unnamed character scalar applies to every resolved Margin
-#'   dimension. A named character vector must name every resolved Margin
-#'   dimension exactly once; order is irrelevant, and fixed `.by` columns must
-#'   not be named. `NA_character_` and `NULL` use typed missing values instead
-#'   of a display label. See *Display labels and grouping identity*.
+#'   dimension. A named character vector or named list must name every
+#'   resolved Margin dimension exactly once; order is irrelevant, and fixed
+#'   `.by` columns must not be named. `NA_character_` and `NULL` use typed
+#'   missing values instead of a display label; only the list can give one
+#'   dimension a `NULL` while another takes a label, because `c()` drops a
+#'   `NULL` element. See *Display labels and grouping identity*.
 #' @param .margin_label_position Either `"last"` (the default) or `"first"`,
 #'   and nothing else; see *Option arguments*.
 #'   This controls the position of a non-missing synthetic label in factor and
@@ -39,7 +41,9 @@
 #' @param .check_margin_label A logical scalar controlling the half of the
 #'   Margin label collision check that reads the data: whether any *value* of a
 #'   Margin dimension is equal to that dimension's display label. Each
-#'   dimension is checked independently, and `.margin_label = NULL` opts out.
+#'   dimension is checked independently, and a typed-missing label opts its
+#'   own dimension out -- `NULL` or `NA_character_`, chosen per dimension in a
+#'   named-list `.margin_label`.
 #'   Every Margin verb uses the same default: `TRUE` for local data frames and
 #'   `FALSE` for lazy inputs, which are read only when the caller asks. A label
 #'   equal to a declared factor *level* is rejected on every backend whatever
@@ -480,9 +484,10 @@
 #'
 #' `NA_character_` and `NULL` both create a typed missing Margin value and do
 #' not create a synthetic factor level. Position is therefore a no-op for
-#' either value. `NA_character_` still participates in collision validation;
-#' `NULL` opts out. A factor NA level is a structural conflict for
-#' `NA_character_` even when `.check_margin_label = FALSE`.
+#' either value, and neither participates in the observed half of collision
+#' validation. What separates them is the declared half: a factor NA level is
+#' a structural conflict for `NA_character_` even when
+#' `.check_margin_label = FALSE`, while `NULL` preserves that level.
 #'
 #' With `.check_margin_label = TRUE`, factor columns follow this contract:
 #'
@@ -490,7 +495,7 @@
 #' |---|---:|---:|---|
 #' | `NA_character_` | yes | yes | Error: NA is already a factor level |
 #' | `NA_character_` | yes | no | Error: NA is already a factor level |
-#' | `NA_character_` | no | yes | Error: the label collides with a value |
+#' | `NA_character_` | no | yes | Allowed; source missing values and margins require structural identity | # nolint: line_length_linter
 #' | `NA_character_` | no | no | Allowed; use typed missing |
 #' | `NULL` | yes | yes | Allowed; source missing values and margins require structural identity | # nolint: line_length_linter
 #' | `NULL` | yes | no | Allowed; preserve the NA level and use typed missing |
@@ -503,12 +508,12 @@
 #' identically, so keep a structural identity column when the difference
 #' matters: `.id` is available from every Margin verb, and
 #' [summarize_with_margins()] can additionally write [grouping_bit()] or
-#' [grouping_id()] as summaries. `.check_margin_label` controls only the
-#' observed row of this table -- whether `NA_character_` collides with an
-#' actual missing value when no NA level is declared; the declared rows above
-#' it are checked whatever this argument says. See `.check_margin_label`
-#' above for its default and *When marginplyr queries your data* for why the
-#' two halves differ.
+#' [grouping_id()] as summaries. `.check_margin_label` controls the observed
+#' half of the check, which no row of this table reaches: a typed-missing
+#' label is not a collision, and a label equal to a declared level is refused
+#' by the declared half. Every row above is therefore decided whatever this
+#' argument says. See `.check_margin_label` above for its default and *When
+#' marginplyr queries your data* for why the two halves differ.
 #'
 #' @section Backend extension design:
 #' Unlike [dplyr::summarize()], the public margin verbs are intentionally not
@@ -697,28 +702,21 @@
 #' is.ordered(priority_result$priority)
 #' levels(priority_result$priority)
 #'
-#' # `.check_margin_label = FALSE` still controls only the observed half of
-#' # the check: whether a missing value already in the column collides with
-#' # `NA_character_` when no NA level is declared. Disabled, the margin row
-#' # and the real missing-value row print alike; `grouping_bit()` tells them
-#' # apart.
+#' # A typed-missing Margin label displays as missing wherever the column
+#' # already does, so the margin row and a real missing-value row print alike;
+#' # `grouping_bit()` tells them apart. A named list chooses per dimension,
+#' # which is the only spelling that can label one and leave another missing.
 #' status_data <- data.frame(
-#'   status = factor(c("active", NA), levels = c("active", "inactive")),
-#'   value = c(1, 2)
+#'   region = c("east", "east", "west"),
+#'   status = factor(c("active", NA, "active"), levels = c("active", "idle")),
+#'   value = c(1, 2, 3)
 #' )
-#' try(summarize_with_margins(
-#'   .data = status_data,
-#'   total = sum(value),
-#'   .grouping = rollup(status),
-#'   .margin_label = NA_character_
-#' ))
 #' summarize_with_margins(
 #'   .data = status_data,
 #'   total = sum(value),
-#'   is_total = grouping_bit(status),
-#'   .grouping = rollup(status),
-#'   .margin_label = NA_character_,
-#'   .check_margin_label = FALSE
+#'   status_is_total = grouping_bit(status),
+#'   .grouping = rollup(region, status),
+#'   .margin_label = list(region = "All regions", status = NULL)
 #' )
 #'
 #' # A direct Parent share, multiple measures through two ordered across()

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -489,7 +489,7 @@
 #' a structural conflict for `NA_character_` even when
 #' `.check_margin_label = FALSE`, while `NULL` preserves that level.
 #'
-#' With `.check_margin_label = TRUE`, factor columns follow this contract:
+#' Factor columns follow this contract:
 #'
 #' | Margin label | NA level | Missing value | Result |
 #' |---|---:|---:|---|

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -104,3 +104,61 @@ cross-cutting identity comparison and link to this detailed eight-case factor
 table. It will explicitly distinguish a source missing value, a factor NA
 level, and a typed-missing Margin label without duplicating the full
 factor-validation reference.
+
+## Amendment: a typed-missing Margin label is not an observed collision
+
+Two rows of the table above described the same displayed result and disagreed
+about it. `NA_character_` with no NA level and a missing value present was an
+error; `NULL` against the same column was allowed. Both produce a typed missing
+Margin value, so on a column that already holds missing values both produce a
+margin row and a source row that display identically. The refusal rejected one
+of two spellings of a result this ADR permits by the other, and it reached the
+caller who had picked the spelling the documentation calls the checked one
+rather than the caller whose result was ambiguous.
+
+The table's third row therefore reads *Allowed; source missing values and
+margins require structural identity*, matching its seventh. `NA_character_` no
+longer participates in the observed half of the collision check: it is excluded
+before the check selects any column, so a call whose every label is
+typed-missing sends no query, as `NULL` already did (ADR 0020). Nothing is
+reported in its place — a message on one spelling and silence on the other
+would move the asymmetry into the diagnostics rather than remove it, and the
+structural identity that resolves the ambiguity is documented where the
+argument is.
+
+The declared half is unchanged, and the first two rows still read *Error*. An
+NA factor level is part of the column's domain whether or not an observation
+uses it, and `levels()` records it, so `NA_character_` proposed against one
+conflicts with something a caller can observe. That is the whole of what now
+separates the two spellings, which is why it is the difference kept.
+
+`CONTEXT.md` narrows *Margin label collision* to a non-missing label to match.
+The code already drew that line for the declared half: the NA-level refusal in
+`validate_margin_label()` is a block of its own above
+`check_declared_label_collision()`, which fires only for a non-missing label.
+
+## Amendment: `.margin_label` accepts a named list
+
+"The rules apply per column when `.margin_label` is a named vector" above could
+not be exercised for `NULL`. A named character vector cannot carry a `NULL`
+element — `c(region = "All", store = NULL)` drops it, and the call then fails
+the requirement to name every Margin dimension — so `NULL` was reachable only
+as an unnamed scalar applying to every dimension at once. Both halves of the
+collision check rested on a per-dimension `NULL` that could not be written, and
+the declared half's refusal named it as the remedy.
+
+`.margin_label` therefore also accepts a named list whose elements are
+character scalars or `NULL`: `list(region = "All", store = NULL)`. A named
+character vector remains accepted as the shorthand for a list with no `NULL`
+element, since that is the ordinary case and the list brackets buy it nothing.
+The requirement to name every Margin dimension is unchanged: an unnamed
+dimension stays a refusal rather than becoming a silent `NULL`, because the
+alternative makes a misspelled name turn every dimension typed-missing with no
+diagnostic.
+
+The declared refusal's remedy names the list spelling rather than the bare
+`NULL` it named before. That `NULL` is the whole of `.margin_label`, so it was
+a remedy only where there was one dimension; a caller with two who followed it
+literally reached a second refusal. `R/margin-label.R` states the rule this
+broke, beside the same pair of refusals: a remedy is offered only where it is
+one.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -373,7 +373,7 @@ validation. What separates them is the declared half: a factor NA level is
 a structural conflict for \code{NA_character_} even when
 \code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
-With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+Factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -36,10 +36,12 @@ way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin
-dimension. A named character vector must name every resolved Margin
-dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
-not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
-of a display label. See \emph{Display labels and grouping identity}.}
+dimension. A named character vector or named list must name every
+resolved Margin dimension exactly once; order is irrelevant, and fixed
+\code{.by} columns must not be named. \code{NA_character_} and \code{NULL} use typed
+missing values instead of a display label; only the list can give one
+dimension a \code{NULL} while another takes a label, because \code{c()} drops a
+\code{NULL} element. See \emph{Display labels and grouping identity}.}
 
 \item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
 and nothing else; see \emph{Option arguments}.
@@ -50,7 +52,9 @@ ordered-factor levels. It does not sort result rows and has no effect for
 \item{.check_margin_label}{A logical scalar controlling the half of the
 Margin label collision check that reads the data: whether any \emph{value} of a
 Margin dimension is equal to that dimension's display label. Each
-dimension is checked independently, and \code{.margin_label = NULL} opts out.
+dimension is checked independently, and a typed-missing label opts its
+own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension in a
+named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
 equal to a declared factor \emph{level} is rejected on every backend whatever
@@ -364,15 +368,16 @@ factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
-either value. \code{NA_character_} still participates in collision validation;
-\code{NULL} opts out. A factor NA level is a structural conflict for
-\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+either value, and neither participates in the observed half of collision
+validation. What separates them is the declared half: a factor NA level is
+a structural conflict for \code{NA_character_} even when
+\code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
 With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
-   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
    \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
@@ -387,12 +392,12 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
-observed row of this table -- whether \code{NA_character_} collides with an
-actual missing value when no NA level is declared; the declared rows above
-it are checked whatever this argument says. See \code{.check_margin_label}
-above for its default and \emph{When marginplyr queries your data} for why the
-two halves differ.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls the observed
+half of the check, which no row of this table reaches: a typed-missing
+label is not a collision, and a label equal to a declared level is refused
+by the declared half. Every row above is therefore decided whatever this
+argument says. See \code{.check_margin_label} above for its default and \emph{When
+marginplyr queries your data} for why the two halves differ.
 }
 
 \section{Database backend coverage}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -372,7 +372,7 @@ validation. What separates them is the declared half: a factor NA level is
 a structural conflict for \code{NA_character_} even when
 \code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
-With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+Factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -39,10 +39,12 @@ way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin
-dimension. A named character vector must name every resolved Margin
-dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
-not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
-of a display label. See \emph{Display labels and grouping identity}.}
+dimension. A named character vector or named list must name every
+resolved Margin dimension exactly once; order is irrelevant, and fixed
+\code{.by} columns must not be named. \code{NA_character_} and \code{NULL} use typed
+missing values instead of a display label; only the list can give one
+dimension a \code{NULL} while another takes a label, because \code{c()} drops a
+\code{NULL} element. See \emph{Display labels and grouping identity}.}
 
 \item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
 and nothing else; see \emph{Option arguments}.
@@ -53,7 +55,9 @@ ordered-factor levels. It does not sort result rows and has no effect for
 \item{.check_margin_label}{A logical scalar controlling the half of the
 Margin label collision check that reads the data: whether any \emph{value} of a
 Margin dimension is equal to that dimension's display label. Each
-dimension is checked independently, and \code{.margin_label = NULL} opts out.
+dimension is checked independently, and a typed-missing label opts its
+own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension in a
+named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
 equal to a declared factor \emph{level} is rejected on every backend whatever
@@ -363,15 +367,16 @@ factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
-either value. \code{NA_character_} still participates in collision validation;
-\code{NULL} opts out. A factor NA level is a structural conflict for
-\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+either value, and neither participates in the observed half of collision
+validation. What separates them is the declared half: a factor NA level is
+a structural conflict for \code{NA_character_} even when
+\code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
 With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
-   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
    \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
@@ -386,12 +391,12 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
-observed row of this table -- whether \code{NA_character_} collides with an
-actual missing value when no NA level is declared; the declared rows above
-it are checked whatever this argument says. See \code{.check_margin_label}
-above for its default and \emph{When marginplyr queries your data} for why the
-two halves differ.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls the observed
+half of the check, which no row of this table reaches: a typed-missing
+label is not a collision, and a label equal to a declared level is refused
+by the declared half. Every row above is therefore decided whatever this
+argument says. See \code{.check_margin_label} above for its default and \emph{When
+marginplyr queries your data} for why the two halves differ.
 }
 
 \section{When marginplyr queries your data}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -39,10 +39,12 @@ way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin
-dimension. A named character vector must name every resolved Margin
-dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
-not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
-of a display label. See \emph{Display labels and grouping identity}.}
+dimension. A named character vector or named list must name every
+resolved Margin dimension exactly once; order is irrelevant, and fixed
+\code{.by} columns must not be named. \code{NA_character_} and \code{NULL} use typed
+missing values instead of a display label; only the list can give one
+dimension a \code{NULL} while another takes a label, because \code{c()} drops a
+\code{NULL} element. See \emph{Display labels and grouping identity}.}
 
 \item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
 and nothing else; see \emph{Option arguments}.
@@ -53,7 +55,9 @@ ordered-factor levels. It does not sort result rows and has no effect for
 \item{.check_margin_label}{A logical scalar controlling the half of the
 Margin label collision check that reads the data: whether any \emph{value} of a
 Margin dimension is equal to that dimension's display label. Each
-dimension is checked independently, and \code{.margin_label = NULL} opts out.
+dimension is checked independently, and a typed-missing label opts its
+own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension in a
+named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
 equal to a declared factor \emph{level} is rejected on every backend whatever
@@ -409,15 +413,16 @@ factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
-either value. \code{NA_character_} still participates in collision validation;
-\code{NULL} opts out. A factor NA level is a structural conflict for
-\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+either value, and neither participates in the observed half of collision
+validation. What separates them is the declared half: a factor NA level is
+a structural conflict for \code{NA_character_} even when
+\code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
 With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
-   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
    \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
@@ -432,12 +437,12 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
-observed row of this table -- whether \code{NA_character_} collides with an
-actual missing value when no NA level is declared; the declared rows above
-it are checked whatever this argument says. See \code{.check_margin_label}
-above for its default and \emph{When marginplyr queries your data} for why the
-two halves differ.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls the observed
+half of the check, which no row of this table reaches: a typed-missing
+label is not a collision, and a label equal to a declared level is refused
+by the declared half. Every row above is therefore decided whatever this
+argument says. See \code{.check_margin_label} above for its default and \emph{When
+marginplyr queries your data} for why the two halves differ.
 }
 
 \section{When marginplyr queries your data}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -418,7 +418,7 @@ validation. What separates them is the declared half: a factor NA level is
 a structural conflict for \code{NA_character_} even when
 \code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
-With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+Factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -57,10 +57,12 @@ way; see \code{\link[=grouping_set]{grouping_set()}}.}
 
 \item{.margin_label}{A display label for dimensions omitted from a grouping
 set. An unnamed character scalar applies to every resolved Margin
-dimension. A named character vector must name every resolved Margin
-dimension exactly once; order is irrelevant, and fixed \code{.by} columns must
-not be named. \code{NA_character_} and \code{NULL} use typed missing values instead
-of a display label. See \emph{Display labels and grouping identity}.}
+dimension. A named character vector or named list must name every
+resolved Margin dimension exactly once; order is irrelevant, and fixed
+\code{.by} columns must not be named. \code{NA_character_} and \code{NULL} use typed
+missing values instead of a display label; only the list can give one
+dimension a \code{NULL} while another takes a label, because \code{c()} drops a
+\code{NULL} element. See \emph{Display labels and grouping identity}.}
 
 \item{.margin_label_position}{Either \code{"last"} (the default) or \code{"first"},
 and nothing else; see \emph{Option arguments}.
@@ -71,7 +73,9 @@ ordered-factor levels. It does not sort result rows and has no effect for
 \item{.check_margin_label}{A logical scalar controlling the half of the
 Margin label collision check that reads the data: whether any \emph{value} of a
 Margin dimension is equal to that dimension's display label. Each
-dimension is checked independently, and \code{.margin_label = NULL} opts out.
+dimension is checked independently, and a typed-missing label opts its
+own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension in a
+named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
 equal to a declared factor \emph{level} is rejected on every backend whatever
@@ -539,15 +543,16 @@ factor NA level and an actually missing factor code.
 
 \code{NA_character_} and \code{NULL} both create a typed missing Margin value and do
 not create a synthetic factor level. Position is therefore a no-op for
-either value. \code{NA_character_} still participates in collision validation;
-\code{NULL} opts out. A factor NA level is a structural conflict for
-\code{NA_character_} even when \code{.check_margin_label = FALSE}.
+either value, and neither participates in the observed half of collision
+validation. What separates them is the declared half: a factor NA level is
+a structural conflict for \code{NA_character_} even when
+\code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
 With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr
-   \code{NA_character_} \tab no \tab yes \tab Error: the label collides with a value \cr
+   \code{NA_character_} \tab no \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NA_character_} \tab no \tab no \tab Allowed; use typed missing \cr
    \code{NULL} \tab yes \tab yes \tab Allowed; source missing values and margins require structural identity \cr
    \code{NULL} \tab yes \tab no \tab Allowed; preserve the NA level and use typed missing \cr
@@ -562,12 +567,12 @@ Source missing values and typed-missing Margin values may display
 identically, so keep a structural identity column when the difference
 matters: \code{.id} is available from every Margin verb, and
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} can additionally write \code{\link[=grouping_bit]{grouping_bit()}} or
-\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls only the
-observed row of this table -- whether \code{NA_character_} collides with an
-actual missing value when no NA level is declared; the declared rows above
-it are checked whatever this argument says. See \code{.check_margin_label}
-above for its default and \emph{When marginplyr queries your data} for why the
-two halves differ.
+\code{\link[=grouping_id]{grouping_id()}} as summaries. \code{.check_margin_label} controls the observed
+half of the check, which no row of this table reaches: a typed-missing
+label is not a collision, and a label equal to a declared level is refused
+by the declared half. Every row above is therefore decided whatever this
+argument says. See \code{.check_margin_label} above for its default and \emph{When
+marginplyr queries your data} for why the two halves differ.
 }
 
 \section{Backend extension design}{
@@ -762,28 +767,21 @@ priority_result <- summarize_with_margins(
 is.ordered(priority_result$priority)
 levels(priority_result$priority)
 
-# `.check_margin_label = FALSE` still controls only the observed half of
-# the check: whether a missing value already in the column collides with
-# `NA_character_` when no NA level is declared. Disabled, the margin row
-# and the real missing-value row print alike; `grouping_bit()` tells them
-# apart.
+# A typed-missing Margin label displays as missing wherever the column
+# already does, so the margin row and a real missing-value row print alike;
+# `grouping_bit()` tells them apart. A named list chooses per dimension,
+# which is the only spelling that can label one and leave another missing.
 status_data <- data.frame(
-  status = factor(c("active", NA), levels = c("active", "inactive")),
-  value = c(1, 2)
+  region = c("east", "east", "west"),
+  status = factor(c("active", NA, "active"), levels = c("active", "idle")),
+  value = c(1, 2, 3)
 )
-try(summarize_with_margins(
-  .data = status_data,
-  total = sum(value),
-  .grouping = rollup(status),
-  .margin_label = NA_character_
-))
 summarize_with_margins(
   .data = status_data,
   total = sum(value),
-  is_total = grouping_bit(status),
-  .grouping = rollup(status),
-  .margin_label = NA_character_,
-  .check_margin_label = FALSE
+  status_is_total = grouping_bit(status),
+  .grouping = rollup(region, status),
+  .margin_label = list(region = "All regions", status = NULL)
 )
 
 # A direct Parent share, multiple measures through two ordered across()

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -548,7 +548,7 @@ validation. What separates them is the declared half: a factor NA level is
 a structural conflict for \code{NA_character_} even when
 \code{.check_margin_label = FALSE}, while \code{NULL} preserves that level.
 
-With \code{.check_margin_label = TRUE}, factor columns follow this contract:\tabular{lrrl}{
+Factor columns follow this contract:\tabular{lrrl}{
    Margin label \tab NA level \tab Missing value \tab Result \cr
    \code{NA_character_} \tab yes \tab yes \tab Error: NA is already a factor level \cr
    \code{NA_character_} \tab yes \tab no \tab Error: NA is already a factor level \cr

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -402,8 +402,8 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
     paste0(
       "`NA_character_` is already a factor level in grouping column:\n",
       "i `g`.\n",
-      "i Use `NULL` for a typed-missing Margin label while preserving the NA ",
-      "level."
+      "i Use `NULL` in a named-list `.margin_label` for a typed-missing ",
+      "Margin label while preserving the NA level."
     )
   )
 
@@ -413,8 +413,8 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
     paste0(
       "`NA_character_` is already a factor level in grouping columns:\n",
       "i `g` and `h`.\n",
-      "i Use `NULL` for a typed-missing Margin label while preserving the NA ",
-      "level."
+      "i Use `NULL` in a named-list `.margin_label` for a typed-missing ",
+      "Margin label while preserving the NA level."
     )
   )
 })

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -388,12 +388,30 @@ test_that("margin label checks handle missing and non-syntactic columns", {
     "second group" = c("y", NA_character_),
     value = 1:2
   )
-  expect_error(
+  # A typed-missing label is not a collision (ADR 0012), so a source missing
+  # value in either column is not what refuses this.
+  expect_no_error(
     summarize_with_margins(
       missing,
       n = dplyr::n(),
       .grouping = rollup(`first group`, `second group`),
       .margin_label = NA_character_
+    )
+  )
+
+  # A non-missing label both columns hold is one, and the refusal quotes a
+  # non-syntactic name as the caller wrote it.
+  colliding <- data.frame(
+    check.names = FALSE,
+    "first group" = c("Total", "x"),
+    "second group" = c("y", "Total"),
+    value = 1:2
+  )
+  expect_error(
+    summarize_with_margins(
+      colliding,
+      n = dplyr::n(),
+      .grouping = rollup(`first group`, `second group`)
     ),
     "grouping columns:\ni `first group` and `second group`"
   )

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -44,7 +44,10 @@ test_that("factor NA levels and missing values obey the eight-case contract", {
     label = c(rep("NA", 4L), rep("NULL", 4L)),
     na_level = rep(c(TRUE, TRUE, FALSE, FALSE), 2L),
     missing_value = rep(c(TRUE, FALSE, TRUE, FALSE), 2L),
-    errors = c(TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE)
+    # Row 3 joins row 7 under ADR 0012's amendment: both spellings of a
+    # typed-missing label produce the same displayed result on a column
+    # holding a missing value, so neither is refused for producing it.
+    errors = c(TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE)
   )
 
   for (i in seq_len(nrow(cases))) {
@@ -285,9 +288,10 @@ test_that("a check with no column left to read contacts nothing", {
     margin_labels = list(group = NULL),
     factor_info = list()
   ))
-  # A missing label asks whether the column holds a missing value, which the
-  # levels do not record, so that one still reads.
-  expect_error(check_observed_label_collision(
+  # Nor does the other spelling of a typed-missing label: whether the column
+  # holds a missing value is no longer asked, so neither reaches the read that
+  # this unreadable column would fail.
+  expect_no_error(check_observed_label_collision(
     unreadable,
     margin_labels = list(group = NA_character_),
     factor_info = factor_info
@@ -756,4 +760,214 @@ test_that("Margin label option errors use the package condition seam", {
       "expand_with_margins"
     )
   }
+})
+
+# A per-dimension `NULL` (#371). `c()` drops a `NULL` element before
+# `.margin_label` is seen, so the list is the only spelling that carries one.
+test_that("a named list carries a per-dimension NULL", {
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    store = c("a", NA, "b"),
+    value = 1:3
+  )
+
+  result <- summarize_with_margins(
+    data,
+    n = sum(value),
+    region_bit = grouping_bit(region),
+    store_bit = grouping_bit(store),
+    .grouping = rollup(region, store),
+    .margin_label = list(region = "All", store = NULL)
+  )
+
+  # The one report the vector cannot express: `region` labelled, `store` typed
+  # missing, and the check left on.
+  expect_identical(result$region[result$region_bit == 1L], "All")
+  expect_true(all(is.na(result$store[result$store_bit == 1L])))
+  expect_false(any(result$store %in% "All", na.rm = TRUE))
+
+  # What `store_bit` is carrying: the source missing value and the margin over
+  # it display identically, which is the ambiguity `NULL` has always been
+  # allowed to produce.
+  ambiguous <- result[result$region == "E" & is.na(result$store), ]
+  expect_identical(nrow(ambiguous), 2L)
+  expect_setequal(ambiguous$store_bit, c(0L, 1L))
+})
+
+test_that("a named list means what the equivalent character vector means", {
+  data <- data.frame(
+    first = c("a", "b"),
+    second = c("x", "y"),
+    value = 1:2
+  )
+  operation <- function(label) {
+    summarize_with_margins(
+      data,
+      n = sum(value),
+      id = grouping_id(first, second),
+      .grouping = rollup(first, second),
+      .margin_label = label
+    )
+  }
+
+  expect_identical(
+    operation(list(first = "All first", second = "All second")),
+    operation(c(first = "All first", second = "All second"))
+  )
+})
+
+test_that("a named list refuses an element that is not a label", {
+  data <- data.frame(first = c("a", "b"), second = c("x", "y"), value = 1:2)
+  operation <- function(label) {
+    summarize_with_margins(
+      data,
+      n = sum(value),
+      .grouping = rollup(first, second),
+      .margin_label = label
+    )
+  }
+
+  cases <- list(
+    list(
+      label = list(first = "All", second = 1L),
+      message = "must each be `NULL` or a character scalar:\ni `second`"
+    ),
+    list(
+      label = list(first = "All", second = c("x", "y")),
+      message = "must each be `NULL` or a character scalar:\ni `second`"
+    ),
+    list(
+      label = list("All", "Total"),
+      message = "must be `NULL`, an unnamed character scalar"
+    )
+  )
+
+  for (case in cases) {
+    error <- expect_error(operation(case$label), case$message, fixed = TRUE)
+    expect_s3_class(error, "marginplyr_error")
+  }
+})
+
+# The name rules are the vector's rules, so a list reaches the same refusals
+# rather than a second set. An unnamed dimension stays a refusal: read as
+# `NULL` it would turn a misspelled name into a silent whole-call change.
+test_that("a named list reaches the vector's name refusals", {
+  data <- data.frame(
+    fixed = c("k", "k"),
+    first = c("a", "b"),
+    second = c("x", "y"),
+    value = 1:2
+  )
+  operation <- function(label) {
+    summarize_with_margins(
+      data,
+      n = sum(value),
+      .by = fixed,
+      .grouping = rollup(first, second),
+      .margin_label = label
+    )
+  }
+
+  expect_error(
+    operation(list(first = "All", second = NULL, fixed = NULL)),
+    "must not name fixed `.by` column:\ni `fixed`",
+    fixed = TRUE
+  )
+  expect_error(
+    operation(list(first = "All", second = NULL, unknown = NULL)),
+    "unknown dimension name:\ni `unknown`",
+    fixed = TRUE
+  )
+  expect_error(
+    operation(list(first = "All")),
+    "must name every Margin dimension.\ni Missing `second`",
+    fixed = TRUE
+  )
+})
+
+# ADR 0012's amendment: a typed-missing label displays as missing wherever the
+# column already holds missing values, which `NULL` has always been allowed to
+# do, so `NA_character_` is not refused for doing the same.
+test_that("a typed-missing label is not an observed collision", {
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    store = c("a", NA, "b"),
+    value = 1:3
+  )
+  operation <- function(label) {
+    summarize_with_margins(
+      data,
+      n = sum(value),
+      .grouping = rollup(region, store),
+      .margin_label = label,
+      .check_margin_label = TRUE,
+      .sort = "last"
+    )
+  }
+
+  expect_no_error(operation(c(region = "All", store = NA_character_)))
+  expect_identical(
+    operation(c(region = "All", store = NA_character_)),
+    operation(list(region = "All", store = NULL))
+  )
+})
+
+test_that("an all-typed-missing label reads no column", {
+  data <- data.frame(group = c("a", NA), value = 1:2)
+  labels <- list(NA_character_, NULL)
+
+  for (label in labels) {
+    expect_no_error(check_observed_label_collision(
+      # A column this cannot select is what proves nothing was selected: a
+      # check that read anything here would fail on the missing column.
+      dplyr::select(data, "value"),
+      margin_labels = list(group = label),
+      factor_info = list()
+    ))
+  }
+})
+
+test_that("a non-missing label is still an observed collision", {
+  data <- data.frame(group = c("All", "b"), value = 1:2)
+
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      n = sum(value),
+      .grouping = rollup(group),
+      .margin_label = "All"
+    ),
+    "already present in grouping column:\ni `group`",
+    fixed = TRUE
+  )
+  expect_match(conditionMessage(error), "`.check_margin_label = FALSE`")
+})
+
+# The remedy has to be one. A bare `NULL` is the whole of `.margin_label`, so
+# it was a remedy only where there was a single dimension.
+test_that("the NA-level refusal names a remedy a caller can write", {
+  status <- structure(
+    c(1L, 2L, NA_integer_),
+    levels = c("kept", NA_character_),
+    class = "factor"
+  )
+  data <- data.frame(region = c("E", "E", "W"), status = status, value = 1:3)
+  operation <- function(label) {
+    summarize_with_margins(
+      data,
+      n = sum(value),
+      .grouping = rollup(region, status),
+      .margin_label = label
+    )
+  }
+
+  error <- expect_error(
+    operation(c(region = "All", status = NA_character_)),
+    "already a factor level in grouping column:\ni `status`",
+    fixed = TRUE
+  )
+  expect_match(conditionMessage(error), "list", fixed = TRUE)
+
+  # Following the remedy has to work with more than one dimension in play.
+  expect_no_error(operation(list(region = "All", status = NULL)))
 })

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -839,6 +839,12 @@ test_that("a named list refuses an element that is not a label", {
     list(
       label = list("All", "Total"),
       message = "must be `NULL`, an unnamed character scalar"
+    ),
+    # A one-row data frame is a named list whose columns are character
+    # scalars, so it is refused for its shape rather than read as labels.
+    list(
+      label = data.frame(first = "All", second = "Total"),
+      message = "must be `NULL`, an unnamed character scalar"
     )
   )
 

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -492,10 +492,12 @@ retail_sales |>
   dplyr::as_tibble()
 ```
 
-`.margin_label = NULL` bypasses collision checks entirely. `NA_character_`
-requests the same typed missing output, but an existing factor NA level is
-always a structural conflict, and whether an actual missing value collides is
-checked only when `.check_margin_label = TRUE`.
+`.margin_label = NULL` and `NA_character_` are the same request: typed missing
+output, and no observed collision check on that dimension. They part on one
+point — an existing factor NA level is always a structural conflict for
+`NA_character_`, whatever `.check_margin_label` says, while `NULL` preserves
+it. A named list chooses either one per dimension, which a named character
+vector cannot do for `NULL`, because `c()` drops a `NULL` element.
 
 A factor NA level and a missing factor code are different even though both
 can print as `<NA>`. Here the second value uses the NA level and the third is


### PR DESCRIPTION
Closes #371.

`.margin_label` chooses a label per dimension, but `NULL` — the value that selects a typed-missing Margin value and opts out of collision checking — was the one choice that could not be made per dimension. `c()` drops a `NULL` element before the argument is reached, and a named list was refused, so `NULL` applied to every dimension or to none. Both halves of the Margin label collision check rested on a per-dimension `NULL` that could not be written: the observed half refused `NA_character_` against a source missing value and offered only a per-call escape, and the declared half's refusal named the unwritable `NULL` as its remedy.

## What changed

**`.margin_label` accepts a named list** whose elements are character scalars or `NULL`. A named character vector is the shorthand for a list holding no `NULL` and is normalized to one, so nothing downstream carries two spellings. The name rules are unchanged, including the requirement to name every Margin dimension — reading an unnamed dimension as `NULL` would turn a misspelled name into a silent whole-call change.

**A typed-missing label is no longer an observed collision.** `NULL` and `NA_character_` produce the same displayed result on a column already holding missing values, and ADR 0012's table permitted that result under one spelling (row 7) while refusing it under the other (row 3). The refusal reached the caller who picked the spelling the documentation calls the checked one, not the caller whose result was ambiguous. The observed check now selects no column for either spelling, so a call whose every label is typed-missing sends no query — as `NULL` already did (ADR 0020). Nothing is reported in its place.

**The declared half is unchanged.** An NA factor level is recorded in `levels()`, so `NA_character_` proposed against one is still refused on every backend whatever `.check_margin_label` says. Its remedy names the list spelling, because the bare `NULL` it named before is the whole of `.margin_label` and so was a remedy only where there was one dimension — the rule the same file states for `.check_margin_label = FALSE`, run backwards.

`.check_margin_label` remains a logical scalar. The eight-case table keeps eight rows.

## What it looks like

```r
retail_sales |>
  summarize_with_margins(
    revenue = sum(revenue),
    store_is_total = grouping_bit(store),
    .grouping = rollup(region, store),
    .margin_label = list(region = "All", store = NULL)
  )
```

The check stays on for `region`, `store` stays typed missing, and `grouping_bit()` tells a source `NA` from the margin over it.

## Design record

Two amendments to ADR 0012 and a narrowing of *Margin label collision* in `CONTEXT.md`, committed separately as `224da50`. The decisions were settled in a grilling session on #371 and are listed in that issue's body.

## Checks

- `lintr::lint_package()` — no lints.
- `NOT_CRAN=true testthat::test_dir("tests/testthat")` — 6260 pass, 0 fail, 0 skip.
- `roxygen2::roxygenise()` — four Rd pages regenerated and committed; no `# nolint` leaked into `man/`.
- `verify-context-budget.R` — 24198 of 24198 bytes, unchanged.