### PR TITLE
Record that the issue tracker is written in English

### DIFF
--- a/design/agents/issue-tracker.md
+++ b/design/agents/issue-tracker.md
@@ -2,6 +2,12 @@
 
 Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
 
+## Language
+
+Everything written to the tracker is in English: issue titles, issue bodies, and comments on them, whichever language the request that prompted them arrived in. The tracker is the one surface where this needs saying, because a request can arrive in another language and be answered where it arrived; every other document here is English because it was authored that way and stays that way by being edited rather than replaced.
+
+An issue is read alongside the files it is about — `AGENTS.md`, `CONTEXT.md`, the ADRs under `design/adr/`, and the code — and it quotes them and is quoted by them. A ticket in another language breaks that in both directions: its quotations no longer match what they quote, and a commit message or an ADR citing it reaches prose its own reader cannot use.
+
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.


### PR DESCRIPTION
`design/agents/issue-tracker.md` gains a *Language* section: issue titles,
bodies, and comments are written in English whichever language the request
that prompted them arrived in.

That file is the home because `AGENTS.md`'s *Issue tracker* entry already
points at it, and because it sits outside the always-loaded closure — the
rule costs `verify-context-budget.R` nothing, and the budget is currently at
its baseline exactly.

The argument the section records is that an issue is read alongside the files
it is about and quotes them, so a ticket in another language breaks the link
in both directions: its quotations stop matching what they quote, and a commit
message or ADR citing it reaches prose its own reader cannot use.

The comment on #402 that prompted this was written in Japanese and has been
rewritten in place.

No review round was run: the diff is one section of one document outside `R/`,
`tests/`, and the always-loaded closure, and `verify-context-budget.R` is the
only gate it could move — it does not.