### PR TITLE
Say what the SQLite Parent-share row was tested under

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -335,7 +335,7 @@ dplyr code may be easier.
 | Verification status | Backends |
 |---|---|
 | Live native execution tested | DuckDB |
-| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses a Parent share on any dialect that converts an ineligible share source rather than refusing it | SQLite |
+| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses the share on these dialects | SQLite |
 | Native SQL generation tested | PostgreSQL |
 | Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections |
 | Non-SQL lazy backend tested | Arrow, dtplyr |

--- a/README.Rmd
+++ b/README.Rmd
@@ -335,7 +335,7 @@ dplyr code may be easier.
 | Verification status | Backends |
 |---|---|
 | Live native execution tested | DuckDB |
-| Live portable Parent-share execution tested | SQLite |
+| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses a Parent share on any dialect that converts an ineligible share source rather than refusing it | SQLite |
 | Native SQL generation tested | PostgreSQL |
 | Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections |
 | Non-SQL lazy backend tested | Arrow, dtplyr |

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ subtotal, explicit dplyr code may be easier.
 | Verification status | Backends |
 |----|----|
 | Live native execution tested | DuckDB |
-| Live portable Parent-share execution tested | SQLite |
+| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses a Parent share on any dialect that converts an ineligible share source rather than refusing it | SQLite |
 | Native SQL generation tested | PostgreSQL |
 | Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections |
 | Non-SQL lazy backend tested | Arrow, dtplyr |

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ subtotal, explicit dplyr code may be easier.
 | Verification status | Backends |
 |----|----|
 | Live native execution tested | DuckDB |
-| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses a Parent share on any dialect that converts an ineligible share source rather than refusing it | SQLite |
+| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses the share on these dialects | SQLite |
 | Native SQL generation tested | PostgreSQL |
 | Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections |
 | Non-SQL lazy backend tested | Arrow, dtplyr |

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -606,6 +606,12 @@ names every verified backend.
   factor level is rejected either way. See *`.check_margin_label` on lazy
   inputs* above.
 
+- A Parent share needs `.check_share_source = FALSE` on a backend that cannot
+  be asked whether a share source is eligible: a connection that executes
+  nothing, such as a `simulate_*()` one, and a dialect that converts an
+  ineligible source rather than refusing it, such as SQLite. See *Parent
+  shares use a staged lazy query* above.
+
 - A fallback query may repeat the source relation once per grouping set.
   Inspect the generated SQL and the database query plan for large workloads;
   marginplyr does not claim that one translation is universally faster.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -606,8 +606,8 @@ names every verified backend.
   factor level is rejected either way. See *`.check_margin_label` on lazy
   inputs* above.
 
-- A Parent share needs `.check_share_source = FALSE` on a backend that cannot
-  be asked whether a share source is eligible: a connection that executes
+- A contextual share needs `.check_share_source = FALSE` on a backend that
+  cannot establish that its source is eligible: a connection that executes
   nothing, such as a `simulate_*()` one, and a dialect that converts an
   ineligible source rather than refusing it, such as SQLite. See *Parent
   shares use a staged lazy query* above.


### PR DESCRIPTION
Closes #372.

The README's *Backend verification* table claimed live portable Parent-share
execution for SQLite. A reader arriving at an RSQLite connection with
documented defaults is refused: the tested path passes
`.check_share_source = FALSE`, and that argument appeared nowhere in either
half of the README. The row now carries the condition and says that the
default refuses the share on the dialects the row names, so the table alone
tells a tested path from one the reader's own defaults reach. It says that of
"these dialects" rather than of SQLite, so it stays true when another
converting dialect joins the cell — MySQL is expected to.

The database-backends vignette's *Practical rules for remote analysis*
checklist gains one bullet beside the `.check_margin_label` one. It names
`.check_share_source`, the two kinds of backend the rule cannot be applied on,
and cites *Parent shares use a staged lazy query*, which owns the argument,
rather than re-deriving it.

Nothing under `R/` changes: the refusal is correct and its diagnostic already
names its own remedy. Whether a caller can record a dialect answer once
instead of per call is #389.

## Verification

| check | result |
|---|---|
| `verify-context-budget.R` | pass, 24198 bytes, unchanged |
| `spelling::spell_check_package()` | clean |
| `lintr::lint_package()` after `pkgload::load_all(".")` | no lints |
| `testthat::test_local()` with `NOT_CRAN` set | pass |
| `rmarkdown::render("README.Rmd")` | regenerated against the installed working tree under pandoc 3.10.1, the version `document.yaml` pins |
| `altdoc::render_docs(parallel = FALSE, freeze = FALSE)` then `verify-site.R` | pass, 19 pages |

The site render was run from a copy of the tree outside this worktree: the
worktree lives under `.claude/`, and quarto ignores a dot-prefixed path.