### PR TITLE
Record the SQL marginplyr sends (ADR 0027)

### DIFF
--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -221,7 +221,9 @@ is what exemption 1 protects. ADR 0014 selects the per-kind entry that reads
 the source, and is amended separately too: its two lookups stand, but the
 second no longer selects a sampler, because there is nothing left to sample.
 ADR 0025 applies this decision's other half to a read this package does not
-issue, and is what the amendment above was written for.
+issue, and is what the amendment above was written for. ADR 0027 records the
+SQL marginplyr sends, and is where a third exemption for `EXPLAIN` was put to
+this decision and refused; nothing here changed as a result.
 
 Evidence: `investigation/query-cost-across-lazy-backends.md` and
 `investigation/share-source-eligibility-on-coercing-dialects.md`.

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -5,23 +5,22 @@ back with `last_sent_queries()`. The record is off unless the caller sets
 `options(marginplyr.audit_sql = TRUE)`; it holds one row per Sent query, with
 the columns `purpose` and `sql` and no others; and it belongs to a single call,
 emptied at the top of `prepare_grouping_plan()`. Each row is written before its
-query is sent, so what the record holds is what was sent rather than what
-succeeded, and a call that fails leaves readable everything it had already sent.
+query is sent, which is the promise `CONTEXT.md`'s **Sent query** entry states.
 
 The capture is `dbplyr::sql_render()` and nothing else. It is client-side, sends
 nothing, and is not one of the execution entry points
 `lazy_execution_entry_points()` catalogs, so **ADR 0020 is not amended**: this
 decision adds no third exemption to it and does not read the opt-in as the
-caller having asked for a query. The four sites that do send — the zero-row
-selection proxy, the observed-label-collision scan, and the dialect probe's
-question and control — send exactly what they sent before this decision, whether
-or not a caller is auditing.
+caller having asked for a query. The four queries that do reach a connection —
+the zero-row selection proxy, the observed-label-collision scan, and the dialect
+probe's question and control — are exactly what they were before this decision,
+whether or not a caller is auditing.
 
 `marginplyr.audit_sql` is the package's first option, and `last_sent_queries()`
 is its first export that reads back what a previous call did; all fifteen others
-are verbs, constructors, or grouping helpers. Neither has a precedent inside
-this package to cite, which is why both are settled here rather than by
-analogy.
+are verbs, constructors, grouping helpers, or the inspection surface ADR 0013
+governs. Neither has a precedent inside this package to cite, which is why both
+are settled here rather than by analogy.
 
 ## Why a record rather than a signal
 
@@ -117,9 +116,11 @@ placement, `inspect_grouping()` appends its proxy query to whatever the previous
 Margin operation left behind, and nothing says the record now spans two calls —
 the `dbplyr::last_sql()` defect, rebuilt inside the feature written to answer
 it.
-`prepare_grouping_plan()` is the common ancestor of all five recorded sites and
-of five entry points rather than four, and within a Margin operation it still
-runs before every one of them.
+What makes `prepare_grouping_plan()` the reset site is not that it contains the
+recorded sites — only the selection proxy is inside it, while the
+observed-label-collision scan and the dialect probe are reached from siblings of
+its own caller. It is that all five entry points reach it, and that it runs
+before every one of the four sites on every path to them.
 
 Per-call rather than accumulating: saying which rows belong to which call
 needs a call identifier this package has no concept of, while a caller who wants
@@ -138,11 +139,9 @@ the defect this whole decision rests on calling a defect.
 
 Every recorded site runs after `grouping_backend()` has classified the input, so
 nothing classifies a second time. `grouping_backend()` returns `is_sql` as a
-field — already computed there for the `kind` cascade — with this contract:
-
-> Whether this input is a SQL backend. Equivalent to `dialect` being non-`NULL`,
-> but `dialect` is the field dispatch reads, and its nullity does not announce
-> itself as the test. The record reads this field and nothing else.
+field — already computed there for the `kind` cascade — and the record reads
+that field and nothing else. Its header carries the contract, and #318 carries
+the wording.
 
 The record remembers it per call where the backend is computed, inside the same
 function whose top holds the reset, so no recorded site is reached with the
@@ -159,8 +158,10 @@ Four claims in the plan this decision settles were true of an earlier codebase
 and are recorded as corrections rather than quietly fixed, because each was a
 reasonable reading and each is now measured against the working tree.
 
-- **The reset function.** `prepare_margin_operation()` is not the common
-  ancestor; `prepare_grouping_plan()` is. See *One call, and which call*.
+- **The reset function.** `prepare_margin_operation()` is reached by the four
+  Margin verbs and not by `inspect_grouping()`, so it is not the site every
+  recorded query runs after. `prepare_grouping_plan()` is. See *One call, and
+  which call*.
 - **"The accessor never errors."** The cited precedent, `rlang::last_error()`,
   errors when empty (#380), and the accessor refuses in two cases here.
 - **ADR 0021 does not reach a condition marginplyr authors.** Its scope is
@@ -207,11 +208,12 @@ that neither rests on the other.
   internal queries are a zero-row read, a scan the caller asked for, and a
   constant referencing no table of theirs — the plan of a constant answers
   nothing.
-- *It is not an audit record.* GoogleSQL has no `EXPLAIN` statement, so on
-  BigQuery — the backend the cost argument was about — the statement simply
+- *It does not record what was sent.* GoogleSQL has no `EXPLAIN` statement, so
+  on BigQuery — the backend the cost argument was about — the statement simply
   fails; SQL Server has none outside Synapse dedicated pool, and SAP HANA's
-  writes to a table rather than returning rows. The only method is
-  `explain.tbl_sql`, so it raises on every `dbplyr::simulate_*()` connection,
+  writes to a table rather than returning rows. The only method reached by a
+  `tbl_lazy` is `explain.tbl_sql`, so it raises on every `dbplyr::simulate_*()`
+  connection,
   which is how this package reaches the dialects it has no driver for. The text
   is `print()` on a data frame, varying with `getOption("width")`, the caller's
   indexes and row counts, and DuckDB's `explain_output`; SQLite's own
@@ -219,9 +221,10 @@ that neither rests on the other.
   format breaks. And the proposed `tryCatch` made those failures silent, which
   contradicts recording a query before it is sent.
 
-  This ground is reached before ADR 0020, not after it, so it would still refuse
-  the feature if dbplyr registered a BigQuery `sql_query_explain()` method
-  tomorrow.
+  This ground is reached before ADR 0020, not after it. It is also independent
+  of the ground above, which is why the two are recorded separately: it would
+  still refuse the feature if dbplyr registered a BigQuery
+  `sql_query_explain()` method tomorrow.
 
 **`"explain"` at every site except `"result"`,** since the other sites talk to
 the backend a moment later anyway. Rejected: it does not avoid the amendment,
@@ -273,6 +276,13 @@ caller already knows, and the `sql` shows the dialect.
 
 **An accessor that returns zero rows in every empty case.** Rejected: see *Four
 answers, distinguished*.
+
+**The name `last_marginplyr_sql()`,** which is what the map's destination called
+this accessor. Rejected: it names no concept in the glossary, and it is singular
+where the value holds up to five rows. `last_` matches all eight precedents, and
+six of the eight do not prefix with the package name; the two that do are about
+warnings, where several packages entrace into one session, which is not the case
+here.
 
 **Deferring the render to the accessor,** so that a refused translation raises
 where raising is allowed. Rejected: it needs a hidden column or a parallel store
@@ -345,6 +355,6 @@ Evidence: `investigation/what-dplyr-explain-sends-per-backend.md` for what
 `investigation/session-state-and-last-call-accessors.md` for what CRAN policy
 and *Writing R Extensions* permit a package environment, for the eight
 last-call precedents and the shape none of them has, and for the fork, PSOCK,
-and callr measurements behind the concurrency sentence;
-`investigation/share-source-schema-vs-data-read.md` for the render/read
-distinction the client-side capture rests on.
+and callr measurements behind the concurrency sentence. That
+`dbplyr::sql_render()` leaves `the$last_sql` untouched, so the capture disturbs
+nothing a caller reads from dbplyr, was measured on #381.

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -1,0 +1,350 @@
+# Record the SQL marginplyr sends
+
+marginplyr keeps a record of the Sent queries of one call, and a caller reads it
+back with `last_sent_queries()`. The record is off unless the caller sets
+`options(marginplyr.audit_sql = TRUE)`; it holds one row per Sent query, with
+the columns `purpose` and `sql` and no others; and it belongs to a single call,
+emptied at the top of `prepare_grouping_plan()`. Each row is written before its
+query is sent, so what the record holds is what was sent rather than what
+succeeded, and a call that fails leaves readable everything it had already sent.
+
+The capture is `dbplyr::sql_render()` and nothing else. It is client-side, sends
+nothing, and is not one of the execution entry points
+`lazy_execution_entry_points()` catalogs, so **ADR 0020 is not amended**: this
+decision adds no third exemption to it and does not read the opt-in as the
+caller having asked for a query. The four sites that do send — the zero-row
+selection proxy, the observed-label-collision scan, and the dialect probe's
+question and control — send exactly what they sent before this decision, whether
+or not a caller is auditing.
+
+`marginplyr.audit_sql` is the package's first option, and `last_sent_queries()`
+is its first export that reads back what a previous call did; all fifteen others
+are verbs, constructors, or grouping helpers. Neither has a precedent inside
+this package to cite, which is why both are settled here rather than by
+analogy.
+
+## Why a record rather than a signal
+
+The audit requirement is that every query marginplyr sends is recorded *and
+distinguishable*. Nothing already available satisfies the second half.
+`dbplyr::last_sql()` — one slot, overwritten by every render that funnels
+through `db_sql_render()`, marginplyr's internal ones included — reports the
+selection proxy after a DuckDB Margin verb, the label scan under
+`.check_margin_label`, and on RSQLite a stale query about an unrelated table
+from earlier in the session, with nothing saying which of those a reader has
+(#381). An answer whose correctness rests on the caller reading in the right
+order, and which is silent when they do not, is the defect this decision exists
+to remove; reproducing it anywhere in the feature would not hold together, which
+is what settles the accessor's refusals and the concurrency sentence below.
+
+A `marginplyr_query_sql` condition delivered through `withCallingHandlers()` was
+the proposed mechanism and is rejected. Its only capability the record lacks is
+streaming across many calls, and the record is per-call, so a caller who wants
+that loops and appends it themselves. Nothing was found that the condition alone
+can do. Against that, it would be the package's first non-error condition, which
+`?marginplyr` and `CONTEXT.md`'s *Package condition* entry both speak against.
+ADR 0015 governs errors, so an inert signal falls outside its rule rather than
+under it — and being outside a rule is not a warrant.
+
+## The record holds the statement, not the execution
+
+A Sent query is SQL. dtplyr's selection proxy reaches data.table and Arrow's
+reads `arrow::schema()`; neither takes a row, so a dtplyr or Arrow call is
+audited and records nothing. `last_sent_queries()`'s Rd states in one sentence
+that the record promises the SQL marginplyr sent, not the execution marginplyr
+caused. Without it, those zero rows are indistinguishable from a hole.
+
+What is promised of a row is that its `sql` is the statement as it was sent.
+That every one of the five is in fact a complete, executable single statement is
+a fact about those five sites and not a contract: promising executability would
+make marginplyr answerable for a property of a backend's parser.
+
+The `purpose` vocabulary is `"result"`, `"selection_proxy"`,
+`"observed_label_collision"`, `"share_dialect"`, and `"share_dialect_control"`.
+**Only `"result"` is promised.** The sites moved substantially inside a year
+(#378), and what an auditor needs is which record is their result; freezing the
+names of marginplyr's internal queries is not part of that. ADR 0015 already
+declines to promise error subclasses for the same reason.
+`"observed_label_collision"` names the half of ADR 0020's split that reads —
+the declared-level collision is found in metadata and sends nothing — and the
+dialect probe is one site producing up to two rows, ADR 0020's exemption 2
+counting the question and the control separately.
+
+## Four answers, distinguished
+
+Completeness is what the record is for, so every case in which it holds fewer
+rows than a reader might expect is told apart from the others rather than
+collapsed into an unaccounted-for zero:
+
+1. **Nothing has been recorded in this session** — `last_sent_queries()` raises
+   a Package condition.
+2. **The last recorded call was not audited** — it raises a Package condition
+   naming `marginplyr.audit_sql`. The option is read once, at the reset, and
+   remembered with the record; otherwise a caller who sets it *after* the call
+   would read zero rows under a live option, which is the silent wrong answer
+   arriving through a side door.
+3. **The call was audited and sent nothing** — a zero-row tibble. This is a
+   correct answer and the only one that returns zero rows: a local input sends
+   nothing by ADR 0020's `is.data.frame()` predicate, and a lazy backend without
+   `collect_selection_proxy` sends nothing until the caller collects.
+4. **A statement had no SQL form on this backend** — a row with
+   `sql = NA_character_`. `dbplyr::sql_render()` passes unknown functions
+   through and raises only where a translation is explicitly refused, and it
+   raises at render rather than at build. Dropping the row is the hole; letting
+   it raise would turn the option into something that fails a call that would
+   otherwise have succeeded. The `NA` row accounts for the site and leaves the
+   call unaffected, and the Rd says what it means.
+
+Both refusals are Package conditions under ADR 0015: the caller avoids each by
+rewriting a call they wrote — running a Margin verb first, or setting the
+option. Recording itself reads `isTRUE(getOption("marginplyr.audit_sql"))` and
+reports nothing at all, because a garbage option value must not turn a caller's
+`summarize_with_margins()` into an error. The accessor is the surface that
+reports it.
+
+The return value is a `dplyr::tibble()`, which ADR 0013 already settled for an
+inspection surface, and no print method, which ADR 0013 already declined for the
+cost it puts on export and snapshot workflows. The Rd shows `writeLines(x$sql)`
+for reading a multi-line statement instead.
+
+## One call, and which call
+
+The reset is at the top of `prepare_grouping_plan()`. The obvious placement —
+`prepare_margin_operation()`, the one function all four Margin verbs converge on
+— is wrong by one caller: `inspect_grouping()` calls `prepare_grouping_plan()`
+directly, and the selection proxy is reached from inside it. Under the obvious
+placement, `inspect_grouping()` appends its proxy query to whatever the previous
+Margin operation left behind, and nothing says the record now spans two calls —
+the `dbplyr::last_sql()` defect, rebuilt inside the feature written to answer
+it.
+`prepare_grouping_plan()` is the common ancestor of all five recorded sites and
+of five entry points rather than four, and within a Margin operation it still
+runs before every one of them.
+
+Per-call rather than accumulating: saying which rows belong to which call
+needs a call identifier this package has no concept of, while a caller who wants
+accumulation loops and appends. Per-call is the half they cannot reconstruct.
+
+Two consequences are documented rather than avoided. Two identical calls need
+not produce identical records, because the dialect verdict is cached per
+dialect for the session. And a package environment is invisible across `fork`,
+PSOCK, and callr: a child inherits the parent's pre-fork record or starts
+empty, and its writes never return, so a read after a parallel run reports the
+last *serial* call. Six precedent Rd pages across five packages document no
+position on this; marginplyr documents one, because a silently stale answer is
+the defect this whole decision rests on calling a defect.
+
+## What decides whether a site records
+
+Every recorded site runs after `grouping_backend()` has classified the input, so
+nothing classifies a second time. `grouping_backend()` returns `is_sql` as a
+field — already computed there for the `kind` cascade — with this contract:
+
+> Whether this input is a SQL backend. Equivalent to `dialect` being non-`NULL`,
+> but `dialect` is the field dispatch reads, and its nullity does not announce
+> itself as the test. The record reads this field and nothing else.
+
+The record remembers it per call where the backend is computed, inside the same
+function whose top holds the reset, so no recorded site is reached with the
+backend unknown, `record_sent_query()` takes no backend argument, and neither
+`validate_margin_label()` nor `check_observed_label_collision()` gains a
+parameter about backends, which is not what either answers. This is the same
+move the option's flag makes, and it adds no failure mode the option does not
+already have: a site reached without a reset misreads the stale flag in exactly
+the same way.
+
+## Corrections
+
+Four claims in the plan this decision settles were true of an earlier codebase
+and are recorded as corrections rather than quietly fixed, because each was a
+reasonable reading and each is now measured against the working tree.
+
+- **The reset function.** `prepare_margin_operation()` is not the common
+  ancestor; `prepare_grouping_plan()` is. See *One call, and which call*.
+- **"The accessor never errors."** The cited precedent, `rlang::last_error()`,
+  errors when empty (#380), and the accessor refuses in two cases here.
+- **ADR 0021 does not reach a condition marginplyr authors.** Its scope is
+  `summarize_margin_union()` and External conditions, so it decides nothing
+  about how a warning this package raised would be repeated. With the file log
+  rejected there is no such warning, and the throttling question has no subject.
+- **The `----`-separated on-disk format is unparseable by its own payload.**
+  SQL's line comment is `--`, so a `dbplyr::sql()` literal reaches the
+  separator. This is secondary to the reason the file log is rejected, and is
+  recorded because it is a fact about the format rather than about the feature.
+
+## Considered options
+
+**A `marginplyr_query_sql` condition.** Rejected: see *Why a record rather than
+a signal*. A scan of 293 installed packages found none documenting a
+user-written handler as the route to observing its ordinary operation; httr2
+signals at exactly this site and documents its accessor instead (#380).
+
+**A caller-supplied logging function**, `options(marginplyr.sql_logger =
+function(sql, purpose) ...)`. Rejected: it inherits the condition's whole
+argument — the record is per-call and a caller can loop — and adds a
+callback-shaped option this package has no precedent for.
+
+**A return value or attribute on the result.** Rejected: it cannot represent the
+query the caller collects *after* marginplyr has returned, which is the one
+purpose that is promised.
+
+**A per-entry-point `.audit_sql` argument.** Rejected in favour of the session
+option. ADR 0020's `.check_margin_label` and `.check_share_source` are arguments
+because they decide *whether a query is sent*; this decides *whether a record is
+kept*, which is a different kind of decision, and an audited session is a
+session-level fact. The recorded sites are shared plumbing that five entry
+points fan into.
+
+**`"explain"` as a second capture method**, selected by
+`marginplyr.audit_sql_method`. Rejected on two grounds recorded separately, so
+that neither rests on the other.
+
+- *The demand is already met.* The proposal predates the record's shape. With
+  the `sql` column in place, a caller reaches a plan without marginplyr
+  mediating: the `"result"` query comes back as an unexecuted lazy object, so
+  `dplyr::explain()` applies to it directly, and the four internal statements
+  are in the record for the caller to put to their own connection. The three
+  internal queries are a zero-row read, a scan the caller asked for, and a
+  constant referencing no table of theirs — the plan of a constant answers
+  nothing.
+- *It is not an audit record.* GoogleSQL has no `EXPLAIN` statement, so on
+  BigQuery — the backend the cost argument was about — the statement simply
+  fails; SQL Server has none outside Synapse dedicated pool, and SAP HANA's
+  writes to a table rather than returning rows. The only method is
+  `explain.tbl_sql`, so it raises on every `dbplyr::simulate_*()` connection,
+  which is how this package reaches the dialects it has no driver for. The text
+  is `print()` on a data frame, varying with `getOption("width")`, the caller's
+  indexes and row counts, and DuckDB's `explain_output`; SQLite's own
+  documentation says applications should not use `EXPLAIN` and names two past
+  format breaks. And the proposed `tryCatch` made those failures silent, which
+  contradicts recording a query before it is sent.
+
+  This ground is reached before ADR 0020, not after it, so it would still refuse
+  the feature if dbplyr registered a BigQuery `sql_query_explain()` method
+  tomorrow.
+
+**`"explain"` at every site except `"result"`,** since the other sites talk to
+the backend a moment later anyway. Rejected: it does not avoid the amendment,
+because ADR 0020 enumerates *queries* rather than sites — `EXPLAIN collect(head(
+.data, 0L))` is not the query exemption 1 names. Independently it is worse than
+either extreme, since a caller reading an empty log could not tell "nothing was
+sent" from "this site does not record under this setting".
+
+**`dbplyr::remote_query_plan()` as the capture.** Rejected with `"explain"`. It
+returns a character vector rather than printing, so it needs no
+`utils::capture.output()` — which corrects the plan but not the feature: it
+inherits every dialect failure above, and the first ground applies to it
+identically.
+
+**An on-disk log written by the package**, `marginplyr.audit_sql_file`.
+Rejected, and rejected as incompatible rather than as worthless. Its honest form
+is write-or-stop: a record whose purpose is completeness must not silently
+acquire a hole, and a file that stopped being written mid-session under a
+suppressed warning is worse than no file, because a reader reads it as complete.
+That form contradicts a garbage option value not being allowed to turn
+`summarize_with_margins()` into an error. The proposed form avoids the
+contradiction by warning and continuing — which *is* the hole — and buys the
+avoidance with the package's first warning of its own, against a sentence
+`?marginplyr` and `CONTEXT.md` state independently. Both routes are closed by
+decisions made elsewhere, and this is recorded conditionally for that reason:
+what would have to change for a file log to return is the treatment of a bad
+option value, or the no-warning axiom.
+
+**An exported `write_sent_queries(path)`.** Rejected separately, because the
+argument above does not reach it: a writer the *caller* calls may raise a
+Package condition on a bad path perfectly legitimately under ADR 0015. It is
+rejected because it is one export standing over `utils::write.csv(
+last_sent_queries(), path)`, and it still fixes a format the package then owns
+and must keep. Holding no format is the feature: no one format answers an
+auditor, and the tibble is what a caller writes to CSV, JSON, parquet, or a
+database row from. `last_sent_queries()`'s Rd carries the recipe.
+
+**A `time` column.** Rejected: row order already carries its ordering value,
+recording a query before it is sent precludes measuring an elapsed one, and the
+column would force every snapshot test and every Rd example to drop it. It was
+proposed for the file log, which is not built. A caller accumulating across
+calls adds their own timestamp — the same answer as the format above, one column
+down.
+
+**A backend column.** Rejected: the rows belong to one call whose backend the
+caller already knows, and the `sql` shows the dialect.
+
+**Accumulating across calls.** Rejected: see *One call, and which call*.
+
+**An accessor that returns zero rows in every empty case.** Rejected: see *Four
+answers, distinguished*.
+
+**Deferring the render to the accessor,** so that a refused translation raises
+where raising is allowed. Rejected: it needs a hidden column or a parallel store
+to survive the two-column record, it would hold the caller's query object and
+its connection reference in package state, and "recorded before it is sent"
+would become "recorded before it is sent, filled in later".
+
+**An `is_sql_lazy_query()` predicate** reading `tbl_lazy`, `dtplyr_step`, and
+`arrow_input_classes()` at the recorder. Rejected, and recorded here because the
+rejection rests on a general rule rather than on this feature: **the package
+does not classify a second time by reading classes it has already read.**
+`is_lazy_backend_input()` in the test suite already asks the package's own
+classifier rather than the classes it reads, and its header says why; the
+predicate is that move run backwards. Two narrower spellings are rejected with
+it — `!is.null(backend$dialect)`, which names something other than what it
+decides, and a `kind %in%` set at the recorder, which is a second place to keep
+in step when a SQL kind is added.
+
+## Test strategy
+
+`lazy_execution_entry_points()` gains `dplyr::explain` and
+`dbplyr::remote_query_plan`, both with `subject_test = FALSE`. This is
+independent of the verdict above and is what makes the rejection structural
+rather than prose: both reach `DBI::dbGetQuery()` from inside dbplyr, where the
+static scan over `R/` cannot follow, so one line of either in `R/` would leave
+the gate silent. `traced_execution_entry_points()` derives from the same catalog
+and covers them without a second edit. The snapshot of entry points scanned for
+moves by two rows; the snapshot of internal functions reaching one does not, and
+that is the assertion.
+
+Neither entry takes a positive control, and the absence is deliberate rather
+than an omission. ADR 0020's controls exist to show the counter can count at
+all, which the existing entries discharge. What these two assert is that
+marginplyr does not call them, and a positive control for that would be
+marginplyr calling `explain()` — the feature this ADR rejects.
+
+`sql_render()` and `show_query()` stay absent from the catalog, so recording the
+result query moves none of ADR 0020's snapshots. That is the same fact as the
+opening paragraph's, asserted where it can fail.
+
+The dialect probe's two rows are SQL by construction — the query is built on a
+connection `DBI::dbIsValid()` has already vetted — and get no runtime test,
+since code re-asking a condition that is always true tells a reader it is
+variable.
+
+## Documentation consequences
+
+The reference carries a section on the record, and it is not called *Audit
+signal*: there is no signal. It states that the feature is off by default, that
+`"result"` is the only promised purpose, that a query is recorded before it is
+sent and so survives a failing call, what each of the four answers above means,
+the SQL-not-execution boundary, and the concurrency position. It names one
+capture, there being one. `vignettes/database_backends.qmd` carries the same
+material against a live backend, with the point that `"result"` is a render and
+not an execution — the caller's own `collect()` is still what runs it.
+
+## Related decisions
+
+ADR 0020 is the rule this decision does not amend, and its *Related decisions*
+gains one line naming this ADR as recording a query it did not exempt, so that a
+reader of ADR 0020 can find that the question was put. Its exemptions 1 and 2
+are three of the five recorded purposes, and its split of the Margin-label
+collision check is why only the observed half takes a row. ADR 0013 fixes the
+return class and forecloses the print method. ADR 0015 is what the accessor's
+two refusals are, and what the recorder's silence about a bad option value is
+measured against. ADR 0021 does not reach here, per *Corrections*.
+
+Evidence: `investigation/what-dplyr-explain-sends-per-backend.md` for what
+`explain()` sends per dialect and where the statement does not exist;
+`investigation/session-state-and-last-call-accessors.md` for what CRAN policy
+and *Writing R Extensions* permit a package environment, for the eight
+last-call precedents and the shape none of them has, and for the fork, PSOCK,
+and callr measurements behind the concurrency sentence;
+`investigation/share-source-schema-vs-data-read.md` for the render/read
+distinction the client-side capture rests on.

--- a/investigation/session-state-and-last-call-accessors.md
+++ b/investigation/session-state-and-last-call-accessors.md
@@ -1,0 +1,668 @@
+# What session state costs an R package, and what shape the last-call precedents take
+
+Investigated: 2026-09-02
+
+#318 justifies a `last_marginplyr_sql()` accessor on two claims: that
+`rlang::last_error()` is the ecosystem precedent for this shape of problem, and
+that marginplyr has no package-environment pattern of its own. #377 records
+that the second is false. This note records what was read and measured about
+the first, and about the four other questions #380 asks: what CRAN policy and
+*Writing R Extensions* permit, what happens to a package environment under
+fork, PSOCK, and callr, whether a user-written `withCallingHandlers()` is an
+idiom the ecosystem actually expects, and what `R CMD check` does to state that
+outlives a call.
+
+It records evidence only. The verdict on whether marginplyr gains such an
+accessor is #383's.
+
+Everything below was read from package sources downloaded from CRAN
+(`download.packages(type = "source")`) rather than from documentation, and
+measured on macOS 15 (arm64), R 4.6.1 (2026-06-24), with rlang 1.3.0,
+dplyr 1.2.1, dbplyr 2.6.0, testthat 3.3.2, httr2 1.3.0, lifecycle 1.0.5,
+duckplyr 1.2.1, ggplot2 4.0.3.
+
+## 1. What CRAN policy and WRE permit
+
+### CRAN Repository Policy
+
+Read at https://cran.r-project.org/web/packages/policies.html on 2026-09-02.
+Three sentences bear on run-time state, and none of them reaches a package's
+own environment:
+
+> A package must not tamper with the code already loaded into R: any attempt to
+> change code in the standard and recommended packages which ship with R is
+> prohibited. Altering the namespace of another package should only be done
+> with the agreement of the maintainer of that package.
+
+> Packages should not modify the global environment (user's workspace).
+
+> Packages should not write in the user's home filespace (including
+> clipboards), nor anywhere else on the file system apart from the R session's
+> temporary directory (or during installation in the location pointed to by
+> `TMPDIR`: and such usage should be cleaned up).
+
+The prohibitions name *another* package's namespace and the *global*
+environment. The policy has no sentence about a package writing to an
+environment it created itself. This is the finding: the permission is an
+absence, not a grant.
+
+The third sentence is quoted because it is the same paragraph and because it
+does bind a different feature #318 bundles — an on-disk log at a caller-chosen
+path. That is #382's question and is not pursued here.
+
+### Writing R Extensions
+
+Read at https://cran.r-project.org/doc/manuals/r-release/R-exts.html on
+2026-09-02. Its statement on sealing, §1.5 *Package namespaces*:
+
+> Namespaces are sealed once they are loaded. Sealing means that imports and
+> exports cannot be changed and that internal variable bindings cannot be
+> changed.
+
+Sealing binds *bindings*, not the objects they point at. WRE's §1.5.3 *Load
+hooks* says nothing about environments created in a hook, and a search of the
+whole manual for "user's workspace", "package state", and "store … state"
+returned nothing on the subject. So WRE neither permits nor forbids a
+package-level environment; it describes the mechanism that makes one work, and
+stops.
+
+Measured, to confirm that reading (`/tmp/seal.R`):
+
+```r
+e <- asNamespace("rlang")
+cat("environmentIsLocked(ns):", environmentIsLocked(e), "\n")
+cat("bindingIsLocked('the', ns):", bindingIsLocked("the", e), "\n")
+r1 <- tryCatch({assign("the", 1, envir = e); "ok"}, error = conditionMessage)
+cat("assign('the', 1, envir = ns):", r1, "\n")
+r2 <- tryCatch({assign("zzz_new", 1, envir = e); "ok"}, error = conditionMessage)
+cat("assign('zzz_new', 1, envir = ns):", r2, "\n")
+the <- get("the", envir = e)
+cat("environmentIsLocked(the):", environmentIsLocked(the), "\n")
+r3 <- tryCatch({the$zzz_probe <- 1; "ok"}, error = conditionMessage)
+cat("the$zzz_probe <- 1:", r3, "-> value", the$zzz_probe, "\n")
+```
+
+```
+environmentIsLocked(ns): TRUE
+bindingIsLocked('the', ns): TRUE
+assign('the', 1, envir = ns): cannot change value of locked binding for 'the'
+assign('zzz_new', 1, envir = ns): cannot add bindings to a locked environment
+environmentIsLocked(the): FALSE
+the$zzz_probe <- 1: ok -> value 1
+```
+
+Writing to the namespace fails both ways — rebinding an existing name and
+adding a new one. Writing *into* an environment the namespace binds succeeds,
+because the binding is untouched. Every precedent in §2 uses that second form.
+
+### What `R CMD check --as-cran` raises
+
+Measured. A throwaway package `statepkg` was built holding one top-level
+`the <- new.env(parent = emptyenv())`, one function that appends to it, one
+that reads it back, and one that returns `Sys.getpid()`; with two testthat
+files and one knitr vignette, all of which read and write it.
+
+```sh
+R CMD build statepkg
+_R_CHECK_FORCE_SUGGESTS_=false R CMD check --as-cran --no-manual statepkg_0.0.1.tar.gz
+```
+
+```
+Status: 1 NOTE
+* checking CRAN incoming feasibility ... [2s/14s] NOTE
+Maintainer: ‘A B <ab@example.com>’
+
+New submission
+```
+
+The only NOTE is the one every unpublished package gets. Nothing in
+`--as-cran` — not the codetools pass, not the namespace check — reported the
+environment or the writes to it.
+
+### Where a top-level `new.env()` lives
+
+`new.env()` at the top level of an `R/` file runs at *install* time and is
+serialized into the package's lazy-load database, so each session deserializes
+its own copy. Measured against the installed `statepkg`:
+
+```
+session A, log at start:  (empty)
+session A, log at end:   written-in-session-A
+session A, after unload+reload:  (empty)
+session B, log:  (empty)
+```
+
+State does not survive `unloadNamespace()` + `library()` in the same session,
+and does not reach a second session. It is session state, not persistent state.
+
+## 2. The precedents' actual shape
+
+A scan of all 293 installed packages' exports for `^last_|_last$` found seven
+packages holding a genuine last-call accessor, eight accessors between them.
+Excluded from the count after inspection: `last_col()`, a tidyselect helper
+re-exported by seven packages; the `stri_*_last()` string helpers;
+`gh::gh_last()`, which follows an HTTP pagination link; and `rhub::last_check()`,
+whose body is `deprecated()`.
+
+| accessor | held in | written | reset | shape | opt-in |
+| --- | --- | --- | --- | --- | --- |
+| `rlang::last_error()` | `the$last_error` | at unhandled-error time | never | one slot, overwritten | no |
+| `rlang::last_warnings()` / `last_messages()` | `the$last_warnings` / `the$last_messages` | on each entraced condition | on first push of a new top-level command | list, appended | yes, `global_entrace()` |
+| `dplyr::last_dplyr_warnings()` | `the$last_warnings` | after a verb finishes | on first push of a new top-level command | list, appended | no |
+| `lifecycle::last_lifecycle_warnings()` | `warnings_env$warnings` | on each deprecation warning | on first push of a new top-level command | list, appended | no |
+| `dbplyr::last_sql()` | `the$last_sql` | in `db_sql_render()` | never | one slot, overwritten | no |
+| `httr2::last_request()` / `last_response()` | `the$last_request` / `the$last_response` | at the *start* of `req_perform1()` | request set, response set to `NULL`, both per call | one slot each, overwritten | no |
+| `duckplyr::last_rel()` | `duckplyr_the$last_rel` | from a `duckdb.materialize_callback` hook | never | one slot, overwritten | no |
+| `ggplot2::last_plot()` | closure over `.last_plot` in `.store` | on plot creation/print | never | one slot, overwritten | no |
+
+Every one is held in a package-level container created at the top level of an
+`R/` file. Six packages use `new.env(parent = emptyenv())` or rlang's
+`new_environment()`; ggplot2 alone uses a closure.
+
+### `rlang::last_error()` — the precedent #318 names
+
+`R/aaa.R:1`:
+
+```r
+the <- new.env(parent = emptyenv())
+```
+
+`R/cnd-last.R`:
+
+```r
+last_error <- function() {
+  err <- peek_last_error()
+
+  if (is_null(err)) {
+    local_options(rlang_backtrace_on_error = "none")
+    stop(
+      "Can't show last error because no error was recorded yet",
+      call. = FALSE
+    )
+  }
+  ...
+}
+
+peek_last_error <- function(cnd) {
+  the$last_error
+}
+poke_last_error <- function(cnd) {
+  the$last_error <- cnd
+}
+```
+
+Three properties of this precedent differ from what #318 proposes for
+`last_marginplyr_sql()`:
+
+- It is written at *error* time, not at call start. `poke_last_error()` is
+  called from five sites (`R/cnd-abort.R:896`, `R/cnd-entrace.R:146`, `:212`,
+  `:379`, `R/cnd-message.R:341`); the comment at `cnd-abort.R:895` is
+  "Save the unhandled error for `rlang::last_error()`". Nothing resets it.
+- It holds one slot, overwritten. `last_error()` is not an accumulator and
+  cannot report more than one error.
+- It **errors** when nothing has been recorded. #318 specifies the opposite —
+  "zero rows if nothing signaled … it never errors".
+
+`last_warnings()` and `last_messages()` are the accumulators, and their reset
+is not "at the start of a call". It is lazy, on write, keyed on the address of
+the top-level frame (`R/cnd-last.R`):
+
+```r
+push_condition <- function(cnd, last) {
+  top <- obj_address(cmd_frame())
+
+  if (has_new_cmd_frame(top)) {
+    the$last_top_frame <- top
+    the[[last]] <- list(cnd)
+    the$n_conditions <- 1L
+  } else {
+    the[[last]] <- c(the[[last]], list(cnd))
+    ...
+  }
+}
+```
+
+rlang documents the heuristic's failure mode in a comment above it: if a GC
+occurs between two commands and the new first frame reuses the old address,
+"we'll wrongly keep collecting warnings instead of starting anew".
+
+`cmd_frame()` carries a knitr special case — under `knitr_in_progress()` it
+looks for a knitr frame rather than `sys.frame(1)` — which is direct evidence
+that "one top-level command" is not a well-defined thing inside a rendered
+document.
+
+### `dplyr::last_dplyr_warnings()` and `lifecycle::last_lifecycle_warnings()`
+
+Both copy rlang's heuristic. dplyr, `R/conditions.R:319`:
+
+```r
+# Flushes warnings if a new top-level command is detected
+push_dplyr_warnings <- function(warnings) {
+  last <- the$last_cmd_frame
+  current <- obj_address(sys.frame(1))
+
+  if (!identical(last, current)) {
+    reset_dplyr_warnings()
+    the$last_cmd_frame <- current
+  }
+
+  the$last_warnings <- c(the$last_warnings, warnings)
+}
+
+# Also used in tests
+reset_dplyr_warnings <- function() {
+  the$last_warnings <- list()
+}
+```
+
+Two things this records. The reset is on write, not at call start — the state
+of a finished command is still readable until the next command writes. And
+`reset_dplyr_warnings()` exists partly for dplyr's own test suite; the comment
+says so.
+
+`last_dplyr_warnings()` is documented `@keywords internal`, so it is exported
+but not indexed as part of dplyr's public surface. `last_error()`,
+`last_sql()`, `last_response()`, `last_rel()`, and
+`last_lifecycle_warnings()` are not marked internal. `ggplot2::last_plot()` is.
+
+Both accumulators bound what they hold, because holding it is not free.
+dplyr's handler (`R/conditions.R:301`):
+
+```r
+# Don't entrace more than 5 warnings because this is very costly
+if (is_null(cnd$trace) && length(state$warnings) < 5) {
+```
+
+rlang counts pushed conditions against `max_entracing()`, default 20, citing
+rlang#1473.
+
+### `dbplyr::last_sql()` — the closest analogue, and it already exists
+
+dbplyr 2.6.0 exports it. NEWS for 2.6.0: "`last_sql()` retrieves the most
+recent SQL query generated by dbplyr, which is useful for debugging (#1471)."
+
+`R/remote.R:127-142`:
+
+```r
+#' Retrieve the last SQL query generated
+#'
+#' This is a helper function that retrieves the most recent SQL query generated
+#' by dbplyr, which can be useful for debugging.
+#'
+#' @return A SQL string, or `NULL` if no query has been generated yet.
+#' @export
+last_sql <- function() {
+  the$last_sql
+}
+```
+
+It is written in one place, `db_sql_render()` (`R/db.R:61-79`):
+
+```r
+  out <- db_sql_render_dispatch(con, sql, ..., sql_options = sql_options)
+  the$last_sql <- out
+  return(out)
+```
+
+Never reset. Not behind an option. Written on every render, whether or not
+anyone will read it.
+
+`db_sql_render()` is the funnel: `collect()` (`R/verb-collect.R:48`),
+`compute()` (`R/verb-compute.R:57`), `collapse()` (`R/verb-collapse.R:17`),
+`do()` (`R/verb-do.R:44`), and `remote_query()` (`R/remote.R:118`) all route
+through it. So for a dbplyr-backed query, "the last SQL dbplyr rendered" is
+already retrievable without any marginplyr code. What it cannot do is report
+more than one — `the$last_sql` is a single slot, and a marginplyr call that
+renders a probe, a schema proxy, a label check, and a result overwrites it four
+times.
+
+### `httr2::last_request()` / `last_response()` — the only reset-at-call-start
+
+`R/req-perform.R:192`, the first two lines of `req_perform1()`:
+
+```r
+  the$last_request <- req
+  the$last_response <- NULL
+  signal(class = "httr2_perform")
+```
+
+and `create_response()` (`R/resp.R:138`) fills `the$last_response` when one
+arrives.
+
+This is the one precedent whose state is cleared at the start of the call, and
+what it clears is one slot it is about to fill — not a log that then
+accumulates within the call. It is also the one precedent that does both: it
+holds the state *and* signals a condition (`httr2_perform`) at the same site.
+
+Its accessors return `NULL` when nothing was recorded; the `_json()` variants
+`cli_abort()`.
+
+### `duckplyr::last_rel()` and `ggplot2::last_plot()`
+
+duckplyr writes from a hook installed on load rather than from its own call
+sites (`R/last.R`):
+
+```r
+last_rel <- function() {
+  duckplyr_the$last_rel
+}
+
+# Ellipsis for future extensions
+last_rel_store <- function(rel, ...) {
+  duckplyr_the$last_rel <- rel
+}
+
+on_load({
+  options(duckdb.materialize_callback = last_rel_store)
+})
+```
+
+ggplot2 uses the pre-environment idiom, a closure (`R/plot-last.R`):
+
+```r
+.plot_store <- function() {
+  .last_plot <- NULL
+
+  list(
+    get = function() .last_plot,
+    set = function(value) .last_plot <<- value
+  )
+}
+.store <- .plot_store()
+```
+
+### Answering #380's question directly
+
+Of the eight accessors, exactly one (httr2) clears state at the start of a
+call. Three
+(rlang's warnings and messages, dplyr, lifecycle) append and flush lazily on
+the first write of a new top-level command, which is not the same thing: the
+previous command's record stays readable until something replaces it. Four
+(rlang's error, dbplyr, duckplyr, ggplot2) hold a single slot and never reset
+at all.
+
+None of the eight is a per-call log that is emptied at call start and then
+appended to several times within the call, which is the shape #318 specifies.
+
+### marginplyr's own precedent
+
+`R/share.R:2301`:
+
+```r
+share_dialect_verdicts <- new.env(parent = emptyenv())
+```
+
+It is the only *package-level* environment in `R/`. `R/conditions.R:95` also
+calls `new.env(parent = emptyenv())`, but inside `new_branch_conditions()`,
+so that one is created per call and dies with it — the two are not the same
+pattern, and #377's reading of `share.R:2301` as the sole instance is right.
+
+Written at `R/share.R:2275`, read at `:2254`, never reset — a memo, in the
+shape of the four never-reset precedents above and the opposite of #318's.
+
+The suite records what the pattern costs there. `tests/testthat/test-share-backends.R:1174-1185`
+carries two helpers built only for it:
+
+```r
+empty_share_dialect_verdicts <- function() {
+  rm(
+    list = ls(share_dialect_verdicts, all.names = TRUE),
+    envir = share_dialect_verdicts
+  )
+}
+
+restore_share_dialect_verdicts <- function(saved) {
+  empty_share_dialect_verdicts()
+  list2env(saved, envir = share_dialect_verdicts)
+  invisible(NULL)
+}
+```
+
+with four `empty_share_dialect_verdicts()` calls and three
+save-and-`on.exit(restore…)` pairs across the file. That is the measured price
+of one package-level environment in this repository's own tests.
+
+## 3. Concurrency
+
+Measured against `dbplyr::last_sql()`, since it is a real last-call accessor
+with no database required (`dbplyr::lazy_frame()` renders without a
+connection). `/tmp/conc.R`, run under `Rscript`:
+
+```r
+suppressMessages({library(dplyr); library(dbplyr)})
+lf <- lazy_frame(x = 1:3, .name = "df")
+
+invisible(capture.output(lf |> filter(x > 1) |> show_query()))   # parent render
+
+seen <- parallel::mclapply(1:2, function(i) {
+  before <- as.character(dbplyr::last_sql())
+  invisible(capture.output(lf |> mutate(child = x + i) |> show_query()))
+  list(before = before, after = as.character(dbplyr::last_sql()))
+}, mc.cores = 2)
+
+cl <- parallel::makeCluster(2, type = "PSOCK")
+parallel::clusterEvalQ(cl, suppressMessages({library(dplyr); library(dbplyr)}))
+psock <- parallel::clusterApply(cl, 1:2, function(i) { ... })
+
+out <- callr::r(function() { ... })
+```
+
+Output, abbreviated to the lines that matter:
+
+```
+00 parent, before anything:  NULL
+01 parent, after PARENT render:  <SQL> SELECT *
+FROM "df"
+WHERE ("x" > 1.0)
+10 fork child 1 saw BEFORE: SELECT *
+FROM "df"
+WHERE ("x" > 1.0)
+11 fork child 1 saw AFTER:  SELECT *, "x" + 1 AS "child"
+FROM "df"
+12 parent after mclapply:   <SQL> SELECT *
+FROM "df"
+WHERE ("x" > 1.0)
+20 PSOCK worker 1 saw BEFORE: NULL
+21 PSOCK worker 1 saw AFTER:  SELECT *, "x" + 1 AS "child"
+FROM "df"
+22 parent after clusterApply: <SQL> SELECT *
+FROM "df"
+WHERE ("x" > 1.0)
+30 callr saw BEFORE: NULL
+31 callr saw AFTER:  SELECT *, "x" + 99.0 AS "child"
+FROM "df"
+32 parent after callr::r: <SQL> SELECT *
+FROM "df"
+WHERE ("x" > 1.0)
+```
+
+Three facts, one of them asymmetric:
+
+- **Fork (`mclapply`).** The child *inherits* the parent's state at fork time —
+  child 1 read back the parent's `WHERE ("x" > 1.0)`, a query the child never
+  issued. Writes in the child do not reach the parent: after `mclapply()`
+  returned, the parent still read its own pre-fork value.
+- **PSOCK.** Workers start empty (`NULL`) because the package is loaded
+  separately in each. Writes do not reach the parent.
+- **callr.** Same as PSOCK: starts empty, writes do not reach the parent.
+
+So a last-call accessor read after a parallel run does not report the calls
+that ran in parallel. It silently reports the last call that ran *serially* in
+the calling process — or, in the fork case inside the worker, a call from
+before the fork. There is no error and no warning; the value is just stale.
+
+**Do the precedents document a position on this?** No. Grep over
+`man/last_sql.Rd`, `man/last_response.Rd`, `man/last_error.Rd`,
+`man/last_warnings.Rd`, `man/last_dplyr_warnings.Rd`, and `man/last_rel.Rd`
+for `parallel`, `fork`, `subprocess`, and `process` returned nothing. Six
+accessors from five packages, and not one of them says what it means in a
+session that ran calls in parallel.
+
+## 4. Is a user-written `withCallingHandlers()` the idiom?
+
+Two scans of the installed library (293 packages, R 4.6.1).
+
+**Rd corpus.** Every Rd topic of every installed package, read with
+`tools::Rd_db()` and searched for `withCallingHandlers`:
+
+```
+packages scanned: 293
+Rd topics mentioning withCallingHandlers: 15
+        pkg                         topic
+       base             StackOverflows.Rd
+       base                    browser.Rd
+       base                 conditions.Rd
+       base                       stop.Rd
+   evaluate         new_output_handler.Rd
+      httr2                  req_error.Rd
+      lintr         nested_pipe_linter.Rd
+      lintr unnecessary_nesting_linter.Rd
+        pak                    sysreqs.Rd
+ parallelly                   killNode.Rd
+      purrr        purrr_error_indexed.Rd
+      rlang               cnd_inherits.Rd
+      rlang               is_installed.Rd
+      rlang       topic-error-chaining.Rd
+      rlang                  try_fetch.Rd
+```
+
+Four are base R's own condition documentation. Four are rlang's, documenting
+the condition system itself. Two are lintr rules *about* the expression. The
+remainder (`httr2::req_error`, `purrr::purrr_error_indexed`,
+`pak::sysreqs`, `evaluate::new_output_handler`, `parallelly::killNode`) are
+about handling *errors* or capturing output, not about observing a package's
+ordinary activity.
+
+**Vignette corpus.** All 1386 installed `*/doc/*` files (`.Rmd`, `.R`, `.md`,
+`.html`):
+
+```
+installed vignette/doc files scanned: 1386
+files hitting withCallingHandlers: 1
+   ggplot2/doc/profiling.html
+```
+
+One hit in 1386, in a profiling vignette, incidental.
+
+The finding is the asymmetry, not either number alone: seven installed
+packages ship a stateful last-call accessor as the documented way to read back
+what happened, and no installed package documents a user-written
+`withCallingHandlers()` on a custom condition as the way to observe its
+ordinary operation. The one package that signals a condition at exactly the
+site this question is about — httr2, `signal(class = "httr2_perform")` — does
+not document it, and ships `last_request()` / `last_response()` as the
+user-facing route to the same information.
+
+Nothing here was searched for and found *against* the accessor idiom. What was
+searched for and not found is the counter-example: a package saying "wrap your
+call in `withCallingHandlers()` to see what we did".
+
+## 5. Interaction with `R CMD check`
+
+Measured with the `statepkg` probe from §1. `state_log()`'s example runs first
+(topics enter `pkg-Ex.R` alphabetically), pushes `"B"`; `state_push()`'s example
+runs second and pushes `"A"`. From `statepkg.Rcheck/statepkg-Ex.Rout`:
+
+```
+> nameEx("state_log")
+> cat("state_log() at start of example B:", state_log(), "\n")
+state_log() at start of example B:
+> state_push("B")
+> state_log()
+[1] "B"
+
+> nameEx("state_push")
+> state_push("A")
+> state_log()
+[1] "B" "A"
+```
+
+The second example read back state the *first* example wrote. WRE's promise
+about examples is about the evaluation environment only:
+
+> Each example is run in a 'clean' environment (so earlier examples cannot be
+> assumed to have been run), and with the variables `T` and `F` redefined to
+> generate an error unless they are set in the example
+
+A package environment is not in that clean environment. All examples run in one
+process, and package-level state carries between them, in alphabetical topic
+order. So an example asserting that `last_x()` equals what *this* example
+produced is order-dependent, and adding or renaming an alphabetically earlier
+topic can change it.
+
+Tests behave the same way. `statepkg.Rcheck/tests/testthat.Rout`:
+
+```
+TEST-A pid: 49052 log:
+TEST-B pid: 49052 log: test-a
+```
+
+One process for the whole `testthat.R` run, and `test-b.R` read what
+`test-a.R` wrote. That is what `dplyr`'s `reset_dplyr_warnings()` — "Also used
+in tests" — and this repository's own `empty_share_dialect_verdicts()` exist
+for.
+
+Vignettes are the exception. The vignette ran in its own process and saw
+nothing:
+
+```
+VIGNETTE pid: 48542 log:
+```
+
+Three further facts about flakiness:
+
+- **testthat's parallel mode changes the picture, and marginplyr does not use
+  it.** `testthat/R/parallel.R`'s header: "Subprocesses run `callr::r_session`
+  R sessions. They are re-used, one R session can be used for several
+  `test_file()` calls." So under `Config/testthat/parallel: true`, state does
+  not reach the main process, but *can* still leak between whichever files
+  happen to share a reused worker — which is not deterministic. marginplyr's
+  `DESCRIPTION` sets `Config/testthat/edition: 3` and no `parallel` key, so
+  today the suite is the single-process case above.
+- **knitr breaks the top-level-command heuristic**, and rlang says so in code
+  rather than prose: `cmd_frame()` (`rlang/R/cnd-last.R`) branches on
+  `knitr_in_progress()` and looks for a knitr frame instead of `sys.frame(1)`.
+- **lifecycle withholds its own example for this reason.** `R/warning.R:15`:
+
+  ```r
+  #' # These examples are not run because `last_lifecycle_warnings()` does not
+  #' # work well within knitr and pkgdown
+  #' \dontrun{
+  ```
+
+  A maintained tidyverse package concluded that its last-call accessor's
+  example could not be run under check and pkgdown, and wrapped it in
+  `\dontrun{}`.
+
+For contrast, a single-slot never-reset accessor tests cleanly. dbplyr's whole
+test for `last_sql()` (`tests/testthat/test-remote.R:101`):
+
+```r
+test_that("last_sql() retrieves the most recent query", {
+  lf <- lazy_frame(x = 1:3, y = c("a", "b", "c"))
+
+  capture.output(lf |> filter(x > 1) |> show_query())
+  expect_match(last_sql(), "WHERE")
+
+  capture.output(lf |> mutate(z = x + 1) |> show_query())
+  expect_match(last_sql(), "\\+ 1")
+})
+```
+
+It writes before every read and never asserts emptiness, so no earlier file's
+state can reach it.
+
+## What was searched for and not found
+
+- Any sentence in the CRAN Repository Policy about a package writing to an
+  environment it owns.
+- Any sentence in *Writing R Extensions* about run-time package state, beyond
+  the sealing rule that describes why the environment idiom works.
+- Any `R CMD check --as-cran` diagnostic for a package-level environment
+  written during a call.
+- Any documentation, in six precedent accessors across five packages, of what
+  the accessor means after a parallel run.
+- Any installed package documenting a user-written `withCallingHandlers()` on
+  its own condition class as the route to observing its ordinary operation.
+- Any precedent whose state is emptied at the start of a call and then appended
+  to more than once within it.

--- a/investigation/session-state-and-last-call-accessors.md
+++ b/investigation/session-state-and-last-call-accessors.md
@@ -617,8 +617,9 @@ Three further facts about flakiness:
   `test_file()` calls." So under `Config/testthat/parallel: true`, state does
   not reach the main process, but *can* still leak between whichever files
   happen to share a reused worker — which is not deterministic. marginplyr's
-  `DESCRIPTION` sets `Config/testthat/edition: 3` and no `parallel` key, so
-  today the suite is the single-process case above.
+  `DESCRIPTION` sets `Config/testthat/edition: 3` and no `parallel` key —
+  `DESCRIPTION` being what is authoritative for that — so the suite was the
+  single-process case above on the date in this header.
 - **knitr breaks the top-level-command heuristic**, and rlang says so in code
   rather than prose: `cmd_frame()` (`rlang/R/cnd-last.R`) branches on
   `knitr_in_progress()` and looks for a knitr frame instead of `sys.frame(1)`.

--- a/investigation/what-dplyr-explain-sends-per-backend.md
+++ b/investigation/what-dplyr-explain-sends-per-backend.md
@@ -1,0 +1,846 @@
+# What dplyr::explain() sends, per backend
+
+Investigated: 2026-09-02
+
+Prompted by #379, which is #377's research ticket for the `"explain"` capture
+method #318 proposes. #318 argues that `explain()` "sends a real statement to
+the backend — no data rows come back (it's a plan, not a result), so it's still
+a schema-shaped operation rather than a data read". ADR 0020 enumerates its
+exemptions rather than deriving them from a shape, so this note records the
+facts under that claim and stops there. The decision is #382's.
+
+Measured on R 4.6.1 (aarch64-apple-darwin23) with dplyr 1.2.1, dbplyr 2.6.0,
+DBI 1.3.0, RSQLite 3.53.3 (SQLite library 3.53.3), duckdb 1.5.5 (DuckDB library
+v1.5.5), dtplyr 1.3.3, arrow 25.0.1. Source was read from the installed
+libraries and from `tidyverse/dplyr` at d5e94e7, `tidyverse/dbplyr` at f478e20,
+`r-dbi/bigrquery` at fdb0f1e, and `sparklyr/sparklyr` at 7f006a6. Scripts are
+throwaway; every command is quoted so each result can be reproduced.
+
+## 1. What `explain()` dispatches to
+
+`dplyr::explain()` is a generic with no default method
+(`R/explain.R` in dplyr):
+
+```r
+explain <- function(x, ...) {
+  UseMethod("explain")
+}
+```
+
+With dplyr, dbplyr, dtplyr and arrow all attached, the methods present are:
+
+```r
+methods("explain")
+#> [1] explain.arrow_dplyr_query* explain.ArrowTabular*
+#> [3] explain.Dataset*           explain.RecordBatchReader*
+#> [5] explain.tbl_sql*
+```
+
+There is no `explain.dtplyr_step`, no `explain.tbl_lazy`, and no
+`explain.data.frame`. A local data frame raises, a dtplyr step raises, and so
+does a `tbl_lazy` that is not a `tbl_sql`:
+
+```r
+dt <- lazy_dt(data.table(x = 1:3, y = c("a","b","c")))
+dplyr::explain(dt |> filter(x > 1) |> summarise(n = .N))
+#> Error in UseMethod("explain") : no applicable method for 'explain' applied
+#>   to an object of class "c('dtplyr_step_subset', 'dtplyr_step')"
+
+dplyr::explain(data.frame(x = 1))
+#> Error in UseMethod("explain") : no applicable method for 'explain' applied
+#>   to an object of class "data.frame"
+
+lf <- dbplyr::lazy_frame(g = "a", v = 1)
+class(lf)
+#> [1] "tbl_TestConnection" "tbl_lazy"           "tbl"
+dplyr::explain(lf)
+#> Error in UseMethod("explain") : no applicable method for 'explain' applied
+#>   to an object of class "c('tbl_TestConnection', 'tbl_lazy', 'tbl')"
+```
+
+The last one is the asymmetry worth naming: `show_query()` has a `tbl_lazy`
+method, `explain()` does not. Every `dbplyr::simulate_*()` connection produces
+a `tbl_lazy` that is not a `tbl_sql`, so `explain()` raises on the whole
+simulator path — which is how marginplyr verifies Snowflake, Spark SQL, Oracle,
+SQL Server and the rest (`R/summarize_with_margins.R`, *Database backend
+coverage*).
+
+```r
+methods("show_query")
+#> [1] show_query.arrow_dplyr_query* show_query.ArrowTabular*
+#> [3] show_query.Dataset*           show_query.dtplyr_step*
+#> [5] show_query.RecordBatchReader* show_query.tbl_lazy*
+```
+
+### Arrow: client-side, no SQL
+
+`arrow:::explain.arrow_dplyr_query`, `explain.ArrowTabular` and
+`explain.Dataset` are all one line:
+
+```r
+function (x, ...) { show_exec_plan(x) }
+```
+
+and `arrow:::show_exec_plan` builds an Acero plan in this process and prints it:
+
+```r
+function (x) {
+    result <- as_record_batch_reader(as_adq(x))
+    plan <- result$Plan()
+    on.exit({ plan$.unsafe_delete(); result$.unsafe_delete() })
+    cat(plan$ToString())
+    invisible(x)
+}
+```
+
+No SQL is generated and no statement is sent. The printed form carries no
+`<SQL>`/`<PLAN>` markers at all — it is a different shape from the dbplyr one:
+
+```r
+tb <- arrow::arrow_table(g = c("a","b"), v = c(1,2))
+utils::capture.output(dplyr::explain(tb |> group_by(g) |> summarise(n = n())))
+#> [1] "ExecPlan with 4 nodes:"
+#> [2] "3:SinkNode{}"
+#> [3] "  2:GroupByNode{keys=[\"g\"], aggregates=["
+#> [4] "  \thash_count_all(*),"
+#> [5] "  ]}"
+#> [6] "    1:ProjectNode{projection=[g]}"
+#> [7] "      0:TableSourceNode{}"
+```
+
+On a `FileSystemDataset` the only difference measured was the source node:
+`0:SourceNode{}` instead of `0:TableSourceNode{}`.
+
+### SQL: `explain.tbl_sql` in dbplyr
+
+```r
+explain.tbl_sql <- function(x, ...) {
+  force(x)
+  show_query(x)
+  cat_line()
+  cat_line("<PLAN>")
+  cat_line(remote_query_plan(x, ...))
+
+  invisible(x)
+}
+```
+
+`show_query()` renders client-side and sends nothing. The round trip is
+`remote_query_plan()`:
+
+```r
+remote_query_plan <- function(x, ...) {
+  dbplyr_explain(remote_con(x), db_sql_render(remote_con(x), x$lazy_query), ...)
+}
+
+dbplyr_explain <- function(con, sql, ...) {
+  check_2ed(con)
+
+  sql <- sql_query_explain(con, sql, ...)
+  n <- length(sql)
+  for (i in seq_len(n - 1)) {
+    db_execute(con, sql[[i]], "Can't explain query.")
+  }
+  expl <- db_get_query(con, sql[[n]], "Can't explain query.")
+
+  out <- utils::capture.output(print(expl))
+  paste(out, collapse = "\n")
+}
+```
+
+Three things follow from that body and matter later. `db_get_query()` is
+`DBI::dbGetQuery()` wrapped in an error handler that appends `Using SQL: <sql>`
+to a `Can't explain query.` abort. A dialect whose `sql_query_explain()` returns
+more than one statement — Oracle is the only one shipped — has every statement
+but the last sent through `db_execute()`, i.e. `DBI::dbExecute()`. And the plan
+text is not the backend's own text: it is `print()` on the returned data frame,
+captured.
+
+## 2. What statement `EXPLAIN` becomes, per dialect
+
+`sql_query_explain()` dispatches on `sql_dialect(con)`, and
+`sql_dialect.default` returns the connection unchanged, so a connection whose
+package registers no method reaches the `DBIConnection` default:
+
+```r
+sql_query_explain.DBIConnection <- function(con, sql, ...) {
+  sql_glue2(con, "EXPLAIN {sql}")
+}
+```
+
+`sql_query_explain()` itself renders without sending, so it can be called on a
+simulated connection even though `explain()` cannot (§1). Against every
+`dbplyr::simulate_*()` connection in dbplyr 2.6.0, for
+`SELECT g, SUM(v) AS v FROM d GROUP BY g`:
+
+```
+postgres   EXPLAIN (FORMAT 'text') SELECT g, SUM(v) AS v FROM d GROUP BY g
+spark_sql  EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+dbi        EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+mysql      EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+odbc       EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+hana       EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+oracle     EXPLAIN PLAN FOR SELECT g, SUM(v) AS v FROM d GROUP BY g
+           ||  SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY())
+mariadb    EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+teradata   EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+access     EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+sqlite     EXPLAIN QUERY PLAN SELECT g, SUM(v) AS v FROM d GROUP BY g
+redshift   EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+snowflake  EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+hive       EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+impala     EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+mssql      EXPLAIN SELECT g, SUM(v) AS v FROM d GROUP BY g
+```
+
+Only four dialects override the default: postgres, sqlite, oracle and redshift.
+`sparklyr` adds a fifth from its own side,
+`sql_query_explain.spark_connection`, which is
+`build_sql("EXPLAIN ", sql, con = con)` (`R/spark_sql.R`) — the same text as the
+default. `bigrquery` registers none: grepping its `R/` for `explain` and
+`EXPLAIN` returns nothing, so a `BigQueryConnection` gets `EXPLAIN {sql}` too.
+
+The statement embeds the caller's query verbatim, table names and literals
+included. Traced on SQLite:
+
+```r
+trace(DBI::dbGetQuery, tracer = quote(message("[sent] ", as.character(statement))))
+dplyr::explain(tbl(con, "d") |> filter(g == "secret-value"))
+#> [sent] SELECT *
+#> FROM `d` AS `q01`
+#> WHERE (0 = 1)
+#> [sent] EXPLAIN QUERY PLAN SELECT *
+#> FROM `d`
+#> WHERE (`g` = 'secret-value')
+```
+
+(The first statement is `dplyr::tbl()`'s own zero-row read, not `explain()`'s.)
+
+### What was measured
+
+Both engines were given `tbl(con, "d") |> group_by(g) |> summarise(n = n())`.
+`explain()` sent exactly one statement on each, and no other.
+
+SQLite:
+
+```
+[dbGetQuery] EXPLAIN QUERY PLAN SELECT `g`, COUNT(*) AS `n`
+FROM `d`
+GROUP BY `g`
+```
+
+DuckDB:
+
+```
+[dbGetQuery] EXPLAIN SELECT g, COUNT(*) AS n
+FROM d
+GROUP BY g
+```
+
+### What the vendors say
+
+All pages fetched 2026-09-02.
+
+**SQLite** — the statement is prepared as usual and the listing is returned in
+place of the run:
+
+> An SQL statement can be preceded by the keyword "EXPLAIN" or by the phrase
+> "EXPLAIN QUERY PLAN". Either modification causes the SQL statement to behave
+> as a query and to return information about how the SQL statement would have
+> operated if the EXPLAIN keyword or phrase had been omitted.
+
+— *EXPLAIN*, https://www.sqlite.org/lang_explain.html, §2. Its §2.1 is headed
+*EXPLAIN operates at run-time, not at prepare-time*:
+
+> The EXPLAIN and EXPLAIN QUERY PLAN prefixes affect the behavior of running a
+> prepared statement using sqlite3_step(). The process of generating a new
+> prepared statement using sqlite3_prepare() or similar is (mostly) unaffected
+> by EXPLAIN.
+
+**DuckDB** — stated outright, twice:
+
+> Note that the query is not actually executed – therefore, we can only see the
+> estimated cardinality (EC) for each operator, which is calculated by using the
+> statistics of the base tables and applying heuristics for each operator.
+
+— *EXPLAIN: Inspect Query Plans*,
+https://duckdb.org/docs/current/guides/meta/explain
+
+> To see the query plan of a query without executing it, run: `EXPLAIN query;`
+> The output of EXPLAIN contains the estimated cardinalities for each operator.
+
+— *Profiling Queries*,
+https://duckdb.org/docs/current/sql/statements/profiling. `EXPLAIN ANALYZE`
+"runs the query" (same page), and dbplyr never generates it.
+
+The clause "by using the statistics of the base tables" is the vendor's own
+account of the `~200,000 rows` measured in §4.
+
+**PostgreSQL** — the reference page states the converse rather than the
+proposition. It never says a plain `EXPLAIN` does not execute; it says `ANALYZE`
+is what makes it execute:
+
+> The ANALYZE option causes the statement to be actually executed, not only
+> planned.
+
+— *EXPLAIN*, https://www.postgresql.org/docs/current/sql-explain.html. The
+contrast is drawn on the chapter page:
+
+> With this option, EXPLAIN actually executes the query, and then displays the
+> true row counts and true run time accumulated within each plan node, along
+> with the same estimates that a plain EXPLAIN shows.
+
+— *14.1. Using EXPLAIN*,
+https://www.postgresql.org/docs/current/using-explain.html, §14.1.2. Planning
+reads statistics, not rows: "In order to allow the PostgreSQL query planner to
+make reasonably informed decisions when optimizing queries, the pg_statistic
+data should be up-to-date for all tables used in the query"
+(sql-explain.html, *Notes*).
+
+**Snowflake** — the only one of the six whose documentation addresses cost
+directly:
+
+> EXPLAIN compiles the SQL statement, but does not execute it, so EXPLAIN does
+> not require a running warehouse.
+
+> Although EXPLAIN does not consume any compute credits, the compilation of the
+> query does consume Cloud Service credits, just as other metadata operations
+> do.
+
+— *EXPLAIN*, https://docs.snowflake.com/en/sql-reference/sql/explain,
+*Usage notes*. So it is not free, and it is not stated to be free: cloud
+services credits are billed above a daily threshold —
+
+> Usage for cloud services is charged only if the daily consumption of cloud
+> services exceeds 10% of the daily usage of virtual warehouses.
+
+— *Understanding compute cost*,
+https://docs.snowflake.com/en/user-guide/cost-understanding-compute.
+
+Snowflake's plan carries byte counts derived from the caller's data:
+`partitionsAssigned` is "the number of partitions from the referenced object
+that are left after compile-time pruning", `bytesAssigned` "the number of bytes
+contained in the partitionsAssigned", and both are "upper bound estimates for
+query execution" (*EXPLAIN*, *Output* and *Usage notes*). The plan is also
+warehouse-dependent: "The EXPLAIN plan might differ depending on the size of the
+current warehouse. If you run EXPLAIN outside of a current warehouse, Snowflake
+constructs the EXPLAIN plan based on the capacity of an XSMALL warehouse."
+
+**Spark SQL** — the documentation says neither that `EXPLAIN` executes nor that
+it does not:
+
+> The EXPLAIN statement is used to provide logical/physical plans for an input
+> statement. By default, this clause provides information about a physical plan
+> only.
+
+— *EXPLAIN*,
+https://spark.apache.org/docs/latest/sql-ref-syntax-qry-explain.html. The page
+carries no execution claim in either direction, and no equivalent of Postgres's
+`ANALYZE` warning or DuckDB's "not actually executed". What it does document is
+that analysis happens — `EXTENDED` yields an "analyzed logical plan" which
+"translates unresolvedAttribute and unresolvedRelation into fully typed
+objects" — so catalog and schema resolution occur. `EXPLAIN COST` reports
+statistics where they exist: "COST — If plan node statistics are available,
+generates a logical plan and the statistics." dbplyr and sparklyr both send the
+unqualified form, so no mode is selected.
+
+**BigQuery** — GoogleSQL has no `EXPLAIN` statement. The clearest vendor
+statement is in the Teradata migration guide, whose `EXPLAIN ...` row reads:
+
+> EXPLAIN ...
+> Not used in BigQuery.
+> Similar features are the query plan explanation in the BigQuery web UI and the
+> slot allocation visible in the INFORMATION_SCHEMA views and in audit logging
+> in Cloud Monitoring.
+
+— *Teradata SQL translation guide*,
+https://cloud.google.com/bigquery/docs/migration/teradata-sql. *Introduction to
+SQL in BigQuery* (https://cloud.google.com/bigquery/docs/introduction-sql)
+enumerates the supported statement categories — query, procedural, DDL, DML,
+DCL, TCL, load and export — and `EXPLAIN` is in none of them; it is also absent
+from the reserved-keyword list on
+https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical. The
+feature that exists instead is not a statement:
+
+> Embedded within query jobs, BigQuery includes diagnostic query plan and timing
+> information. This is similar to the information provided by statements such as
+> EXPLAIN in other database and analytical systems. This information can be
+> retrieved from the API responses of methods such as jobs.get.
+
+— *Query plan and timeline*,
+https://cloud.google.com/bigquery/docs/query-plan-explanation.
+
+The question #379 asks — whether there is a statement about `EXPLAIN` matching
+the one `investigation/query-cost-across-lazy-backends.md` records for
+`LIMIT 0` — therefore has no subject on BigQuery. There is nothing to exempt.
+What BigQuery documents for the preflight purpose is the dry run, and it does
+carry the exemption:
+
+> Dry runs don't use query slots, and you are not charged for performing a dry
+> run.
+
+— *Run a query*, https://cloud.google.com/bigquery/docs/running-queries. The
+same section names its limit for external data: "A dry run of a federated query
+that uses an external data source might report a lower bound of 0 bytes of
+data, even if rows are returned." A dry run is reached through
+`JobConfiguration.dryRun` or `bq query --dry_run`, neither of which dbplyr's
+`explain()` path can produce.
+
+This was searched for and not found, and the absence is the finding. Twelve
+Google Cloud pages were read in full and grepped case-insensitively for
+`explain` — the GoogleSQL query-syntax, DDL, DML, other-statements and lexical
+references, *Introduction to SQL in BigQuery*, *Overview of BigQuery analytics*,
+*Run a query*, *Estimate and control costs*, *Get query performance insights*,
+and the Snowflake and Teradata translation guides. Only the two named above
+mention it, and no page documents an `EXPLAIN` statement or its billing.
+`EXPLAIN ANALYZE` was searched for on `cloud.google.com` and not found either;
+`ML.EXPLAIN_PREDICT`, `ML.EXPLAIN_FORECAST` and `ML.GLOBAL_EXPLAIN` exist but
+are BigQuery ML table-valued functions that run as ordinary queries.
+
+## 3. Return value
+
+dplyr's `explain()` documents `@return The first argument, invisibly.`
+(`man/explain.Rd`, *Value*: "The first argument, invisibly."), and the
+behaviour was confirmed:
+
+```r
+res <- dplyr::explain(q)
+identical(res, q)
+#> [1] TRUE
+withVisible(dplyr::explain(q))$visible
+#> [1] FALSE
+```
+
+It prints with `cat()`, not `message()` — dbplyr's NEWS records the change under
+*dbplyr 1.4.0*: "`show_query()` and `explain()` use `cat()` rather than
+message." and, under *dbplyr 1.0.0*: "`explain()` and `show_query()` now
+invisibly return the first argument, making them easier to use inside a
+pipeline." So `utils::capture.output()` does capture it, with no
+`type = "message"`:
+
+```r
+utils::capture.output(dplyr::explain(q))
+#> [1] "<SQL>"
+#> [2] "SELECT `g`, COUNT(*) AS `n`"
+#> [3] "FROM `d`"
+#> [4] "GROUP BY `g`"
+#> [5] ""
+#> [6] "<PLAN>"
+#> [7] "  id parent notused                       detail"
+#> [8] "1  6      0     216                       SCAN d"
+#> [9] "2  8      0       0 USE TEMP B-TREE FOR GROUP BY"
+```
+
+#318's premise is therefore right about `explain()` and wrong about the plan.
+dbplyr exports `remote_query_plan()`, documented as giving "the query plan (as
+computed by the remote database)" with `x` "currently must be a `tbl_sql`"
+(`man/remote_name.Rd`), and it *returns* the plan without printing:
+
+```r
+p <- dbplyr::remote_query_plan(q)
+class(p); length(p)
+#> [1] "character"
+#> [1] 1
+```
+
+`remote_query()` is its client-side counterpart and returns the SQL with no
+round trip. Neither has an arrow or a dtplyr equivalent.
+
+`explain()`'s `...` reaches `sql_query_explain()`, which calls
+`check_dots_used()`, so the only extra argument any shipped dialect accepts is
+Postgres's `format`:
+
+```r
+dbplyr::sql_query_explain(simulate_postgres(), sql("SELECT 1"), format = "json")
+#> EXPLAIN (FORMAT 'json') SELECT 1
+dbplyr::sql_query_explain(simulate_postgres(), sql("SELECT 1"), analyze = TRUE)
+#> Error: Arguments in `...` must be used.
+#> x Problematic argument:
+#> * analyze = TRUE
+```
+
+No documented argument turns `explain()` into `EXPLAIN ANALYZE`.
+
+## 4. Stability of the printed output
+
+The two markers `<SQL>` and `<PLAN>` are literals in `explain.tbl_sql`, so they
+are invariant across every SQL backend and every dbplyr version that has that
+body. They are also the only invariant part. Nothing below them is:
+
+**The plan text is a printed data frame, so it depends on `getOption("width")`.**
+`dbplyr_explain()` renders it with `utils::capture.output(print(expl))`:
+
+```r
+options(width = 80); cat(dbplyr::remote_query_plan(q))
+#>   id parent notused                       detail
+#> 1  6      0     216                       SCAN d
+#> 2  8      0       0 USE TEMP B-TREE FOR GROUP BY
+
+options(width = 30); cat(dbplyr::remote_query_plan(q))
+#>   id parent notused
+#> 1  6      0     216
+#> 2  8      0       0
+#>                         detail
+#> 1                       SCAN d
+#> 2 USE TEMP B-TREE FOR GROUP BY
+```
+
+**It depends on the caller's schema.** The same SQLite query before and after
+`CREATE INDEX idx_g ON d(g)`:
+
+```
+<PLAN>
+  id parent notused detail
+1  2      0     216 SCAN d
+```
+
+```
+<PLAN>
+  id parent notused                           detail
+1  3      0      63 SEARCH d USING INDEX idx_g (g=?)
+```
+
+**It depends on the caller's data.** DuckDB's plan carries cardinality
+estimates. The same query text against a 3-row and a 200,000-row table:
+
+```
+[15] small: │           ~1 row          │
+     big  : │          ~5 rows          │
+[30] small: │          ~3 rows          │
+     big  : │       ~200,000 rows       │
+[38] small: │          ~3 rows          │
+     big  : │       ~200,000 rows       │
+[47] small: │          ~3 rows          │
+     big  : │       ~200,000 rows       │
+```
+
+Those numbers come from statistics DuckDB reads while planning. Over a Parquet
+file the estimate is the file's exact row count, which means the footer was
+read:
+
+```r
+arrow::write_parquet(data.frame(g = ..., v = ...), pq)   # 12345 rows
+tb <- tbl(con, sql(sprintf("SELECT * FROM read_parquet('%s')", pq)))
+dplyr::explain(tb |> group_by(g) |> summarise(n = n(), .groups = "drop"))
+#> │        ~7,803 rows        │
+#> │        ~12,345 rows       │
+#> │        READ_PARQUET       │
+#> │        READ_PARQUET       │
+#> │        ~12,345 rows       │
+```
+
+**It depends on a session setting the caller controls.** DuckDB's
+`explain_output`:
+
+```r
+DBI::dbExecute(con, "SET explain_output = 'physical_only'")   # 20 lines
+DBI::dbExecute(con, "SET explain_output = 'optimized_only'")  # 29 lines
+DBI::dbExecute(con, "SET explain_output = 'all'")             # 62 lines
+```
+
+DuckDB documents the three values and names `physical_only` "The default
+setting" (*EXPLAIN: Inspect Query Plans*,
+https://duckdb.org/docs/current/guides/meta/explain).
+
+**And it is drawn with box-drawing characters on DuckDB.** For the same
+aggregate over the same three-row table, the block under `<PLAN>` ran to 3 lines
+on SQLite and 42 on DuckDB, the latter a stack of `┌─┴─┐` frames. The two
+backends share no line but `<SQL>` and `<PLAN>`.
+
+**What the vendors say about the format.** SQLite states the strongest position
+of the six, and states it twice:
+
+> The output from EXPLAIN and EXPLAIN QUERY PLAN is intended for interactive
+> analysis and troubleshooting only. The details of the output format are
+> subject to change from one release of SQLite to the next. Applications should
+> not use EXPLAIN or EXPLAIN QUERY PLAN since their exact behavior is variable
+> and only partially documented.
+
+— *EXPLAIN*, https://www.sqlite.org/lang_explain.html, §2.
+
+> Warning: The data returned by the EXPLAIN QUERY PLAN command is intended for
+> interactive debugging only. The output format may change between SQLite
+> releases. Applications should not depend on the output format of the EXPLAIN
+> QUERY PLAN command.
+
+> Alert: As warned above, the EXPLAIN QUERY PLAN output format did change
+> substantially with the version 3.24.0 release (2018-06-04). Additional minor
+> changes occurred in version 3.36.0 (2021-06-18). Further changes are possible
+> in subsequent releases.
+
+— *EXPLAIN QUERY PLAN*, https://www.sqlite.org/eqp.html, §1. The same page
+documents the raw four-column shape dbplyr receives: "each node of the tree
+consists of four fields: An integer node id, an integer parent id, an auxiliary
+integer field that is not currently used, and a description of the node" — the
+`id`, `parent`, `notused`, `detail` columns printed above.
+
+PostgreSQL carries no "subject to change" sentence about the format, and the
+closest statement is about the content:
+
+> Also note that the numbers, and even the selected query strategy, might vary
+> between PostgreSQL releases due to planner improvements.
+
+— *EXPLAIN*, https://www.postgresql.org/docs/current/sql-explain.html,
+*Examples*. It endorses machine parsing through a different route: "Non-text
+output contains the same information as the text output format, but is easier
+for programs to parse" (`FORMAT`, *Parameters*) — and `FORMAT` is the one
+extra argument dbplyr's Postgres method exposes.
+
+DuckDB and Spark document nothing about output-format stability in either
+direction. Three DuckDB pages (`guides/meta/explain`,
+`guides/meta/explain_analyze`, `sql/statements/profiling`) and Spark's
+`sql-ref-syntax-qry-explain` were read in full; none contains a stability
+statement. Spark documents something else that bears on it — the printed plan
+is not necessarily the plan that runs:
+
+> When true, enable adaptive query execution, which re-optimizes the query plan
+> in the middle of query execution, based on accurate runtime statistics.
+
+— *Performance Tuning*,
+https://spark.apache.org/docs/latest/sql-performance-tuning.html, on
+`spark.sql.adaptive.enabled`, "enabled by default since Apache Spark 3.2.0".
+
+Snowflake documents no stability guarantee either, but offers `EXPLAIN USING
+{ TABULAR | JSON | TEXT }` with `TABULAR` as the default, and names
+`RESULT_SCAN` and the JSON form as the supported ways to post-process the
+output (*EXPLAIN*, *Usage notes*). dbplyr sends the unqualified form, so the
+default applies.
+
+## 5. Does `EXPLAIN` ever fail where the query would succeed?
+
+Yes, and the clearest case is a backend marginplyr's *Database backend coverage*
+list does not name but dbplyr reaches: **BigQuery**. (It appears in
+`R/summarize_with_margins.R` only in the cost paragraph, as the vendor whose
+byte billing `LIMIT` does not reduce.) `bigrquery` registers no
+`sql_query_explain` method, so `explain()` emits literal `EXPLAIN <sql>`, and
+GoogleSQL has no such statement (§2). The query itself would run.
+
+**Snowflake** documents one failure of its own, the only one on its EXPLAIN
+page:
+
+> If any of the database objects in the EXPLAIN statement are INFORMATION_SCHEMA
+> objects, the statement fails with error `EXPLAIN command has insufficient
+> privilege on object <objName>`.
+
+— *EXPLAIN*, https://docs.snowflake.com/en/sql-reference/sql/explain,
+*Usage notes*.
+
+**PostgreSQL** restricts `EXPLAIN` to an enumerated list of statements — "Any
+SELECT, INSERT, UPDATE, DELETE, MERGE, VALUES, EXECUTE, DECLARE, CREATE TABLE
+AS, or CREATE MATERIALIZED VIEW AS statement" (*EXPLAIN*, *Parameters*) — but
+dbplyr only ever renders a `SELECT`, so the restriction is not reachable from
+this path. Neither PostgreSQL page states a case where `EXPLAIN` errors on a
+statement the bare form would run.
+
+**SQLite** documents a divergence rather than a failure, and it too is out of
+reach from dbplyr:
+
+> Some PRAGMA statements do their work during sqlite3_prepare() rather than
+> during sqlite3_step(). Those PRAGMA statements are unaffected by EXPLAIN. […]
+> For consistent results, avoid using EXPLAIN on PRAGMA statements.
+
+— *EXPLAIN*, https://www.sqlite.org/lang_explain.html, §2.1. It also records
+that "The authorizer callback is invoked regardless of the presence of EXPLAIN
+or EXPLAIN QUERY PLAN".
+
+**DuckDB and Spark document no failure case.** Spark's *Error Conditions* page
+(https://spark.apache.org/docs/latest/sql-error-conditions.html) contains no
+occurrence of `EXPLAIN` at all, and its EXPLAIN reference names no excluded
+statement. DuckDB's three EXPLAIN pages name none either.
+
+**Oracle is the one dialect where `explain()` writes.** Its
+`sql_query_explain()` returns two statements, and `dbplyr_explain()` sends every
+statement but the last through `db_execute()`, i.e. `DBI::dbExecute()`:
+
+```
+oracle  EXPLAIN PLAN FOR SELECT …  ||  SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY())
+```
+
+That first statement populates a `PLAN_TABLE`; the second reads it back. Every
+other dialect sends one statement through `DBI::dbGetQuery()`.
+
+### What was measured
+
+No such case was found on SQLite or DuckDB. `remote_query_plan()` succeeded on
+every marginplyr query shape tried:
+
+```
+######## SQLite ########
+summarize .by                ok (146 chars of plan)
+summarize rollup             ok (815 chars of plan)
+summarize cube               ok (1070 chars of plan)
+share_of_parent              FAILED (see below)
+expand_with_margins          ok (311 chars of plan)
+
+######## DuckDB ########
+summarize .by                ok (1663 chars of plan)
+summarize rollup             ok (1273 chars of plan)
+summarize cube               ok (1273 chars of plan)
+share_of_parent              ok (10985 chars of plan)
+expand_with_margins          ok (2391 chars of plan)
+```
+
+The SQLite `share_of_parent` line is not an `EXPLAIN` failure: marginplyr
+refused to build the query at all, because SQLite converts a non-numeric value
+to a number rather than refusing it (ADR 0020's second exemption). No plan was
+requested.
+
+Both engines accepted `EXPLAIN` over the `UNION ALL` shape marginplyr's
+portable path generates (three branches, 57 lines of output on SQLite) and over
+a `WITH`-rendered form of the same query
+(`sql_options(cte = TRUE)`), so neither the union nor the CTE rendering is a
+problem for the statement dbplyr wraps.
+
+## 6. What the statement references, and what comes back
+
+The statement references the caller's table by name and carries their literals,
+because it is their query with a prefix (§2). Nothing about the prefix changes
+what the query names.
+
+What comes back is a plan, and on three of the six dialects the vendor
+documents that the plan carries a quantity derived from the caller's data.
+DuckDB's estimated cardinality is "calculated by using the statistics of the
+base tables"; Snowflake's `bytesAssigned` is "the number of bytes contained in
+the partitionsAssigned", itself the count left "after compile-time pruning";
+PostgreSQL's estimates come from `pg_statistic`. All three are quoted above with
+their URLs, and the DuckDB one was measured: a Parquet source's estimate was the
+file's exact row count.
+
+Whether that makes `EXPLAIN` a read of the caller's data is the question ADR
+0020 answers, and this note does not.
+
+One fact about this repository's own gate is worth recording, since it was
+measured rather than assumed. `explain()` reaches `DBI::dbGetQuery()` — traced
+above — and `DBI::dbGetQuery` is already in `lazy_execution_entry_points()` in
+`tests/testthat/test-query-policy.R`, so the runtime counter that traces that
+binding sees an `explain()` call without any edit. The snapshot beside it does
+not: it walks the bodies bound in marginplyr's namespace for calls to the
+catalog's own names, and a body calling `explain()` names `dplyr::explain`,
+which is not one of them. #377 lists whether to add it as an open question.
+
+## 7. Where a claim could not be measured
+
+BigQuery, Snowflake and Spark were not measured. `bigrquery`, `sparklyr` and
+`odbc` are not installed in this environment, and none of the three has a
+`dbplyr::simulate_*()` path that would help: `explain()` raises on every
+simulated connection (§1), and dbplyr ships no BigQuery simulator at all
+(`grep "^simulate_"` over dbplyr's exports lists sixteen, none of them
+BigQuery). Everything recorded about those three is vendor documentation,
+quoted with its URL and the date it was fetched.
+
+PostgreSQL was not measured either. RPostgres 1.4.10 is installed but no server
+was available, so what is recorded for it is the rendered statement — which is
+the simulator's answer and needs no server — and the PostgreSQL documentation.
+Oracle likewise: the two-statement form above is rendered, not sent.
+
+## 8. Three dialects outside the ticket's enumerated set
+
+#379 enumerated RSQLite, DuckDB, Postgres, BigQuery, Snowflake and Spark.
+Sections 1–7 stop there. This section covers SQL Server, SAP HANA and Teradata,
+which dbplyr also reaches, because §2 established that dbplyr's default is a
+bare `EXPLAIN {sql}` and the question of which dialects that default is *valid*
+in does not stop at the six the ticket named. Same investigation, same date;
+nothing above is overturned.
+
+None of the three was measured — no driver and no server for any of them here —
+so everything below is vendor documentation, quoted with its URL and the date
+it was fetched, in the form §7 already fixes for BigQuery, Snowflake and Spark.
+
+### SQL Server: no `EXPLAIN`, except on Synapse dedicated SQL pool
+
+Microsoft's `EXPLAIN (Transact-SQL)` topic exists, and its Applies-to banner is
+a single product:
+
+> "**Applies to:** Azure Synapse Analytics (dedicated SQL pool only)"
+
+— *EXPLAIN (Transact-SQL)*,
+<https://learn.microsoft.com/en-us/sql/t-sql/queries/explain-transact-sql?view=azure-sqldw-latest>
+(fetched 2026-09-02). Its syntax is
+`EXPLAIN [WITH_RECOMMENDATIONS] SQL_statement [;]`, it returns an XML document
+rather than a result set of plan rows, and the same page adds "This syntax is
+not supported by serverless SQL pool" and "**EXPLAIN** is not supported in a
+user transaction". *T-SQL statements in dedicated SQL pool*
+(<https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-reference-tsql-statements>,
+fetched 2026-09-02) lists `EXPLAIN` under "Query statements"; the SQL Server
+T-SQL reference has no corresponding entry.
+
+For SQL Server, Azure SQL Database, Azure SQL Managed Instance and Fabric SQL
+database the documented equivalent is a session setting issued as its own
+batch, not a modifier on the statement. *SET SHOWPLAN_ALL (Transact-SQL)*
+(<https://learn.microsoft.com/en-us/sql/t-sql/statements/set-showplan-all-transact-sql?view=sql-server-ver17>,
+fetched 2026-09-02):
+
+> "Causes Microsoft SQL Server not to execute Transact-SQL statements. Instead,
+> SQL Server returns detailed information about how the statements would be
+> executed (a query plan) [...]"
+
+> "SET SHOWPLAN_TEXT and SET SHOWPLAN_ALL cannot be specified inside a stored
+> procedure; they must be the only statements in a batch."
+
+`SET SHOWPLAN_XML` carries the same "must be the only statement in a batch"
+restriction (*SET SHOWPLAN_XML (Transact-SQL)*,
+<https://learn.microsoft.com/en-us/sql/t-sql/statements/set-showplan-xml-transact-sql?view=sql-server-ver17>,
+fetched 2026-09-02).
+
+`SET STATISTICS PROFILE` is **not** an equivalent and should not be read as one:
+*SET STATISTICS PROFILE (Transact-SQL)*
+(<https://learn.microsoft.com/en-us/sql/t-sql/statements/set-statistics-profile-transact-sql?view=sql-server-ver17>,
+fetched 2026-09-02) says "each executed query returns its regular result set,
+followed by an additional result set that shows a profile of the query
+execution" — an actual-plan option, which executes.
+
+### SAP HANA: `EXPLAIN PLAN ... FOR`, and a privilege
+
+*EXPLAIN PLAN Statement (Data Manipulation)*, SAP HANA Platform 2.0 SPS 08,
+<https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d9ec5575191014a251e58ecf90997a.html>
+(fetched 2026-09-02), gives the syntax as
+
+```text
+EXPLAIN PLAN [ SET STATEMENT_NAME = <statement_name> ] FOR <explain_plan_entry>
+```
+
+and adds two things that matter here: "The result of the evaluation is stored in
+the EXPLAIN_PLAN_TABLE view for examination" — so it returns no plan rows to the
+caller — and "You must have the OPTIMIZER ADMIN system privilege". The SAP HANA
+Cloud page
+(<https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-sql-reference-guide/explain-plan-statement-data-manipulation>,
+fetched 2026-09-02) splits it into `EXPLAIN RECOMPILED PLAN ... FOR <subquery>`
+and a plan-cache form.
+
+Whether a bare `EXPLAIN <select>` parses on HANA **could not be established from
+the documentation**, and is recorded as unestablished rather than guessed. What
+is established is that the reference documents no such statement: the *Data
+Manipulation Statements* index
+(<https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/209eaa85751910149a30f95c936075be.html>,
+fetched 2026-09-02) lists `EXPLAIN PLAN` as its only EXPLAIN entry. Confirming
+the parser's behaviour needs a live server.
+
+### Teradata: supported, and one form partially executes
+
+*EXPLAIN Request Modifier*, Teradata Vantage SQL Data Manipulation Language,
+Analytics Database 20.00, publication B035-1146-200K,
+<https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Manipulation-Language/Query-and-Workload-Analysis-Statements/EXPLAIN-Request-Modifier>
+(fetched 2026-09-02):
+
+> "The Optimizer processes an explained request in the same way that the request
+> would be processed without the EXPLAIN modifier, except that the SQL within
+> the request is not actually executed. However, for a dynamic plan, the request
+> is partially executed."
+
+> "To EXPLAIN a request, you must have the permissions that are required to
+> execute that request."
+
+The syntax is `[ STATIC | DYNAMIC ] EXPLAIN [ IN XML [NODDLTEXT] ] SQL_request`,
+with `STATIC` the default. So the bare form dbplyr would send does not execute;
+`DYNAMIC EXPLAIN` does, partially.
+
+### Retrieval note
+
+docs.teradata.com and help.sap.com are client-rendered single-page applications,
+and a plain fetch of either topic URL returns a navigation shell with none of the
+text above. The quotes were retrieved from each vendor's own content API backing
+those exact pages — FluidTopics at
+`docs.teradata.com/api/khub/maps/.../topics/{id}/content` and
+`help.sap.com/http.svc/pagecontent?deliverable_id=...&file_path=...` — both
+first-party endpoints on the vendor domains. The Microsoft quotes came from
+direct fetches of the Learn pages.


### PR DESCRIPTION
Closes #385, and closes map #377 — this is the map's last ticket.

## What this adds

- `design/adr/0027-record-the-sql-marginplyr-sends.md`. One feature of the
  four #318 bundled survives: a per-call record of the Sent queries, opt-in
  through `marginplyr.audit_sql`, read back with `last_sent_queries()`, and
  captured by a client-side `dbplyr::sql_render()`. The condition (#381), the
  `"explain"` capture method (#382), the on-disk log and the explicit writer
  (#384), and an `is_sql_lazy_query()` predicate (#386) are rejected in
  *Considered options*, each with the argument that rejected it, along with
  the per-entry-point `.audit_sql` argument and the alternatives #318 had
  already ruled out.
- One line in ADR 0020's *Related decisions*. **ADR 0020 is not amended**: the
  capture sends nothing, so there is no third exemption and the opt-in is not
  read as the caller asking. The line records that the question was put and
  refused, so a reader of ADR 0020 can find it.
- `investigation/what-dplyr-explain-sends-per-backend.md` and
  `investigation/session-state-and-last-call-accessors.md`, from the research
  branches for #379 and #380. The ADR cites both as evidence, and a citation
  to a note on a throwaway branch does not resolve.

## What this does not add

No R code. Writing the implementation is out of the map's scope; #318 now holds
the specification for it, rewritten to what the map settled.

`CONTEXT.md` needs nothing: **Sent query** entered from #381 and was widened by
#383, and a rejected feature names no term.

## Gates

`verify-context-budget.R` and `verify-verifier-invocation.R` pass. Nothing else
in the repository reads `design/` or `investigation/`, and no generated file is
affected.