### PR TITLE
Decide that an ancestor share is a documented join

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -39,6 +39,14 @@
 #' empty [grouping_set()], and a specification without one is rejected naming
 #' that fix.
 #'
+#' Neither helper reaches a level between the two. For a denominator at a
+#' named ancestor level, move that dimension into `.by` and use
+#' `share_of_total()`; the [recipes guide][recipes] writes that out, and the
+#' join for the case where the levels above the ancestor have to stay in the
+#' same result.
+#'
+#' [recipes]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
+#'
 #' @section Direct shares:
 #' A direct call must be the complete right-hand side of an explicitly named
 #' summary. Its argument must be the bare name of one eligible ordinary summary

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -473,6 +473,41 @@ why it does not reach a denominator that is not selected: `share_of_total()`
 accepts any plan containing a Grand total set, while this restriction on
 `share_of_parent()` still stands.
 
+A denominator at a *named ancestor level* — what fraction of its region a
+channel row is, in `rollup(region, store, channel)` — was rejected, and that
+deferral does not reach it either. ADR 0017's route is that a Grand total set
+is not selected at all; this one is selected, by the caller, and a rollup's
+parent chain is a total order, so the set two levels up is as unambiguous as
+the immediate parent. There is nothing for a selection model to decide, and
+refusing an ancestor denominator on parent ambiguity would copy a restriction
+for a reason that does not apply to it.
+
+It is refused because the value is already reachable, by the placement rule
+ADR 0017 states in the other direction. A caller who wants a cross-partition
+denominator moves that column out of `.by`; a caller who wants an ancestor
+denominator moves it in. `.by = region` with
+`.grouping = rollup(store, channel)` gives every row its share of its region
+through `share_of_total()`, with no join and no key of the caller's own.
+Placement is what chooses a denominator, and this is that lever run the other
+way rather than a workaround for a missing helper.
+
+What the placement costs is the rows above the ancestor: `region` becomes a
+fixed key, so no set of the plan pools regions and the result loses its
+all-regions row. A share against an ancestor level together with the rows
+above it is therefore the residue, and it is a documented join rather than an
+API: *Compare a row with an ancestor level* in the recipes guide owns the two
+things that join has to get right, which are the ones a caller does not
+discover — the ancestor level is selected by Grouping identity rather than by
+Margin label, and the join key carries each surviving dimension's inclusion
+bit beside its value, without which an omitted dimension matches a source
+`NA`.
+
+Naming the ancestor would also have to be an argument, and this decision
+refuses additional arguments to the helper in `across()`, so the form would be
+unavailable in the grammar column-wise shares are written in. That is a reason
+not to prefer an argument over some other spelling; it is not why an ancestor
+denominator is refused. The placement rule is.
+
 ## Amendment: the eligible-type rule is established without reading a row
 
 The decision above stands: the eligible-type rule is enforced on every backend,

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -474,9 +474,9 @@ accepts any plan containing a Grand total set, while this restriction on
 `share_of_parent()` still stands.
 
 A denominator at a *named ancestor level* — what fraction of its region a
-channel row is, in `rollup(region, store, channel)` — was rejected, and that
-deferral does not reach it either. ADR 0017's route is that a Grand total set
-is not selected at all; this one is selected, by the caller, and a rollup's
+channel row is, in `rollup(region, store, channel)` — was rejected (#375), and
+that deferral does not reach it either. ADR 0017's route is that a Grand total
+set is not selected at all; this one is selected, by the caller, and a rollup's
 parent chain is a total order, so the set two levels up is as unambiguous as
 the immediate parent. There is nothing for a selection model to decide, and
 refusing an ancestor denominator on parent ambiguity would copy a restriction
@@ -495,12 +495,8 @@ What the placement costs is the rows above the ancestor: `region` becomes a
 fixed key, so no set of the plan pools regions and the result loses its
 all-regions row. A share against an ancestor level together with the rows
 above it is therefore the residue, and it is a documented join rather than an
-API: *Compare a row with an ancestor level* in the recipes guide owns the two
-things that join has to get right, which are the ones a caller does not
-discover — the ancestor level is selected by Grouping identity rather than by
-Margin label, and the join key carries each surviving dimension's inclusion
-bit beside its value, without which an omitted dimension matches a source
-`NA`.
+API. *Compare a row with an ancestor level* in the recipes guide owns what
+that join has to get right.
 
 Naming the ancestor would also have to be an argument, and this decision
 refuses additional arguments to the helper in `across()`, so the form would be

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -56,6 +56,12 @@ any Grouping specification whose plan contains one. \code{\link[=rollup]{rollup(
 always produce one; \code{\link[=grouping_sets]{grouping_sets()}} produces one only when it includes an
 empty \code{\link[=grouping_set]{grouping_set()}}, and a specification without one is rejected naming
 that fix.
+
+Neither helper reaches a level between the two. For a denominator at a
+named ancestor level, move that dimension into \code{.by} and use
+\code{share_of_total()}; the \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} writes that out, and the
+join for the case where the levels above the ancestor have to stay in the
+same result.
 }
 \section{Direct shares}{
 

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -306,4 +306,8 @@ the plan: its denominator is the Grand total set, the grouping set in which
 every dimension is omitted, so it is defined for any plan containing one
 rather than for a rollup alone. See the
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
-for both helpers' value, source-summary, ordering, and `across()` rules.
+for both helpers' value, source-summary, ordering, and `across()` rules, and
+[Compare a row with an ancestor
+level](https://sayuks.github.io/marginplyr/vignettes/recipes.html#compare-a-row-with-an-ancestor-level)
+for a denominator neither helper reaches, which a caller assembles from the
+same identity values.

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -428,12 +428,12 @@ identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
 sets out the three kinds of apparent missingness this confuses, and why
 `share_of_parent()` cannot make the same mistake internally.
 
-**`na_matches = "na"` is not the default on a database.** `dplyr::left_join()`
-matches `NA` to `NA` by default, so a local pipeline is right without the
-argument; dbplyr's default is `"never"`, so the same pipeline silently drops
-the unnamed store's share against a database. Writing it explicitly makes the
-two agree, and dbplyr translates it to the dialect's own missing-safe
-comparison:
+**`na_matches = "na"` is written explicitly because the default differs by
+backend.** `dplyr::left_join()` matches `NA` to `NA`, so a local pipeline is
+right without the argument; dbplyr's method does not, so the same pipeline
+drops the unnamed store's share against a database and says nothing. Both
+halves are below — the join as written, then the same join with the argument
+dropped:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -477,20 +477,39 @@ duckdb_sales |>
 ```
 
 ```{r}
+#| eval: !expr has_duckdb
+
+duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    region_absent = grouping_bit(region),
+    store_absent = grouping_bit(store),
+    .grouping = rollup(region, store, product, channel)
+  ) |>
+  left_join(
+    duckdb_store_totals,
+    by = c("region", "region_absent", "store", "store_absent")
+  ) |>
+  mutate(share_of_store = revenue / store_revenue) |>
+  filter(is.na(store)) |>
+  select(region, store, product, channel, revenue, share_of_store) |>
+  collect()
+```
+
+```{r}
 #| include: false
 #| eval: !expr has_duckdb
 
 DBI::dbDisconnect(con, shutdown = TRUE)
 ```
 
-The unnamed store keeps its share on the database. As in [Name the grouping
-set on every row](#name-the-grouping-set-on-every-row), the Margin order does
-not survive the join — `arrange()` after it, or collect first.
+The unnamed store keeps its share in the first and loses it in the second, and
+the two calls differ by one argument. As in [Name the grouping set on every
+row](#name-the-grouping-set-on-every-row), the Margin order does not survive
+the join — `arrange()` after it, or collect first.
 
-Reaching an ancestor level is not part of the helpers' API, and
-[ADR 0010][adr10] records why: the `.by` route above already answers the
-question, and the join is for the residue where the levels above the ancestor
-have to stay in the same result.
+Reaching an ancestor level is not part of the helpers' API.
+[ADR 0010][adr10] records why.
 
 [adr10]: https://github.com/sayuks/marginplyr/blob/main/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -294,7 +294,205 @@ For a denominator one rollup level up rather than at the top, use
 reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 documents both helpers, and [Get
 started](https://sayuks.github.io/marginplyr/vignettes/get_started.html)
-compares them side by side.
+compares them side by side. For a level between the two, [Compare a row with
+an ancestor level](#compare-a-row-with-an-ancestor-level) runs the same `.by`
+lever the other way.
+
+## Compare a row with an ancestor level
+
+`share_of_parent()` reaches the level immediately above and `share_of_total()`
+reaches the top. In a three-level report the question in between is an
+ordinary one: what fraction of its *region* is a channel row? A store's parent
+is its region, but a channel's is its store, so neither helper answers it as
+written.
+
+Move the ancestor dimension into `.by`. The Grand total set of a fixed
+partition is that partition's own total, so `share_of_total()` measures
+against the region with no join and no key of your own:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    share_of_region = share_of_total(revenue),
+    .by = region,
+    .grouping = rollup(store, channel),
+    .sort = "last"
+  )
+```
+
+Placement is what chooses a denominator, and this is the lever from [Compare
+each row with the right total](#compare-each-row-with-the-right-total) run the
+other way: move a column out of `.by` to pool partitions, move it in to
+measure against it.
+
+What the move costs is the levels above the ancestor. `region` is a fixed key,
+so no grouping set of the plan pools regions and the result has no all-regions
+row. When a report needs both — a share against an ancestor level *and* the
+levels above it — read the ancestor level out of the result and join it back.
+
+The example below adds `product`, so that the level being measured against is
+genuinely intermediate: in `rollup(region, store, product, channel)` the
+parent of a channel row is its product, and `region`/`store` is two levels
+further up. Select that level and keep the revenue under a name of its own:
+
+```{r}
+store_totals <- retail_sales |>
+  summarize_with_margins(
+    store_revenue = sum(revenue),
+    region_absent = grouping_bit(region),
+    store_absent = grouping_bit(store),
+    product_absent = grouping_bit(product),
+    channel_absent = grouping_bit(channel),
+    .grouping = rollup(region, store, product, channel)
+  ) |>
+  filter(
+    region_absent == 0L,
+    store_absent == 0L,
+    product_absent == 1L,
+    channel_absent == 1L
+  ) |>
+  select(region, region_absent, store, store_absent, store_revenue)
+
+store_totals
+```
+
+Then summarize the whole rollup, retain the same bits, and divide:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    region_absent = grouping_bit(region),
+    store_absent = grouping_bit(store),
+    .grouping = rollup(region, store, product, channel),
+    .sort = "last"
+  ) |>
+  left_join(
+    store_totals,
+    by = c("region", "region_absent", "store", "store_absent"),
+    na_matches = "na"
+  ) |>
+  mutate(share_of_store = revenue / store_revenue) |>
+  select(region, store, product, channel, revenue, share_of_store)
+```
+
+The store with no name gets its own denominator, and the two levels that have
+no store — the region subtotals and the grand total — get `NA` rather than a
+number. Two things make that come out right, and neither announces itself.
+
+**The key is Grouping identity, not the displayed value.** The level is
+selected by `grouping_bit()` rather than by a Margin label, for the reason
+[Keep only one grouping set](#keep-only-one-grouping-set) gives: a source
+value can equal the label. The same argument reaches the join key, which is
+why each dimension's bit travels beside its value. Without the bits, a row
+whose store is *omitted* joins to the row whose store is *missing in the
+source*, because both display the same thing. With `.margin_label = NULL` they
+are both `NA` and the result is a number rather than a gap:
+
+```{r}
+label_free_totals <- retail_sales |>
+  summarize_with_margins(
+    store_revenue = sum(revenue),
+    region_absent = grouping_bit(region),
+    store_absent = grouping_bit(store),
+    product_absent = grouping_bit(product),
+    channel_absent = grouping_bit(channel),
+    .grouping = rollup(region, store, product, channel),
+    .margin_label = NULL
+  ) |>
+  filter(
+    region_absent == 0L,
+    store_absent == 0L,
+    product_absent == 1L,
+    channel_absent == 1L
+  ) |>
+  select(region, store, store_revenue)
+
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .grouping = rollup(region, store, product, channel),
+    .margin_label = NULL,
+    .sort = "last"
+  ) |>
+  left_join(label_free_totals, by = c("region", "store"), na_matches = "na") |>
+  mutate(share_of_store = revenue / store_revenue) |>
+  filter(region == "East", is.na(store)) |>
+  select(region, store, product, channel, revenue, share_of_store)
+```
+
+The last row is East's region subtotal, and its share is greater than one: it
+took the unnamed store's revenue as its denominator. [Grouping
+identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
+sets out the three kinds of apparent missingness this confuses, and why
+`share_of_parent()` cannot make the same mistake internally.
+
+**`na_matches = "na"` is not the default on a database.** `dplyr::left_join()`
+matches `NA` to `NA` by default, so a local pipeline is right without the
+argument; dbplyr's default is `"never"`, so the same pipeline silently drops
+the unnamed store's share against a database. Writing it explicitly makes the
+two agree, and dbplyr translates it to the dialect's own missing-safe
+comparison:
+
+```{r}
+#| eval: !expr has_duckdb
+
+con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+duckdb_sales <- dplyr::copy_to(con, retail_sales, "retail_sales")
+
+duckdb_store_totals <- duckdb_sales |>
+  summarize_with_margins(
+    store_revenue = sum(revenue, na.rm = TRUE),
+    region_absent = grouping_bit(region),
+    store_absent = grouping_bit(store),
+    product_absent = grouping_bit(product),
+    channel_absent = grouping_bit(channel),
+    .grouping = rollup(region, store, product, channel)
+  ) |>
+  filter(
+    region_absent == 0L,
+    store_absent == 0L,
+    product_absent == 1L,
+    channel_absent == 1L
+  ) |>
+  select(region, region_absent, store, store_absent, store_revenue)
+
+duckdb_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    region_absent = grouping_bit(region),
+    store_absent = grouping_bit(store),
+    .grouping = rollup(region, store, product, channel)
+  ) |>
+  left_join(
+    duckdb_store_totals,
+    by = c("region", "region_absent", "store", "store_absent"),
+    na_matches = "na"
+  ) |>
+  mutate(share_of_store = revenue / store_revenue) |>
+  filter(is.na(store)) |>
+  select(region, store, product, channel, revenue, share_of_store) |>
+  collect()
+```
+
+```{r}
+#| include: false
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(con, shutdown = TRUE)
+```
+
+The unnamed store keeps its share on the database. As in [Name the grouping
+set on every row](#name-the-grouping-set-on-every-row), the Margin order does
+not survive the join — `arrange()` after it, or collect first.
+
+Reaching an ancestor level is not part of the helpers' API, and
+[ADR 0010][adr10] records why: the `.by` route above already answers the
+question, and the join is for the residue where the levels above the ancestor
+have to stay in the same result.
+
+[adr10]: https://github.com/sayuks/marginplyr/blob/main/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
 
 ## Keep only one grouping set
 


### PR DESCRIPTION
Closes #375.

A share against a named ancestor level — what fraction of its region a channel
row is, in `rollup(region, store, channel)` — is refused as API and answered as
a recipe. ADR 0010 records the decision; the recipes guide owns the join.

**The `cube()` deferral does not reach it.** That deferral rests on a grouping
set having several strictly less detailed sets in the same plan. A rollup's
chain is a total order, so an ancestor two levels up is as unambiguous as the
immediate parent, and refusing it on parent ambiguity would copy a restriction
for a reason that does not apply — what ADR 0017 already refused in the other
direction.

**It is refused because the value is reachable by placement.** ADR 0017's rule
for pooling partitions, run the other way: `.by = region` with
`.grouping = rollup(store, channel)` gives every row its share of its region
through `share_of_total()`, with no join. What that costs is the levels above
the ancestor, and that residue is the recipe.

**The recipe owns two correctness points**, each shown failing:

- the join key carries each dimension's inclusion bit beside its value —
  without them, under `.margin_label = NULL`, East's region subtotal takes the
  source-`NA` store's revenue as its denominator and reports a share of 5.2375;
- `na_matches = "na"` is explicit because dbplyr's default is `"never"` while
  `dplyr::left_join()`'s is `"na"` — without it the same pipeline is right
  locally and drops the unnamed store's share on a database. The DuckDB chunk
  shows the fix holding there.

No gate is added: the section has no `must_error` chunk to write a
`verify-site.R` marker from, and the numbers are a caller's pipeline rather
than a package contract, so the chunks executing under `altdoc.yaml` is the
check. No `NEWS.md` entry, there being no API change.

## Checks

`lintr::lint_package()` and `spelling::spell_check_package()` clean,
`roxygen2::roxygenise()` produces no diff, `quarto render` of the guide
succeeds over all 75 chunks with DuckDB present, and `testthat::test_local()`
is 6263 passing / 0 failing / 0 skipped with `MARGINPLYR_REQUIRED_SUGGESTS=all`.