### PR TITLE
Restate the caller's spelling in the native adapter's translation error

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -503,10 +503,15 @@ restate_argument_lines <- function(text, restatements, rendered) {
 # the name of the message vector rather than part of its text. The span is read
 # to the last backtick on the line, because a non-syntactic name the caller
 # wrote puts backticks inside it.
+#
+# The trailing period is captured rather than required, and put back as it was
+# found: eager dplyr ends the sentence with one and dbplyr does not, and the
+# sentence around the span belongs to whichever raised the condition
+# (ADR 0022).
 restate_argument_bullet <- function(line, restatements) {
   found <- regmatches(
     line,
-    regexec("^([i\u2139] )?In argument: `(.*)`\\.$", line)
+    regexec("^([i\u2139] )?In argument: `(.*)`(\\.)?$", line)
   )[[1L]]
   if (length(found) == 0L) {
     return(line)
@@ -515,7 +520,7 @@ restate_argument_bullet <- function(line, restatements) {
   if (is.na(restored)) {
     return(line)
   }
-  paste0(found[[2L]], "In argument: `", restored, "`.")
+  paste0(found[[2L]], "In argument: `", restored, "`", found[[4L]])
 }
 
 # Rewrites the internal grouping-column names dplyr built the context from into

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -1,8 +1,14 @@
+# `caller_labels` is `new_summary_arguments()`'s, parallel to the `dots` this
+# is handed, and is what the translation error below is restated with. It is
+# required rather than defaulted, because a default computed here would be
+# computed from dots this has already rewritten, and would restate a spelling
+# the caller never wrote (ADR 0024).
 summarize_margin_native <- function(.data,
                                     dots,
                                     plan,
                                     margin_labels,
                                     reserved_names,
+                                    caller_labels,
                                     set_id_name = NULL,
                                     set_id_is_internal = FALSE) {
   con <- dbplyr::remote_con(.data)
@@ -12,6 +18,9 @@ summarize_margin_native <- function(.data,
     sql = TRUE,
     con = con
   )
+  # After the rewrite, because the rewritten dots are the expressions dplyr
+  # will quote.
+  restatements <- branch_argument_map(dots, caller_labels)
   group_vars <- unique(c(plan$by, plan$dimensions))
   if (!is.null(set_id_name)) {
     set_id_quo <- rlang::new_quosure(
@@ -50,23 +59,34 @@ summarize_margin_native <- function(.data,
     flag_quos <- list()
   }
 
-  check_summary_output_names(
+  # Forced here rather than left to lazy evaluation inside the check, so that
+  # the translation error a summarize of the caller's expressions can raise is
+  # restated and the check's own Package conditions are not reached by the
+  # restatement at all.
+  output_names <- with_native_restatement(
     native_summary_output_names(.data, dots),
+    restatements
+  )
+  check_summary_output_names(
+    output_names,
     group_vars = group_vars,
     internal_names = flag_names,
     set_id_name = set_id_name,
     set_id_is_internal = set_id_is_internal
   )
 
-  result <- dplyr::summarize(
-    .data = dplyr::group_by(
-      .data,
-      dplyr::pick(dplyr::all_of(group_vars))
+  result <- with_native_restatement(
+    dplyr::summarize(
+      .data = dplyr::group_by(
+        .data,
+        dplyr::pick(dplyr::all_of(group_vars))
+      ),
+      !!!dots,
+      !!!set_id_quos,
+      !!!flag_quos,
+      .groups = "drop"
     ),
-    !!!dots,
-    !!!set_id_quos,
-    !!!flag_quos,
-    .groups = "drop"
+    restatements
   )
 
   result <- attach_grouping_sets_query(result, plan$sets)
@@ -92,6 +112,24 @@ summarize_margin_native <- function(.data,
   }
 
   result
+}
+
+# The error dbplyr raises when it cannot translate a rewritten expression is
+# the one condition this adapter produces while the verb runs; everything else
+# it does builds a query. Both of the calls that hand dplyr the caller's
+# expressions are wrapped, because either can be the first to translate them,
+# and nothing between them is.
+#
+# Not `with_branch_conditions()`: this adapter issues its summarize once and
+# repeats nothing, so the deduplication and the grouping-value restatement have
+# nothing to act on (ADR 0022, *Amendment*).
+with_native_restatement <- function(expr, restatements) {
+  tryCatch(
+    expr,
+    error = function(cnd) {
+      stop(restate_condition_arguments(cnd, restatements))
+    }
+  )
 }
 
 # What `check_summary_output_names()` needs and the grouped summarize above

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -1,26 +1,22 @@
-# `caller_labels` is `new_summary_arguments()`'s, parallel to the `dots` this
-# is handed, and is what the translation error below is restated with. It is
-# required rather than defaulted, because a default computed here would be
-# computed from dots this has already rewritten, and would restate a spelling
-# the caller never wrote (ADR 0024).
+# `summaries` is `stage_margin_summaries()`'s, taken whole for the reason its
+# header gives, and read here for its labels as well as its dots.
 summarize_margin_native <- function(.data,
-                                    dots,
+                                    summaries,
                                     plan,
                                     margin_labels,
                                     reserved_names,
-                                    caller_labels,
                                     set_id_name = NULL,
                                     set_id_is_internal = FALSE) {
   con <- dbplyr::remote_con(.data)
   dots <- rewrite_grouping_dots(
-    dots,
+    summaries$dots,
     plan = plan,
     sql = TRUE,
     con = con
   )
   # After the rewrite, because the rewritten dots are the expressions dplyr
   # will quote.
-  restatements <- branch_argument_map(dots, caller_labels)
+  restatements <- branch_argument_map(dots, summaries$labels)
   group_vars <- unique(c(plan$by, plan$dimensions))
   if (!is.null(set_id_name)) {
     set_id_quo <- rlang::new_quosure(
@@ -59,13 +55,16 @@ summarize_margin_native <- function(.data,
     flag_quos <- list()
   }
 
-  # Forced here rather than left to lazy evaluation inside the check, so that
-  # the translation error a summarize of the caller's expressions can raise is
-  # restated and the check's own Package conditions are not reached by the
-  # restatement at all.
-  output_names <- with_native_restatement(
+  # dbplyr translates the caller's expressions here, this being the first of
+  # the two summarizes below to reach them, and raises where it cannot. That
+  # error is the whole of what ADR 0022 restates in this adapter. The call is
+  # forced out of the check's lazy argument so that the check's own Package
+  # conditions stay outside the catch.
+  output_names <- tryCatch(
     native_summary_output_names(.data, dots),
-    restatements
+    error = function(cnd) {
+      stop(restate_condition_arguments(cnd, restatements))
+    }
   )
   check_summary_output_names(
     output_names,
@@ -75,18 +74,15 @@ summarize_margin_native <- function(.data,
     set_id_is_internal = set_id_is_internal
   )
 
-  result <- with_native_restatement(
-    dplyr::summarize(
-      .data = dplyr::group_by(
-        .data,
-        dplyr::pick(dplyr::all_of(group_vars))
-      ),
-      !!!dots,
-      !!!set_id_quos,
-      !!!flag_quos,
-      .groups = "drop"
+  result <- dplyr::summarize(
+    .data = dplyr::group_by(
+      .data,
+      dplyr::pick(dplyr::all_of(group_vars))
     ),
-    restatements
+    !!!dots,
+    !!!set_id_quos,
+    !!!flag_quos,
+    .groups = "drop"
   )
 
   result <- attach_grouping_sets_query(result, plan$sets)
@@ -112,24 +108,6 @@ summarize_margin_native <- function(.data,
   }
 
   result
-}
-
-# The error dbplyr raises when it cannot translate a rewritten expression is
-# the one condition this adapter produces while the verb runs; everything else
-# it does builds a query. Both of the calls that hand dplyr the caller's
-# expressions are wrapped, because either can be the first to translate them,
-# and nothing between them is.
-#
-# Not `with_branch_conditions()`: this adapter issues its summarize once and
-# repeats nothing, so the deduplication and the grouping-value restatement have
-# nothing to act on (ADR 0022, *Amendment*).
-with_native_restatement <- function(expr, restatements) {
-  tryCatch(
-    expr,
-    error = function(cnd) {
-      stop(restate_condition_arguments(cnd, restatements))
-    }
-  )
 }
 
 # What `check_summary_output_names()` needs and the grouped summarize above

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1019,16 +1019,15 @@ stage_margin_summaries <- function(operation,
   result <- tryCatch(
     {
       if (use_native) {
-        # The labels travel with the dots: what this adapter restates is the
-        # one error dbplyr raises translating them, and it restates that error
-        # alone (ADR 0022).
+        # What this adapter restates is the one error dbplyr raises
+        # translating the caller's expressions, and that error alone
+        # (ADR 0022).
         summarize_margin_native(
           operation$data,
-          dots = summaries$dots,
+          summaries = summaries,
           plan = plan,
           margin_labels = operation$margin_labels,
           reserved_names = reserved_names,
-          caller_labels = summaries$labels,
           set_id_name = set_id_name,
           set_id_is_internal = set_id_is_internal
         )

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1019,15 +1019,16 @@ stage_margin_summaries <- function(operation,
   result <- tryCatch(
     {
       if (use_native) {
-        # The labels stay behind: the native adapter issues one `summarize()`
-        # and repeats nothing, and the backends holding the capability are
-        # lazy, so no condition is raised while the verb runs (ADR 0022).
+        # The labels travel with the dots: what this adapter restates is the
+        # one error dbplyr raises translating them, and it restates that error
+        # alone (ADR 0022).
         summarize_margin_native(
           operation$data,
           dots = summaries$dots,
           plan = plan,
           margin_labels = operation$margin_labels,
           reserved_names = reserved_names,
+          caller_labels = summaries$labels,
           set_id_name = set_id_name,
           set_id_is_internal = set_id_is_internal
         )

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -229,12 +229,18 @@ postgres as on a local input, and the sentence above confining the scope to
 `summarize_margin_union()` no longer holds. #411 implements what follows.
 
 What is extended is the restatement and not `with_branch_conditions()`. The
-native adapter issues one `summarize()` and repeats nothing, so the
-deduplication and the grouping-value restatement have nothing to act on; the one
-sentence of the old reasoning that survives is that one. The error is caught
-around that single `summarize()`, `restate_condition_arguments()` applied with
-the map `branch_argument_map()` builds from the rewritten dots and the caller's
-labels, and the condition re-raised. Nothing else about the adapter moves.
+native adapter summarizes the caller's expressions once and repeats nothing, so
+the deduplication and the grouping-value restatement have nothing to act on; the
+one sentence of the old reasoning that survives is that one. The error is
+caught, `restate_condition_arguments()` applied with the map
+`branch_argument_map()` builds from the rewritten dots and the caller's labels,
+and the condition re-raised. Nothing else about the adapter moves.
+
+It is caught around both calls that hand dplyr those expressions — the adapter
+summarizes them a second time, ungrouped, to learn the output names — because
+which of the two dbplyr translates first is dbplyr's business and not a contract
+this can rest on. Measured on the date #410 was written, the ungrouped one is
+reached first, so it is the one the tests exercise.
 
 Errors only. A branch `summarize()` on a lazy backend still builds a query
 without evaluating the caller's expression, so everything the original reasoning

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -229,18 +229,23 @@ postgres as on a local input, and the sentence above confining the scope to
 `summarize_margin_union()` no longer holds. #411 implements what follows.
 
 What is extended is the restatement and not `with_branch_conditions()`. The
-native adapter summarizes the caller's expressions once and repeats nothing, so
-the deduplication and the grouping-value restatement have nothing to act on; the
-one sentence of the old reasoning that survives is that one. The error is
-caught, `restate_condition_arguments()` applied with the map
-`branch_argument_map()` builds from the rewritten dots and the caller's labels,
-and the condition re-raised. Nothing else about the adapter moves.
+native adapter summarizes the caller's expressions and repeats nothing, so the
+deduplication and the grouping-value restatement have nothing to act on; the one
+sentence of the old reasoning that survives is that one. The error is caught,
+`restate_condition_arguments()` applied with the map `branch_argument_map()`
+builds from the rewritten dots and the caller's labels, and the condition
+re-raised.
 
-It is caught around both calls that hand dplyr those expressions — the adapter
-summarizes them a second time, ungrouped, to learn the output names — because
-which of the two dbplyr translates first is dbplyr's business and not a contract
-this can rest on. Measured on the date #410 was written, the ungrouped one is
-reached first, so it is the one the tests exercise.
+It is caught around `native_summary_output_names()` and not the grouped
+`summarize()`. The adapter hands dplyr those expressions twice — once ungrouped
+to learn the output names, once grouped to build the query — and the ungrouped
+call runs first, so it is the one dbplyr translates and the one that raises.
+Which of the two dbplyr reaches first is not a contract, and nothing here rests
+on it being permanent: the tests assert the restored spelling through the verb,
+so a dbplyr that moved the translation to the grouped call fails them rather
+than dropping the restatement silently. Nothing else about the adapter moves,
+beyond forcing that call out of the check's lazy argument, which keeps the
+check's own Package conditions outside the catch.
 
 Errors only. A branch `summarize()` on a lazy backend still builds a query
 without evaluating the caller's expression, so everything the original reasoning

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -108,6 +108,19 @@ summarize_failing_rollup <- function() {
   )
 }
 
+# The native grouping-sets adapter's own reproduction. `simulate_postgres()`
+# holds that capability and needs no optional backend, dbplyr being an Import,
+# so the native path is asserted wherever the suite runs. What the adapter
+# hands dplyr splices a SQL literal whose own deparse overflows the width
+# `as_label()` deparses at, so the label dbplyr's error quotes collapses to
+# `+...` for any dot combining a helper with anything else (#410).
+native_grouping_sets_input <- function() {
+  dbplyr::tbl_lazy(
+    data.frame(a = c("x", "y"), value = c(1, 2)),
+    con = dbplyr::simulate_postgres()
+  )
+}
+
 # One plan whose two grouping sets raise whatever the caller asks them to.
 # `dplyr::n()` is 3 only in the grouping set that groups by nothing, which
 # `rollup()` runs second, so `whole` is the later branch and `fail` makes it
@@ -689,6 +702,63 @@ test_that("a branch error quotes the caller's own spelling", {
   expect_s3_class(error$parent, "condition")
 })
 
+# The one condition the native adapter raises while the verb runs, and the
+# only part of ADR 0022 that reaches it: an error dbplyr raises translating the
+# rewritten expression. Both directions are asserted, because a restoration
+# that quietly stopped happening reads exactly like a package whose contexts
+# were all still faithful.
+test_that("a native translation error quotes the caller's own spelling", {
+  # `a`, `value`, and `no_such_column` are read from the lazy input, which
+  # codetools reads as undefined globals wherever a verb's arguments are
+  # written inside a function.
+  # nolint start: object_usage_linter.
+  error <- expect_error(
+    summarize_with_margins(
+      native_grouping_sets_input(),
+      total = sum(value) + grouping_bit(a) + no_such_column,
+      .grouping = rollup(a)
+    )
+  )
+  # nolint end
+
+  message <- conditionMessage(error)
+  # The trailing newline is part of the assertion: dbplyr's sentence carries no
+  # period, and the restatement puts back the punctuation it found rather than
+  # a period of its own.
+  expect_match(
+    message,
+    "In argument: `total = sum(value) + grouping_bit(a) + no_such_column`\n",
+    fixed = TRUE
+  )
+  expect_false(grepl("+...", message, fixed = TRUE))
+  # The condition itself is still dbplyr's, restated context and all.
+  expect_s3_class(error$parent, "condition")
+})
+
+test_that("a native label two dots share is left as dplyr wrote it", {
+  # `a`, `value`, and `no_such_column` are read from the lazy input, which
+  # codetools reads as undefined globals wherever a verb's arguments are
+  # written inside a function.
+  # nolint start: object_usage_linter.
+  error <- expect_error(
+    summarize_with_margins(
+      native_grouping_sets_input(),
+      grouping_bit(a) + no_such_column,
+      grouping_bit(a) + value,
+      .grouping = rollup(a)
+    )
+  )
+  # nolint end
+
+  # Two unnamed dots the callers spelled differently collapse to one label, so
+  # `branch_argument_map()` finds no single candidate and drops the entry.
+  expect_match(
+    conditionMessage(error),
+    "In argument: `+...`",
+    fixed = TRUE
+  )
+})
+
 test_that("a propagated error keeps its class, diagnostic, and cause", {
   error <- expect_error(summarize_failing_rollup())
 
@@ -812,6 +882,12 @@ test_that("a bullet this cannot read leaves the condition alone", {
   expect_identical(
     restated(paste0("i In argument: `dplyr::all_of(\"x\")`.", cause)),
     paste0("i In argument: `c(x)`.", cause)
+  )
+  # dbplyr's bullet carries no trailing period, and one is neither required to
+  # read the span nor added when the bullet is rebuilt.
+  expect_identical(
+    restated(paste0("i In argument: `dplyr::all_of(\"x\")`", cause)),
+    paste0("i In argument: `c(x)`", cause)
   )
   # A wording dplyr could move to.
   expect_identical(

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -121,6 +121,34 @@ native_grouping_sets_input <- function() {
   )
 }
 
+# A summary expression dbplyr cannot translate, on that input.
+native_translation_failure <- function() {
+  # `a`, `value`, and `no_such_column` are read from the lazy input, which
+  # codetools reads as undefined globals wherever a verb's arguments are
+  # written inside a function.
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    native_grouping_sets_input(),
+    total = sum(value) + grouping_bit(a) + no_such_column,
+    .grouping = rollup(a)
+  )
+  # nolint end
+}
+
+# The same failure under two unnamed dots the caller spelled differently. Both
+# collapse to one label, so the span says which expression raised the error but
+# not which argument did.
+native_shared_label_failure <- function() {
+  # nolint start: object_usage_linter.
+  summarize_with_margins(
+    native_grouping_sets_input(),
+    grouping_bit(a) + no_such_column,
+    grouping_bit(a) + value,
+    .grouping = rollup(a)
+  )
+  # nolint end
+}
+
 # One plan whose two grouping sets raise whatever the caller asks them to.
 # `dplyr::n()` is 3 only in the grouping set that groups by nothing, which
 # `rollup()` runs second, so `whole` is the later branch and `fail` makes it
@@ -692,9 +720,12 @@ test_that("a branch error quotes the caller's own spelling", {
   error <- expect_error(summarize_across_failure())
 
   message <- conditionMessage(error)
+  # The trailing period is part of the assertion: eager dplyr's sentence
+  # carries one, and the rebuild puts back the punctuation it found rather
+  # than dropping or doubling it.
   expect_match(
     message,
-    "`dplyr::across(c(grade), ~sum(nope(.x)))`",
+    "`dplyr::across(c(grade), ~sum(nope(.x)))`.",
     fixed = TRUE
   )
   expect_false(grepl("all_of", message, fixed = TRUE))
@@ -708,18 +739,7 @@ test_that("a branch error quotes the caller's own spelling", {
 # that quietly stopped happening reads exactly like a package whose contexts
 # were all still faithful.
 test_that("a native translation error quotes the caller's own spelling", {
-  # `a`, `value`, and `no_such_column` are read from the lazy input, which
-  # codetools reads as undefined globals wherever a verb's arguments are
-  # written inside a function.
-  # nolint start: object_usage_linter.
-  error <- expect_error(
-    summarize_with_margins(
-      native_grouping_sets_input(),
-      total = sum(value) + grouping_bit(a) + no_such_column,
-      .grouping = rollup(a)
-    )
-  )
-  # nolint end
+  error <- expect_error(native_translation_failure())
 
   message <- conditionMessage(error)
   # The trailing newline is part of the assertion: dbplyr's sentence carries no
@@ -736,22 +756,10 @@ test_that("a native translation error quotes the caller's own spelling", {
 })
 
 test_that("a native label two dots share is left as dplyr wrote it", {
-  # `a`, `value`, and `no_such_column` are read from the lazy input, which
-  # codetools reads as undefined globals wherever a verb's arguments are
-  # written inside a function.
-  # nolint start: object_usage_linter.
-  error <- expect_error(
-    summarize_with_margins(
-      native_grouping_sets_input(),
-      grouping_bit(a) + no_such_column,
-      grouping_bit(a) + value,
-      .grouping = rollup(a)
-    )
-  )
-  # nolint end
+  error <- expect_error(native_shared_label_failure())
 
-  # Two unnamed dots the callers spelled differently collapse to one label, so
-  # `branch_argument_map()` finds no single candidate and drops the entry.
+  # `branch_argument_map()` finds no single candidate for the shared label and
+  # drops the entry, so dplyr's own quotation stands.
   expect_match(
     conditionMessage(error),
     "In argument: `+...`",


### PR DESCRIPTION
Implements #411 (decision: #410, ADR 0022's *Amendment: the native adapter's translation error is restated too*).

A caller on duckdb or postgres whose summary expression dbplyr cannot translate was quoted `total = +...`. The label is not truncated by length: `rewrite_grouping_dots()` splices in a SQL literal whose own deparse overflows the width `as_label()` deparses at, so any dot combining a contextual helper with anything else was unreadable. It now quotes what the caller wrote, as a local input already did.

## Changes

- `restate_argument_bullet()` captures the bullet's trailing period rather than requiring it, and rebuilds with what it captured. dbplyr's sentence carries none, so the reader matched nothing there even where the map's key already equalled the span.
- `summarize_margin_native()` takes the caller's labels, builds the map from its rewritten dots, and re-raises a restated error. Not `with_branch_conditions()`: the adapter summarizes once and repeats nothing. Errors only.
- The catch wraps both calls that hand dplyr the caller's expressions. The adapter also summarizes them ungrouped to learn the output names, and that call runs first — measured here, it is the one that raises. `check_summary_output_names()` stays outside it, its argument forced before it, so a Package condition is never reached by the restatement. ADR 0022's amendment is corrected to say this; it had said the catch was around the grouped `summarize()` alone.
- The native call site's comment claiming no condition is raised while the verb runs is gone. It was false when written.

## Tests

Both directions, through `dbplyr::simulate_postgres()`, which needs no optional backend: the restoration, and the label two differently spelled unnamed dots collapse to, which `branch_argument_map()` drops so dplyr's own quotation stands. The seam test gains the periodless bullet.

Verified additionally against a live duckdb connection.

Closes #411.