### PR TITLE
Name the queries marginplyr sends (#381, #383)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,6 +161,15 @@ absorbing reads every column of the input while a caller who is told can read
 fewer.
 _Avoid_: Pulling backend, fallback backend, collecting backend
 
+**Sent query**:
+One SQL statement a Margin operation gives to a backend, recorded with the
+purpose it was sent for. Exactly one purpose is the caller's result — the query
+a Margin verb returns unexecuted, which the caller runs themselves; every other
+purpose is a query marginplyr sends for its own reasons, and which those are is
+not fixed. A Sent query is recorded before it is sent, so the record holds what
+was sent rather than what succeeded.
+_Avoid_: Audit record, context, logged query
+
 **Contextual helper**:
 A spelling whose meaning inside a Margin summary arises only through static
 rewriting, and which is therefore recognized by spelling and never resolved

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -162,12 +162,15 @@ fewer.
 _Avoid_: Pulling backend, fallback backend, collecting backend
 
 **Sent query**:
-One SQL statement a Margin operation gives to a backend, recorded with the
-purpose it was sent for. Exactly one purpose is the caller's result — the query
-a Margin verb returns unexecuted, which the caller runs themselves; every other
-purpose is a query marginplyr sends for its own reasons, and which those are is
-not fixed. A Sent query is recorded before it is sent, so the record holds what
-was sent rather than what succeeded.
+One SQL statement marginplyr gives to a backend while compiling a Grouping
+plan or while executing the Margin operation built on one, recorded with the
+purpose it was sent for. `inspect_grouping()` compiles a plan without a Margin
+operation, so it sends Sent queries too. Exactly one purpose is the caller's
+result — the query a Margin verb returns unexecuted, which the caller runs
+themselves; every other purpose is a query marginplyr sends for its own
+reasons, and which those are is not fixed. A Sent query is recorded before it
+is sent, so the record holds what was sent rather than what succeeded, and a
+call that fails leaves every Sent query it had already sent readable.
 _Avoid_: Audit record, context, logged query
 
 **Contextual helper**:


### PR DESCRIPTION
One glossary term added to `CONTEXT.md`. No R source, no generated file, no dependency.

Map #377 is deciding what marginplyr records about the SQL it sends. Per that map's Notes a term enters `CONTEXT.md` from the ticket that fixes it, never from a ticket of its own, so the entry arrives ahead of the ADR rather than with it: #381 fixed the concept and the name of its field, #383 corrected its scope.

## Why `purpose`, and not `context` or `site`

`context` could not be the name. `CONTEXT.md:240` already defines **Condition context**, and **Margin operation** (`CONTEXT.md:62`) lists `operation context` under `_Avoid_`; a third use would collide with both.

`purpose` is what the values are, and it survives what `site` would not. #378 re-identified the query sites against the current code and found they had moved in under a year — `probe_share_sources()` gone, `check_margin_label_collision()` renamed — while what each query was sent *for* did not move.

## Two properties are in the definition rather than left to an implementation

**Which purpose is promised.** Only the caller's result. Every other purpose is a query marginplyr sends for its own reasons, and the entry says plainly that which those are is not fixed, so the vocabulary can grow without the promise growing with it. ADR 0015 already declines to promise error subclasses for the same reason.

**Recorded before it is sent.** A record that drops a query whose `collect()` failed is a record that can hide a failure, and the share dialect probe reaches that path most often — it usually ends in `abort_share_source_dialect()`. Leaving this to the implementation would make it the kind of promise a reader has no way to check.

## The second commit widens the first sentence

The term as #381 wrote it said *a Margin operation*. #383 measured that `inspect_grouping()` calls `prepare_grouping_plan()` directly (`R/inspect-grouping.R:157`) and reaches `grouping_selection_proxy()` — one of the recorded sites — through `R/grouping-plan.R:232`, without ever passing `prepare_margin_operation()`. `inspect_grouping()` is not a Margin operation (`CONTEXT.md:62`), so a term written over Margin operations alone excluded a call that sends one.

The closing sentence states what "recorded before it is sent" already implied and what #383 promised outright: a call that fails leaves every query it had already sent readable.

## Checks

`CONTEXT.md` is not in the closure `verify-context-budget.R` measures — that closure is derived from `CLAUDE.md`'s `@` references, which reach `AGENTS.md` only — so the baseline is untouched. Nothing under `man/`, `NAMESPACE`, or `README.md` regenerates, there being no roxygen, `README.Rmd`, or `DESCRIPTION` change.

Rebased onto `origin/main`; the branch's whole diff is the 12 added lines above.
