### PR TITLE
Empty the Sent query record at every entry point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -304,6 +304,7 @@
   share, with the control that tells a refusal from a question that could
   not be put. Each is recorded before it is sent, so a call refused by a
   collision or by an ineligible share source leaves readable every query it
-  had already sent. A call refused before it sent anything -- by an argument
-  its verb rejects -- reads back as the empty record it is, rather than as the
-  previous call's. The option is off by default (#318, #400, #401, #409).
+  had already sent. A call one of these verbs refused before sending anything
+  reads back as the empty record it is, rather than as the previous call's,
+  and is a call the session has recorded. The option is off by default
+  (#318, #400, #401, #409).

--- a/NEWS.md
+++ b/NEWS.md
@@ -304,4 +304,6 @@
   share, with the control that tells a refusal from a question that could
   not be put. Each is recorded before it is sent, so a call refused by a
   collision or by an ineligible share source leaves readable every query it
-  had already sent. The option is off by default (#318, #400, #401).
+  had already sent. A call refused before it sent anything -- by an argument
+  its verb rejects -- reads back as the empty record it is, rather than as the
+  previous call's. The option is off by default (#318, #400, #401, #409).

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -92,6 +92,7 @@ expand_with_margins <- function(.data,
                                 .duplicates = c("error", "drop", "keep"),
                                 .id = NULL,
                                 .sort = c("none", "last", "first")) {
+  reset_sent_queries()
   call <- rlang::current_call()
   with_margin_error_call(
     {

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -149,9 +149,6 @@ prepare_grouping_plan <- function(.data,
                                   validate_grouping = NULL,
                                   validate_names = NULL,
                                   call = rlang::caller_call()) {
-  # First, before anything that can raise: every entry point reaches this
-  # function, and every recorded site runs after it (ADR 0027).
-  reset_sent_queries()
   stopifnot(rlang::is_quosure(by_quo), rlang::is_quosure(grouping_quo))
   stopifnot(is.null(validate_grouping) || is.function(validate_grouping))
   stopifnot(is.null(validate_names) || is.function(validate_names))

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -136,6 +136,7 @@ inspect_grouping <- function(.data,
                              .grouping = NULL,
                              .duplicates = c("error", "drop", "keep"),
                              .format = c("text", "list")) {
+  reset_sent_queries()
   call <- rlang::current_call()
   grouping_quo <- rlang::enquo(.grouping)
   by_quo <- rlang::enquo(.by)

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -119,6 +119,7 @@ nest_by_with_margins <- function(.data,
                                  .sort = c("none", "last", "first"),
                                  .key = "data",
                                  .keep = FALSE) {
+  reset_sent_queries()
   call <- rlang::current_call()
   grouping_quo <- rlang::enquo(.grouping)
   by_quo <- rlang::enquo(.by)

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -165,6 +165,7 @@ nest_with_margins <- function(.data,
                               .sort = c("none", "last", "first"),
                               .key = "data",
                               .keep = FALSE) {
+  reset_sent_queries()
   call <- rlang::current_call()
   if (is.null(.key)) {
     .key <- "data"

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -10,11 +10,9 @@ sent_queries <- new.env(parent = emptyenv())
 # `TRUE` is "not audited", and nothing here reports it.
 #
 # Called as the first statement of every entry point, ahead of the argument
-# validation each of them opens with: a call refused there is a call that
-# began, and what `last_sent_queries()` answers for it is its own empty record
-# rather than the previous call's (ADR 0027). The backend is not known yet, so
-# the SQL flag starts `FALSE` and `remember_sent_query_backend()` sets it where
-# the backend is computed.
+# validation each of them opens with (ADR 0027). The backend is not known yet,
+# so the SQL flag starts `FALSE` and `remember_sent_query_backend()` sets it
+# where the backend is computed.
 reset_sent_queries <- function() {
   sent_queries$recorded <- TRUE
   sent_queries$audited <- isTRUE(getOption("marginplyr.audit_sql"))
@@ -97,8 +95,10 @@ record_sent_query <- function(purpose, query) {
 #' call made in this process and not one made in a worker.
 #'
 #' @section Four answers:
-#' - Nothing has been recorded in this session -- no Margin verb has run --
-#'   and the call is refused with a `"marginplyr_error"`.
+#' - Nothing has been recorded in this session -- no Margin verb has begun --
+#'   and the call is refused with a `"marginplyr_error"`. A verb that began and
+#'   then refused your call has begun, so what is read after one is its own
+#'   record, empty, and not this refusal.
 #' - The last call was not audited, the option being unset or holding a value
 #'   other than `TRUE` when the call began, and the call is refused with a
 #'   `"marginplyr_error"` naming `marginplyr.audit_sql`. The option is read

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -9,10 +9,12 @@ sent_queries <- new.env(parent = emptyenv())
 # reading per call, kept with this call's record (ADR 0027). Anything but
 # `TRUE` is "not audited", and nothing here reports it.
 #
-# Called at the very top of `prepare_grouping_plan()`, which every entry point
-# reaches before any recorded site. The backend is not known yet, so the SQL
-# flag starts `FALSE` and `remember_sent_query_backend()` sets it where the
-# backend is computed.
+# Called as the first statement of every entry point, ahead of the argument
+# validation each of them opens with: a call refused there is a call that
+# began, and what `last_sent_queries()` answers for it is its own empty record
+# rather than the previous call's (ADR 0027). The backend is not known yet, so
+# the SQL flag starts `FALSE` and `remember_sent_query_backend()` sets it where
+# the backend is computed.
 reset_sent_queries <- function() {
   sent_queries$recorded <- TRUE
   sent_queries$audited <- isTRUE(getOption("marginplyr.audit_sql"))

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -834,6 +834,7 @@ summarize_with_margins <- function(.data,
                                    .duplicates = c("error", "drop", "keep"),
                                    .id = NULL,
                                    .sort = c("none", "last", "first")) {
+  reset_sent_queries()
   call <- rlang::current_call()
   dots <- rlang::enquos(...)
   grouping_quo <- rlang::enquo(.grouping)

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -154,45 +154,38 @@ the same way.
 
 ## Amendment: the reset is the first statement of each entry point, not of the plan
 
-**"emptied at the top of `prepare_grouping_plan()`"** no longer holds, and
-neither does *One call, and which call*'s first sentence. The record is emptied
-at the top of every entry point instead. Nothing else here changes: what the
-record holds, what it promises, and which four answers it gives are untouched,
-and this amendment is what makes the third of them reachable where it was not.
+**"emptied at the top of `prepare_grouping_plan()`"** no longer holds, nor does
+*One call, and which call*'s first sentence, nor the last clause of
+*Corrections*' first entry, which names the same site. The record is emptied at
+the first statement of `summarize_with_margins()`, `expand_with_margins()`,
+`nest_with_margins()`, `nest_by_with_margins()`, and `inspect_grouping()`
+instead, ahead of the argument validation each of them opens with — which
+`prepare_grouping_plan()` runs after (#409).
 
-`prepare_grouping_plan()` runs before every recorded site, which is what that
-section establishes, and that is not enough: it also runs *after* the argument
-validation each entry point opens with. A call refused there — `.sort` given a
-value outside its vocabulary, a `.data` no verb accepts, a summary two readings
-claim — never reached the reset, so `last_sent_queries()` answered it with the
-previous successful call's rows verbatim, and the audited flag deciding which
-of the four answers is given was that previous call's too (#409).
+The bound is the body. A call R refuses before entering one, an argument
+matching no formal, reaches no statement of it and leaves the previous call's
+record readable. That is a call that never began, and it is the same reading
+under which one refused *inside* the body did.
 
-That is the defect this decision exists to remove, arriving in the one place
-the decision itself left open: a record readable after a call it does not
-belong to, with nothing saying so. A refusal is a call that began, so the
-answer it takes is *The call was audited and sent nothing* — the zero-row
-tibble, which having sent nothing is exactly true of it.
+Two of the four answers move with that reading. A refusal inside the body takes
+*The call was audited and sent nothing*, the third. And it is a call the session
+recorded, so a session whose only call was refused is answered with that
+zero-row tibble rather than with the first — which now says that no verb reached
+its own body, where before it said that none had completed one.
 
-The reset therefore moves to the first statement of `summarize_with_margins()`,
-`expand_with_margins()`, `nest_with_margins()`, `nest_by_with_margins()`, and
-`inspect_grouping()`, ahead of everything that can raise. What made
-`prepare_grouping_plan()` the site — that all five reach it, and reach it
-before any recorded site — is preserved rather than traded away: the five reach
-it still, and a reset before their validation is a reset before it. Neither of
-the two things that function computes is read by the reset: `.grouping` is not
-resolved yet, and the backend is unknown, which is why the SQL flag starts
-`FALSE` and `remember_sent_query_backend()` stays where the backend is
-computed.
+What made `prepare_grouping_plan()` the site — that all five entry points reach
+it, and reach it before any recorded site — is preserved rather than traded
+away: the five reach it still, and a reset before their validation is a reset
+before it. Neither of the two things that function computes is read by the
+reset: `.grouping` is not resolved yet, and the backend is unknown, which is why
+the SQL flag starts `FALSE` and `remember_sent_query_backend()` stays where the
+backend is computed.
 
-Five sites are not five rules. `test-sent-queries.R` reads the loaded namespace
-and asserts that the set of functions calling `reset_sent_queries()` is exactly
-the set of exported functions taking `.grouping`, and that each of them calls
-it first. An entry point added without a reset, and a validation moved above
-one, are each what that gate fires on. A structural gate is what this placement
-needs and the old one did not: one function's top is a place a reader can see,
-while "before every refusal in five bodies" is a property nothing but a scan
-can hold.
+What moves with the placement is a gate. `test-sent-queries.R` reads the loaded
+namespace and asserts that the set of functions calling `reset_sent_queries()`
+is exactly the set of exported functions taking `.grouping`, and that each of
+them calls it first. An entry point added without a reset, and a validation
+moved above one, are each what it fires on.
 
 ## Corrections
 

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -152,6 +152,48 @@ move the option's flag makes, and it adds no failure mode the option does not
 already have: a site reached without a reset misreads the stale flag in exactly
 the same way.
 
+## Amendment: the reset is the first statement of each entry point, not of the plan
+
+**"emptied at the top of `prepare_grouping_plan()`"** no longer holds, and
+neither does *One call, and which call*'s first sentence. The record is emptied
+at the top of every entry point instead. Nothing else here changes: what the
+record holds, what it promises, and which four answers it gives are untouched,
+and this amendment is what makes the third of them reachable where it was not.
+
+`prepare_grouping_plan()` runs before every recorded site, which is what that
+section establishes, and that is not enough: it also runs *after* the argument
+validation each entry point opens with. A call refused there — `.sort` given a
+value outside its vocabulary, a `.data` no verb accepts, a summary two readings
+claim — never reached the reset, so `last_sent_queries()` answered it with the
+previous successful call's rows verbatim, and the audited flag deciding which
+of the four answers is given was that previous call's too (#409).
+
+That is the defect this decision exists to remove, arriving in the one place
+the decision itself left open: a record readable after a call it does not
+belong to, with nothing saying so. A refusal is a call that began, so the
+answer it takes is *The call was audited and sent nothing* — the zero-row
+tibble, which having sent nothing is exactly true of it.
+
+The reset therefore moves to the first statement of `summarize_with_margins()`,
+`expand_with_margins()`, `nest_with_margins()`, `nest_by_with_margins()`, and
+`inspect_grouping()`, ahead of everything that can raise. What made
+`prepare_grouping_plan()` the site — that all five reach it, and reach it
+before any recorded site — is preserved rather than traded away: the five reach
+it still, and a reset before their validation is a reset before it. Neither of
+the two things that function computes is read by the reset: `.grouping` is not
+resolved yet, and the backend is unknown, which is why the SQL flag starts
+`FALSE` and `remember_sent_query_backend()` stays where the backend is
+computed.
+
+Five sites are not five rules. `test-sent-queries.R` reads the loaded namespace
+and asserts that the set of functions calling `reset_sent_queries()` is exactly
+the set of exported functions taking `.grouping`, and that each of them calls
+it first. An entry point added without a reset, and a validation moved above
+one, are each what that gate fires on. A structural gate is what this placement
+needs and the old one did not: one function's top is a place a reader can see,
+while "before every refusal in five bodies" is a property nothing but a scan
+can hold.
+
 ## Corrections
 
 Four claims in the plan this decision settles were true of an earlier codebase

--- a/man/last_sent_queries.Rd
+++ b/man/last_sent_queries.Rd
@@ -51,8 +51,10 @@ call made in this process and not one made in a worker.
 \section{Four answers}{
 
 \itemize{
-\item Nothing has been recorded in this session -- no Margin verb has run --
-and the call is refused with a \code{"marginplyr_error"}.
+\item Nothing has been recorded in this session -- no Margin verb has begun --
+and the call is refused with a \code{"marginplyr_error"}. A verb that began and
+then refused your call has begun, so what is read after one is its own
+record, empty, and not this refusal.
 \item The last call was not audited, the option being unset or holding a value
 other than \code{TRUE} when the call began, and the call is refused with a
 \code{"marginplyr_error"} naming \code{marginplyr.audit_sql}. The option is read

--- a/tests/testthat/helper-margin-verbs.R
+++ b/tests/testthat/helper-margin-verbs.R
@@ -1,0 +1,24 @@
+# Every exported verb taking the argument named, derived from the signatures so
+# that a seventh arrives at a caller as a wrapper a list is missing rather than
+# as a position nothing covers. The six it answers today are the same six for
+# `.by`, `.grouping`, and any other Margin argument, `summarise_with_margins()`
+# included: the derivation reads exports rather than function objects, so a
+# synonym that stopped being one would show as an entry the list no longer
+# covers.
+#
+# Here rather than in whichever test file wanted it first, because testthat
+# gives each file its own environment: `test-grouping-plan.R` builds one
+# forwarding wrapper per verb from it, and `test-sent-queries.R` reads the
+# entry points out of it, and a second copy is what would drift. That is the
+# argument `helper-namespace-walk.R`'s header makes for the two readings it
+# holds; this is a third reading and not one of those, being about a
+# signature rather than about a body.
+verbs_taking <- function(arg) {
+  Filter(
+    function(name) {
+      object <- getExportedValue("marginplyr", name)
+      is.function(object) && arg %in% names(formals(object))
+    },
+    getNamespaceExports("marginplyr")
+  )
+}

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -833,22 +833,6 @@ test_that("the empty spellings that already had a reading keep it", {
   )
 })
 
-# Every exported verb taking the argument named, derived from the signatures so
-# that a seventh arrives below as a wrapper a list is missing rather than as a
-# position nothing covers. The six it answers today are the same six for both
-# arguments, `summarise_with_margins()` included: the derivation reads exports
-# rather than function objects, so a synonym that stopped being one would show
-# as an entry the list no longer covers.
-verbs_taking <- function(arg) {
-  Filter(
-    function(name) {
-      object <- getExportedValue("marginplyr", name)
-      is.function(object) && arg %in% names(formals(object))
-    },
-    getNamespaceExports("marginplyr")
-  )
-}
-
 # One wrapper per verb, forwarding both arguments with `{{ }}`. File level
 # because two tests below put different expressions through the same six
 # verbs; a second copy could disagree with the derivation above while this

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -475,3 +475,184 @@ test_that("a refused share leaves the probe's row readable", {
   expect_s3_class(condition, "marginplyr_error")
   expect_identical(record$purpose, "share_dialect")
 })
+
+# --- a call refused before its plan ------------------------------------------
+
+# The entry points, derived rather than listed: an entry point is an exported
+# function that compiles a Grouping plan of its own, and `.grouping` is how a
+# specification reaches one. An entry point taking a plan by some other route
+# would go unread here, which is a bound this states rather than hides -- the
+# equality in the structural gate below is what would report it, the new
+# function calling `reset_sent_queries()` without being in this set.
+margin_entry_points <- function() {
+  ns <- asNamespace("marginplyr")
+  Filter(
+    function(name) ".grouping" %in% names(formals(get(name, envir = ns))),
+    getNamespaceExports("marginplyr")
+  )
+}
+
+# The entry points, each with an argument it refuses in the validation it opens
+# with -- before a Grouping plan is compiled, and so before any query could
+# have been sent. `.duplicates` is the one option every entry point takes, and
+# a local input keeps what is under test the refusal rather than the backend.
+refused_entry_point_calls <- function() {
+  lapply(margin_entry_points(), function(verb) {
+    args <- list(
+      quote(sent_queries_data()),
+      .grouping = quote(rollup(g)),
+      .duplicates = "bogus"
+    )
+    if (verb %in% c("summarize_with_margins", "summarise_with_margins")) {
+      args <- c(args, list(total = quote(sum(v, na.rm = TRUE))))
+    }
+    list(verb = verb, args = args)
+  })
+}
+
+test_that("a call refused before its plan reports its own empty record", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  # The verbs whose refused call left the previous call's record readable,
+  # rather than one expectation per case: which entry point is stale is what a
+  # failure here has to say, and the case is not otherwise in the report.
+  stale <- character()
+
+  for (case in refused_entry_point_calls()) {
+    with_audit_option(TRUE, {
+      summarize_with_margins(
+        remote,
+        total = sum(v, na.rm = TRUE),
+        .grouping = rollup(g, h)
+      )
+      recorded <- nrow(last_sent_queries())
+      condition <- rlang::catch_cnd(
+        eval(rlang::call2(case$verb, !!!case$args)),
+        classes = "marginplyr_error"
+      )
+      record <- last_sent_queries()
+    })
+    # A prior call that recorded nothing would leave zero rows to empty, and
+    # a case that raised nothing refused at no point at all: either passes the
+    # count on a record this test never put anything into.
+    if (recorded == 0L || is.null(condition) || nrow(record) != 0L) {
+      stale <- c(stale, case$verb)
+    }
+  }
+
+  expect_identical(stale, character())
+  # The count above is all the loop reads, so the zero-row answer's shape is
+  # asserted once, on the record the last case left.
+  expect_sent_nothing()
+})
+
+test_that("a call refused before its plan reads the option for itself", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, summarize_with_margins(
+    remote,
+    total = sum(v, na.rm = TRUE),
+    .grouping = rollup(g, h)
+  ))
+  with_audit_option(FALSE, {
+    expect_error(
+      summarize_with_margins(
+        remote,
+        total = sum(v, na.rm = TRUE),
+        .grouping = rollup(g, h),
+        .duplicates = "bogus"
+      ),
+      class = "marginplyr_error"
+    )
+  })
+
+  # The refused call was the unaudited one, so the flag it left is what the
+  # accessor reports -- not the audited flag of the call before it.
+  expect_unaudited()
+})
+
+# --- the reset site, structurally --------------------------------------------
+
+# Which functions empty the record is a property of every entry point rather
+# than of any one call, so it is read from the loaded namespace; the shared
+# visitor and enumeration come from `helper-namespace-walk.R`, whose header
+# says why a structural gate reads a namespace at all.
+
+# Whether `fn` empties the record anywhere in its body.
+empties_the_record <- function(fn) {
+  found <- FALSE
+  visit_calls(body(fn), function(node) {
+    head <- node[[1]]
+    if (is.name(head) && identical(as.character(head), "reset_sent_queries")) {
+      found <<- TRUE
+    }
+  })
+  found
+}
+
+# The first expression of `fn`'s body, which is the body itself where it is not
+# a braced block.
+first_statement <- function(fn) {
+  fn_body <- body(fn)
+  if (!is.call(fn_body) || !identical(as.character(fn_body[[1]]), "{")) {
+    return(fn_body)
+  }
+  fn_body[[2]]
+}
+
+test_that("every entry point empties the record before anything else", {
+  ns <- asNamespace("marginplyr")
+  entry_points <- margin_entry_points()
+
+  emptying <- Filter(
+    function(name) empties_the_record(get(name, envir = ns)),
+    namespace_functions(ns)
+  )
+  # Both directions at once: an entry point that stopped emptying the record
+  # leaves the record spanning two calls, and a function that empties it
+  # part-way through one truncates that call's own (ADR 0027).
+  expect_setequal(emptying, entry_points)
+
+  late <- Filter(
+    function(name) {
+      opening <- first_statement(get(name, envir = ns))
+      !identical(opening, quote(reset_sent_queries()))
+    },
+    entry_points
+  )
+  # Named rather than counted: a validation moved above the reset is what this
+  # fires on, and which entry point took it is not otherwise in the report.
+  expect_identical(late, character())
+})
+
+test_that("the reset scan tells a first statement from a later one", {
+  # Both readings run over synthetic functions rather than over a member of the
+  # namespace, since a member that failed either is what the gate above reports.
+  resets_first <- function() {
+    reset_sent_queries()
+    stop("unreachable")
+  }
+  resets_later <- function() {
+    stop("unreachable")
+    reset_sent_queries()
+  }
+  bare <- function() reset_sent_queries()
+  reset <- quote(reset_sent_queries())
+
+  expect_true(empties_the_record(resets_first))
+  expect_true(empties_the_record(resets_later))
+  expect_false(empties_the_record(function() NULL))
+  expect_identical(first_statement(resets_first), reset)
+  expect_false(identical(first_statement(resets_later), reset))
+  # An unbraced body is the statement itself, which the gate above reads for no
+  # entry point today and would read for one written that way.
+  expect_identical(first_statement(bare), reset)
+})

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -644,17 +644,50 @@ empties_the_record <- function(fn) {
   found
 }
 
+# `expr` with covr's instrumentation taken off, where it has any.
+#
+# covr measures a namespace by replacing each statement in it with
+# `if (TRUE) { covr:::count(<key>); <statement> }`, so a reader that takes a
+# statement by position takes covr's wrapper rather than the statement. Every
+# other structural gate in this suite goes through `visit_calls()`, which finds
+# a call wherever the wrapper puts it; this file holds the one that reads a
+# position, and the coverage job is where it reported all six entry points at
+# once.
+#
+# Read through the wrapper rather than skip under covr: a gate that stops
+# asserting in one job reads exactly like a gate nothing violates, which is the
+# failure a structural gate exists to prevent. The shape is covr's and not
+# documented, so a covr that changed it fails this gate instead of quieting it
+# -- the direction the reading has to fail in, and why no `skip()` is here.
+strip_coverage_wrapper <- function(expr) {
+  if (!is.call(expr) || !identical(expr[[1]], quote(`if`)) ||
+        length(expr) != 3L || !identical(expr[[2]], TRUE)) {
+    return(expr)
+  }
+  branch <- expr[[3]]
+  if (!is.call(branch) || !identical(branch[[1]], quote(`{`)) ||
+        length(branch) != 3L) {
+    return(expr)
+  }
+  counter <- branch[[2]]
+  if (!is.call(counter) || !identical(counter[[1]], quote(covr:::count))) {
+    return(expr)
+  }
+  branch[[3]]
+}
+
 # The first expression of `fn`'s body, which is the body itself where it is not
-# a braced block.
+# a braced block. Both readings go through the unwrapping above, because covr
+# wraps an unbraced body whole and wraps each statement of a braced one.
 first_statement <- function(fn) {
-  fn_body <- body(fn)
+  fn_body <- strip_coverage_wrapper(body(fn))
   if (!is.call(fn_body) || !identical(as.character(fn_body[[1]]), "{")) {
     return(fn_body)
   }
   if (length(fn_body) < 2L) {
     return(NULL)
   }
-  fn_body[[2]]
+  strip_coverage_wrapper(fn_body[[2]])
 }
 
 test_that("every entry point empties the record before anything else", {
@@ -712,4 +745,49 @@ test_that("the reset scan tells a first statement from a later one", {
   # subscript error the gate would report as neither verdict.
   expect_identical(first_statement(bare), reset)
   expect_null(first_statement(function() {}))
+})
+
+test_that("the reset scan reads through covr's instrumentation", {
+  # The shape covr rewrites a statement into, written out rather than produced
+  # by calling covr: covr is supplied by the coverage workflow and is in no
+  # dependency field, so a test that called it would put it in one. Measured on
+  # covr 3.6.5.9001, which is what the coverage job installed when this gate
+  # reported all six entry points against a package that resets in all six.
+  reset <- quote(reset_sent_queries())
+
+  braced <- function() NULL
+  body(braced) <- quote({
+    if (TRUE) {
+      covr:::count("marginplyr/R/grouping-plan.R:1:1:1:1")
+      reset_sent_queries()
+    }
+    if (TRUE) {
+      covr:::count("marginplyr/R/grouping-plan.R:2:1:2:1")
+      stop("unreachable")
+    }
+  })
+
+  unbraced <- function() NULL
+  body(unbraced) <- quote(if (TRUE) {
+    covr:::count("marginplyr/R/grouping-plan.R:1:1:1:1")
+    reset_sent_queries()
+  })
+
+  expect_identical(first_statement(braced), reset)
+  expect_identical(first_statement(unbraced), reset)
+  # The instrumented body still answers the other reading, which walks rather
+  # than counts positions and is what the wrapper leaves alone.
+  expect_true(empties_the_record(braced))
+
+  # An `if (TRUE)` a caller wrote is not a wrapper, so the unwrapping may not
+  # take it apart: it has no counter in it, and taking it apart would report a
+  # first statement that is not the one the entry point opens with.
+  authored <- function() NULL
+  body(authored) <- quote({
+    if (TRUE) {
+      validate()
+      reset_sent_queries()
+    }
+  })
+  expect_false(identical(first_statement(authored), reset))
 })

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -1,8 +1,10 @@
 # The record is emptied at the top of every call, so no test here isolates
-# `sent_queries` itself. Two pieces of state do leak between tests and are
-# restored on exit by every test that writes one: the option, and the
-# per-dialect verdict cache the share tests below empty so that the probe
-# sends its queries at all. ADR 0027 is the decision these assert.
+# `sent_queries` itself, save the one asserting what a session with no call in
+# it answers -- which is the one state a call cannot put back. Two other pieces
+# of state leak between tests and are restored on exit by every test that
+# writes one: the option, and the per-dialect verdict cache the share tests
+# below empty so that the probe sends its queries at all. ADR 0027 is the
+# decision these assert.
 
 sent_queries_data <- function() {
   data.frame(
@@ -478,26 +480,12 @@ test_that("a refused share leaves the probe's row readable", {
 
 # --- a call refused before its plan ------------------------------------------
 
-# The entry points, derived rather than listed: an entry point is an exported
-# function that compiles a Grouping plan of its own, and `.grouping` is how a
-# specification reaches one. An entry point taking a plan by some other route
-# would go unread here, which is a bound this states rather than hides -- the
-# equality in the structural gate below is what would report it, the new
-# function calling `reset_sent_queries()` without being in this set.
-margin_entry_points <- function() {
-  ns <- asNamespace("marginplyr")
-  Filter(
-    function(name) ".grouping" %in% names(formals(get(name, envir = ns))),
-    getNamespaceExports("marginplyr")
-  )
-}
-
 # The entry points, each with an argument it refuses in the validation it opens
 # with -- before a Grouping plan is compiled, and so before any query could
 # have been sent. `.duplicates` is the one option every entry point takes, and
 # a local input keeps what is under test the refusal rather than the backend.
 refused_entry_point_calls <- function() {
-  lapply(margin_entry_points(), function(verb) {
+  lapply(verbs_taking(".grouping"), function(verb) {
     args <- list(
       quote(sent_queries_data()),
       .grouping = quote(rollup(g)),
@@ -577,6 +565,64 @@ test_that("a call refused before its plan reads the option for itself", {
   # The refused call was the unaudited one, so the flag it left is what the
   # accessor reports -- not the audited flag of the call before it.
   expect_unaudited()
+
+  # And the other direction, where a stale flag would refuse a call that was
+  # audited rather than answer it with the zero rows it sent.
+  summarize_with_margins(
+    remote,
+    total = sum(v, na.rm = TRUE),
+    .grouping = rollup(g, h)
+  )
+  with_audit_option(TRUE, {
+    expect_error(
+      summarize_with_margins(
+        remote,
+        total = sum(v, na.rm = TRUE),
+        .grouping = rollup(g, h),
+        .duplicates = "bogus"
+      ),
+      class = "marginplyr_error"
+    )
+  })
+  expect_sent_nothing()
+})
+
+test_that("a call refused before its plan is a call the session recorded", {
+  # The one reading a later call cannot restore, so the whole record is saved
+  # and put back: emptying it is how the session's first call is reached
+  # twice.
+  saved <- as.list(sent_queries, all.names = TRUE)
+  empty_the_record <- function() {
+    rm(list = names(saved), envir = sent_queries)
+  }
+  on.exit(
+    {
+      empty_the_record()
+      list2env(saved, envir = sent_queries)
+    },
+    add = TRUE
+  )
+
+  empty_the_record()
+  # The control: with nothing recorded, the accessor refuses rather than
+  # answering, which is what makes the read after the refusal an assertion.
+  expect_error(last_sent_queries(), class = "marginplyr_error")
+
+  with_audit_option(TRUE, {
+    expect_error(
+      summarize_with_margins(
+        sent_queries_data(),
+        total = sum(v, na.rm = TRUE),
+        .grouping = rollup(g),
+        .duplicates = "bogus"
+      ),
+      class = "marginplyr_error"
+    )
+  })
+
+  # A verb that began and then refused the call has begun, so the answer is
+  # its own empty record and not the session's first (ADR 0027).
+  expect_sent_nothing()
 })
 
 # --- the reset site, structurally --------------------------------------------
@@ -605,12 +651,20 @@ first_statement <- function(fn) {
   if (!is.call(fn_body) || !identical(as.character(fn_body[[1]]), "{")) {
     return(fn_body)
   }
+  if (length(fn_body) < 2L) {
+    return(NULL)
+  }
   fn_body[[2]]
 }
 
 test_that("every entry point empties the record before anything else", {
   ns <- asNamespace("marginplyr")
-  entry_points <- margin_entry_points()
+  # An entry point is an exported function that compiles a Grouping plan of
+  # its own, and `.grouping` is how a specification reaches one. One taking a
+  # plan by some other route would go unread, which the equality below is what
+  # reports: it is the function calling `reset_sent_queries()` from outside
+  # this set.
+  entry_points <- verbs_taking(".grouping")
 
   emptying <- Filter(
     function(name) empties_the_record(get(name, envir = ns)),
@@ -653,6 +707,9 @@ test_that("the reset scan tells a first statement from a later one", {
   expect_identical(first_statement(resets_first), reset)
   expect_false(identical(first_statement(resets_later), reset))
   # An unbraced body is the statement itself, which the gate above reads for no
-  # entry point today and would read for one written that way.
+  # entry point today and would read for one written that way. An empty braced
+  # one has no first statement to read, and answers that rather than raising a
+  # subscript error the gate would report as neither verdict.
   expect_identical(first_statement(bare), reset)
+  expect_null(first_statement(function() {}))
 })

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -644,6 +644,17 @@ empties_the_record <- function(fn) {
   found
 }
 
+# The head of the counter call covr's wrapper holds, assembled rather than
+# written as a `:::` call. `R CMD check`'s *unstated dependencies in tests*
+# reads a `:::` in a test source from the parse tree, so spelling it there
+# makes covr a dependency this package would have to declare -- and covr is
+# supplied by `test-coverage.yaml`'s `extra-packages`, belonging in no
+# dependency field of its own (`AGENTS.md`, *Dependency metadata*). Assembling
+# it names the same call without putting the token where that scan reads.
+coverage_counter <- function() {
+  call(":::", as.name("covr"), as.name("count"))
+}
+
 # `expr` with covr's instrumentation taken off, where it has any.
 #
 # covr measures a namespace by replacing each statement in it with
@@ -670,7 +681,7 @@ strip_coverage_wrapper <- function(expr) {
     return(expr)
   }
   counter <- branch[[2]]
-  if (!is.call(counter) || !identical(counter[[1]], quote(covr:::count))) {
+  if (!is.call(counter) || !identical(counter[[1]], coverage_counter())) {
     return(expr)
   }
   branch[[3]]
@@ -753,23 +764,26 @@ test_that("the reset scan reads through covr's instrumentation", {
   # dependency field, so a test that called it would put it in one. Measured on
   # covr 3.6.5.9001, which is what the coverage job installed when this gate
   # reported all six entry points against a package that resets in all six.
+  # Only the counter's head is substituted in, for the reason its own reader
+  # gives; the wrapper around it is the literal covr writes.
   reset <- quote(reset_sent_queries())
+  counter <- coverage_counter()
 
   braced <- function() NULL
-  body(braced) <- quote({
+  body(braced) <- bquote({
     if (TRUE) {
-      covr:::count("marginplyr/R/grouping-plan.R:1:1:1:1")
+      .(counter)("marginplyr/R/grouping-plan.R:1:1:1:1")
       reset_sent_queries()
     }
     if (TRUE) {
-      covr:::count("marginplyr/R/grouping-plan.R:2:1:2:1")
+      .(counter)("marginplyr/R/grouping-plan.R:2:1:2:1")
       stop("unreachable")
     }
   })
 
   unbraced <- function() NULL
-  body(unbraced) <- quote(if (TRUE) {
-    covr:::count("marginplyr/R/grouping-plan.R:1:1:1:1")
+  body(unbraced) <- bquote(if (TRUE) {
+    .(counter)("marginplyr/R/grouping-plan.R:1:1:1:1")
     reset_sent_queries()
   })
 


### PR DESCRIPTION
Fixes #409.

## What was wrong

`reset_sent_queries()` sat at the top of `prepare_grouping_plan()`, which every
entry point reaches before any recorded site — and *after* the argument
validation each of them opens with. A call refused there never emptied the
record, so `last_sent_queries()` answered it with the previous successful
call's rows verbatim, and the audited flag deciding which of ADR 0027's four
answers to give was that previous call's too.

The issue's reproduction now prints what it says it should:

```
--- after successful call 1: purposes ---
[1] "selection_proxy" "result"

--- call 2 refused with ---
marginplyr_error : `.sort` must be one of "none", "last", or "first".

--- last_sent_queries() after the failed call 2 ---
character(0)
rows: 0
identical(r1, r2): FALSE
```

## What changed

The reset is the first statement of `summarize_with_margins()`,
`expand_with_margins()`, `nest_with_margins()`, `nest_by_with_margins()`, and
`inspect_grouping()`, ahead of everything that can raise. What made
`prepare_grouping_plan()` the site is preserved rather than traded away: the
five reach it still, and a reset before their validation is a reset before
every recorded site. Neither thing that function computes is read by the reset
— `.grouping` is unresolved and the backend unknown — so
`remember_sent_query_backend()` stays where the backend is computed.

Five sites are not five rules. `test-sent-queries.R` gains a structural gate
over the loaded namespace: the set of functions calling `reset_sent_queries()`
is exactly the set of exported functions taking `.grouping`, and each calls it
first. An entry point added without a reset, and a validation moved above one,
are each what it fires on — verified by removing the reset from
`expand_with_margins()`, which names that verb in all three assertions.

The behavioural half runs every entry point's early-validation refusal after an
audited RSQLite call that recorded rows, and asserts the record it leaves is
the zero-row one; a second test asserts the refusal re-reads
`marginplyr.audit_sql` for itself.

ADR 0027 carries the move as an amendment, superseding the reset site its
opening paragraph and *One call, and which call* named. `NEWS.md` gains the
sentence for it.

## Checks

`lintr::lint_package()` clean; full suite green with `NOT_CRAN=true`.