### PR TITLE
Decide that a caller writes a Margin order key of their own

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -319,6 +319,7 @@ markers <- list(
   ),
   "docs/vignettes/recipes.html" = c(
     "Put each subtotal with the rows it summarizes",
+    "Write the sort key yourself",
     "Compare each row with the right total",
     "Keep only one grouping set",
     "Name the grouping set on every row",

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,9 +91,9 @@
   property of the returned object and may not survive further verbs applied to
   a lazy result. `compute()` materializes a sorted lazy result in the Margin
   order; it records no dbplyr window ordering, because the key reads Grouping
-  bits from a column the result does not expose. Another presentation order —
-  a dimension descending, or rows ordered by a measure — is the same key
-  written as an `arrange()` of your own, which the recipes guide shows.
+  bits from a column the result does not expose. A dimension descending is the
+  same key written as an `arrange()` of your own, and rows ordered by a measure
+  is that key with one column added; the recipes guide shows both.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,7 +91,9 @@
   property of the returned object and may not survive further verbs applied to
   a lazy result. `compute()` materializes a sorted lazy result in the Margin
   order; it records no dbplyr window ordering, because the key reads Grouping
-  bits from a column the result does not expose.
+  bits from a column the result does not expose. Another presentation order —
+  a dimension descending, or rows ordered by a measure — is the same key
+  written as an `arrange()` of your own, which the recipes guide shows.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -341,9 +341,9 @@
 #' `.duplicates` policy the verb accepts with no diagnostic, and lazy inputs
 #' stay lazy.
 #'
-#' The [recipes guide][recipes] shows a Margin order before and after, and
-#' shows a join dropping one from a lazy result with no diagnostic naming this
-#' package.
+#' The [recipes guide][recipes] shows a Margin order before and after, shows
+#' the key written as an `arrange()` you control, and shows a join dropping a
+#' Margin order from a lazy result with no diagnostic naming this package.
 #'
 #' [recipes]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
 #'

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -177,6 +177,15 @@ order is lost on lazy backends. The trap moves out of marginplyr into caller
 code that nothing designed. Keeping the bit columns to keep the order is not
 the result the caller asked for.
 
+**A per-dimension direction on `.sort`**, so that a dimension can descend
+under a Margin order (#373). Rejected: it reaches a reversed dimension and not
+the request one step past it, ordering dimensions by a measure, which needs a
+value no ordering over the result's columns produces. A caller writes that key
+themselves either way, and the documentation carrying it carries the reversed
+dimension too, so the argument would not retire what it duplicates. It is also
+the wrong shape for `match_margin_choice()`, which admits one string from a
+fixed list, and it would have to name dimensions a composite has none of.
+
 **Leaving both out and keeping row order unspecified.** Rejected: the
 existing guidance tells a caller to add a `grouping_bit()` summary per
 dimension and drop it again, which fails on lazy backends for the reason
@@ -380,56 +389,40 @@ allocated after that choice, so a one-occurrence plan that ran on the native
 path still runs there and still stages the column; what changes is only where
 the projection dropping it sits.
 
-## Amendment: a caller writes the key too, and dropping a Grouping bit is safe
+## Amendment: a caller writes the key too, and one clause is narrowed
 
-`.sort` gives a caller three choices, and both of them that order rows leave
-every dimension's values ascending. #373 asked for the fourth thing a report
-wants — a dimension descending, newest period first — and for the request one
-step past it, dimensions ordered by a measure. Neither is added to `.sort`,
-whose vocabulary stays `"none"`, `"last"`, and `"first"`. What is added is the
-statement that the key is a caller's to write, and a correction to one clause
-of the `.bits` rejection above.
+`.sort`'s vocabulary stays `"none"`, `"last"`, and `"first"`; the direction
+#373 asked for is written by the caller, and *Considered options* above records
+why the argument was refused. What this amendment settles is how far a
+caller-written key reaches, which two entries there answered on a measurement
+that turns out to be narrower than they state.
 
-**A direction argument would not retire the recipe it competes with.** A
-per-dimension direction reaches the first request. The second is outside what
-any sort key expresses: ordering regions by revenue needs the region's own
-measure on each of its rows, which is a value no ordering over the result's
-columns produces. So a caller wanting it writes the key themselves whichever
-way this decision goes, and the documentation carrying that has to carry the
-first request too or send its reader between two mechanisms for one question.
-The extension would be an alternative spelling of something the guide has to
-show regardless.
+**Both entries rest on "the caller must drop those columns afterwards, and
+`arrange()` followed by dropping a summarized column is exactly the shape
+dbplyr flattens".** Measured against dbplyr 2.6.0, dropping a *Grouping bit*
+does not lose the order on either adapter for a plan whose result is wrapped by
+the projection that places and labels the grouping columns: the bit is produced
+by the aggregate query or by the `UNION ALL`, so it stays resolvable in the
+`FROM` of the query carrying the `ORDER BY` after the projection stops
+selecting it. That covers every `rollup()` and `cube()`, and the recipe #373
+asked for is one.
 
-Its own cost is the vocabulary. `match_margin_choice()` admits one string from
-a fixed list and reads an untouched formal default by `identical()`, which is
-what refuses a prefix (#110) and a `NULL` (#144); a per-dimension direction is
-not that shape. It would also have to name dimensions, and a composite
-dimension has no single name while `cube()`, `grouping_sets()`, and
-`grouping_spec()` each give the plan a different set of them. `.sort` is
-shared by four verbs, so the shape is decided once for all of them.
+Where no such projection exists the entries hold. A plan of one grouping-set
+occurrence under `.margin_label = NULL` labels and casts nothing — the shape
+the amendment above is about — so the caller's `arrange()` applies to the query
+the summary ends in and the `select()` dropping the bits wraps it: RSQLite
+rendered no `ORDER BY` at all, with dbplyr's "ORDER BY is ignored in subqueries
+without LIMIT", while DuckDB kept it. A column the caller computed after the
+summary is in that position on every plan, which is why the measure-ordered
+recipe cannot drop its window column and DuckDB refuses the query with the
+binder error this decision names.
 
-**What `.sort` writes that a caller cannot is narrower than the `.bits`
-rejection says.** That entry rejects handing the Grouping bits over because
-"the caller must drop those columns afterwards, and `arrange()` followed by
-dropping a summarized column is exactly the shape dbplyr flattens, so the order
-is lost on lazy backends". Measured against dbplyr 2.6.0, dropping a *Grouping
-bit* does not lose the order on DuckDB or on SQLite: a bit is produced by the
-aggregate query, which the labelling projection already wraps, so it stays
-resolvable in the `FROM` of the query carrying the `ORDER BY` after the
-projection stops selecting it. The `UNION ALL` adapter puts it in a subquery
-for the same reason. This is the implementation rule above, reached from the
-caller's side.
+**"Unavailable at all under `.margin_label = NULL`" is withdrawn.** The
+`grouping_bit()` recipe runs there, and returned the intended order on DuckDB;
+what the dimensions lose is their labels, not their bits.
 
-The rejection stands. What is flattened is a column the caller computed
-*after* the summary, which sits in the query carrying the `ORDER BY` rather
-than below it — the window function the measure-ordered request needs is
-exactly that, and dropping it makes DuckDB reject the query with the binder
-error this decision describes. A caller keeps such a column in the result, or
-collects before dropping it.
-`investigation/writing-a-margin-order-key-by-hand.md` holds both measurements,
-and `vignettes/recipes.qmd` shows both cases.
-
-The narrowing changes no argument this decision reached. `.bits` was rejected
-for handing a caller a shape that fails on the second request while `.sort`
-answers the first without a helper column at all, and both halves of that
-survive.
+So what `.sort` writes that a caller cannot is narrower than these entries say,
+and the reason to keep writing it is the one the entries make second: a caller
+who writes the key holds a helper column whose safety depends on the plan, and
+`.sort` needs none. `investigation/writing-a-margin-order-key-by-hand.md` holds
+the measurements, and `vignettes/recipes.qmd` shows what a caller writes.

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -379,3 +379,57 @@ observable difference to break: one occurrence is one such plan.
 allocated after that choice, so a one-occurrence plan that ran on the native
 path still runs there and still stages the column; what changes is only where
 the projection dropping it sits.
+
+## Amendment: a caller writes the key too, and dropping a Grouping bit is safe
+
+`.sort` gives a caller three choices, and both of them that order rows leave
+every dimension's values ascending. #373 asked for the fourth thing a report
+wants — a dimension descending, newest period first — and for the request one
+step past it, dimensions ordered by a measure. Neither is added to `.sort`,
+whose vocabulary stays `"none"`, `"last"`, and `"first"`. What is added is the
+statement that the key is a caller's to write, and a correction to one clause
+of the `.bits` rejection above.
+
+**A direction argument would not retire the recipe it competes with.** A
+per-dimension direction reaches the first request. The second is outside what
+any sort key expresses: ordering regions by revenue needs the region's own
+measure on each of its rows, which is a value no ordering over the result's
+columns produces. So a caller wanting it writes the key themselves whichever
+way this decision goes, and the documentation carrying that has to carry the
+first request too or send its reader between two mechanisms for one question.
+The extension would be an alternative spelling of something the guide has to
+show regardless.
+
+Its own cost is the vocabulary. `match_margin_choice()` admits one string from
+a fixed list and reads an untouched formal default by `identical()`, which is
+what refuses a prefix (#110) and a `NULL` (#144); a per-dimension direction is
+not that shape. It would also have to name dimensions, and a composite
+dimension has no single name while `cube()`, `grouping_sets()`, and
+`grouping_spec()` each give the plan a different set of them. `.sort` is
+shared by four verbs, so the shape is decided once for all of them.
+
+**What `.sort` writes that a caller cannot is narrower than the `.bits`
+rejection says.** That entry rejects handing the Grouping bits over because
+"the caller must drop those columns afterwards, and `arrange()` followed by
+dropping a summarized column is exactly the shape dbplyr flattens, so the order
+is lost on lazy backends". Measured against dbplyr 2.6.0, dropping a *Grouping
+bit* does not lose the order on DuckDB or on SQLite: a bit is produced by the
+aggregate query, which the labelling projection already wraps, so it stays
+resolvable in the `FROM` of the query carrying the `ORDER BY` after the
+projection stops selecting it. The `UNION ALL` adapter puts it in a subquery
+for the same reason. This is the implementation rule above, reached from the
+caller's side.
+
+The rejection stands. What is flattened is a column the caller computed
+*after* the summary, which sits in the query carrying the `ORDER BY` rather
+than below it — the window function the measure-ordered request needs is
+exactly that, and dropping it makes DuckDB reject the query with the binder
+error this decision describes. A caller keeps such a column in the result, or
+collects before dropping it.
+`investigation/writing-a-margin-order-key-by-hand.md` holds both measurements,
+and `vignettes/recipes.qmd` shows both cases.
+
+The narrowing changes no argument this decision reached. `.bits` was rejected
+for handing a caller a shape that fails on the second request while `.sort`
+answers the first without a helper column at all, and both halves of that
+survive.

--- a/investigation/writing-a-margin-order-key-by-hand.md
+++ b/investigation/writing-a-margin-order-key-by-hand.md
@@ -1,0 +1,156 @@
+# Writing a Margin order key by hand
+
+Investigated: 2026-09-02
+
+Evidence gathered while deciding #373 — whether reversing a dimension belongs
+in `.sort`, or whether the answer is a recipe writing the sort key as an
+`arrange()` the caller controls. ADR 0018 had already rejected `.bits`, an
+argument handing the Grouping bits to the caller, "on measurement: the caller
+must drop those columns afterwards, and `arrange()` followed by dropping a
+summarized column is exactly the shape dbplyr flattens, so the order is lost on
+lazy backends". Whether that reaches a caller-written key was the question, and
+the answer turned out to depend on which column is dropped.
+
+## Environment
+
+All measurements on 2026-09-02, one machine, macOS (Darwin 25.5.0).
+
+| Component | Version |
+|---|---|
+| R | 4.6.1 |
+| dplyr | 1.2.1 |
+| dbplyr | 2.6.0 |
+| rlang | 1.3.0 |
+| duckdb (R package) | 1.5.5 |
+| DuckDB engine | v1.5.5 |
+| RSQLite | 3.53.3 |
+| SQLite engine | 3.53.3 |
+
+DuckDB exercises the native `GROUP BY GROUPING SETS` adapter and SQLite the
+portable `UNION ALL` one, so every claim below that names both names both
+adapters.
+
+## Dropping a Grouping bit keeps the order; dropping a computed column loses it
+
+The reversed-dimension key, written as the reporter wrote it:
+
+```r
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    yb = grouping_bit(year), rb = grouping_bit(region),
+    .grouping = rollup(year, region)
+  ) |>
+  arrange(yb, is.na(year), desc(year), rb, is.na(region), region) |>
+  select(-yb, -rb)
+```
+
+Returned 2026 above 2025 with the subtotals attached on a local data frame, on
+DuckDB, and on SQLite. The `select()` is what ADR 0018's rejection describes,
+and it did not lose the order on either backend. The rendered DuckDB query says
+why:
+
+```sql
+SELECT
+  CASE WHEN ("..marginplyr_grouping_1" = 1) THEN 'Total' ... END AS "year",
+  CASE WHEN ("..marginplyr_grouping_2" = 1) THEN 'Total' ... END AS region,
+  revenue
+FROM (
+  SELECT "year", region, SUM(revenue) AS revenue,
+         GROUPING("year") AS yb, GROUPING(region) AS rb, ...
+  FROM retail_sales
+  GROUP BY GROUPING SETS (("year", region), ("year"), ())
+) AS q01
+ORDER BY yb, ("year" IS NULL), "year" DESC, rb, (region IS NULL), region
+```
+
+A Grouping bit is produced by the aggregate query, which the labelling
+projection already wraps, so `yb` and `rb` are resolvable in the `FROM` of the
+query carrying the `ORDER BY` even after the projection stops selecting them.
+The `UNION ALL` adapter puts them in a subquery for the same reason. This is
+ADR 0018's own implementation rule — the sort key must be resolvable in the
+`FROM` clause of the query that carries the `ORDER BY` — reached from the
+caller's side.
+
+The same recipe under `.margin_label = NULL` returned the same row order on
+DuckDB. There the dimensions keep their input types, so `desc(year)` orders
+integers rather than the labelled character column; `.sort` has that property
+too, since it also orders the result's own columns after labelling.
+
+A column the caller computes *after* the summary is in the query that carries
+the `ORDER BY`, not below it, and dropping it takes the order with it. The
+measure-ordered case is that shape:
+
+```r
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    rb = grouping_bit(region), sb = grouping_bit(store),
+    .grouping = rollup(region, store)
+  ) |>
+  mutate(.by = region,
+         region_revenue = max(ifelse(sb == 1, revenue, NA), na.rm = TRUE)) |>
+  arrange(rb, desc(region_revenue), region, sb, desc(revenue), store) |>
+  select(region, store, revenue)
+```
+
+On DuckDB:
+
+```
+Error in `collect()`:
+! Failed to collect lazy table.
+Caused by error in `DBI::dbSendQuery()`:
+! Binder Error: Referenced column "region_revenue" not found in FROM clause!
+Candidate bindings: "region", "revenue", "rb"
+
+LINE 22: ORDER BY rb, region_revenue DESC, region, sb, revenue DESC, store
+```
+
+Which is the failure ADR 0018 describes, with the binder error it names.
+
+## The measure-ordered case needs a window function, not a self-join
+
+#373 and its triage both say the second presentation request — regions
+ordered by revenue, stores ordered by revenue inside them, subtotals still
+adjacent —
+"needs the parent measure on every row and so a self-join back onto the
+subtotal rows". A grouped `mutate()` reaches it instead, and it is the
+`mutate()` above: the region's own subtotal row is already in the result, so
+`max(ifelse(sb == 1, revenue, NA))` over the region partition puts that measure
+on every row of the region without reading the input again. dbplyr renders it
+as a window function.
+
+Keeping the helper columns, it returned West's stores, West's subtotal, East's
+stores, East's subtotal, and the grand total — on a local data frame, on
+DuckDB, and on SQLite, all three agreeing. So the case is reachable while the
+result stays lazy; what is not reachable is dropping the helper columns from a
+lazy result, per the section above.
+
+## Two ways past the binder error, one of which is not a promise
+
+`collect()` before the `select()` returned the intended order, which is the
+local case and says nothing about SQL.
+
+`compute()` before the `select()` also returned it, on DuckDB. That is a
+measurement and not a guarantee: `compute()` materializes a table, a table has
+no row order in SQL, and the subsequent `select()` renders a fresh query with
+no `ORDER BY` at all. It happened to return insertion order. It is recorded
+here so a later reader does not rediscover it and take it for a supported
+route; `vignettes/recipes.qmd` deliberately does not show it.
+
+## A hand-written key and `.sort` agree on a labelled numeric dimension
+
+`.sort` orders the result's own columns, which are character once
+`.margin_label` has been applied, and a hand-written `arrange()` names those
+same columns — but the rendered SQL names them ambiguously, since the
+aggregate subquery holds a column of the same name holding the pre-label
+value. Whether
+the two agree therefore depends on the dialect resolving `ORDER BY <name>` to
+the output column.
+
+Measured on a four-row input with `year` an integer taking `999` and `1000`,
+where character and numeric order disagree. `.sort = "last"` put 1000 before
+999; the hand-written key with `desc(year)` put 999 before 1000 — character
+order in both directions — and local, DuckDB, and SQLite all three returned
+that. So the dialects tested resolve to the output column and the two keys do
+not diverge on this input.

--- a/investigation/writing-a-margin-order-key-by-hand.md
+++ b/investigation/writing-a-margin-order-key-by-hand.md
@@ -30,7 +30,7 @@ DuckDB exercises the native `GROUP BY GROUPING SETS` adapter and SQLite the
 portable `UNION ALL` one, so every claim below that names both names both
 adapters.
 
-## Dropping a Grouping bit keeps the order; dropping a computed column loses it
+## Which column is dropped decides whether the order survives
 
 The reversed-dimension key, written as the reporter wrote it:
 
@@ -47,8 +47,8 @@ retail_sales |>
 
 Returned 2026 above 2025 with the subtotals attached on a local data frame, on
 DuckDB, and on SQLite. The `select()` is what ADR 0018's rejection describes,
-and it did not lose the order on either backend. The rendered DuckDB query says
-why:
+and on this plan it did not lose the order on either backend. The rendered
+DuckDB query says why:
 
 ```sql
 SELECT
@@ -73,9 +73,23 @@ ADR 0018's own implementation rule — the sort key must be resolvable in the
 caller's side.
 
 The same recipe under `.margin_label = NULL` returned the same row order on
-DuckDB. There the dimensions keep their input types, so `desc(year)` orders
-integers rather than the labelled character column; `.sort` has that property
-too, since it also orders the result's own columns after labelling.
+DuckDB, where the dimensions keep their input types and `desc(year)` therefore
+ordered integers rather than a labelled character column.
+
+The wrapping projection is what the measurement above turns on, and a plan can
+be built that has none. `grouping_sets(grouping_set(year, region))` holds one
+occurrence, and under `.margin_label = NULL` nothing is labelled or cast, so
+the caller's `arrange()` applies to the query the summary ends in and the
+`select()` dropping the bits wraps that query. RSQLite rendered no `ORDER BY`
+at all, with dbplyr's own warning:
+
+```
+ORDER BY is ignored in subqueries without LIMIT
+```
+
+DuckDB kept the ordering on the same input. Restoring either half of the shape
+restored it on RSQLite too: with `.margin_label = "Total"` the cast projection
+wraps the aggregate, and with a `rollup()` the union does.
 
 A column the caller computes *after* the summary is in the query that carries
 the `ORDER BY`, not below it, and dropping it takes the order with it. The
@@ -112,9 +126,8 @@ Which is the failure ADR 0018 describes, with the binder error it names.
 
 #373 and its triage both say the second presentation request — regions
 ordered by revenue, stores ordered by revenue inside them, subtotals still
-adjacent —
-"needs the parent measure on every row and so a self-join back onto the
-subtotal rows". A grouped `mutate()` reaches it instead, and it is the
+adjacent — "needs the parent measure on every row and so a self-join back
+onto the subtotal rows". A grouped `mutate()` reaches it instead, and it is the
 `mutate()` above: the region's own subtotal row is already in the result, so
 `max(ifelse(sb == 1, revenue, NA))` over the region partition puts that measure
 on every row of the region without reading the input again. dbplyr renders it
@@ -134,9 +147,9 @@ local case and says nothing about SQL.
 `compute()` before the `select()` also returned it, on DuckDB. That is a
 measurement and not a guarantee: `compute()` materializes a table, a table has
 no row order in SQL, and the subsequent `select()` renders a fresh query with
-no `ORDER BY` at all. It happened to return insertion order. It is recorded
-here so a later reader does not rediscover it and take it for a supported
-route; `vignettes/recipes.qmd` deliberately does not show it.
+no `ORDER BY` at all. It happened to return insertion order, and is recorded
+here so that a later reader who rediscovers it has the reason it proves
+nothing.
 
 ## A hand-written key and `.sort` agree on a labelled numeric dimension
 
@@ -144,9 +157,8 @@ route; `vignettes/recipes.qmd` deliberately does not show it.
 `.margin_label` has been applied, and a hand-written `arrange()` names those
 same columns — but the rendered SQL names them ambiguously, since the
 aggregate subquery holds a column of the same name holding the pre-label
-value. Whether
-the two agree therefore depends on the dialect resolving `ORDER BY <name>` to
-the output column.
+value. Whether the two agree therefore depends on the dialect resolving
+`ORDER BY <name>` to the output column.
 
 Measured on a four-row input with `year` an integer taking `999` and `1000`,
 where character and numeric order disagree. `.sort = "last"` put 1000 before

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -342,9 +342,9 @@ plan, and never changes which adapter runs. It composes with every
 \code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
 stay lazy.
 
-The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
-shows a join dropping one from a lazy result with no diagnostic naming this
-package.
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, shows
+the key written as an \code{arrange()} you control, and shows a join dropping a
+Margin order from a lazy result with no diagnostic naming this package.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -341,9 +341,9 @@ plan, and never changes which adapter runs. It composes with every
 \code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
 stay lazy.
 
-The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
-shows a join dropping one from a lazy result with no diagnostic naming this
-package.
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, shows
+the key written as an \code{arrange()} you control, and shows a join dropping a
+Margin order from a lazy result with no diagnostic naming this package.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -387,9 +387,9 @@ plan, and never changes which adapter runs. It composes with every
 \code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
 stay lazy.
 
-The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
-shows a join dropping one from a lazy result with no diagnostic naming this
-package.
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, shows
+the key written as an \code{arrange()} you control, and shows a join dropping a
+Margin order from a lazy result with no diagnostic naming this package.
 }
 
 \section{Display labels and grouping identity}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -396,9 +396,9 @@ plan, and never changes which adapter runs. It composes with every
 \code{.duplicates} policy the verb accepts with no diagnostic, and lazy inputs
 stay lazy.
 
-The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, and
-shows a join dropping one from a lazy result with no diagnostic naming this
-package.
+The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} shows a Margin order before and after, shows
+the key written as an \code{arrange()} you control, and shows a join dropping a
+Margin order from a lazy result with no diagnostic naming this package.
 }
 
 \section{Relationship to dplyr summaries}{

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -45,7 +45,7 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. Two recipes execute against DuckDB, so
+Only dplyr and dbplyr are required. Three recipes execute against DuckDB, so
 their chunks evaluate only when DuckDB is installed at the version marginplyr
 asks for. Where a package is missing or too old the code is still shown, but
 its output is absent. Everything else runs either locally or against
@@ -107,13 +107,145 @@ competing with one.
 derived from it.** Any later verb is free to reorder, and on a lazy backend
 one usually does — see [Name the grouping set on every
 row](#name-the-grouping-set-on-every-row) for a join that drops it silently.
-When some other presentation order is what you want, `arrange()` after the
-fact and do not ask for a Margin order at all.
+When some other presentation order is what you want, write the key yourself:
+[Write the sort key yourself](#write-the-sort-key-yourself) shows it as an
+`arrange()` you control.
 
 [Grouping
 identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
 explains why Grouping-plan order and a Margin order answer different
 questions.
+
+## Write the sort key yourself
+
+A Margin order leaves every dimension's values ascending, so a report that
+wants the newest year at the top asks for the same key with one term changed.
+`grouping_bit()` puts the Grouping bits the key reads into the result, and the
+`arrange()` is then the key above with `desc()` on the term you are reversing:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    yb = grouping_bit(year),
+    rb = grouping_bit(region),
+    .grouping = rollup(year, region)
+  ) |>
+  arrange(yb, is.na(year), desc(year), rb, is.na(region), region) |>
+  select(-yb, -rb)
+```
+
+2026 sits above 2025 and each subtotal is still under its own rows, because
+everything ahead of the reversed term is what it was.
+
+An order no sort key can express is written the same way, with one more
+column. Ordering regions by revenue needs each region's own revenue on every
+one of its rows, and that number is already in the result as the region's
+subtotal row, so a grouped `mutate()` can put it there:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    rb = grouping_bit(region),
+    sb = grouping_bit(store),
+    .grouping = rollup(region, store)
+  ) |>
+  mutate(
+    .by = region,
+    region_revenue = max(ifelse(sb == 1, revenue, NA), na.rm = TRUE)
+  ) |>
+  arrange(rb, desc(region_revenue), region, sb, desc(revenue), store) |>
+  select(region, store, revenue)
+```
+
+**On a lazy backend, which column you drop decides whether the order
+survives.** A column the summary produced is in the query underneath the one
+carrying the `ORDER BY`, so dropping it leaves the ordering something it can
+still read. A column you computed afterwards is in that same query, and
+dropping it takes the ordering with it.
+
+A Grouping bit is the first kind, so the reversed-year recipe runs on a
+database unchanged:
+
+```{r}
+#| eval: !expr has_duckdb
+
+# `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets in
+# the session's temporary directory rather than in `~/.duckdb`.
+con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
+
+duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    yb = grouping_bit(year),
+    rb = grouping_bit(region),
+    .grouping = rollup(year, region)
+  ) |>
+  arrange(yb, is.na(year), desc(year), rb, is.na(region), region) |>
+  select(-yb, -rb) |>
+  collect()
+```
+
+`region_revenue` is the second kind, and the database says so rather than
+returning the rows in some other order:
+
+```{r}
+#| label: dropping-a-computed-sort-term
+#| must_error: true
+#| eval: !expr has_duckdb
+
+duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    rb = grouping_bit(region),
+    sb = grouping_bit(store),
+    .grouping = rollup(region, store)
+  ) |>
+  mutate(
+    .by = region,
+    region_revenue = max(ifelse(sb == 1, revenue, NA), na.rm = TRUE)
+  ) |>
+  arrange(rb, desc(region_revenue), region, sb, desc(revenue), store) |>
+  select(region, store, revenue) |>
+  collect()
+```
+
+Keep the column and the result stays lazy and stays ordered, at the cost of
+carrying it:
+
+```{r}
+#| eval: !expr has_duckdb
+
+duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    rb = grouping_bit(region),
+    sb = grouping_bit(store),
+    .grouping = rollup(region, store)
+  ) |>
+  mutate(
+    .by = region,
+    region_revenue = max(ifelse(sb == 1, revenue, NA), na.rm = TRUE)
+  ) |>
+  arrange(rb, desc(region_revenue), region, sb, desc(revenue), store) |>
+  collect()
+```
+
+`collect()` before the `select()` is the other way, and gives up laziness to
+get a report with no helper columns in it.
+
+```{r}
+#| include: false
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(con, shutdown = TRUE)
+```
+
+The [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+states the whole key under *Margin order*.
 
 ## Compare each row with the right total
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -139,9 +139,10 @@ retail_sales |>
 everything ahead of the reversed term is what it was.
 
 An order no sort key can express is written the same way, with one more
-column. Ordering regions by revenue needs each region's own revenue on every
-one of its rows, and that number is already in the result as the region's
-subtotal row, so a grouped `mutate()` can put it there:
+column. Ordering regions by revenue, and the stores inside each region by
+revenue, needs each region's own revenue on every one of its rows; that number
+is already in the result as the region's subtotal row, so a grouped `mutate()`
+can put it there, and the `sb` term keeps each subtotal under its own stores:
 
 ```{r}
 retail_sales |>
@@ -159,14 +160,15 @@ retail_sales |>
   select(region, store, revenue)
 ```
 
-**On a lazy backend, which column you drop decides whether the order
-survives.** A column the summary produced is in the query underneath the one
-carrying the `ORDER BY`, so dropping it leaves the ordering something it can
-still read. A column you computed afterwards is in that same query, and
-dropping it takes the ordering with it.
+**On a lazy backend, dropping a helper column can cost the order.** Whether
+it does is decided by the query dbplyr builds, which this package does not own
+— but you are told when it happens, either by dbplyr warning that it discarded
+an `ORDER BY` or by the database refusing a query that orders on a column no
+longer in it.
 
-A Grouping bit is the first kind, so the reversed-year recipe runs on a
-database unchanged:
+A Grouping bit usually survives, because the bits of a `rollup()` are computed
+in the query underneath the one the ordering sits in. The reversed-year recipe runs on
+a database unchanged:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -188,8 +190,9 @@ duckdb_sales |>
   collect()
 ```
 
-`region_revenue` is the second kind, and the database says so rather than
-returning the rows in some other order:
+`region_revenue` does not survive it. You computed it after the summary, so it
+is in the same query as the ordering rather than underneath it, and dropping it
+leaves an `ORDER BY` naming a column that is gone:
 
 ```{r}
 #| label: dropping-a-computed-sort-term
@@ -443,8 +446,6 @@ seeing this needs a live database:
 ```{r}
 #| eval: !expr has_duckdb
 
-# `shared_home = FALSE` keeps DuckDB's extension cache and stored secrets in
-# the session's temporary directory rather than in `~/.duckdb`.
 con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
 duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
 


### PR DESCRIPTION
Closes #373.

`.sort` orders every dimension's values ascending, so a report wanting the
newest period at the top had no argument to ask for it, and the one section
covering row order sent such a reader to a bare `arrange()` — the one thing
that drops the subtotal adjacency they came for.

**The decision: the key stays a caller's to write.** `.sort`'s vocabulary stays
`"none"`, `"last"`, and `"first"`.

A direction argument would not retire the recipe it competes with. It reaches
the reversed dimension and not the request one step past it — regions ordered
by revenue, stores ordered by revenue inside them — which needs each region's
own measure on every one of its rows and so is outside what any ordering over
the result's columns expresses. A caller writes that key by hand whichever way
this went. Its own cost is the vocabulary: `match_margin_choice()` admits one
string from a fixed list and reads an untouched formal by `identical()` (#110,
#144), a per-dimension direction has to name dimensions that a composite has no
single name for, and `.sort` is shared by four verbs.

ADR 0010's `.subtotals = "one"` rejection is not the precedent. "A presentation
rule" there is about a computed value whose definition a presentation choice
would obscure; `.sort` computes no value.

## What was measured

- **Dropping a Grouping bit does not lose the order.** ADR 0018 rejected
  `.bits` partly because "`arrange()` followed by dropping a summarized column
  is exactly the shape dbplyr flattens". Against dbplyr 2.6.0 that does not
  reach a Grouping bit on DuckDB or SQLite: a bit is produced by the aggregate
  query, which the labelling projection already wraps, so it stays resolvable
  in the `FROM` of the query carrying the `ORDER BY`. The amendment narrows
  that clause; the rejection stands on its other half.
- **Dropping a column computed after the summary does.** DuckDB refuses it with
  `Binder Error: Referenced column "region_revenue" not found in FROM clause!`
- **The measure-ordered case needs no self-join**, contrary to the ticket and
  its triage. The region's subtotal row is already in the result, so a grouped
  `mutate()` puts the measure on every row and dbplyr renders it as a window
  function.
- **`compute()` returned the intended order on DuckDB without promising it.**
  A materialized table has no row order in SQL and the following `select()`
  renders a query with no `ORDER BY`, so the guide does not show it; the
  investigation note records the measurement so it is not taken for a route.

## Changes

| File | Change |
|---|---|
| `design/adr/0018-…` | One amendment: the decision, and the narrowed `.bits` clause |
| `investigation/writing-a-margin-order-key-by-hand.md` | New note — three backends, the binder error, why `compute()` is not shown |
| `vignettes/recipes.qmd` | New section *Write the sort key yourself*; the closing sentence that sent readers away is replaced |
| `.github/scripts/verify-site.R` | The section title as a marker |
| `R/summarize_with_margins.R`, `man/` | One clause on the *Margin order* pointer |
| `NEWS.md` | One clause on the existing `.sort` bullet |

The new section's `must_error` chunk is not a marker: it needs a database, and
the comment there says only the database-free ones are listed. It is
`must_error: true` and not a class — what refuses the call is dbplyr's
flattening reaching DuckDB's binder, so pinning `duckdb_error` would fix the
assertion to one dialect's condition class where the prose names neither.

## Checks

`lintr::lint_package()` clean, `spelling::spell_check_package()` clean, full
suite passing with no failures and no skips under `NOT_CRAN`,
`verify-context-budget.R` and `verify-verifier-invocation.R` pass. Every chunk
the new section adds was run against DuckDB 1.5.5 and against the working tree,
and the measure-ordered pipeline against SQLite 3.53.3 as well. `README.md`
needed no regeneration.
