### PR TITLE
Cite a location by name rather than by line number

### DIFF
--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,12 +24,14 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 24198L
+baseline_bytes <- 23384L
 baseline_note <- paste(
-  "#295 deleting the arguments three sections restated and moving the rest to",
-  "`test-documentation.R` and `altdoc.yaml`, over #293's baseline; the 5957",
-  "bytes that removed paid for restoring the rule no file held, that no",
-  "package is promoted to Imports merely to make a check pass"
+  "moving the `must_error` implementation's three load-bearing properties to",
+  "`inst/vignette-hooks/must-error.R`, whose header had deferred outward for",
+  "facts about itself, over #295's baseline; the 1056 bytes that freed paid",
+  "for the rule that a citation names its target rather than a line number,",
+  "and for deleting the *Dependency metadata* conclusion *Code comments*",
+  "re-derived beside its own citation to it"
 )
 
 entry <- "CLAUDE.md"

--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -26,12 +26,11 @@ source(".github/scripts/ci-helpers.R")
 # it.
 baseline_bytes <- 23384L
 baseline_note <- paste(
-  "moving the `must_error` implementation's three load-bearing properties to",
-  "`inst/vignette-hooks/must-error.R`, whose header had deferred outward for",
-  "facts about itself, over #295's baseline; the 1056 bytes that freed paid",
-  "for the rule that a citation names its target rather than a line number,",
-  "and for deleting the *Dependency metadata* conclusion *Code comments*",
-  "re-derived beside its own citation to it"
+  "#416 deleting the `must_error` implementation's three load-bearing",
+  "properties, which `inst/vignette-hooks/must-error.R` already stated at the",
+  "three sites holding them, over #295's baseline; 322 of the 1056 bytes that",
+  "removed paid for the rule that a citation names its target rather than a",
+  "line number"
 )
 
 entry <- "CLAUDE.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,12 @@ compares the two, so an amendment leaves it standing and wrong. ADR 0023
 settled this once already, for a rule that governed one file while two others
 re-derived it.
 
+This holds wherever a maintained document points, not only in a comment: a
+citation names its target — a function, a heading, a chunk, an ADR or issue
+number — and not a line number, which an edit above it leaves pointing at a
+different line rather than at nothing. A SHA, and a permalink pinned to one,
+do not move.
+
 A comment describes the code it sits beside, in the present tense. What a
 review found, which round answered it, and what a test elsewhere now covers are
 things the code does not hold — the commit message and the test are where each
@@ -370,8 +376,7 @@ are. A `srcref` opens at `function(`, so no header is inside any of them, and
 an installed package carries no `srcref` at all, `keep.source.pkgs` being
 `FALSE`. Such a gate would have to skip where every existing one runs, and
 `verify-backend.R` fails a job for a skip naming no withheld backend. This is a
-hand audit for the reason *Dependency metadata* above is one: what defeats the
-scan is what a scanner can express, not missing configuration.
+hand audit for the reason *Dependency metadata* above is one.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,21 +126,6 @@ which imports knitr — the `DBI = FALSE` case from *Dependency metadata*, so a
 guard on knitr in a vignette would never fire
 (`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
 
-Three properties are load-bearing and easy to lose in a rewrite. It is
-implemented as a wrapper around knitr's `evaluate` hook, which inspects the
-returned result objects; that keeps knitr's own error rendering, whereas
-catching the condition in a helper prints an `<error/rlang_error>` header and
-a backtrace through the helper, which no reader would see. Because knitr
-does not call that hook for a chunk it does not evaluate, a chunk withheld by
-an availability guard is skipped without a special case — a guarded chunk that
-never runs must not be reported as a chunk that stopped failing, or
-`_R_CHECK_DEPENDS_ONLY_` builds break. And the definition undoes itself from an
-`after.knit` hook, which `knit()` runs from `on.exit()` so that a render halted
-by the option restores as a completed one does; knitr restores neither the
-`opts_hooks` entry nor a `knit_hooks` entry installed while it runs, and the
-`document` hook — the obvious alternative — is not called on the halted path
-(`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
-
 `.github/scripts/verify-must-error.R` is the gate, run by `altdoc.yaml` and
 locally with `Rscript .github/scripts/verify-must-error.R`. It knits fixture
 documents covering each form, the guarded chunk, a malformed option value, and

--- a/inst/vignette-hooks/must-error.R
+++ b/inst/vignette-hooks/must-error.R
@@ -16,10 +16,25 @@
 #     must_error: true               any error will do
 #     must_error: marginplyr_error   the error must carry that condition class
 #
-# `AGENTS.md` is authoritative for when to mark a chunk and for the three
-# properties of this implementation that are load-bearing: it wraps knitr's
-# `evaluate` hook and inspects the result objects, it does nothing for a chunk
-# knitr never evaluated, and it undoes itself from `after.knit`.
+# `AGENTS.md` is authoritative for when to mark a chunk. Three properties of
+# what follows are load-bearing and easy to lose in a rewrite.
+#
+# It is implemented as a wrapper around knitr's `evaluate` hook, which inspects
+# the returned result objects; that keeps knitr's own error rendering, whereas
+# catching the condition in a helper prints an `<error/rlang_error>` header and
+# a backtrace through the helper, which no reader would see.
+#
+# Because knitr does not call that hook for a chunk it does not evaluate, a
+# chunk withheld by an availability guard is skipped without a special case -- a
+# guarded chunk that never runs must not be reported as a chunk that stopped
+# failing, or `_R_CHECK_DEPENDS_ONLY_` builds break.
+#
+# And the definition undoes itself from an `after.knit` hook, which `knit()`
+# runs from `on.exit()` so that a render halted by the option restores as a
+# completed one does; knitr restores neither the `opts_hooks` entry nor a
+# `knit_hooks` entry installed while it runs, and the `document` hook -- the
+# obvious alternative -- is not called on the halted path
+# (`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
 
 local({
   # Sourcing this twice -- two setup chunks in one document, or a second

--- a/inst/vignette-hooks/must-error.R
+++ b/inst/vignette-hooks/must-error.R
@@ -16,25 +16,8 @@
 #     must_error: true               any error will do
 #     must_error: marginplyr_error   the error must carry that condition class
 #
-# `AGENTS.md` is authoritative for when to mark a chunk. Three properties of
-# what follows are load-bearing and easy to lose in a rewrite.
-#
-# It is implemented as a wrapper around knitr's `evaluate` hook, which inspects
-# the returned result objects; that keeps knitr's own error rendering, whereas
-# catching the condition in a helper prints an `<error/rlang_error>` header and
-# a backtrace through the helper, which no reader would see.
-#
-# Because knitr does not call that hook for a chunk it does not evaluate, a
-# chunk withheld by an availability guard is skipped without a special case -- a
-# guarded chunk that never runs must not be reported as a chunk that stopped
-# failing, or `_R_CHECK_DEPENDS_ONLY_` builds break.
-#
-# And the definition undoes itself from an `after.knit` hook, which `knit()`
-# runs from `on.exit()` so that a render halted by the option restores as a
-# completed one does; knitr restores neither the `opts_hooks` entry nor a
-# `knit_hooks` entry installed while it runs, and the `document` hook -- the
-# obvious alternative -- is not called on the halted path
-# (`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
+# `AGENTS.md` is authoritative for when to mark a chunk. What a rewrite of this
+# file must keep is stated at the sites that hold it, and not here.
 
 local({
   # Sourcing this twice -- two setup chunks in one document, or a second
@@ -176,7 +159,9 @@ local({
   # finished does. The child-mode guard is what keeps a child document's own
   # `knit()` from restoring while the parent still has chunks to run; a hook
   # this one displaced is still called there, because skipping the restoration
-  # is not a reason to swallow someone else's hook.
+  # is not a reason to swallow someone else's hook. The `document` hook was the
+  # alternative weighed
+  # (`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
   previous_after_knit <- knitr::knit_hooks$get("after.knit")
 
   knitr::knit_hooks$set(after.knit = function(...) {

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -297,10 +297,12 @@ test_that("a formula is walked as the call to `~` that it is", {
   # cover the sites and the shapes this one does not.
 
   # A formula in the `.fns` position of `across()` is the one spelling of this
-  # that users are documented to write (`R/share.R:307`), and it was the only
-  # shape in #130's tables asserted at the walk alone. The guard is where the
-  # caller meets it, so it is asserted there too: `.x` is over-reported by
-  # design, and the read of `share` beside it must still be refused.
+  # that users are documented to write (the *Indirect `.fns`* bullet of
+  # `share_of_parent()`'s *Rejected forms and supported rewrites*), and it was
+  # the only shape in #130's tables asserted at the walk alone. The guard is
+  # where the caller meets it, so it is asserted there too: `.x` is
+  # over-reported by design, and the read of `share` beside it must still be
+  # refused.
   from_across <- expect_error(
     summarize_with_margins(
       data,
@@ -1093,11 +1095,12 @@ test_that("a formula wrapping a share helper is refused, not computed", {
 
 test_that("the head is walked before the arguments, and the guard says so", {
   # The walk returns symbols in source order, and the head is syntactically
-  # first. That is not an internal detail: the guard names
-  # `share_dependency[[1L]]` (`R/share.R:786`), so this order decides which
-  # share an expression reading two of them is reported against. Asserting it
-  # through the message is what makes it a property of the diagnostic the
-  # caller reads rather than of the vector the walk happens to build.
+  # first. That is not an internal detail: the guard in
+  # `plan_share_expressions()` names `share_dependency[[1L]]`, so this order
+  # decides which share an expression reading two of them is reported against.
+  # Asserting it through the message is what makes it a property of the
+  # diagnostic the caller reads rather than of the vector the walk happens to
+  # build.
   data <- data.frame(
     region = c("East", "East", "West"),
     value = c(1, 3, 6)


### PR DESCRIPTION
A line number fails differently from every other reference this repository writes. A renamed function or a moved file makes a citation unfindable, and a grep reports it; an edit above a cited line leaves the citation resolving, to something else. Nothing reports that, so the claim stays in the closure reading as though it were still true.

## What the rule says

Added to *Code comments* in `AGENTS.md`, after the paragraph on what a citation does:

> This holds wherever a maintained document points, not only in a comment: a citation names its target — a function, a heading, a chunk, an ADR or issue number — and not a line number, which an edit above it leaves pointing at a different line rather than at nothing. A SHA, and a permalink pinned to one, do not move.

## The measurement

A scan over every tracked source, excluding generated files and `investigation/`, found two violations. Both were already false:

| site | cited | what that line now holds | drift |
|---|---|---|---|
| `test-static-expression-analysis.R` | `R/share.R:307` | roxygen about non-numeric sources, not the `.fns` bullet meant | 8 lines |
| `test-static-expression-analysis.R` | `R/share.R:786` | `[[` inside a `vapply()` over `ordinary_records`, not the guard | 71 lines |

Both are rewritten to name what they point at: the *Indirect `.fns`* bullet of `share_of_parent()`'s *Rejected forms and supported rewrites*, and `plan_share_expressions()`.

The same scan found five coordinates that are not references — the testthat skip output `verify-backend.R` parses, and the synthetic covr counter keys `test-sent-queries.R` builds. The rule governs what a citation points *with*, so a coordinate quoted as data is outside it without needing to be named. No exception clause was added for them.

`investigation/`, issues, pull requests, and commit messages are outside the rule. `investigation/README.md` says a note "is not maintained afterwards", which is what makes a coordinate in one a record of where something was rather than a claim about where it is.

## The budget

`AGENTS.md` was at 24198 of 24198, so the rule had to be paid for.

| | bytes |
|---|---|
| before | 24198 |
| delete the `must_error` implementation's three load-bearing properties, which `inst/vignette-hooks/must-error.R` already states at the three sites holding them | −1056 |
| the rule | +322 |
| delete the *Dependency metadata* conclusion *Code comments* re-derived beside its own citation to it | −80 |
| **baseline** | **23384** |

The 80-byte deletion is the new rule applied to the paragraph that states it — a citation to *Dependency metadata* followed by a re-derivation of its conclusion.

The first commit *moved* the three properties into `inst/vignette-hooks/must-error.R`'s header. The review found that all three were already there, as inline comments on the code each is about, so the move made a second copy inside one file. The third commit deletes the header copy; the header now says only that a rewrite reads those sites. What the closure held was a third copy, so deleting it was right and relocating it was not.

## Review

Ran `mattpocock-skills:code-review` against `main...HEAD`. Three findings answered, three rejected with evidence; the record is in the review comment on this PR.

## Checks

`lintr::lint_package()` — no lints. `testthat::test_local()` under `NOT_CRAN=true` — no failures, warnings, or skips. `verify-context-budget.R` — 23384 within 23384.