### PR TITLE
Name a way forward when the nesting verbs refuse a lazy table (#374)

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -388,7 +388,13 @@ markers <- list(
     # what ADR 0023's condition 3 keeps out of a marker. #223's phase 3 left
     # this marker in place deliberately until the file behind it was
     # re-authored, since moving it is the same edit.
-    "which can be nested"
+    "which can be nested",
+    # That refusal's remedy, added in #374, quoted whole: it interpolates
+    # nothing, so ADR 0023's condition 3 leaves every run of it available and
+    # the longest one pins the most. Its backticks are the diagnostic's own
+    # and reach the page literally, as the `Error in` marker two entries up
+    # already does.
+    "Collect it with `dplyr::collect()` first."
   ),
   "docs/man/summarize_with_margins.html" = c(
     "summarise_with_margins",

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,14 +51,23 @@ assert_string_scalar <- function(x) {
 # joins a vector with by default would read as a conjunction. This is the same
 # call `match_margin_choice()` makes about an option vocabulary, and the
 # `toString()` comma both replace was neutral between the two readings.
+#
+# `expand_with_margins()` is not named beside `dplyr::collect()`, under the
+# rule ADR 0012's amendment states. It takes the same grouping specification
+# and stays lazy, but it returns rows rather than the list column this call
+# asked for, and `assert_lazy_table()` refuses a `RecordBatchReader` that
+# reaches this refusal.
 assert_nest_possible <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.
   valid_classes <- c("data.frame", "dtplyr_step")
   if (!inherits(x, valid_classes)) {
-    abort_marginplyr(paste0(
-      "{.arg {nm}} must be one of the following classes, which can be ",
-      "nested: {.or {.code {valid_classes}}}."
+    abort_marginplyr(c(
+      paste0(
+        "{.arg {nm}} must be one of the following classes, which can be ",
+        "nested: {.or {.code {valid_classes}}}."
+      ),
+      i = "Collect it with {.fun dplyr::collect} first."
     ))
   }
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,7 +74,8 @@ summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html) shows
 
 - Calculates each scalar summary's share of its immediate rollup parent.
 
-- Can expand or nest the source rows behind every subtotal.
+- Can expand the source rows behind every subtotal, or nest them for local and
+  `dtplyr` inputs.
 
 New to the idea? Start with [Get
 started](https://sayuks.github.io/marginplyr/vignettes/get_started.html).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ shows `.sort` at work and what it does not promise.
 
 - Calculates each scalar summary’s share of its immediate rollup parent.
 
-- Can expand or nest the source rows behind every subtotal.
+- Can expand the source rows behind every subtotal, or nest them for
+  local and `dtplyr` inputs.
 
 New to the idea? Start with [Get
 started](https://sayuks.github.io/marginplyr/vignettes/get_started.html).

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -87,6 +87,14 @@ test_that("shared argument assertions use the package condition seam", {
   expect_s3_class(logical_error, "marginplyr_error")
   expect_s3_class(string_error, "marginplyr_error")
   expect_s3_class(nest_error, "marginplyr_error")
+
+  # The nesting refusal's remedy, which the pattern above does not reach: it
+  # matches the main line, and a refusal that lost its bullet still has one.
+  expect_match(
+    conditionMessage(nest_error),
+    "Collect it with `dplyr::collect()` first.",
+    fixed = TRUE
+  )
 })
 
 # The rule `static_call_args()` states: its elements can be R's empty argument,

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -468,7 +468,7 @@ collect(dt_query)
 
 `nest_with_margins()` also supports dtplyr and remains lazy until collection.
 SQL database and Arrow tables cannot use the nesting verbs because their
-result contains a list column, and the refusal names the classes that can:
+result contains a list column:
 
 ```{r}
 #| label: nesting-a-sql-table


### PR DESCRIPTION
Closes #374.

`assert_nest_possible()` named the classes it accepts and stopped. It now
carries a remedy bullet:

```
`.data` must be one of the following classes, which can be nested:
`data.frame` or `dtplyr_step`.
i Collect it with `dplyr::collect()` first.
```

The decision the ticket existed to take — `dplyr::collect()` and not
`expand_with_margins()` — is argued in [#374's decision
comment](https://github.com/sayuks/marginplyr/issues/374#issuecomment-5506835548),
and the commit message carries what each edit rests on. In short: the sibling
verb answers a different question (rows, not the list column this call asked
for) and is not a route every input reaching this refusal can take, which is
the case ADR 0012's amendment names under *a remedy is offered only where it is
one*.

Also here: the README bullet now carries the narrower verb's backend range, and
`database_backends.qmd` loses a clause describing the diagnostic rendered three
lines below it.

Split out, deliberately: #391 (`assert_lazy_table()`'s own missing route) and
#392 (whether that vignette clause is one site or a form).

Checks: `lintr::lint_package()` clean; full suite 6263 passing, no failures, no
skips; `verify-context-budget.R` and `verify-verifier-invocation.R` pass;
`README.md` regenerated against the installed working tree under
`document.yaml`'s pandoc 3.10.1 pin.