### PR TITLE
Decide that a share-source assertion is scoped to one call

### DIFF
--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -62,7 +62,9 @@
 #'   a backend that could not be asked which of those it does. It changes
 #'   nothing where the rule can be applied — a local data frame, a `dtplyr`
 #'   step, and a database that refuses an ineligible summary itself all apply
-#'   it whatever this argument says. See *Contextual shares*.
+#'   it whatever this argument says. It is scoped to the call it is written in:
+#'   there is no session default and no connection default that records the
+#'   answer once. See *Contextual shares*.
 #' @param .duplicates One of `"error"`, `"drop"`, or `"keep"`, and nothing
 #'   else, controlling duplicate grouping sets after expansion; see *Option
 #'   arguments*.

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -504,6 +504,68 @@ unavailable in the grammar column-wise shares are written in. That is a reason
 not to prefer an argument over some other spelling; it is not why an ancestor
 denominator is refused. The placement rule is.
 
+A *scope wider than one call* for `.check_share_source` -- an option, a
+connection attribute, or a `local_*()` helper recording the caller's assertion
+once -- was rejected (#389).
+[ADR 0027](0027-record-the-sql-marginplyr-sends.md) refuses the option form
+already, by the distinction it draws between what decides whether a query is
+sent and what decides whether a record is kept. What the other two vehicles
+need, and what per-call rests on, is where the assertion has to be readable.
+Where the dialect converts, `.check_share_source = FALSE` produces numbers from
+values nothing has checked, and the call that produced them is the only place
+that fact can be read. An option makes it a property of the session, a
+connection attribute a property of an object built elsewhere, and a `local_*()`
+helper a property of a frame that need not be the one the call is written in;
+under all three, a reader with the call in front of them cannot tell a share
+the rule was applied to from one it was not. A connection attribute is refused
+for a further reason of its own: the connection is not marginplyr's object, and
+recording marginplyr's meaning on it writes this package's state onto something
+the caller built with DBI and shares with every other package reading that
+connection.
+
+The objection recorded beside `share_dialect_verdicts` does not transfer, and
+the analogy runs the other way. That objection is that a *wrong* fact recorded
+once governs every later connection carrying that dialect, and what answers it
+is asking again, which [ADR 0020](0020-ask-before-reading-a-lazy-input.md)
+confines to the attempt that went unanswered -- the case that could be wrong.
+Asking again is available because the question is put to the dialect. Nothing
+puts the question again to the caller: the only thing the package can do with
+an assertion it declines to reuse is refuse the share, which is what the caller
+opted out of. A measured answer, meanwhile, is keyed on the dialect class and
+so is reused by every connection carrying that dialect for the rest of the
+session, where a connection attribute would be keyed on one connection --
+narrower than the scope the package already grants that measured fact. Nor is
+the scope decided by the strength of the evidence behind the assertion:
+strength decides whether to accept an assertion at all, and this one is
+accepted. It is decided by where the consequence has to be visible.
+
+None of this reaches what a caller writes in their own code. A wrapper of their
+own that fixes the argument carries the same invisibility, and that is theirs
+to weigh; what is refused here is the invisibility marginplyr's API would
+impose on every caller.
+
+*Per-share granularity*, so that a caller vouches for one share's source and
+keeps the rule on another (#389), was rejected because nothing could act on it.
+The argument reaches one checker, `check_dialect_share_sources()`, which every
+dbplyr kind routes to; the local and dtplyr checkers take it and ignore it, the
+rule being applied on their backends already. There, `FALSE` returns before the
+dialect is asked anything, and where the dialect refuses, the database applies
+the rule itself whatever the argument said. Where the dialect converts or could
+not be asked, nothing is known about any individual source: the verdict is the
+dialect's, and it is the same verdict for every source in the call. A per-share
+opt-out would vouch for one source and leave the other refused, and a refused
+source stops the call, so it reaches no result `.check_share_source = TRUE`
+does not already reach and differs only in the diagnostic. What `FALSE` gives
+up on such a dialect is the refusal and not a check, the rule being applied to
+no source there whatever the argument says.
+
+Calculating the vouched share and returning the other as `NA` is what per-share
+granularity would have to mean to reach a result of its own, and it is rejected
+as a decision of its own rather than as this one's granularity: the refusal
+states that marginplyr will not produce a number nothing has checked, and an
+`NA` in its place discards that statement into a value that reads like missing
+data.
+
 ## Amendment: the eligible-type rule is established without reading a row
 
 The decision above stands: the eligible-type rule is enforced on every backend,

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -95,7 +95,9 @@ converts a value of another type to a number rather than refusing it, and
 a backend that could not be asked which of those it does. It changes
 nothing where the rule can be applied — a local data frame, a \code{dtplyr}
 step, and a database that refuses an ineligible summary itself all apply
-it whatever this argument says. See \emph{Contextual shares}.}
+it whatever this argument says. It is scoped to the call it is written in:
+there is no session default and no connection default that records the
+answer once. See \emph{Contextual shares}.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, and nothing
 else, controlling duplicate grouping sets after expansion; see \emph{Option

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -383,7 +383,11 @@ the next share request asks again, so a dropped connection or a warehouse that
 was resuming does not refuse your shares for the rest of the session. A
 connection that executes nothing, such as the simulators used above, cannot be
 asked and is refused for the same reason; `.check_share_source = FALSE`
-calculates the share from sources you have established yourself.
+calculates the share from sources you have established yourself. What is
+remembered is the dialect's answer and not yours: `.check_share_source` is
+scoped to the call it is written in, so a dialect that converts needs it on
+every share request, and there is no session or connection default that
+records it once.
 
 A refusing dialect is therefore shown against a live DuckDB table rather than
 the simulator used above. The diagnostic is DuckDB's own, and the column it
@@ -606,11 +610,11 @@ names every verified backend.
   factor level is rejected either way. See *`.check_margin_label` on lazy
   inputs* above.
 
-- A contextual share needs `.check_share_source = FALSE` on a backend that
-  cannot establish that its source is eligible: a connection that executes
-  nothing, such as a `simulate_*()` one, and a dialect that converts an
-  ineligible source rather than refusing it, such as SQLite. See *Parent
-  shares use a staged lazy query* above.
+- A contextual share needs `.check_share_source = FALSE` on every call against
+  a backend that cannot establish that its source is eligible: a connection
+  that executes nothing, such as a `simulate_*()` one, and a dialect that
+  converts an ineligible source rather than refusing it, such as SQLite. See
+  *Parent shares use a staged lazy query* above.
 
 - A fallback query may repeat the source relation once per grouping set.
   Inspect the generated SQL and the database query plan for large workloads;


### PR DESCRIPTION
Closes #389.

`.check_share_source` keeps the scope it has: one call. Per-share granularity is
refused too. Both rejections go to ADR 0010's *Considered options*, the
reference gains one sentence stating the scope, and `database_backends.qmd`
states the asymmetry where a reader meets it. No code changes.

The commit message holds the argument. Two things are worth naming here because
they are what the review changed:

- The record is a *Considered options* entry and not an amendment.
  `design/architecture.md` amends an ADR when its decision changed observably,
  and nothing here changed; #375 put a refusal of the same shape in the same
  place.
- The option vehicle is refused by ADR 0027's distinction, cited rather than
  re-argued. ADR 0027 settles `marginplyr.audit_sql` as the package's first
  option and names `.check_share_source` on the argument side of that
  distinction, so the branch's original supporting reason -- that marginplyr
  has no option of its own -- was contradicted by the design record and is
  gone.

## Review

`mattpocock-skills:code-review` against the merge-base with `main`, four rounds.
Rounds 1-3 raised seven findings; round 4 raised none.

| Round | Finding | Disposition |
|---|---|---|
| 1 Standards | The amendment paraphrased the `share_dialect_verdicts` objection without *wrong*, contradicting its own next paragraph; `R/share.R` caches every measured verdict permanently and ADR 0020 confines asking again to an unanswered attempt | Rewritten; the paragraph now names the wrong fact and cites ADR 0020's bound |
| 1 Standards, 1 Spec | "reached only where the dialect converts or could not be asked" is false: `share_source_checker()` routes every dbplyr kind to `check_dialect_share_sources()`, and the early return precedes the verdict, so `FALSE` is read on a refusing dialect too | Rewritten; what is confined to converts/unknown is the refusal, not the reach |
| 1 Standards | The form: `design/architecture.md` amends an ADR when its decision changed observably | Moved from an amendment into *Considered options*, per #375's precedent |
| 1 Standards | The `getOption()` count was the ticket's measurement copied where nothing checks it | Deleted with the sentence holding it (see round 3) |
| 1 Spec | The `local_*()` vehicle was named in the verdict but not reached by the reasoning | One clause added: a frame that need not be the one the call is written in |
| 1 Spec | "The ticket's premise is corrected with it" and "not raised as a ticket" address the ticket, not the decision | Deleted; the durable fact -- what `FALSE` gives up is the refusal, not a check -- stays |
| 2 Standards | "marginplyr holds no session state of its own" is false: `share_dialect_verdicts` is exactly that | Deleted (see round 3) |
| 2 Standards | "`FALSE` produces numbers from values nothing has checked" over-covers: on local, dtplyr, and a refusing dialect the rule still applies | Scoped to the converting dialect |
| 3 Standards | "No option of marginplyr's own exists yet ... the wrong first inhabitant" is contradicted by ADR 0027, which also owns a reason this is an argument, so the block held a second undrifting-checked reason | Sentence deleted; ADR 0027 cited for the option vehicle |
| 3 Standards | "Where `.check_share_source = FALSE` has an effect at all" still covers `"unknown"` on a refusing dialect, where the database applies the rule | Narrowed to "where the dialect converts" |

Round 4 verified the ADR 0027 citation is a derivation from the cited sentence
rather than an inversion, that the readability argument is owned here and
duplicated nowhere, that arrow never reaches `share_source_checker()` so the
three-route enumeration is exhaustive, and that the commit message's claims hold
against the diff.

## Checks

`lintr::lint_package()` and `spelling::spell_check_package()` clean,
`roxygen2::roxygenise()` writes only `summarize_with_margins.Rd`, `quarto
render` of `database_backends.qmd` succeeds, and the suite is 6263 passing with
every optional Suggest installed.