### PR TITLE
Name a way forward when a verb refuses a RecordBatchReader

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -147,14 +147,23 @@ assert_margin_input <- function(x) {
 # alternatives to pick one of; a blacklist refuses every entry at once, so a
 # second name would be refused alongside the first and not instead of it.
 # Nothing renders today, the vector holding one name.
+#
+# `dplyr::collect()` is not named beside `arrow::as_arrow_table()`, under the
+# rule ADR 0012's amendment states. Both resolve the refusal for every verb
+# reaching this guard, but they leave the caller in different places -- one a
+# local tibble, the other the Arrow table the verb answers as an Arrow query --
+# and converting is the smaller of the two.
 assert_lazy_table <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.
   invalid_lazy_table_names <- "RecordBatchReader"
   if (inherits(x, invalid_lazy_table_names)) {
-    abort_marginplyr(paste0(
-      "{.arg {nm}} must not be an object of the following classes: ",
-      "{.code {invalid_lazy_table_names}}."
+    abort_marginplyr(c(
+      paste0(
+        "{.arg {nm}} must not be an object of the following classes: ",
+        "{.code {invalid_lazy_table_names}}."
+      ),
+      i = "Convert it with {.fun arrow::as_arrow_table} first."
     ))
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,10 +53,10 @@ assert_string_scalar <- function(x) {
 # `toString()` comma both replace was neutral between the two readings.
 #
 # `expand_with_margins()` is not named beside `dplyr::collect()`, under the
-# rule ADR 0012's amendment states. It takes the same grouping specification
-# and stays lazy, but it returns rows rather than the list column this call
-# asked for, and `assert_lazy_table()` refuses a `RecordBatchReader` that
-# reaches this refusal.
+# rule ADR 0012's second amendment states. It takes the same grouping
+# specification and stays lazy, but it returns rows rather than the list column
+# this call asked for, and `assert_lazy_table()` refuses a `RecordBatchReader`
+# that reaches this refusal.
 assert_nest_possible <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.
@@ -148,11 +148,9 @@ assert_margin_input <- function(x) {
 # second name would be refused alongside the first and not instead of it.
 # Nothing renders today, the vector holding one name.
 #
-# `dplyr::collect()` is not named beside `arrow::as_arrow_table()`, under the
-# rule ADR 0012's amendment states. Both resolve the refusal for every verb
-# reaching this guard, but they leave the caller in different places -- one a
-# local tibble, the other the Arrow table the verb answers as an Arrow query --
-# and converting is the smaller of the two.
+# `dplyr::collect()` resolves this refusal too and is not named beside
+# `arrow::as_arrow_table()`, under the rule ADR 0012's third amendment states
+# for two routes that leave the caller in different places.
 assert_lazy_table <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -162,3 +162,46 @@ a remedy only where there was one dimension; a caller with two who followed it
 literally reached a second refusal. `R/margin-label.R` states the rule this
 broke, beside the same pair of refusals: a remedy is offered only where it is
 one.
+
+## Amendment: one route is named where two resolve a refusal differently
+
+The rule above separates a remedy from a non-remedy. It does not decide
+between two routes that both are, and #391 is the case it does not reach.
+`assert_lazy_table()` refuses a `RecordBatchReader`, and both
+`arrow::as_arrow_table()` and `dplyr::collect()` resolve that refusal for every
+verb reaching the guard. Neither is the `expand_with_margins()` of #374 —
+neither answers a different question, and neither leads to a second refusal.
+
+They leave the caller in different places. Collecting yields a local tibble;
+converting yields the Arrow table the verb then answers as an Arrow query, and
+the row order differs with them. Cost does not separate them either: a
+`RecordBatchReader` is one-shot, so both consume it and both materialize it
+whole.
+
+**Where two routes both resolve one refusal for one object but leave the caller
+in different places, the refusal names one: the route that leaves the caller
+where the call they wrote would have.** That is `arrow::as_arrow_table()` here.
+Naming both would describe the choice rather than resolve it, and a reader
+following either arrives somewhere the diagnostic did not say they would.
+
+`or` stays available for the case that looks like this one and is not.
+`assert_margin_input()`'s `Convert it with {.fun as.data.frame} or {.fun
+dplyr::tbl} first.` is one bullet over a duck-typed rejection, where the caller
+cannot see which class was refused; its two spellings name the route for two
+different supplied objects rather than two routes for one. What decides is
+therefore whether one object has both routes, and not the count of names in the
+bullet.
+
+### Considered options
+
+*Name both, joined by `or`.* Rejected above: it is the shape this amendment
+exists to separate from `assert_margin_input()`'s.
+
+*Name `dplyr::collect()` alone.* It is the sibling guard's wording and the
+route with no optional package in it. Rejected because it asks the caller to
+leave the backend they chose, which is more than the refusal requires, and
+because the verb answers an Arrow input in Arrow — collecting changes what the
+call returns as well as what it accepts.
+
+*Leave the refusal with no remedy.* That is the defect #391 reported, and the
+one #374 fixed beside it.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -642,4 +642,13 @@ test_that("lazy-table assertions use the package condition seam", {
   )
 
   expect_s3_class(error, "marginplyr_error")
+
+  # The refusal's remedy, which the pattern above does not reach: it matches
+  # the main line, and a refusal that lost its bullet still has one. The same
+  # pin the nesting refusal carries above.
+  expect_match(
+    conditionMessage(error),
+    "Convert it with `arrow::as_arrow_table()` first.",
+    fixed = TRUE
+  )
 })


### PR DESCRIPTION
Closes #391.

`assert_lazy_table()` named the class it refuses and stopped. It now carries a
remedy bullet:

```
`.data` must not be an object of the following classes: `RecordBatchReader`.
i Convert it with `arrow::as_arrow_table()` first.
```

The guard is shared, so the bullet is read from `summarize_with_margins()`,
`expand_with_margins()`, and `inspect_grouping()`. `nest_with_margins()` never
reaches it and its diagnostic is unchanged.

`arrow::as_arrow_table()` and not `dplyr::collect()` was the decision the ticket
existed to take; the commit message holds the argument, and the triage comment
on #391 holds the measurements both routes were chosen between.

`test-utils.R` pins the bullet — the existing expectations match the main line,
which a refusal that lost its remedy still has.

Full suite green with `NOT_CRAN=true`, `lintr::lint_package()` clean,
`roxygen2::roxygenise()` a no-op.