### PR TITLE
Document the Sent query record in ?marginplyr and the database-backends guide

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -364,6 +364,9 @@ markers <- list(
     "Parent shares use a staged lazy query",
     "share_of_total",
     "Completion stays in the lazy input pipeline",
+    # The Sent-query section, by its heading rather than by anything it
+    # renders: every chunk in it is behind `has_duckdb`, so on a machine
+    # without DuckDB the section produces no output for a marker to quote.
     "Record the SQL marginplyr sends",
     "Only DuckDB and SQLite are exercised as live SQL databases",
     "DuckDB covers native SQL end to end",

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -364,6 +364,7 @@ markers <- list(
     "Parent shares use a staged lazy query",
     "share_of_total",
     "Completion stays in the lazy input pipeline",
+    "Record the SQL marginplyr sends",
     "Only DuckDB and SQLite are exercised as live SQL databases",
     "DuckDB covers native SQL end to end",
     "dozen-plus fallback dialects",

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -133,8 +133,9 @@
 #' [last_sent_queries()] gives four answers, and each of the three that could
 #' look like an empty record is told apart from the others:
 #'
-#' - Nothing has been recorded in this session -- no Margin verb has run --
-#'   and the call is refused with a `"marginplyr_error"`.
+#' - Nothing has been recorded in this session -- neither a Margin verb nor
+#'   [inspect_grouping()] has run -- and the call is refused with a
+#'   `"marginplyr_error"`.
 #' - The last call was not audited, the option being unset or holding a value
 #'   other than `TRUE` when the call began, and the call is refused with a
 #'   `"marginplyr_error"` naming `marginplyr.audit_sql`. The option is read

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -87,6 +87,65 @@
 #' summary expressions run when you collect the result rather than while the
 #' verb runs, so what they raise is the collecting call's to report.
 #'
+#' @section Recording the SQL marginplyr sends:
+#' marginplyr keeps no record of the SQL it sends unless you ask for one.
+#' `options(marginplyr.audit_sql = TRUE)` switches the record on, and
+#' [last_sent_queries()] reads back what the most recent call sent:
+#'
+#' ```r
+#' # `sales_db` is a lazy table on a SQL connection.
+#' old <- options(marginplyr.audit_sql = TRUE)
+#'
+#' summarize_with_margins(
+#'   sales_db,
+#'   revenue = sum(revenue),
+#'   .grouping = rollup(region, store)
+#' )
+#'
+#' last_sent_queries()
+#' options(old)
+#' ```
+#'
+#' The record is a tibble of two character columns -- `purpose`, what the
+#' query was sent for, and `sql`, the statement as it was rendered -- with one
+#' row per query, in the order the queries were sent. It belongs to a single
+#' call, being emptied at the start of every one.
+#'
+#' `"result"` is the one `purpose` promised: the query a Margin verb returns
+#' unexecuted, which your own [dplyr::collect()] is still what runs. Every
+#' other row is a query marginplyr sends for its own reasons, and the names
+#' those rows carry are not fixed.
+#'
+#' A query is recorded before it is sent, so the record holds what was sent
+#' rather than what succeeded, and a call that fails leaves readable every
+#' query it had already sent.
+#'
+#' What is recorded is the SQL marginplyr sent, not the execution marginplyr
+#' caused. An audited call on a data frame, a dtplyr table, or an Arrow table
+#' therefore records nothing, and that zero-row answer is correct rather than
+#' a hole.
+#'
+#' There is one capture, `dbplyr::sql_render()`. It renders in your own
+#' session and sends nothing the call did not already send, so what
+#' *[When marginplyr queries your data][summarize_with_margins]* enumerates is
+#' the same whether or not you are recording.
+#'
+#' [last_sent_queries()] gives four answers, and each of the three that could
+#' look like an empty record is told apart from the others:
+#'
+#' - Nothing has been recorded in this session -- no Margin verb has run --
+#'   and the call is refused with a `"marginplyr_error"`.
+#' - The last call was not audited, the option being unset or holding a value
+#'   other than `TRUE` when the call began, and the call is refused with a
+#'   `"marginplyr_error"` naming `marginplyr.audit_sql`. The option is read
+#'   once, as the call begins; setting it afterwards does not audit a call
+#'   already made.
+#' - The call was audited and sent nothing: a zero-row tibble, the only answer
+#'   with zero rows.
+#' - A statement had no SQL form on this backend -- a translation dbplyr
+#'   refuses when the query is rendered -- and its row holds `NA` in `sql`.
+#'   The call itself is unaffected.
+#'
 #' @section Guides:
 #' - [Get started][g1]
 #' - [Recipes for common reporting tasks][g5]

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -99,6 +99,67 @@ summary expressions run when you collect the result rather than while the
 verb runs, so what they raise is the collecting call's to report.
 }
 
+\section{Recording the SQL marginplyr sends}{
+
+marginplyr keeps no record of the SQL it sends unless you ask for one.
+\code{options(marginplyr.audit_sql = TRUE)} switches the record on, and
+\code{\link[=last_sent_queries]{last_sent_queries()}} reads back what the most recent call sent:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# `sales_db` is a lazy table on a SQL connection.
+old <- options(marginplyr.audit_sql = TRUE)
+
+summarize_with_margins(
+  sales_db,
+  revenue = sum(revenue),
+  .grouping = rollup(region, store)
+)
+
+last_sent_queries()
+options(old)
+}\if{html}{\out{</div>}}
+
+The record is a tibble of two character columns -- \code{purpose}, what the
+query was sent for, and \code{sql}, the statement as it was rendered -- with one
+row per query, in the order the queries were sent. It belongs to a single
+call, being emptied at the start of every one.
+
+\code{"result"} is the one \code{purpose} promised: the query a Margin verb returns
+unexecuted, which your own \code{\link[dplyr:collect]{dplyr::collect()}} is still what runs. Every
+other row is a query marginplyr sends for its own reasons, and the names
+those rows carry are not fixed.
+
+A query is recorded before it is sent, so the record holds what was sent
+rather than what succeeded, and a call that fails leaves readable every
+query it had already sent.
+
+What is recorded is the SQL marginplyr sent, not the execution marginplyr
+caused. An audited call on a data frame, a dtplyr table, or an Arrow table
+therefore records nothing, and that zero-row answer is correct rather than
+a hole.
+
+There is one capture, \code{dbplyr::sql_render()}. It renders in your own
+session and sends nothing the call did not already send, so what
+\emph{\link[=summarize_with_margins]{When marginplyr queries your data}} enumerates is
+the same whether or not you are recording.
+
+\code{\link[=last_sent_queries]{last_sent_queries()}} gives four answers, and each of the three that could
+look like an empty record is told apart from the others:
+\itemize{
+\item Nothing has been recorded in this session -- no Margin verb has run --
+and the call is refused with a \code{"marginplyr_error"}.
+\item The last call was not audited, the option being unset or holding a value
+other than \code{TRUE} when the call began, and the call is refused with a
+\code{"marginplyr_error"} naming \code{marginplyr.audit_sql}. The option is read
+once, as the call begins; setting it afterwards does not audit a call
+already made.
+\item The call was audited and sent nothing: a zero-row tibble, the only answer
+with zero rows.
+\item A statement had no SQL form on this backend -- a translation dbplyr
+refuses when the query is rendered -- and its row holds \code{NA} in \code{sql}.
+The call itself is unaffected.
+}
+}
+
 \section{Guides}{
 
 \itemize{

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -145,8 +145,9 @@ the same whether or not you are recording.
 \code{\link[=last_sent_queries]{last_sent_queries()}} gives four answers, and each of the three that could
 look like an empty record is told apart from the others:
 \itemize{
-\item Nothing has been recorded in this session -- no Margin verb has run --
-and the call is refused with a \code{"marginplyr_error"}.
+\item Nothing has been recorded in this session -- neither a Margin verb nor
+\code{\link[=inspect_grouping]{inspect_grouping()}} has run -- and the call is refused with a
+\code{"marginplyr_error"}.
 \item The last call was not audited, the option being unset or holding a value
 other than \code{TRUE} when the call began, and the call is refused with a
 \code{"marginplyr_error"} naming \code{marginplyr.audit_sql}. The option is read

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -599,7 +599,8 @@ sent$purpose
 
 The record is a tibble of two character columns, `purpose` and `sql`, holding
 one row per query in the order it was sent. It belongs to that one call: the
-next Margin verb empties it and starts again.
+next call to a Margin verb — or to `inspect_grouping()`, which compiles a
+grouping plan and sends queries of its own — empties it and starts again.
 
 `"result"` is the only `purpose` marginplyr promises, and it is the query
 `audit_query` holds:
@@ -621,17 +622,19 @@ collect(audit_query)
 
 Recording adds no query of its own. The capture is `dbplyr::sql_render()`,
 which renders in your session and sends nothing, so the `"selection_proxy"`
-row above — the zero-row read that answers what columns and types the input
-has — was sent whether or not you were recording. Names other than `"result"`
-are marginplyr's own and are not fixed, so match on `"result"` and read the
-rest as context.
+row above was sent whether or not you were recording. *When marginplyr queries
+your data* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+is what enumerates those queries and says which backends receive them. Names
+other than `"result"` are marginplyr's own and are not fixed, so match on
+`"result"` and read the rest as context.
 
 `last_sent_queries()` gives four answers, and it tells apart the three that
-could look like an empty record. It refuses with a marginplyr error when no
-Margin verb has run in this session, and refuses again — naming
-`marginplyr.audit_sql` — when the last call was not audited: the option is read
-once as a call begins, so setting it afterwards cannot audit a call already
-made. An audited call that sent nothing returns a zero-row tibble, the only
+could look like an empty record. It refuses with a marginplyr error when
+nothing has been recorded in this session — neither a Margin verb nor
+`inspect_grouping()` has run. It refuses again, naming `marginplyr.audit_sql`,
+when the last call was not audited: the option is read once as a call begins,
+so setting it afterwards cannot audit a call already made. An audited call that sent nothing returns a zero-row tibble, the only
 answer with zero rows — a data frame, a dtplyr table, and an Arrow table send
 no SQL, so an audited call on one records nothing and that is correct rather
 than a hole. And a statement dbplyr refuses to translate for the backend keeps

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -566,6 +566,99 @@ The
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 states where each backend reports these errors.
 
+## Record the SQL marginplyr sends
+
+The sections above read one query at a time with `show_query()`. An audit
+usually wants all of them, including the ones marginplyr sends for its own
+reasons. `options(marginplyr.audit_sql = TRUE)` records the SQL of a single
+call, and `last_sent_queries()` reads that record back:
+
+```{r}
+#| eval: !expr has_duckdb
+
+old <- options(marginplyr.audit_sql = TRUE)
+
+audit_con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+audit_sales <- copy_to(
+  audit_con,
+  january_sales,
+  name = "january_sales",
+  temporary = TRUE,
+  overwrite = TRUE
+)
+
+audit_query <- audit_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    .grouping = rollup(region, store)
+  )
+
+sent <- last_sent_queries()
+sent$purpose
+```
+
+The record is a tibble of two character columns, `purpose` and `sql`, holding
+one row per query in the order it was sent. It belongs to that one call: the
+next Margin verb empties it and starts again.
+
+`"result"` is the only `purpose` marginplyr promises, and it is the query
+`audit_query` holds:
+
+```{r}
+#| eval: !expr has_duckdb
+
+writeLines(sent$sql[sent$purpose == "result"])
+```
+
+That row is a render and not an execution. `audit_query` is still lazy, and
+your own `collect()` is what runs it, exactly as in the sections above:
+
+```{r}
+#| eval: !expr has_duckdb
+
+collect(audit_query)
+```
+
+Recording adds no query of its own. The capture is `dbplyr::sql_render()`,
+which renders in your session and sends nothing, so the `"selection_proxy"`
+row above — the zero-row read that answers what columns and types the input
+has — was sent whether or not you were recording. Names other than `"result"`
+are marginplyr's own and are not fixed, so match on `"result"` and read the
+rest as context.
+
+`last_sent_queries()` gives four answers, and it tells apart the three that
+could look like an empty record. It refuses with a marginplyr error when no
+Margin verb has run in this session, and refuses again — naming
+`marginplyr.audit_sql` — when the last call was not audited: the option is read
+once as a call begins, so setting it afterwards cannot audit a call already
+made. An audited call that sent nothing returns a zero-row tibble, the only
+answer with zero rows — a data frame, a dtplyr table, and an Arrow table send
+no SQL, so an audited call on one records nothing and that is correct rather
+than a hole. And a statement dbplyr refuses to translate for the backend keeps
+its row with `NA` in `sql`, leaving the call itself unaffected.
+
+Each row is written before its query is sent, so a call that fails leaves
+readable every query it had already sent.
+
+marginplyr writes no file. The tibble is what you write, in whatever format
+your audit takes:
+
+```{r}
+#| eval: false
+
+utils::write.csv(last_sent_queries(), "sent-queries.csv")
+```
+
+The record is per call and nothing accumulates on your behalf, so a batch is
+read one call at a time and bound afterwards.
+
+```{r}
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(audit_con)
+options(old)
+```
+
 ## Backend verification levels
 
 Support is not one status. SQL simulation is useful evidence about rendering,


### PR DESCRIPTION
Closes #402. #318's step 6, written once against the implementation #400 and
#401 settled.

## What changed

**`?marginplyr`** gains `@section Recording the SQL marginplyr sends:` after
*Errors and warnings*. It is not called *Audit signal* — there is no signal,
and the title matches ADR 0027's. It states: the record is off until
`options(marginplyr.audit_sql = TRUE)`; `last_sent_queries()` is how a caller
reads it; the two character columns and their row order; that only `"result"`
is promised; that a row is written before its query is sent, so a failing call
leaves readable everything it had already sent; the SQL-not-execution boundary;
the four answers; and that the one capture is `dbplyr::sql_render()`, a
client-side render that sends nothing the call did not already send. A short
non-executed example in the register of the existing error example.

**`vignettes/database_backends.qmd`** gains *Record the SQL marginplyr sends*
between *Other lazy backends* and *Backend verification levels*, so that it
follows the backends it is about. It runs against a live DuckDB table and shows
the real `c("selection_proxy", "result")` record, renders the `"result"` SQL
with `writeLines()`, and then collects the query — which is the point stated
plainly beside it: that row is a render, not an execution, and the caller's own
`collect()` is still what runs it. The four answers are carried briefly, and
that **marginplyr writes no file** is said in the guide rather than only in the
Rd, with `utils::write.csv(last_sent_queries(), path)` beside it.

**`.github/scripts/verify-site.R`** gains the section heading as a marker for
that page. The section's chunks are all behind `has_duckdb`, so nothing they
produce can serve as one.

`@section When marginplyr queries your data:` is unchanged, which is the same
fact as the capture sentence above: recording sends nothing new, so what that
section enumerates still reaches the connection unasked and only that.

## Gates

- `roxygen2::roxygenise()` — `man/marginplyr-package.Rd` regenerated and committed
- `spelling::spell_check_package()` — no errors
- `lintr::lint_package()` after `pkgload::load_all()` — no lints
- `Rscript .github/scripts/verify-context-budget.R` — within baseline, unmoved
- `Rscript .github/scripts/verify-verifier-invocation.R` — passes
- Full suite with `NOT_CRAN=true` — 6337 pass, 0 fail, 0 skip
- Site rendered from the working tree install; `Rscript .github/scripts/verify-site.R` passes over `docs/`
- `R CMD check` on a built tarball — one NOTE, the worktree's own `.git` file, environmental
- `README.md` not regenerated: no chunk of `README.Rmd` changed