### PR TITLE
Decide ADR 0022 covers the native adapter's translation error

### DIFF
--- a/design/adr/0021-report-a-repeated-execution-condition-once.md
+++ b/design/adr/0021-report-a-repeated-execution-condition-once.md
@@ -101,8 +101,8 @@ Undoing the styling is also not sufficient by itself for the pointer: the
 stripped link renders the call without the backticks dplyr writes around it
 otherwise, so that pattern admits both spellings.
 
-Evidence: `investigation/dplyr-condition-context-rendering.md`, whose revisions
-section holds the measured report counts, the rendered pointer line, and the
+Evidence: `investigation/dplyr-condition-context-rendering.md`, whose 2026-08-18
+revisions section holds the measured report counts, the rendered pointer line, and the
 two things measured beside them and found not to need changing — the wrap
 indent that survives styling, and the error path that carries no styling at
 all.

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -212,3 +212,65 @@ synthetic condition standing in for a dplyr wording change asserts that a span
 matching nothing is left alone. A restoration that quietly stopped happening
 would otherwise read exactly like a package whose contexts were all still
 faithful.
+
+## Amendment: the native adapter's translation error is restated too
+
+*Considered Options* rejected extending the restatement to the native
+grouping-sets adapter "as covering nothing today, since both backends holding
+the capability are lazy". *Scope* names the exception in the same document — an
+error raised while dbplyr translates the rewritten expression does arrive while
+the verb runs — so the two disagreed about whether anything was there. The
+exception is what is there, and it was never measured. #410 measured it:
+`investigation/what-truncates-an-argument-label-on-the-native-adapter.md`.
+
+The scope therefore includes that error. A caller whose summary expression
+dbplyr cannot translate is quoted the expression they wrote, on duckdb and
+postgres as on a local input, and the sentence above confining the scope to
+`summarize_margin_union()` no longer holds.
+
+What is extended is the restatement and not `with_branch_conditions()`. The
+native adapter issues one `summarize()` and repeats nothing, so the
+deduplication and the grouping-value restatement have nothing to act on; the
+one sentence of the old reasoning that survives is that one. The error is
+caught around that single `summarize()`, `restate_condition_arguments()` is
+applied with the map `branch_argument_map()` builds from the rewritten dots and
+the caller's labels, and it is re-raised. Nothing else about the adapter moves.
+
+Errors only. A branch `summarize()` on a lazy backend still builds a query
+without evaluating the caller's expression, so everything the original
+reasoning covers is still covered by it; a translation *warning* was searched
+for and not produced, and writing the mechanism against an unmeasured shape is
+what the rest of this decision declines to do.
+
+`restate_argument_bullet()`'s pattern requires a trailing period, and dbplyr's
+bullet does not carry one, so the mechanism read the native bullet as matching
+nothing and passed it through even where the map's key already equalled the
+span. The period becomes optional **and is put back as it was found**: rebuilding
+with an unconditional period would add one to dbplyr's sentence, and the sentence
+around the span is dplyr's.
+
+One argument above stops carrying, and this is what replaces it. *dplyr's
+rendering is reproduced only as far as it is observable* rests the #199
+constraint on `as_label()` emitting neither `+...` nor `.data$x`, so that
+dplyr's label of one argument can never equal marginplyr's label of another. On
+the native adapter marginplyr's own label **is** `+...`, because the rewrite
+splices in a SQL literal whose deparse is multi-line — measured, and independent
+of the length of the caller's expression, which is also why the same section's
+"substituting the caller's own would print the same `+...`" is false here. What
+holds instead is the collision drop this decision already specifies: two unnamed
+dots that both collapse to `+...` produce no map entry and leave dplyr's
+quotation standing, and a named dot carries `name = ` into its label, so it
+collides with neither an unnamed dot nor a differently-named one. The constraint
+is met by the degradation rather than by the asymmetry.
+
+Tests assert on rendered messages through `dbplyr::simulate_postgres()`, which
+needs no optional backend, so the native path is asserted wherever the suite
+runs rather than only where a database is installed. Both directions are
+asserted, as above: the restoration, and the collision that leaves dplyr's
+quotation alone.
+
+`R/summarize_with_margins.R` carried this ADR's rejected reasoning beside its
+citation, as a comment saying no condition is raised while the verb runs. It was
+false on the day it was written, and it is the second copy ADR 0023 names: the
+citation would have stayed correct across this amendment and the re-derivation
+did not. It goes.

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -224,53 +224,50 @@ exception is what is there, and it was never measured. #410 measured it:
 `investigation/what-truncates-an-argument-label-on-the-native-adapter.md`.
 
 The scope therefore includes that error. A caller whose summary expression
-dbplyr cannot translate is quoted the expression they wrote, on duckdb and
+dbplyr cannot translate will be quoted the expression they wrote, on duckdb and
 postgres as on a local input, and the sentence above confining the scope to
-`summarize_margin_union()` no longer holds.
+`summarize_margin_union()` no longer holds. #411 implements what follows.
 
 What is extended is the restatement and not `with_branch_conditions()`. The
 native adapter issues one `summarize()` and repeats nothing, so the
-deduplication and the grouping-value restatement have nothing to act on; the
-one sentence of the old reasoning that survives is that one. The error is
-caught around that single `summarize()`, `restate_condition_arguments()` is
-applied with the map `branch_argument_map()` builds from the rewritten dots and
-the caller's labels, and it is re-raised. Nothing else about the adapter moves.
+deduplication and the grouping-value restatement have nothing to act on; the one
+sentence of the old reasoning that survives is that one. The error is caught
+around that single `summarize()`, `restate_condition_arguments()` applied with
+the map `branch_argument_map()` builds from the rewritten dots and the caller's
+labels, and the condition re-raised. Nothing else about the adapter moves.
 
 Errors only. A branch `summarize()` on a lazy backend still builds a query
-without evaluating the caller's expression, so everything the original
-reasoning covers is still covered by it; a translation *warning* was searched
-for and not produced, and writing the mechanism against an unmeasured shape is
-what the rest of this decision declines to do.
+without evaluating the caller's expression, so everything the original reasoning
+covers is still covered by it; a translation *warning* was searched for and not
+produced, and writing the mechanism against an unmeasured shape is what the rest
+of this decision declines to do.
 
 `restate_argument_bullet()`'s pattern requires a trailing period, and dbplyr's
-bullet does not carry one, so the mechanism read the native bullet as matching
-nothing and passed it through even where the map's key already equalled the
-span. The period becomes optional **and is put back as it was found**: rebuilding
-with an unconditional period would add one to dbplyr's sentence, and the sentence
+bullet does not carry one, so the mechanism reads the native bullet as matching
+nothing and passes it through even where the map's key already equals the span.
+The period becomes optional **and is put back as it was found**: rebuilding with
+an unconditional period would add one to dbplyr's sentence, and the sentence
 around the span is dplyr's.
 
 One argument above stops carrying, and this is what replaces it. *dplyr's
 rendering is reproduced only as far as it is observable* rests the #199
-constraint on `as_label()` emitting neither `+...` nor `.data$x`, so that
-dplyr's label of one argument can never equal marginplyr's label of another. On
-the native adapter marginplyr's own label **is** `+...`, because the rewrite
-splices in a SQL literal whose deparse is multi-line — measured, and independent
-of the length of the caller's expression, which is also why the same section's
-"substituting the caller's own would print the same `+...`" is false here. What
-holds instead is the collision drop this decision already specifies: two unnamed
-dots that both collapse to `+...` produce no map entry and leave dplyr's
-quotation standing, and a named dot carries `name = ` into its label, so it
-collides with neither an unnamed dot nor a differently-named one. The constraint
-is met by the degradation rather than by the asymmetry.
+constraint on `as_label()` emitting neither `+...` nor `.data$x`, so that dplyr's
+label of one argument can never equal marginplyr's label of another. On the
+native adapter marginplyr's own label **is** `+...`, and the same measurement
+makes that section's "substituting the caller's own would print the same `+...`"
+false here. What holds in its place is the rule *The identification is a test
+against marginplyr's own rendering* already states: a label two dots share is
+restored only where the callers' own labels agree as well, and left as dplyr
+wrote it where they do not. The constraint is met by that degradation rather
+than by the asymmetry.
 
 Tests assert on rendered messages through `dbplyr::simulate_postgres()`, which
-needs no optional backend, so the native path is asserted wherever the suite
-runs rather than only where a database is installed. Both directions are
-asserted, as above: the restoration, and the collision that leaves dplyr's
-quotation alone.
+needs no optional backend, so the native path is asserted wherever the suite runs
+rather than only where a database is installed. Both directions are asserted, as
+above: the restoration, and the shared label that leaves dplyr's quotation alone.
 
-`R/summarize_with_margins.R` carried this ADR's rejected reasoning beside its
+`R/summarize_with_margins.R` carries this ADR's rejected reasoning beside its
 citation, as a comment saying no condition is raised while the verb runs. It was
 false on the day it was written, and it is the second copy ADR 0023 names: the
-citation would have stayed correct across this amendment and the re-derivation
-did not. It goes.
+citation stays correct across this amendment and the re-derivation did not. It
+goes with #411.

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -215,11 +215,13 @@ does not decide it there, and the truncation is marginplyr's.
 another."** That followed from `as_label()` emitting neither `+...` nor
 `.data$x`. On the native adapter marginplyr's own label *is* `+...`, so the
 asymmetry is gone and the property #199's hard constraint needs no longer
-follows from it. What was measured to hold in its place is the collision drop
-`branch_argument_map()` already performs: two unnamed dots that both collapse
-to `+...` yield no map entry and leave dplyr's quotation standing, and a named
-dot carries `name = ` into its label, so it collides with neither an unnamed
-dot nor a differently-named one.
+follows from it. What holds in its place is the rule
+`branch_argument_map()` already applies to a shared label: two unnamed dots
+that both collapse to `+...` yield no map entry where the callers spelled them
+differently, and the entry is kept where they spelled them alike, the
+restoration being unique whichever dot dplyr meant. A named dot carries
+`name = ` into its label, so it shares a label with neither an unnamed dot nor
+a differently-named one.
 
 Neither correction reaches the eager path, where the measurements above stand
 as taken.

--- a/investigation/dplyr-condition-context-rendering.md
+++ b/investigation/dplyr-condition-context-rendering.md
@@ -2,6 +2,7 @@
 
 Investigated: 2026-08-18
 Revised: 2026-08-18 — ADR 0021
+Revised: 2026-09-04 — investigation/what-truncates-an-argument-label-on-the-native-adapter.md
 
 Measured while implementing #199, which asked for a Condition context quoting
 the caller's own spelling of a summary argument. ADR 0022 records the decision
@@ -195,6 +196,33 @@ Continuation lines began with two literal spaces ahead of any escape at
 all in `$message` or `$body` — rlang holds the bare bullets and cli formats
 them at print — so a reading that removes styling was a no-op on the error
 path.
+
+## Revisions (2026-09-04)
+
+Two claims in *How dplyr renders the label* were established on the eager path
+and do not hold on the native grouping-sets adapter.
+`investigation/what-truncates-an-argument-label-on-the-native-adapter.md` is
+the note that established the correction, and holds the measurements.
+
+**"The abbreviation is dplyr's and not a marginplyr artefact."** Measured here
+on a long infix expression, and true of it. On the native adapter the label is
+truncated because `rewrite_grouping_dots()` splices in a `dbplyr` SQL literal
+whose deparse is multi-line, so `rlang::as_label()` answers `+...` for
+`grouping_bit(a)`'s rewrite on its own. The length of the caller's expression
+does not decide it there, and the truncation is marginplyr's.
+
+**"dplyr's label of one argument can never equal marginplyr's label of
+another."** That followed from `as_label()` emitting neither `+...` nor
+`.data$x`. On the native adapter marginplyr's own label *is* `+...`, so the
+asymmetry is gone and the property #199's hard constraint needs no longer
+follows from it. What was measured to hold in its place is the collision drop
+`branch_argument_map()` already performs: two unnamed dots that both collapse
+to `+...` yield no map entry and leave dplyr's quotation standing, and a named
+dot carries `name = ` into its label, so it collides with neither an unnamed
+dot nor a differently-named one.
+
+Neither correction reaches the eager path, where the measurements above stand
+as taken.
 
 ## Searched for and not found
 

--- a/investigation/what-truncates-an-argument-label-on-the-native-adapter.md
+++ b/investigation/what-truncates-an-argument-label-on-the-native-adapter.md
@@ -1,0 +1,202 @@
+# What truncates an argument label on the native grouping-sets adapter
+
+Investigated: 2026-09-04
+
+ADR 0022 confines the Condition-context restatement to `summarize_margin_union()`
+and rejects extending it to the native grouping-sets adapter "as covering nothing
+today, since both backends holding the capability are lazy". Its own *Scope*
+section names an exception to that reasoning — an error dbplyr raises while it
+translates the rewritten expression does arrive while the verb runs — and leaves
+it quoting the rewrite. This note measures that exception: what the caller is
+shown today, why the label is unreadable, and whether the mechanism ADR 0022
+already has would restore it if applied there. It was prompted by #410.
+
+Everything below was run against marginplyr at `4f367b4` with R 4.6.1,
+dplyr 1.2.1, dbplyr 2.6.0, rlang 1.3.0, and cli 3.6.6, on a live DuckDB
+connection (duckdb 1.5.5) and on `dbplyr::simulate_postgres()`, which agreed.
+
+## Method, and which measurements are simulations
+
+Nothing under `R/` was modified. The SQL-rewritten dots the native adapter hands
+dplyr were captured during execution with
+`trace(rewrite_grouping_dots, where = asNamespace("marginplyr"))`, and the
+package's own `summary_argument_labels()`, `branch_argument_map()`, and
+`restate_condition_arguments()` (all `R/conditions.R`) were then applied to the
+real condition objects.
+
+Two measurements are therefore **simulations**, and are marked as such below: the
+native adapter does not call that machinery on this date, so the package's real
+functions were applied to the real condition after the fact rather than observed
+firing in place. Everything else is an observation of an unmodified call.
+
+## The bullet a native-path translation error carries
+
+Measured on
+`summarize_with_margins(remote, total = sum(value) + grouping_bit(a) + no_such_column, .grouping = rollup(a))`:
+
+```
+ℹ In argument: `total = +...`
+Caused by error:
+! Object `no_such_column` not found.
+```
+
+The condition chain has the shape ADR 0022 assumes for an error — the argument
+bullet alone, the marker being the element's name rather than part of its text,
+and the caller's diagnostic in `$parent`:
+
+```
+-- chain[[1]] class: rlang_error/error/condition
+   message[1] (name="i"): "In argument: `total = +...`"
+-- chain[[2]] class: rlang_error/error/condition
+   message[1] (name=NULL): "Object `no_such_column` not found."
+```
+
+The same call on a local input, where the restatement applies, renders:
+
+```
+ℹ In argument: `total = sum(value) + grouping_bit(a) + no_such_column`.
+ℹ In group 1: `a = "x"`.
+Caused by error:
+! object 'no_such_column' not found
+```
+
+## What truncates the label
+
+Not the length of the caller's expression. Three readings settle it.
+
+Handing dbplyr's lazy `summarize()` an expression of the caller's own shape
+produces an untruncated bullet:
+
+```
+ℹ In argument: `total = sum(value) + 0L + no_such_column`
+Caused by error:
+! Object `no_such_column` not found.
+```
+
+A shorter caller expression is truncated all the same:
+`total = grouping_bit(a) + no_such_column` renders `` `total = +...` ``.
+
+And `rlang::as_label()` over the rewrite itself, in isolation:
+
+| expression | `as_label()` |
+|---|---|
+| a bare `dbplyr::sql_glue2()` literal | `<sql>` |
+| `grouping_bit(a)`'s rewrite alone, `sql = TRUE` | `+...` |
+| `sum(value) + <sql literal>` | `+...` |
+
+So what truncates the label is that the rewrite splices in a SQL literal whose
+deparse is multi-line. The consequence is that native-path translation errors are
+unreadable across the board rather than in a long-expression corner: any dot
+combining a helper with anything else labels as `+...`, and the one case that
+escapes — a dot that is the helper alone — labels as `<sql>`, which names the
+caller's expression no better.
+
+## The span, marginplyr's own label, and uniqueness
+
+`summary_argument_labels()` over the captured rewritten dots answers
+`total = +...`, identical to the span dplyr put in the bullet. Read with the
+trailing period made optional (see below):
+
+```
+relaxed span: "total = +..." 
+span == marginplyr's rewritten label: TRUE 
+span matches exactly one label: TRUE 
+```
+
+`rlang::as_label()` of the caller's own spelling is
+`total = sum(value) + grouping_bit(a) + no_such_column`, with no `...` in it, so
+what a substitution would put back is readable.
+
+`branch_argument_map()` over the captured dots and the caller's labels builds
+
+```
+                                           total = +... 
+"total = sum(value) + grouping_bit(a) + no_such_column" 
+```
+
+## One byte separates the two bullet formats
+
+The bullets differ in exactly one character:
+
+```
+native bullet: "In argument: `total = +...`"                                      ends with '.': FALSE
+local  bullet: "In argument: `total = sum(value) + grouping_bit(a) + no_such_column`."  ends with '.': TRUE
+```
+
+`restate_argument_bullet()` (`R/conditions.R:506-519`) matches
+`` "^([iℹ] )?In argument: `(.*)`\\.$" ``, which requires the period. Programmatic
+extraction of the native bullet with that pattern returns `character(0)`: the
+pattern does not match, so no span is read and the map is never consulted, even
+though its key already equals the span.
+
+The pattern was written against eager dplyr's bullet, which carries the period.
+dbplyr's does not.
+
+## End to end (simulation)
+
+**(a) With the mechanism exactly as it stands.**
+`restate_condition_arguments(err, map)` returns the message unchanged, and so
+does wrapping the failing `summarize()` in `with_branch_conditions()`. The cause
+is the period alone.
+
+**(b) With the trailing period made optional in the bullet reader**, everything
+else being the package's own map and run reading:
+
+```
+ℹ In argument: `total = sum(value) + grouping_bit(a) + no_such_column`
+Caused by error:
+! Object `no_such_column` not found.
+```
+
+The restoration is a string-level substitution performed on a message that
+already exists, so there is no stage at which the substituted caller label could
+be truncated a second time.
+
+## The uniqueness boundary
+
+Two *unnamed* dots that both collapse to `+...` collide. `branch_argument_map()`
+finds no single candidate and drops the entry:
+
+```
+labels of two unnamed rewritten dots:
+[1] "+..." "+..."
+map built from them:
+named character(0)
+```
+
+so dplyr's own quotation stands, which is the degradation ADR 0022 documents. A
+named dot carries `name = ` into its label, so it can collide with neither an
+unnamed dot nor a differently-named one.
+
+## What this overturns
+
+Two claims in `investigation/dplyr-condition-context-rendering.md` (2026-08-18)
+were established on the eager path and do not hold on this one. That note gains a
+revisions entry pointing here.
+
+- *"the abbreviation is dplyr's and not a marginplyr artefact."* True there, where
+  it was measured on a long infix expression. On the native path the truncation is
+  produced by marginplyr's own rewrite, and the length of the caller's expression
+  does not decide it.
+- *"dplyr's label of one argument can never equal marginplyr's label of another,
+  which is the property #199's hard constraint needed."* That rested on
+  `as_label()` emitting neither `+...` nor `.data$x`. On the native path
+  marginplyr's own label **is** `+...`, so the asymmetry is gone. What was measured
+  to hold in its place is the collision drop above: a colliding label yields no map
+  entry, and a named dot cannot collide with an unnamed one.
+
+ADR 0022's *"substituting the caller's own would print the same `+...`"* is false
+for this case for the first of those reasons, and its *Considered Options*
+rejection of extending the restatement is not supported by "covering nothing
+today": the case exists on both backends holding the capability, on this date.
+
+## Searched for and not found
+
+- No condition field naming the failing dot on the native path either — the
+  chain carries the same two links and nothing else, so the identification is a
+  text comparison here for the same reason the 2026-08-18 note gives.
+- No dbplyr option, connection field, or `simulate_*` variant that changes the
+  bullet's trailing punctuation; the two spellings come from dplyr's eager path
+  and dbplyr's respectively.
+- No translation *warning* was produced by any expression tried, so whether the
+  warning shape reaches this path is unestablished rather than ruled out.

--- a/investigation/what-truncates-an-argument-label-on-the-native-adapter.md
+++ b/investigation/what-truncates-an-argument-label-on-the-native-adapter.md
@@ -7,9 +7,10 @@ and rejects extending it to the native grouping-sets adapter "as covering nothin
 today, since both backends holding the capability are lazy". Its own *Scope*
 section names an exception to that reasoning — an error dbplyr raises while it
 translates the rewritten expression does arrive while the verb runs — and leaves
-it quoting the rewrite. This note measures that exception: what the caller is
-shown today, why the label is unreadable, and whether the mechanism ADR 0022
-already has would restore it if applied there. It was prompted by #410.
+it quoting the rewrite. This note measures that exception on the date above:
+what the caller was shown, why the label is unreadable, and whether the
+mechanism ADR 0022 already has would restore it if applied there. It was
+prompted by #410.
 
 Everything below was run against marginplyr at `4f367b4` with R 4.6.1,
 dplyr 1.2.1, dbplyr 2.6.0, rlang 1.3.0, and cli 3.6.6, on a live DuckDB
@@ -80,8 +81,8 @@ And `rlang::as_label()` over the rewrite itself, in isolation:
 
 | expression | `as_label()` |
 |---|---|
-| a bare `dbplyr::sql_glue2()` literal | `<sql>` |
-| `grouping_bit(a)`'s rewrite alone, `sql = TRUE` | `+...` |
+| a bare SQL literal — what a dot that is `grouping_bit(a)` alone rewrites to | `<sql>` |
+| `<sql literal> + 1` | `+...` |
 | `sum(value) + <sql literal>` | `+...` |
 
 So what truncates the label is that the rewrite splices in a SQL literal whose
@@ -154,8 +155,9 @@ be truncated a second time.
 
 ## The uniqueness boundary
 
-Two *unnamed* dots that both collapse to `+...` collide. `branch_argument_map()`
-finds no single candidate and drops the entry:
+Two *unnamed* dots that both collapse to `+...` share a label. Where the callers
+spelled them differently, `branch_argument_map()` finds no single candidate and
+drops the entry — measured on two such dots:
 
 ```
 labels of two unnamed rewritten dots:
@@ -164,31 +166,12 @@ map built from them:
 named character(0)
 ```
 
-so dplyr's own quotation stands, which is the degradation ADR 0022 documents. A
-named dot carries `name = ` into its label, so it can collide with neither an
-unnamed dot nor a differently-named one.
-
-## What this overturns
-
-Two claims in `investigation/dplyr-condition-context-rendering.md` (2026-08-18)
-were established on the eager path and do not hold on this one. That note gains a
-revisions entry pointing here.
-
-- *"the abbreviation is dplyr's and not a marginplyr artefact."* True there, where
-  it was measured on a long infix expression. On the native path the truncation is
-  produced by marginplyr's own rewrite, and the length of the caller's expression
-  does not decide it.
-- *"dplyr's label of one argument can never equal marginplyr's label of another,
-  which is the property #199's hard constraint needed."* That rested on
-  `as_label()` emitting neither `+...` nor `.data$x`. On the native path
-  marginplyr's own label **is** `+...`, so the asymmetry is gone. What was measured
-  to hold in its place is the collision drop above: a colliding label yields no map
-  entry, and a named dot cannot collide with an unnamed one.
-
-ADR 0022's *"substituting the caller's own would print the same `+...`"* is false
-for this case for the first of those reasons, and its *Considered Options*
-rejection of extending the restatement is not supported by "covering nothing
-today": the case exists on both backends holding the capability, on this date.
+so dplyr's own quotation stands, which is the degradation ADR 0022 documents.
+Where the callers spelled them alike the entry is kept, the restoration being
+unique whichever dot dplyr meant — the rule the ADR body already states, read
+here off `R/conditions.R:390-397` rather than measured. A named dot carries
+`name = ` into its label, so it shares a label with neither an unnamed dot nor a
+differently-named one.
 
 ## Searched for and not found
 


### PR DESCRIPTION
Records the decision on #410 and lands the evidence. Implementation is #411; no `R/` file changes here.

## What was decided

ADR 0022 rejected extending the Condition-context restatement to the native grouping-sets adapter "as covering nothing today, since both backends holding the capability are lazy", while its own *Scope* section named the exception that reasoning misses. #410 measured it, and neither claim holding up the rejection survived:

- The stated reason is contradicted by the ADR's own Scope section — a dbplyr translation error does arrive while the verb runs.
- The crux sentence supporting it, "substituting the caller's own would print the same `+...`", is false for this case. The truncation comes from `rewrite_grouping_dots()` splicing in a `dbplyr` `sql` object whose own `deparse()` is 59 characters, against the width of 60 at which `as_label()` deparses the whole expression — so anything spliced beside it overflows and rlang replaces the call's arguments with `...`. The caller's expression length does not decide it, and the restoration is a string-level substitution with no second truncation stage.

The case is not a corner: every dot combining a helper with anything else renders `+...`, and a dot that is the helper alone renders `<sql>`. The same call on a local input quotes the caller correctly, so today the backend decides the quality of the diagnostic — the asymmetry ADR 0022 exists to remove. `CONTEXT.md`'s *Condition context* entry already promises the restatement without qualification.

## The part most easily lost

ADR 0022 rests #199's hard constraint on "`as_label()` emits neither `+...` nor `.data$x`, so dplyr's label of one argument can never equal marginplyr's label of another." On the native adapter marginplyr's own label **is** `+...`, so that asymmetry is gone. The amendment replaces the argument rather than dropping it: what holds instead is the rule the decision already specifies for a shared label — a label two dots share is restored only where the *callers'* own labels agree as well, and left as dplyr wrote it where they do not; and a named dot carries `name = ` into its label, so it shares a label with neither an unnamed dot nor a differently-named one. Extending the mechanism without writing this down would leave the constraint resting on a sentence that had become false.

## Files

| file | what changed |
|---|---|
| `investigation/what-truncates-an-argument-label-on-the-native-adapter.md` | new — the measurements, with the two simulated steps marked as such |
| `investigation/dplyr-condition-context-rendering.md` | `Revised:` line and a `Revisions (2026-09-04)` section: two of its claims were established on the eager path and do not hold on this one |
| `design/adr/0022-...` | *Amendment: the native adapter's translation error is restated too* |
| `design/adr/0021-...` | citation narrowed to the note's 2026-08-18 revisions section, there now being two |

The evidence goes to a dated note rather than into the ADR, per `investigation/README.md`'s *Authority*: the note is authoritative for what was measured, the ADR for the decision.

Closes #410.

