### PR TITLE
Delete the vignette prose restating a diagnostic printed below it (#392)

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -711,11 +711,16 @@ rejection with evidence. Naming which one is what the disposition does, and a
 comment is not among them: a finding a comment would answer is one of the
 others.
 
-A finding about prose is one of four: the prose is false, it duplicates an
-argument another file owns and can drift from it, it breaks a rule a repository
-document states, or something a repository document is required to hold is
-missing from it. How prose reads is not one, and no record holds a finding that
-is.
+A finding about prose is one of five: the prose is false, it duplicates an
+argument another file owns and can drift from it, it restates what a diagnostic
+rendered beside it says, it breaks a rule a repository document states, or
+something a repository document is required to hold is missing from it. How
+prose reads is not one, and no record holds a finding that is.
+
+The third does not reach a sentence saying what that diagnostic does not say —
+a contrast, or the answer the caller would otherwise have got — which is the
+page's own argument and not a copy of anything. #392 measured the `must_error`
+chunks under `vignettes/` and found both forms.
 
 Two answers join the list above when a finding is about prose. A claim found
 false is deleted rather than restated, as *Code comments* in `AGENTS.md`

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -717,10 +717,10 @@ rendered beside it says, it breaks a rule a repository document states, or
 something a repository document is required to hold is missing from it. How
 prose reads is not one, and no record holds a finding that is.
 
-The third does not reach a sentence saying what that diagnostic does not say —
-a contrast, or the answer the caller would otherwise have got — which is the
-page's own argument and not a copy of anything. #392 measured the `must_error`
-chunks under `vignettes/` and found both forms.
+The restatement case does not reach a sentence saying what the diagnostic does
+not say — a contrast, or the answer the caller would otherwise have got — which
+is the page's own argument and not a copy of anything. #392 measured the
+`must_error` chunks under `vignettes/` and found both forms.
 
 Two answers join the list above when a finding is about prose. A claim found
 false is deleted rather than restated, as *Code comments* in `AGENTS.md`

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -510,8 +510,7 @@ reasons.
 
 The first is a summary Arrow's own engine cannot evaluate. Arrow answers one of
 those by reading the whole input — every column, not just the ones the summary
-names — and computing it in R, so marginplyr refuses it before a row is read
-and tells you the two ways to get it computed:
+names — and computing it in R, so marginplyr refuses it before a row is read:
 
 ```{r}
 #| label: arrow-absorbed-summary

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -524,11 +524,10 @@ arrow::arrow_table(january_sales) |>
   )
 ```
 
-Collecting first is one rewrite; selecting the columns the summary needs before
-collecting is the other, and it is the one Arrow's own route cannot take for
-you. Which expressions this reaches is Arrow's to decide and changes with its
-version, so the shapes are described in one place rather than repeated here —
-see the [`summarize_with_margins()`
+Selecting the columns the summary needs before collecting is the rewrite
+Arrow's own route cannot take for you. Which expressions this reaches is
+Arrow's to decide and changes with its version, so the shapes are described in
+one place rather than repeated here — see the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
 An Arrow dataset answers the same expressions with Arrow's own error rather
 than this one, because a dataset never reads itself into R.

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -268,8 +268,7 @@ This is a union of:
 ```
 
 Both rollups contain `()`, which is why the call above asks for `"drop"`.
-Without it, the default `.duplicates = "error"` catches the overlap and names
-the positions that collide:
+Without it, the default `.duplicates = "error"` catches the overlap:
 
 ```{r}
 #| label: duplicate-grouping-sets
@@ -802,7 +801,7 @@ retail_sales |>
 ```
 
 A `grouping_sets()` specification qualifies only when it includes an empty
-`grouping_set()`; one without it is rejected naming that fix:
+`grouping_set()`; one without it is rejected:
 
 ```{r}
 #| label: total-share-without-grand-total


### PR DESCRIPTION
Closes #392.

#374 deleted one clause of this shape from `database_backends.qmd` and left
open whether that was one editorial call or a form the vignettes repeat. It is
a form. All 19 `must_error` chunks under `vignettes/` were scanned with the
paragraph above each one; five carried a sentence asserting what the refusal
below it contains, and three of those are bare restatement:

| vignette | the clause |
| --- | --- |
| `database_backends.qmd` | `and tells you the two ways to get it computed` |
| `get_started.qmd` | `and names the positions that collide` |
| `get_started.qmd` | `is rejected naming that fix` |

Each sentence keeps the argument it was making and loses only the promise about
the diagnostic's content. The Arrow one also asserted a count, which is the
failure #374 already met once — the clause it deleted had gone incomplete when
the refusal below it gained a remedy bullet.

The two remaining clauses stay: `not a silently different answer` and `instead
of choosing a parent` say what the diagnostic does not, so a reader learns from
them something the rendered refusal never tells them.

`design/architecture.md`'s *Answering a review* gains the rule as a fifth kind
a prose finding may be, naming the contrast case as what it does not reach.
Not `AGENTS.md`: its always-loaded closure is at 24198 of a 24198-byte
baseline, and the reasons its *Code comments* section gives for auditing by
hand are `R/`-specific and do not transfer to a vignette.

No marker moves, though one was close — `verify-site.R` pins the backends
guide's absorbed-summary section through the prose `refuses it before a row is
read`, since the chunk is behind `has_arrow`, and this edit shortens the
sentence around that run while leaving it whole.

Checks: `lintr::lint_package()` clean; full suite 6263 passing with no failures
and no skips under `MARGINPLYR_REQUIRED_SUGGESTS=all`; `verify-must-error.R`,
`verify-verifier-invocation.R`, and `verify-context-budget.R` pass with the
baseline unmoved; the site renders and `verify-site.R` verifies it.
