### PR TITLE
Catalog explain and remote_query_plan as execution entry points

### DIFF
--- a/tests/testthat/_snaps/query-policy.md
+++ b/tests/testthat/_snaps/query-policy.md
@@ -7,14 +7,14 @@
       1    dplyr           collect        FALSE
       2    dplyr           compute        FALSE
       3    dplyr              pull        FALSE
-      4     base     as.data.frame         TRUE
-      5   tibble         as_tibble         TRUE
-      6      DBI        dbGetQuery        FALSE
-      7      DBI       dbSendQuery        FALSE
-      8      DBI   dbSendStatement        FALSE
-      9      DBI           dbFetch        FALSE
-      10     DBI       dbReadTable        FALSE
-      11   dplyr           explain        FALSE
+      4    dplyr           explain        FALSE
+      5     base     as.data.frame         TRUE
+      6   tibble         as_tibble         TRUE
+      7      DBI        dbGetQuery        FALSE
+      8      DBI       dbSendQuery        FALSE
+      9      DBI   dbSendStatement        FALSE
+      10     DBI           dbFetch        FALSE
+      11     DBI       dbReadTable        FALSE
       12  dbplyr remote_query_plan        FALSE
 
 # marginplyr functions reaching an execution entry point

--- a/tests/testthat/_snaps/query-policy.md
+++ b/tests/testthat/_snaps/query-policy.md
@@ -3,17 +3,19 @@
     Code
       lazy_execution_entry_points()
     Output
-         package            name subject_test
-      1    dplyr         collect        FALSE
-      2    dplyr         compute        FALSE
-      3    dplyr            pull        FALSE
-      4     base   as.data.frame         TRUE
-      5   tibble       as_tibble         TRUE
-      6      DBI      dbGetQuery        FALSE
-      7      DBI     dbSendQuery        FALSE
-      8      DBI dbSendStatement        FALSE
-      9      DBI         dbFetch        FALSE
-      10     DBI     dbReadTable        FALSE
+         package              name subject_test
+      1    dplyr           collect        FALSE
+      2    dplyr           compute        FALSE
+      3    dplyr              pull        FALSE
+      4     base     as.data.frame         TRUE
+      5   tibble         as_tibble         TRUE
+      6      DBI        dbGetQuery        FALSE
+      7      DBI       dbSendQuery        FALSE
+      8      DBI   dbSendStatement        FALSE
+      9      DBI           dbFetch        FALSE
+      10     DBI       dbReadTable        FALSE
+      11   dplyr           explain        FALSE
+      12  dbplyr remote_query_plan        FALSE
 
 # marginplyr functions reaching an execution entry point
 

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -90,19 +90,31 @@ find_local_assignment <- function(fn, var_name) {
 # on the local table it produced. No `DBI::` entry takes one: invoking it is
 # itself a read, and its first argument is a connection rather than the caller's
 # data, so a subject test there would count nothing at all.
+#
+# `dplyr::explain` and `dbplyr::remote_query_plan` are members because each
+# reaches `DBI::dbGetQuery()` from inside dbplyr, where the walk over `R/`
+# cannot follow: one line of either there would leave the gate silent, which
+# reads exactly like a package calling neither (ADR 0027). They take no subject
+# test for the reason the `DBI::` entries take none. Neither takes a positive
+# control either, and that is deliberate: what they assert is that marginplyr
+# does not call them, so a positive control would be marginplyr calling
+# `explain()`.
 lazy_execution_entry_points <- function() {
   data.frame(
     package = c(
       "dplyr", "dplyr", "dplyr", "base", "tibble",
-      "DBI", "DBI", "DBI", "DBI", "DBI"
+      "DBI", "DBI", "DBI", "DBI", "DBI",
+      "dplyr", "dbplyr"
     ),
     name = c(
       "collect", "compute", "pull", "as.data.frame", "as_tibble",
-      "dbGetQuery", "dbSendQuery", "dbSendStatement", "dbFetch", "dbReadTable"
+      "dbGetQuery", "dbSendQuery", "dbSendStatement", "dbFetch", "dbReadTable",
+      "explain", "remote_query_plan"
     ),
     subject_test = c(
       FALSE, FALSE, FALSE, TRUE, TRUE,
-      FALSE, FALSE, FALSE, FALSE, FALSE
+      FALSE, FALSE, FALSE, FALSE, FALSE,
+      FALSE, FALSE
     ),
     stringsAsFactors = FALSE
   )

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -93,28 +93,24 @@ find_local_assignment <- function(fn, var_name) {
 #
 # `dplyr::explain` and `dbplyr::remote_query_plan` are members because each
 # reaches `DBI::dbGetQuery()` from inside dbplyr, where the walk over `R/`
-# cannot follow: one line of either there would leave the gate silent, which
-# reads exactly like a package calling neither (ADR 0027). They take no subject
-# test for the reason the `DBI::` entries take none. Neither takes a positive
-# control either, and that is deliberate: what they assert is that marginplyr
-# does not call them, so a positive control would be marginplyr calling
-# `explain()`.
+# cannot follow (ADR 0027). Neither takes a positive control: one for
+# "marginplyr does not call this" would be marginplyr calling it.
 lazy_execution_entry_points <- function() {
   data.frame(
     package = c(
-      "dplyr", "dplyr", "dplyr", "base", "tibble",
+      "dplyr", "dplyr", "dplyr", "dplyr", "base", "tibble",
       "DBI", "DBI", "DBI", "DBI", "DBI",
-      "dplyr", "dbplyr"
+      "dbplyr"
     ),
     name = c(
-      "collect", "compute", "pull", "as.data.frame", "as_tibble",
+      "collect", "compute", "pull", "explain", "as.data.frame", "as_tibble",
       "dbGetQuery", "dbSendQuery", "dbSendStatement", "dbFetch", "dbReadTable",
-      "explain", "remote_query_plan"
+      "remote_query_plan"
     ),
     subject_test = c(
-      FALSE, FALSE, FALSE, TRUE, TRUE,
+      FALSE, FALSE, FALSE, FALSE, TRUE, TRUE,
       FALSE, FALSE, FALSE, FALSE, FALSE,
-      FALSE, FALSE
+      FALSE
     ),
     stringsAsFactors = FALSE
   )


### PR DESCRIPTION
Closes #399.

`lazy_execution_entry_points()` in `tests/testthat/test-query-policy.R` now
holds `dplyr::explain` and `dbplyr::remote_query_plan`, both with
`subject_test = FALSE`. Each reaches `DBI::dbGetQuery()` from inside dbplyr,
where the walk over `R/` cannot follow, so one line of either there would
leave the gate reporting a clean result — which reads exactly like a package
calling neither. That is what makes ADR 0027's rejection structural rather
than prose.

`traced_execution_entry_points()` derives from the same catalog and needed no
edit. The snapshot of the scanned entry-point set moves by exactly these two
rows; the snapshot of internal functions reaching an entry point does not
move, which is the assertion. `sql_render()` and `show_query()` stay absent.

A comment records why neither entry takes a positive control: what they assert
is that marginplyr does not call them, so a control would be marginplyr
calling `explain()`.

## Local gates

- `lintr::lint_package()` after `pkgload::load_all()` — no lints
- Full suite with `NOT_CRAN=true` — exit 0
- `Rscript .github/scripts/verify-suite-coverage.R` — 707 tests, all covered