### PR TITLE
Record the queries the four internal sites send

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -298,9 +298,8 @@
   than answered with zero rows, and a statement dbplyr cannot translate for
   the backend is recorded as `NA` without failing the call. The record also
   holds the queries marginplyr sends for its own reasons on the way: the
-  zero-row selection proxy it reads a lazy input's columns from, which is what
-  an audited `inspect_grouping()` records; the scan under
-  `.check_margin_label` looking for an observed value equal to a Margin
+  zero-row selection proxy it reads a lazy input's columns from; the scan
+  under `.check_margin_label` looking for an observed value equal to a Margin
   label; and the question it asks a dialect before calculating a contextual
   share, with the control that tells a refusal from a question that could
   not be put. Each is recorded before it is sent, so a call refused by a

--- a/NEWS.md
+++ b/NEWS.md
@@ -296,5 +296,13 @@
   a data frame or a `dtplyr` table records nothing. Reading before any call
   has run, or after a call made while the option was off, is refused rather
   than answered with zero rows, and a statement dbplyr cannot translate for
-  the backend is recorded as `NA` without failing the call. The option is off
-  by default (#318, #400).
+  the backend is recorded as `NA` without failing the call. The record also
+  holds the queries marginplyr sends for its own reasons on the way: the
+  zero-row selection proxy it reads a lazy input's columns from, which is what
+  an audited `inspect_grouping()` records; the scan under
+  `.check_margin_label` looking for an observed value equal to a Margin
+  label; and the question it asks a dialect before calculating a contextual
+  share, with the control that tells a refusal from a question that could
+  not be put. Each is recorded before it is sent, so a call refused by a
+  collision or by an ineligible share source leaves readable every query it
+  had already sent. The option is off by default (#318, #400, #401).

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -10,7 +10,9 @@ grouping_selection_proxy <- function(.data,
     return(as.data.frame(arrow::schema(.data)))
   }
   if (backend$collect_selection_proxy) {
-    return(dplyr::collect(utils::head(.data, n = 0L)))
+    proxy <- utils::head(.data, n = 0L)
+    record_sent_query("selection_proxy", proxy)
+    return(dplyr::collect(proxy))
   }
   .data
 }

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -267,7 +267,9 @@ check_observed_label_collision <- function(data,
     }
   )
   names(checks) <- read_cols
-  found <- dplyr::collect(dplyr::summarize(data, !!!checks))
+  query <- dplyr::summarize(data, !!!checks)
+  record_sent_query("observed_label_collision", query)
+  found <- dplyr::collect(query)
   found <- vapply(
     read_cols,
     function(col) {

--- a/R/share.R
+++ b/R/share.R
@@ -2405,9 +2405,7 @@ probe_share_dialect <- function(con) {
 # the share. An unrecognised status therefore fails closed by construction,
 # and that is the property worth writing down rather than asserting.
 #
-# `purpose` is the name this query is recorded under (ADR 0027), and the
-# caller passes a different one for the question and for the control, the two
-# being one function called twice.
+# `purpose` is the name this query is recorded under (ADR 0027).
 probe_share_dialect_answer <- function(con, expr, purpose) {
   query <- tryCatch(
     dplyr::summarize(

--- a/R/share.R
+++ b/R/share.R
@@ -2369,9 +2369,17 @@ share_dialect_can_be_asked <- function(con) {
 # it dbplyr asks the connection for the query's fields before it can build a
 # `tbl`, which is a further query for a schema this frame already knows.
 probe_share_dialect <- function(con) {
-  probe <- probe_share_dialect_answer(con, quote(sum("x", na.rm = TRUE)))
+  probe <- probe_share_dialect_answer(
+    con,
+    quote(sum("x", na.rm = TRUE)),
+    purpose = "share_dialect"
+  )
   if (identical(probe, "raised")) {
-    control <- probe_share_dialect_answer(con, quote(sum(z, na.rm = TRUE)))
+    control <- probe_share_dialect_answer(
+      con,
+      quote(sum(z, na.rm = TRUE)),
+      purpose = "share_dialect_control"
+    )
     if (identical(control, "answered")) {
       return("refuses")
     }
@@ -2396,7 +2404,11 @@ probe_share_dialect <- function(con) {
 # every value it does not recognise to `"unknown"` -- the answer that refuses
 # the share. An unrecognised status therefore fails closed by construction,
 # and that is the property worth writing down rather than asserting.
-probe_share_dialect_answer <- function(con, expr) {
+#
+# `purpose` is the name this query is recorded under (ADR 0027), and the
+# caller passes a different one for the question and for the control, the two
+# being one function called twice.
+probe_share_dialect_answer <- function(con, expr, purpose) {
   query <- tryCatch(
     dplyr::summarize(
       dplyr::tbl(con, dbplyr::sql("SELECT 1 AS z"), vars = "z"),
@@ -2407,6 +2419,7 @@ probe_share_dialect_answer <- function(con, expr) {
   if (is.null(query)) {
     return("unanswerable")
   }
+  record_sent_query(purpose, query)
   answer <- tryCatch(
     list(value = suppressMessages(suppressWarnings(dplyr::collect(query)))),
     error = function(cnd) NULL

--- a/tests/testthat/helper-share-dialect-verdicts.R
+++ b/tests/testthat/helper-share-dialect-verdicts.R
@@ -1,0 +1,23 @@
+# The per-dialect verdict cache is package state, so a test that reads what a
+# call records starts from an empty one -- what a call records is only
+# observable from there -- and puts back whatever the rest of the suite had
+# recorded. Restoring empties first, so that an entry the test itself wrote is
+# not left beside the saved ones.
+#
+# Shared rather than written where they are used because testthat gives each
+# test file its own environment, so a second file reaching this cache would
+# otherwise carry a copy of both bodies. `test-share-backends.R` reads the
+# cache to assert what is recorded under a dialect, and
+# `test-sent-queries.R` empties it so that the probe sends its queries at all.
+empty_share_dialect_verdicts <- function() {
+  rm(
+    list = ls(share_dialect_verdicts, all.names = TRUE),
+    envir = share_dialect_verdicts
+  )
+}
+
+restore_share_dialect_verdicts <- function(saved) {
+  empty_share_dialect_verdicts()
+  list2env(saved, envir = share_dialect_verdicts)
+  invisible(NULL)
+}

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -1,6 +1,8 @@
 # The record is emptied at the top of every call, so no test here isolates
-# `sent_queries` itself; only the option leaks between tests, and every test
-# that sets it restores it on exit. ADR 0027 is the decision these assert.
+# `sent_queries` itself. Two pieces of state do leak between tests and are
+# restored on exit by every test that writes one: the option, and the
+# per-dialect verdict cache the share tests below empty so that the probe
+# sends its queries at all. ADR 0027 is the decision these assert.
 
 sent_queries_data <- function() {
   data.frame(
@@ -148,6 +150,19 @@ test_that("an audited dtplyr call sent nothing", {
   with_audit_option(TRUE, {
     summarize_with_margins(
       dtplyr::lazy_dt(sent_queries_data()),
+      total = sum(v, na.rm = TRUE),
+      .grouping = rollup(g, h)
+    )
+    expect_sent_nothing()
+  })
+})
+
+test_that("an audited arrow call sent nothing", {
+  skip_if_suggest_absent("arrow")
+
+  with_audit_option(TRUE, {
+    summarize_with_margins(
+      arrow::arrow_table(sent_queries_data()),
       total = sum(v, na.rm = TRUE),
       .grouping = rollup(g, h)
     )
@@ -377,19 +392,6 @@ test_that("an audited RSQLite call records no selection proxy", {
   expect_identical(record$purpose, "result")
 })
 
-test_that("an audited arrow call sent nothing", {
-  skip_if_suggest_absent("arrow")
-
-  with_audit_option(TRUE, {
-    summarize_with_margins(
-      arrow::arrow_table(sent_queries_data()),
-      total = sum(v, na.rm = TRUE),
-      .grouping = rollup(g, h)
-    )
-    expect_sent_nothing()
-  })
-})
-
 # --- the label scan row ------------------------------------------------------
 
 test_that("an audited label check records its scan", {
@@ -416,20 +418,8 @@ test_that("an audited label check records its scan", {
 # --- the dialect probe's rows ------------------------------------------------
 
 # The verdict is cached per dialect for the session, so a probe sends its
-# queries only against an empty cache; both tests below empty it the way
-# `test-share-backends.R` does and put back what the rest of the suite had.
-empty_sent_queries_verdicts <- function() {
-  rm(
-    list = ls(share_dialect_verdicts, all.names = TRUE),
-    envir = share_dialect_verdicts
-  )
-}
-
-restore_sent_queries_verdicts <- function(saved) {
-  empty_sent_queries_verdicts()
-  list2env(saved, envir = share_dialect_verdicts)
-  invisible(NULL)
-}
+# queries only against an empty cache; both tests below empty it through
+# `helper-share-dialect-verdicts.R`.
 
 test_that("an audited DuckDB share records the probe and its control", {
   skip_if_suggest_absent("duckdb", "DBI")
@@ -438,8 +428,8 @@ test_that("an audited DuckDB share records the probe and its control", {
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   remote <- sent_queries_table(con)
   saved <- as.list(share_dialect_verdicts, all.names = TRUE)
-  on.exit(restore_sent_queries_verdicts(saved), add = TRUE)
-  empty_sent_queries_verdicts()
+  on.exit(restore_share_dialect_verdicts(saved), add = TRUE)
+  empty_share_dialect_verdicts()
 
   with_audit_option(TRUE, {
     summarize_with_margins(
@@ -464,8 +454,8 @@ test_that("a refused share leaves the probe's row readable", {
   on.exit(DBI::dbDisconnect(con), add = TRUE)
   remote <- sent_queries_table(con)
   saved <- as.list(share_dialect_verdicts, all.names = TRUE)
-  on.exit(restore_sent_queries_verdicts(saved), add = TRUE)
-  empty_sent_queries_verdicts()
+  on.exit(restore_share_dialect_verdicts(saved), add = TRUE)
+  empty_share_dialect_verdicts()
 
   # SQLite converts a string to a number rather than refusing it, so the share
   # is refused here, after the probe's query has already been recorded.

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -335,3 +335,153 @@ test_that("grouping_backend() answers is_sql = FALSE for dtplyr", {
   backend <- grouping_backend(dtplyr::lazy_dt(sent_queries_data()))
   expect_false(backend$is_sql)
 })
+
+# --- the selection proxy row -------------------------------------------------
+
+test_that("an audited DuckDB call records its selection proxy", {
+  skip_if_suggest_absent("duckdb", "DBI")
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    summarize_with_margins(
+      remote,
+      total = sum(v, na.rm = TRUE),
+      .grouping = rollup(g, h)
+    )
+    record <- last_sent_queries()
+  })
+
+  expect_identical(record$purpose, c("selection_proxy", "result"))
+  expect_match(record$sql[[1L]], "sent_queries", fixed = TRUE)
+})
+
+test_that("an audited RSQLite call records no selection proxy", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    summarize_with_margins(
+      remote,
+      total = sum(v, na.rm = TRUE),
+      .grouping = rollup(g, h)
+    )
+    record <- last_sent_queries()
+  })
+
+  expect_identical(record$purpose, "result")
+})
+
+test_that("an audited arrow call sent nothing", {
+  skip_if_suggest_absent("arrow")
+
+  with_audit_option(TRUE, {
+    summarize_with_margins(
+      arrow::arrow_table(sent_queries_data()),
+      total = sum(v, na.rm = TRUE),
+      .grouping = rollup(g, h)
+    )
+    expect_sent_nothing()
+  })
+})
+
+# --- the label scan row ------------------------------------------------------
+
+test_that("an audited label check records its scan", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    summarize_with_margins(
+      remote,
+      total = sum(v, na.rm = TRUE),
+      .grouping = rollup(g, h),
+      .check_margin_label = TRUE
+    )
+    record <- last_sent_queries()
+  })
+
+  expect_identical(record$purpose, c("observed_label_collision", "result"))
+  expect_match(record$sql[[1L]], "Total", fixed = TRUE)
+})
+
+# --- the dialect probe's rows ------------------------------------------------
+
+# The verdict is cached per dialect for the session, so a probe sends its
+# queries only against an empty cache; both tests below empty it the way
+# `test-share-backends.R` does and put back what the rest of the suite had.
+empty_sent_queries_verdicts <- function() {
+  rm(
+    list = ls(share_dialect_verdicts, all.names = TRUE),
+    envir = share_dialect_verdicts
+  )
+}
+
+restore_sent_queries_verdicts <- function(saved) {
+  empty_sent_queries_verdicts()
+  list2env(saved, envir = share_dialect_verdicts)
+  invisible(NULL)
+}
+
+test_that("an audited DuckDB share records the probe and its control", {
+  skip_if_suggest_absent("duckdb", "DBI")
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- sent_queries_table(con)
+  saved <- as.list(share_dialect_verdicts, all.names = TRUE)
+  on.exit(restore_sent_queries_verdicts(saved), add = TRUE)
+  empty_sent_queries_verdicts()
+
+  with_audit_option(TRUE, {
+    summarize_with_margins(
+      remote,
+      total = sum(v, na.rm = TRUE),
+      share = share_of_parent(total),
+      .grouping = rollup(g, h)
+    )
+    record <- last_sent_queries()
+  })
+
+  # DuckDB refuses summing a string, which is the answer the control is sent
+  # to tell from a question that could not be put here at all.
+  probes <- grep("^share_dialect", record$purpose, value = TRUE)
+  expect_identical(probes, c("share_dialect", "share_dialect_control"))
+})
+
+test_that("a refused share leaves the probe's row readable", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+  saved <- as.list(share_dialect_verdicts, all.names = TRUE)
+  on.exit(restore_sent_queries_verdicts(saved), add = TRUE)
+  empty_sent_queries_verdicts()
+
+  # SQLite converts a string to a number rather than refusing it, so the share
+  # is refused here, after the probe's query has already been recorded.
+  with_audit_option(TRUE, {
+    condition <- rlang::catch_cnd(
+      summarize_with_margins(
+        remote,
+        total = sum(v, na.rm = TRUE),
+        share = share_of_parent(total),
+        .grouping = rollup(g, h)
+      ),
+      classes = "marginplyr_error"
+    )
+    record <- last_sent_queries()
+  })
+
+  expect_s3_class(condition, "marginplyr_error")
+  expect_identical(record$purpose, "share_dialect")
+})

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1163,26 +1163,11 @@ test_that("a lazy backend that answers nothing refuses to establish a share", {
   expect_match(dbplyr::sql_render(query), "UNION ALL", fixed = TRUE)
 })
 
-# The per-dialect verdict cache is package state, so the three tests that read
-# what it records start from an empty one -- what a call records is only
-# observable from there -- and put back whatever the rest of the suite had
-# recorded. Restoring empties first, so that an entry the test itself wrote is
-# not left beside the saved ones. Only those three need either helper: the
-# verdict tests after them call `probe_share_dialect()` directly or assert the
-# cache as they found it, and the live-backend tests further down write to it
-# through the verb without reading what it holds.
-empty_share_dialect_verdicts <- function() {
-  rm(
-    list = ls(share_dialect_verdicts, all.names = TRUE),
-    envir = share_dialect_verdicts
-  )
-}
-
-restore_share_dialect_verdicts <- function(saved) {
-  empty_share_dialect_verdicts()
-  list2env(saved, envir = share_dialect_verdicts)
-  invisible(NULL)
-}
+# Only the three tests below need either helper from
+# `helper-share-dialect-verdicts.R`: the verdict tests after them call
+# `probe_share_dialect()` directly or assert the cache as they found it, and
+# the live-backend tests further down write to it through the verb without
+# reading what it holds.
 
 # What the dialect does with an ineligible summary is a property of the
 # dialect, so it is asked once and reused — which is only observable across


### PR DESCRIPTION
Closes #401.

The three recording sites #400 left, with the `"result"` row already landed:

- `"selection_proxy"` — the zero-row proxy, in the `collect_selection_proxy`
  branch only. The arrow branch reads `arrow::schema()` and the fall-through
  branch sends nothing, so neither takes a row.
- `"observed_label_collision"` — the label scan under `.check_margin_label`.
- `"share_dialect"` and `"share_dialect_control"` — the dialect probe's
  question and its control. The probe is one function called twice, so it
  takes its purpose as an argument and `probe_share_dialect()` passes the two
  values. Its row is written after the `tryCatch` that builds the query: a
  query that could not be built was never sent.

Every row is written before the `collect()` it describes, which is what makes
the record hold what was sent rather than what succeeded. The test of that is
a share the eligible-type rule refuses: the probe's row is readable after the
`marginplyr_error`.

`nest_by_with_margins()`'s two `collect()` calls take no row and no code says
so — `assert_nest_possible()` restricts input before nesting runs, so the
`is_sql` gate already withholds them.

The dialect probe's two rows get no runtime test that they are SQL. The
snapshot of internal functions reaching an execution entry point does not move.

## Gates

`lintr::lint_package()`, `roxygen2::roxygenise()` (no diff),
`spelling::spell_check_package()`, the suite with `NOT_CRAN=true`,
`Rscript .github/scripts/verify-suite-coverage.R`, and `R CMD check` on a built
tarball all pass.