### PR TITLE
Keep a declared NA factor level across the dtplyr branch union

### DIFF
--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -101,10 +101,10 @@ margin_column_info <- function(data_proxy,
           # is at risk, only a union that drops one puts it there, and only a
           # sentinel keeps a value on that level apart from the typed missing
           # a margin row carries, which `as.character()` spells the same way
-          # (ADR 0012). The backend is read here because this is the one place
-          # it is, and both sides of the route -- `label_margin_branch()` and
-          # `restore_margin_factors()` -- then read one answer rather than
-          # deciding twice.
+          # (ADR 0012). Settled here so that both sides of the route --
+          # `label_margin_branch()` and `restore_margin_factors()` -- read one
+          # answer rather than deciding twice, which is what they would do:
+          # neither is handed the backend.
           encode_missing_label = has_na_in_level &&
             backend$drops_na_factor_level_on_union &&
             backend$can_encode_factor_missing_values

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -88,12 +88,26 @@ margin_column_info <- function(data_proxy,
       names(schema)[vapply(schema, is.factor, logical(1))],
       function(col) {
         x <- schema[[col]]
+        has_na_in_level <- anyNA(levels(x))
         list(
           col = col,
           levels = levels(x),
           ordered = is.ordered(x),
-          has_na_in_level = anyNA(levels(x)),
-          preserve_missing_value = backend$can_encode_factor_missing_values
+          has_na_in_level = has_na_in_level,
+          preserve_missing_value = backend$can_encode_factor_missing_values,
+          # Whether this column takes the encode-and-rebuild route even where
+          # its Margin label is missing and so adds no level. All three terms
+          # are necessary and none is implied by the others: only an NA level
+          # is at risk, only a union that drops one puts it there, and only a
+          # sentinel keeps a value on that level apart from the typed missing
+          # a margin row carries, which `as.character()` spells the same way
+          # (ADR 0012). The backend is read here because this is the one place
+          # it is, and both sides of the route -- `label_margin_branch()` and
+          # `restore_margin_factors()` -- then read one answer rather than
+          # deciding twice.
+          encode_missing_label = has_na_in_level &&
+            backend$drops_na_factor_level_on_union &&
+            backend$can_encode_factor_missing_values
         )
       }
     )

--- a/R/factor.R
+++ b/R/factor.R
@@ -19,22 +19,17 @@ encodes_missing_label_factor <- function(info, label) {
   is_missing_margin_label(label) && isTRUE(info$encode_missing_label)
 }
 
-# The sentinel each such column is carried as, keyed by column; empty where no
-# column takes the route. Built once per branch so that the value a branch
-# omitting the dimension writes is the one the branches including it encode to.
-missing_label_sentinels <- function(factor_info, margin_labels) {
-  encoded <- Filter(
-    function(info) {
-      encodes_missing_label_factor(info, margin_labels[[info$col]])
-    },
-    factor_info
-  )
+# The sentinel each factor dimension is carried as while it crosses the branch
+# union as character, keyed by column. Derived once so that the value a branch
+# omitting the dimension writes is the one the branches including it encode to,
+# rather than the two arms deriving it apart.
+margin_factor_sentinels <- function(factor_info, margin_labels) {
   stats::setNames(
     lapply(
-      encoded,
+      factor_info,
       function(info) factor_missing_sentinel(info, margin_labels[[info$col]])
     ),
-    vapply(encoded, function(info) info$col, character(1))
+    vapply(factor_info, function(info) info$col, character(1))
   )
 }
 

--- a/R/factor.R
+++ b/R/factor.R
@@ -11,6 +11,33 @@ factor_missing_sentinel <- function(info, .margin_name) {
   sentinel
 }
 
+# Whether a factor dimension crosses the branch union as character despite a
+# missing Margin label, which is what `encode_missing_label` in
+# `R/backend-metadata.R` records for the column. Both sides of the route read
+# this, so neither can encode what the other does not rebuild.
+encodes_missing_label_factor <- function(info, label) {
+  is_missing_margin_label(label) && isTRUE(info$encode_missing_label)
+}
+
+# The sentinel each such column is carried as, keyed by column; empty where no
+# column takes the route. Built once per branch so that the value a branch
+# omitting the dimension writes is the one the branches including it encode to.
+missing_label_sentinels <- function(factor_info, margin_labels) {
+  encoded <- Filter(
+    function(info) {
+      encodes_missing_label_factor(info, margin_labels[[info$col]])
+    },
+    factor_info
+  )
+  stats::setNames(
+    lapply(
+      encoded,
+      function(info) factor_missing_sentinel(info, margin_labels[[info$col]])
+    ),
+    vapply(encoded, function(info) info$col, character(1))
+  )
+}
+
 encode_factor_for_margin <- function(x,
                                      missing_sentinel,
                                      preserve_missing_value) {
@@ -72,8 +99,15 @@ restore_margin_factors <- function(.data,
   Reduce(
     function(data, info) {
       label <- margin_labels[[info$col]]
+      # A missing label adds no level, so a column the branches carried as
+      # their own class arrives with its levels already intact. The exception
+      # is one that crossed the union as character to keep them, which is
+      # rebuilt on its declared levels: `NULL` appends none.
       if (is_missing_margin_label(label)) {
-        return(data)
+        if (!encodes_missing_label_factor(info, label)) {
+          return(data)
+        }
+        return(reconstruct_factor(data, info, NULL, position = position))
       }
       reconstruct_factor(data, info, label, position = position)
     },

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -64,7 +64,8 @@ backend_capabilities <- function(kind) {
     "native_grouping_sets",
     "native_duplicate_sets",
     "records_window_order",
-    "invents_row_on_column_add"
+    "invents_row_on_column_add",
+    "drops_na_factor_level_on_union"
   )
   enabled <- list(
     local = c(
@@ -85,7 +86,17 @@ backend_capabilities <- function(kind) {
       # column-less one a column and stays empty, and a SQL table with no
       # columns cannot be constructed at all. `other` is granted nothing, so
       # an unrecognised backend keeps the ordinary attachment.
-      "invents_row_on_column_add"
+      "invents_row_on_column_add",
+      # `data.table`'s rbind drops a declared NA factor level from the result
+      # and turns the values that used it into missing codes, whatever the
+      # branches held -- it does so for a list of one table. Every branch list
+      # this kind produces is combined that way, so a dimension carrying such
+      # a level has to cross the union as character and be rebuilt after it
+      # (#408). No other kind is granted this: a local frame's `bind_rows()`
+      # keeps the level, and the two that lose it -- duckdb drops it on the
+      # way in and arrow refuses the column outright -- lose it before any
+      # branch exists, which is outside what marginplyr promises (ADR 0016).
+      "drops_na_factor_level_on_union"
     ),
     arrow = "can_read_schema",
     duckdb = c(

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -381,10 +381,17 @@ label_margin_branch <- function(.data,
     function(col) !is_missing_margin_label(margin_labels[[col]]),
     included
   )
+  # Keyed by column, and empty unless the union would drop a declared NA level
+  # (`encodes_missing_label_factor()`). A branch reads it twice, and the two
+  # reads are what put a column on one side of the union in the encoding the
+  # other side carries.
+  sentinels <- missing_label_sentinels(factor_info, margin_labels)
   encoded_factors <- Filter(
     function(info) {
-      info$col %in% labelled_included &&
-        isTRUE(info$preserve_missing_value)
+      info$col %in% included &&
+        (info$col %in% names(sentinels) ||
+           (info$col %in% labelled_included &&
+              isTRUE(info$preserve_missing_value)))
     },
     factor_info
   )
@@ -443,6 +450,14 @@ label_margin_branch <- function(.data,
           return(rlang::expr(rep(!!label, dplyr::n())))
         }
         return(label)
+      }
+      if (col %in% names(sentinels)) {
+        # The typed missing this margin row carries, spelled as the included
+        # branches spell one. `as.character()` of the prototype cannot: it is
+        # `NA`, which is also what a value on the NA level becomes, and the
+        # union is where the two would stop being distinguishable (ADR 0012).
+        # Full size for the reason the labelled arm above is.
+        return(rlang::expr(rep(!!sentinels[[col]], dplyr::n())))
       }
       value <- prototypes[[col]]
       if (is.null(value)) NA else value

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -381,15 +381,26 @@ label_margin_branch <- function(.data,
     function(col) !is_missing_margin_label(margin_labels[[col]]),
     included
   )
-  # Keyed by column, and empty unless the union would drop a declared NA level
-  # (`encodes_missing_label_factor()`). A branch reads it twice, and the two
-  # reads are what put a column on one side of the union in the encoding the
-  # other side carries.
-  sentinels <- missing_label_sentinels(factor_info, margin_labels)
+  sentinels <- margin_factor_sentinels(factor_info, margin_labels)
+  # Columns whose Margin label is missing and which cross the union as
+  # character anyway, because it would otherwise drop their declared NA level
+  # (`encodes_missing_label_factor()`). Empty on every other backend, and the
+  # set is read from the whole plan rather than from this branch so that both
+  # arms below put the column in the same encoding.
+  missing_label_encoded <- vapply(
+    Filter(
+      function(info) {
+        encodes_missing_label_factor(info, margin_labels[[info$col]])
+      },
+      factor_info
+    ),
+    function(info) info$col,
+    character(1)
+  )
   encoded_factors <- Filter(
     function(info) {
       info$col %in% included &&
-        (info$col %in% names(sentinels) ||
+        (info$col %in% missing_label_encoded ||
            (info$col %in% labelled_included &&
               isTRUE(info$preserve_missing_value)))
     },
@@ -401,14 +412,10 @@ label_margin_branch <- function(.data,
       encoded_factors,
       function(info) {
         col <- info$col
-        missing_sentinel <- factor_missing_sentinel(
-          info,
-          margin_labels[[col]]
-        )
         rlang::expr(
           encode_factor_for_margin(
             !!margin_column_pronoun(col),
-            missing_sentinel = !!missing_sentinel,
+            missing_sentinel = !!sentinels[[col]],
             preserve_missing_value = TRUE
           )
         )
@@ -451,7 +458,7 @@ label_margin_branch <- function(.data,
         }
         return(label)
       }
-      if (col %in% names(sentinels)) {
+      if (col %in% missing_label_encoded) {
         # The typed missing this margin row carries, spelled as the included
         # branches spell one. `as.character()` of the prototype cannot: it is
         # `NA`, which is also what a value on the NA level becomes, and the

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -39,8 +39,12 @@ factor_contract_data <- function(has_na_level, has_missing_value) {
   )
 }
 
-test_that("factor NA levels and missing values obey the eight-case contract", {
-  cases <- data.frame(
+# The eight rows of ADR 0012's table, in its order. Shared rather than written
+# per backend: what the dtplyr test below asserts is that the contract does not
+# depend on which backend the call was handed (#408), and a second copy of the
+# table could only weaken that.
+factor_contract_cases <- function() {
+  data.frame(
     label = c(rep("NA", 4L), rep("NULL", 4L)),
     na_level = rep(c(TRUE, TRUE, FALSE, FALSE), 2L),
     missing_value = rep(c(TRUE, FALSE, TRUE, FALSE), 2L),
@@ -49,6 +53,10 @@ test_that("factor NA levels and missing values obey the eight-case contract", {
     # holding a missing value, so neither is refused for producing it.
     errors = c(TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE)
   )
+}
+
+test_that("factor NA levels and missing values obey the eight-case contract", {
+  cases <- factor_contract_cases()
 
   for (i in seq_len(nrow(cases))) {
     case <- cases[i, ]
@@ -79,6 +87,131 @@ test_that("factor NA levels and missing values obey the eight-case contract", {
       expect_identical(margin$n, 2L)
       expect_identical(levels(result$group), levels(data$group))
     }
+  }
+})
+
+# The same eight rows on the one backend that can lose one of them. The local
+# branches are combined by `bind_rows()`, which keeps a declared NA level;
+# dtplyr combines them with `data.table`'s rbind, which drops one outright and
+# turns the values that used it into missing codes, so the row that preserves
+# an NA level under a typed-missing label went missing there with no diagnostic
+# (#408). dtplyr is where this is asserted because it is the only backend that
+# preserves such a level at all -- a plain duckdb round trip already drops it
+# and arrow refuses the column -- so it is the only one ADR 0012's "local and
+# factor-preserving lazy adapters" clause reaches.
+#
+# Each case is compared against the local result rather than against a literal,
+# because what the contract says is that the two agree.
+# A result's rows in an order both backends produce. Two are compared here and
+# they place a missing value within one grouping set differently -- the local
+# branch puts it last and `data.table` puts it first -- which is an ordering
+# property ADR 0018 leaves to the backend and not what these cases assert.
+#
+# The integer code is what is compared rather than the displayed value: it is
+# the only reading that separates a value on an NA level, which has one, from
+# the typed missing a margin row carries, which has none.
+factor_contract_rows <- function(result) {
+  rows <- data.frame(
+    code = as.integer(result$group),
+    bit = result$bit,
+    n = result$n
+  )
+  rows <- rows[order(rows$code, rows$bit, rows$n, na.last = TRUE), ]
+  row.names(rows) <- NULL
+  rows
+}
+
+test_that("dtplyr obeys the eight-case contract as the local backend does", {
+  skip_if_suggest_absent("dtplyr")
+  cases <- factor_contract_cases()
+
+  for (i in seq_len(nrow(cases))) {
+    case <- cases[i, ]
+    data <- factor_contract_data(case$na_level, case$missing_value)
+    label <- if (case$label == "NA") NA_character_ else NULL
+    info <- paste(case, collapse = "/")
+    operation <- function(input) {
+      summarize_with_margins(
+        input,
+        n = dplyr::n(),
+        bit = grouping_bit(group),
+        .grouping = rollup(group),
+        .margin_label = label
+      )
+    }
+
+    if (case$errors) {
+      error <- expect_error(operation(dtplyr::lazy_dt(data)), info = info)
+      expect_s3_class(error, "marginplyr_error")
+      next
+    }
+
+    result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+    expected <- operation(data)
+    expect_s3_class(result$group, "factor")
+    expect_identical(levels(result$group), levels(data$group), info = info)
+    expect_identical(
+      levels(result$group),
+      levels(expected$group),
+      info = info
+    )
+    expect_identical(
+      factor_contract_rows(result),
+      factor_contract_rows(expected),
+      info = info
+    )
+  }
+})
+
+# The eight cases above declare an NA level that no value uses, so they assert
+# the level survives and not that a value on it stays distinguishable from the
+# typed missing a margin row carries. That distinction is the whole of what
+# ADR 0012 separates, and it is what an encoding that merely restored the
+# levels would lose: `as.character()` spells both as `NA`.
+test_that("dtplyr keeps a used NA level apart from a typed missing", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.frame(
+    group = structure(
+      c(1L, 2L),
+      levels = c("x", NA_character_),
+      class = "factor"
+    ),
+    value = 1:2
+  )
+
+  # Both branch-building verbs, because the branch union they share is where
+  # the level was lost; the Grouping set identifier is what says which rows a
+  # branch stands for, since the displayed value cannot.
+  queries <- list(
+    summarize_with_margins = summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      n = dplyr::n(),
+      .grouping = rollup(group),
+      .margin_label = NULL,
+      .id = "set"
+    ),
+    expand_with_margins = expand_with_margins(
+      dtplyr::lazy_dt(data),
+      .grouping = rollup(group),
+      .margin_label = NULL,
+      .id = "set"
+    )
+  )
+
+  for (verb in names(queries)) {
+    result <- dplyr::collect(queries[[verb]])
+    expect_identical(levels(result$group), c("x", NA), info = verb)
+    source_rows <- result[result$set == 1L, , drop = FALSE]
+    margin_rows <- result[result$set == 2L, , drop = FALSE]
+    # The source row that uses the NA level prints as `<NA>` while `is.na()`
+    # is false; every margin row is a typed missing, where it is true.
+    expect_identical(
+      sort(as.integer(source_rows$group)),
+      c(1L, 2L),
+      info = verb
+    )
+    expect_false(any(is.na(source_rows$group)), info = verb)
+    expect_true(all(is.na(margin_rows$group)), info = verb)
   }
 })
 

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -142,7 +142,13 @@ test_that("dtplyr obeys the eight-case contract as the local backend does", {
 
     if (case$errors) {
       error <- expect_error(operation(dtplyr::lazy_dt(data)), info = info)
-      expect_s3_class(error, "marginplyr_error")
+      # The same assertion the local loop makes, so that the two error rows
+      # are compared across backends as the six allowed ones are.
+      expect_match(
+        deparse1(conditionCall(error)),
+        "summarize_with_margins",
+        fixed = TRUE
+      )
       next
     }
 
@@ -179,18 +185,31 @@ test_that("dtplyr keeps a used NA level apart from a typed missing", {
     value = 1:2
   )
 
-  # Both branch-building verbs, because the branch union they share is where
-  # the level was lost; the Grouping set identifier is what says which rows a
-  # branch stands for, since the displayed value cannot.
-  queries <- list(
-    summarize_with_margins = summarize_with_margins(
+  # Every Margin verb, because the branch union they share is where the level
+  # was lost; the Grouping set identifier is what says which rows a branch
+  # stands for, since the displayed value cannot.
+  results <- list(
+    summarize_with_margins = dplyr::collect(summarize_with_margins(
       dtplyr::lazy_dt(data),
       n = dplyr::n(),
       .grouping = rollup(group),
       .margin_label = NULL,
       .id = "set"
-    ),
-    expand_with_margins = expand_with_margins(
+    )),
+    expand_with_margins = dplyr::collect(expand_with_margins(
+      dtplyr::lazy_dt(data),
+      .grouping = rollup(group),
+      .margin_label = NULL,
+      .id = "set"
+    )),
+    nest_with_margins = dplyr::collect(nest_with_margins(
+      dtplyr::lazy_dt(data),
+      .grouping = rollup(group),
+      .margin_label = NULL,
+      .id = "set"
+    )),
+    # Local already: this verb returns a row-wise result rather than a query.
+    nest_by_with_margins = nest_by_with_margins(
       dtplyr::lazy_dt(data),
       .grouping = rollup(group),
       .margin_label = NULL,
@@ -198,8 +217,8 @@ test_that("dtplyr keeps a used NA level apart from a typed missing", {
     )
   )
 
-  for (verb in names(queries)) {
-    result <- dplyr::collect(queries[[verb]])
+  for (verb in names(results)) {
+    result <- results[[verb]]
     expect_identical(levels(result$group), c("x", NA), info = verb)
     source_rows <- result[result$set == 1L, , drop = FALSE]
     margin_rows <- result[result$set == 2L, , drop = FALSE]


### PR DESCRIPTION
Fixes #408.

## What was wrong

On a dtplyr input, `summarize_with_margins(.margin_label = NULL)` returned a
factor dimension whose declared `NA` level had been dropped; the same call on
the same data through the local backend kept it. ADR 0012's sixth row promises
the level is preserved, and ADR 0016 places factor levels on the side
marginplyr constructs. Neither is qualified by backend.

## Root cause

`data.table`'s rbind drops a declared `NA` level from the result and turns the
values that used it into missing codes — for a list of one table as much as for
a union of branches:

```r
f <- structure(c(1L, 1L), levels = c("x", NA_character_), class = "factor")
a <- data.table::data.table(group = f)
levels(data.table::rbindlist(list(a))$group)
#> [1] "x"
```

The non-missing-label path never met that. A label is not one of the column's
levels, so its columns already crossed the union as character and were rebuilt
after it. A missing label adds no level, so its columns crossed as factors, and
the level was gone before restoration could keep it.

## The fix

A factor dimension whose Margin label is missing now takes the same
encode-and-rebuild route where the union would drop such a level. That is the
new `drops_na_factor_level_on_union` capability in `backend_capabilities()`,
granted to `dtplyr` alone.

The encoding has to be the sentinel one rather than `as.character()`: a value
on the `NA` level and the typed missing a margin row carries are both `NA` in
character, and the union is where the two would stop being distinguishable.
`margin_column_info()` decides it once per column as `encode_missing_label`, so
`label_margin_branch()` and `restore_margin_factors()` read one answer instead
of deciding twice.

## Backends other than dtplyr

Measured, and untouched. A plain duckdb round trip already drops the level
(`levels()` is `"x"` before any Margin verb runs), and `arrow` refuses the
column outright — `Invalid: Cannot insert dictionary values containing nulls`.
Both lose it before any branch exists, so ADR 0012's *local and
factor-preserving lazy adapters where supported* clause reaches dtplyr alone.

## Tests

The eight cases of ADR 0012's table had only ever run on a local data frame.
The table moved to a `factor_contract_cases()` helper and now runs on dtplyr
too, each case compared against the local result rather than against a literal.

A second test covers a value that *uses* the `NA` level, which no case in the
table does: it asserts the source row stays on the level (`is.na()` false) while
the margin rows are typed missing (`is.na()` true), for both
`summarize_with_margins()` and `expand_with_margins()`. That is what an encoding
which merely restored the levels would lose.

Row order is not asserted across backends: the two place a missing value within
one grouping set differently, which ADR 0018 leaves to the backend.

## Local checks

- `testthat::test_local()` with `NOT_CRAN=true`: 6373 pass, 0 fail, 0 skip.
- `lintr::lint_package()` after `pkgload::load_all()`: no lints.
- `.github/scripts/verify-context-budget.R`: within baseline.
- `roxygen2::roxygenise()`: no generated-file diff (no roxygen changed).