### PR TITLE
Restore an NA factor level on every column crossing the union (#415)

### DIFF
--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -49,8 +49,8 @@ grouping_selection_proxy <- function(.data,
 # rather than anything a caller can rewrite their way out of -- either a proxy
 # that does not answer for its own columns, or a subclass whose `[[` is not
 # column extraction. It is still worth stopping on, and stopping bare: silence
-# here would report the dimension as an absent prototype and label its margin
-# rows `NA` instead.
+# here would report a column with no levels and no prototype as one the input
+# declared that way.
 proxy_columns <- function(data_proxy, cols) {
   columns <- stats::setNames(
     lapply(cols, function(col) data_proxy[[col]]),
@@ -72,9 +72,8 @@ proxy_columns <- function(data_proxy, cols) {
 # `carried` names the input columns that reach the result beside the Margin
 # dimensions -- a fixed `.by` key, or a column the verb passes through. They
 # cross the same branch union and lose a declared NA level in the same place,
-# so `factors` covers them too (#415). Each verb states its own set, because
-# what a result carries is a property of the verb: only a column present in
-# the result can be rebuilt after the union.
+# so `factors` covers them too (#415). Which columns those are is settled by
+# `prepare_margin_operation()`'s `carried_columns`.
 #
 # `prototypes` stays keyed to the dimensions alone. It stands for the value a
 # branch omitting a dimension writes, and only a dimension is ever omitted.

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -51,12 +51,12 @@ grouping_selection_proxy <- function(.data,
 # column extraction. It is still worth stopping on, and stopping bare: silence
 # here would report the dimension as an absent prototype and label its margin
 # rows `NA` instead.
-proxy_columns <- function(data_proxy, dimensions) {
+proxy_columns <- function(data_proxy, cols) {
   columns <- stats::setNames(
-    lapply(dimensions, function(col) data_proxy[[col]]),
-    dimensions
+    lapply(cols, function(col) data_proxy[[col]]),
+    cols
   )
-  absent <- dimensions[vapply(columns, is.null, logical(1))]
+  absent <- cols[vapply(columns, is.null, logical(1))]
   if (length(absent) > 0L) {
     stop(
       "The selection proxy has no column",
@@ -69,10 +69,25 @@ proxy_columns <- function(data_proxy, dimensions) {
   columns
 }
 
+# `carried` names the input columns that reach the result beside the Margin
+# dimensions -- a fixed `.by` key, or a column the verb passes through. They
+# cross the same branch union and lose a declared NA level in the same place,
+# so `factors` covers them too (#415). Each verb states its own set, because
+# what a result carries is a property of the verb: only a column present in
+# the result can be rebuilt after the union.
+#
+# `prototypes` stays keyed to the dimensions alone. It stands for the value a
+# branch omitting a dimension writes, and only a dimension is ever omitted.
+#
+# No query is added. The selection proxy already holds every column for each
+# kind that can restore factors, so reading more of it is a second read of the
+# one snapshot ADR 0002 acquired rather than a second acquisition.
 margin_column_info <- function(data_proxy,
                                dimensions,
-                               backend) {
-  if (length(dimensions) == 0L) {
+                               backend,
+                               carried = character()) {
+  read <- unique(c(dimensions, carried))
+  if (length(read) == 0L) {
     return(list(factors = list(), prototypes = list()))
   }
 
@@ -80,9 +95,9 @@ margin_column_info <- function(data_proxy,
     return(list(factors = list(), prototypes = list()))
   }
 
-  schema <- proxy_columns(data_proxy, dimensions)
+  schema <- proxy_columns(data_proxy, read)
 
-  prototypes <- lapply(schema, function(x) x[NA_integer_])
+  prototypes <- lapply(schema[dimensions], function(x) x[NA_integer_])
   factors <- if (backend$can_restore_factors) {
     lapply(
       names(schema)[vapply(schema, is.factor, logical(1))],

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -114,6 +114,9 @@ expand_with_margins <- function(.data,
     .duplicates = .duplicates,
     .sort = .sort,
     duplicates_choices = margin_duplicates_choices,
+    # An expansion branch is the input's own rows, so every column of the input
+    # reaches the result and none of them is summarised away.
+    carried_columns = function(data_vars, plan) data_vars,
     .id = .id,
     call = call
   )

--- a/R/factor.R
+++ b/R/factor.R
@@ -11,7 +11,7 @@ factor_missing_sentinel <- function(info, .margin_name) {
   sentinel
 }
 
-# Whether a factor dimension crosses the branch union as character despite a
+# Whether a factor column crosses the branch union as character despite a
 # missing Margin label, which is what `encode_missing_label` in
 # `R/backend-metadata.R` records for the column. Both sides of the route read
 # this, so neither can encode what the other does not rebuild.
@@ -19,15 +19,17 @@ encodes_missing_label_factor <- function(info, label) {
   is_missing_margin_label(label) && isTRUE(info$encode_missing_label)
 }
 
-# The sentinel each factor dimension is carried as while it crosses the branch
+# The sentinel each factor column is carried as while it crosses the branch
 # union as character, keyed by column. Derived once so that the value a branch
-# omitting the dimension writes is the one the branches including it encode to,
+# omitting a dimension writes is the one the branches including it encode to,
 # rather than the two arms deriving it apart.
 margin_factor_sentinels <- function(factor_info, margin_labels) {
   stats::setNames(
     lapply(
       factor_info,
-      function(info) factor_missing_sentinel(info, margin_labels[[info$col]])
+      function(info) {
+        factor_missing_sentinel(info, margin_label_of(margin_labels, info$col))
+      }
     ),
     vapply(factor_info, function(info) info$col, character(1))
   )
@@ -93,7 +95,7 @@ restore_margin_factors <- function(.data,
 
   Reduce(
     function(data, info) {
-      label <- margin_labels[[info$col]]
+      label <- margin_label_of(margin_labels, info$col)
       # A missing label adds no level, so a column the branches carried as
       # their own class arrives with its levels already intact. The exception
       # is one that crossed the union as character to keep them, which is

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -130,6 +130,18 @@ is_missing_margin_label <- function(label) {
   is.null(label) || is.na(label)
 }
 
+# One column's Margin label, and `NULL` for a column that has none.
+# `factor_info` names the factor columns crossing the branch union while
+# `margin_labels` is keyed to the Margin dimensions alone, so every read that
+# iterates the former reaches a name the latter does not hold (#415), where
+# `[[` raises a subscript error rather than answering that it is unlabelled.
+margin_label_of <- function(margin_labels, col) {
+  if (!col %in% names(margin_labels)) {
+    return(NULL)
+  }
+  margin_labels[[col]]
+}
+
 validate_margin_label <- function(.data,
                                   dimensions,
                                   by,
@@ -207,7 +219,7 @@ check_declared_label_collision <- function(margin_labels,
   declared <- vapply(
     factor_info,
     function(info) {
-      label <- margin_labels[[info$col]]
+      label <- margin_label_of(margin_labels, info$col)
       !is_missing_margin_label(label) && label %in% info$levels
     },
     logical(1)
@@ -390,16 +402,24 @@ label_margin_branch <- function(.data,
   missing_label_encoded <- vapply(
     Filter(
       function(info) {
-        encodes_missing_label_factor(info, margin_labels[[info$col]])
+        encodes_missing_label_factor(
+          info,
+          margin_label_of(margin_labels, info$col)
+        )
       },
       factor_info
     ),
     function(info) info$col,
     character(1)
   )
+  # A column `factor_info` names that is not a dimension is a fixed `.by` key
+  # or one the verb passes through, so it is in every branch rather than in
+  # the ones that include it, and it is never labelled: only the encoded arm
+  # above can select it (#415).
   encoded_factors <- Filter(
     function(info) {
-      info$col %in% included &&
+      present <- !(info$col %in% plan$dimensions) || info$col %in% included
+      present &&
         (info$col %in% missing_label_encoded ||
            (info$col %in% labelled_included &&
               isTRUE(info$preserve_missing_value)))

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -229,6 +229,12 @@ check_margin_id_collision <- function(.id, names, where) {
   invisible(NULL)
 }
 
+# `carried_columns` answers which of the input's columns the verb's result
+# holds beside the Margin dimensions, given the input's column names and the
+# compiled plan. Each verb hands in its own answer rather than a word naming
+# its kind, the shape `abort_margin_label_collision()` takes, because the
+# answer is a property of the verb: only a column the result holds can have
+# its factor levels rebuilt after the branch union (#415).
 prepare_margin_operation <- function(.data,
                                      by_quo,
                                      grouping_quo,
@@ -238,11 +244,13 @@ prepare_margin_operation <- function(.data,
                                      .duplicates,
                                      .sort,
                                      duplicates_choices,
+                                     carried_columns,
                                      .id = NULL,
                                      validate_grouping = NULL,
                                      call = rlang::caller_call()) {
   stopifnot(rlang::is_quosure(by_quo), rlang::is_quosure(grouping_quo))
   stopifnot(is.null(validate_grouping) || is.function(validate_grouping))
+  stopifnot(is.function(carried_columns))
 
   with_margin_error_call(
     {
@@ -286,7 +294,8 @@ prepare_margin_operation <- function(.data,
       column_info <- margin_column_info(
         data_proxy,
         plan$dimensions,
-        backend = backend
+        backend = backend,
+        carried = carried_columns(data_vars, plan)
       )
       margin_labels <- resolve_margin_labels(
         .margin_label,

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -254,6 +254,11 @@ nest_margin_pipeline <- function(.data,
     .duplicates = .duplicates,
     .sort = .sort,
     duplicates_choices = nest_duplicates_choices,
+    # Nesting expands every column and then folds all but the grouping columns
+    # into `.key`, so the fixed `.by` keys are what the result carries as
+    # columns of its own. A payload column is inside a cell by the time the
+    # finalizer runs, where nothing rebuilds it.
+    carried_columns = function(data_vars, plan) plan$by,
     .id = .id,
     call = call
   )

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -875,6 +875,12 @@ summarize_with_margins <- function(.data,
     .duplicates = .duplicates,
     .sort = .sort,
     duplicates_choices = margin_duplicates_choices,
+    # A summary result holds the grouping columns and the caller's outputs, so
+    # the fixed `.by` keys are the whole of what it carries from the input. A
+    # summary output is free to reuse another column's name, which is why this
+    # is not the input's column names narrowed to what the result happens to
+    # hold: that name would be rebuilt from the input column's levels.
+    carried_columns = function(data_vars, plan) plan$by,
     .id = .id,
     validate_grouping = share_grouping_spec_validator(share_kinds),
     call = call

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -234,6 +234,152 @@ test_that("dtplyr keeps a used NA level apart from a typed missing", {
   }
 })
 
+# A factor column that is not a Margin dimension crosses the same branch union
+# and loses the same declared NA level there (#415). Neither a fixed `.by` key
+# nor a passed-through column is labelled, so each takes the route #408 opened
+# for a dimension whose Margin label is missing, and the set `factor_info`
+# names widens from the Margin dimensions to the factor columns crossing the
+# union.
+na_level_carried_data <- function(ordered = FALSE) {
+  carried_class <- if (ordered) c("ordered", "factor") else "factor"
+  data.frame(
+    key = structure(
+      c(1L, 2L),
+      levels = c("p", NA_character_),
+      class = "factor"
+    ),
+    passthrough = structure(
+      c(1L, 2L),
+      levels = c("a", NA_character_),
+      class = carried_class
+    ),
+    group = factor(c("g1", "g2")),
+    value = 1:2
+  )
+}
+
+# Compared against the local result the way the #408 cases are, and by integer
+# code for the reason `factor_contract_rows()` gives: a value on the NA level
+# and a typed missing are one displayed value and two codes. Sorted because
+# ADR 0018 leaves within-set row order to the backend.
+expect_carried_factor_agrees <- function(result, expected, col) {
+  expect_identical(levels(result[[col]]), c("a", NA))
+  expect_identical(levels(result[[col]]), levels(expected[[col]]))
+  expect_identical(
+    sort(as.integer(result[[col]])),
+    sort(as.integer(expected[[col]]))
+  )
+  expect_false(any(is.na(result[[col]])))
+  expect_identical(any(is.na(result[[col]])), any(is.na(expected[[col]])))
+}
+
+test_that("dtplyr keeps a used NA level on a fixed .by key", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_carried_data()
+  operation <- function(input) {
+    summarize_with_margins(
+      input,
+      n = dplyr::n(),
+      .by = key,
+      .grouping = rollup(group)
+    )
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  expect_s3_class(result$key, "factor")
+  expect_identical(levels(result$key), c("p", NA))
+  expect_identical(levels(result$key), levels(expected$key))
+  expect_identical(
+    sort(as.integer(result$key)),
+    sort(as.integer(expected$key))
+  )
+  # Every row of both results holds a value on the NA level, so `is.na()` is
+  # false throughout: the key is never a margin row's typed missing.
+  expect_false(any(is.na(result$key)))
+  expect_identical(any(is.na(result$key)), any(is.na(expected$key)))
+})
+
+test_that("dtplyr keeps a used NA level on a passed-through column", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_carried_data()
+  operation <- function(input) {
+    expand_with_margins(input, .grouping = rollup(group))
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  expect_s3_class(result$passthrough, "factor")
+  expect_carried_factor_agrees(result, expected, "passthrough")
+})
+
+test_that("a passed-through ordered factor keeps its ordering", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_carried_data(ordered = TRUE)
+  operation <- function(input) {
+    expand_with_margins(input, .grouping = rollup(group))
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  expect_s3_class(result$passthrough, "ordered")
+  expect_s3_class(expected$passthrough, "ordered")
+  expect_carried_factor_agrees(result, expected, "passthrough")
+})
+
+test_that("a Margin label position adds no level to a carried column", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_carried_data()
+
+  for (position in c("first", "last")) {
+    result <- dplyr::collect(expand_with_margins(
+      dtplyr::lazy_dt(data),
+      .grouping = rollup(group),
+      .margin_label = "All",
+      .margin_label_position = position
+    ))
+    # The dimension takes the label at the requested end; neither carried
+    # column takes one at either, so their levels are what the input declared.
+    expect_identical(
+      levels(result$group),
+      if (identical(position, "first")) {
+        c("All", "g1", "g2")
+      } else {
+        c("g1", "g2", "All")
+      },
+      info = position
+    )
+    expect_identical(levels(result$key), c("p", NA), info = position)
+    expect_identical(levels(result$passthrough), c("a", NA), info = position)
+  }
+})
+
+# The route a carried column takes is unobservable in a result that has taken
+# it correctly: a factor with no NA level is rebuilt on the levels it already
+# had. So what the acceptance asks for -- that such a column is not encoded to
+# character and not rebuilt -- is asserted where the decision is made.
+test_that("a carried factor with no NA level takes no encode route", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_carried_data()
+  proxy <- grouping_selection_proxy(dtplyr::lazy_dt(data))
+  info <- margin_column_info(
+    proxy,
+    dimensions = "group",
+    carried = c("key", "passthrough"),
+    backend = grouping_backend(dtplyr::lazy_dt(data))
+  )
+
+  encode <- vapply(info$factors, function(x) x$encode_missing_label, logical(1))
+  names(encode) <- vapply(info$factors, function(x) x$col, character(1))
+  expect_setequal(names(encode), c("group", "key", "passthrough"))
+  expect_false(encode[["group"]])
+  expect_true(encode[["key"]])
+  expect_true(encode[["passthrough"]])
+  # Prototypes stand for the value an omitted dimension writes, and only a
+  # dimension is ever omitted, so widening the factor read leaves them alone.
+  expect_identical(names(info$prototypes), "group")
+})
+
 test_that("NA factor levels stay structural when collision checks are off", {
   with_na_level <- factor_contract_data(
     has_na_level = TRUE,

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -253,6 +253,7 @@ na_level_carried_data <- function(ordered = FALSE) {
       levels = c("a", NA_character_),
       class = carried_class
     ),
+    plain = factor(c("q", "r")),
     group = factor(c("g1", "g2")),
     value = 1:2
   )
@@ -262,15 +263,18 @@ na_level_carried_data <- function(ordered = FALSE) {
 # code for the reason `factor_contract_rows()` gives: a value on the NA level
 # and a typed missing are one displayed value and two codes. Sorted because
 # ADR 0018 leaves within-set row order to the backend.
-expect_carried_factor_agrees <- function(result, expected, col) {
-  expect_identical(levels(result[[col]]), c("a", NA))
-  expect_identical(levels(result[[col]]), levels(expected[[col]]))
+expect_passthrough_agrees <- function(result, expected) {
+  expect_identical(levels(result$passthrough), c("a", NA))
+  expect_identical(levels(result$passthrough), levels(expected$passthrough))
   expect_identical(
-    sort(as.integer(result[[col]])),
-    sort(as.integer(expected[[col]]))
+    sort(as.integer(result$passthrough)),
+    sort(as.integer(expected$passthrough))
   )
-  expect_false(any(is.na(result[[col]])))
-  expect_identical(any(is.na(result[[col]])), any(is.na(expected[[col]])))
+  expect_false(any(is.na(result$passthrough)))
+  expect_identical(
+    any(is.na(result$passthrough)),
+    any(is.na(expected$passthrough))
+  )
 }
 
 test_that("dtplyr keeps a used NA level on a fixed .by key", {
@@ -310,7 +314,7 @@ test_that("dtplyr keeps a used NA level on a passed-through column", {
   result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
   expected <- operation(data)
   expect_s3_class(result$passthrough, "factor")
-  expect_carried_factor_agrees(result, expected, "passthrough")
+  expect_passthrough_agrees(result, expected)
 })
 
 test_that("a passed-through ordered factor keeps its ordering", {
@@ -324,7 +328,7 @@ test_that("a passed-through ordered factor keeps its ordering", {
   expected <- operation(data)
   expect_s3_class(result$passthrough, "ordered")
   expect_s3_class(expected$passthrough, "ordered")
-  expect_carried_factor_agrees(result, expected, "passthrough")
+  expect_passthrough_agrees(result, expected)
 })
 
 test_that("a Margin label position adds no level to a carried column", {
@@ -365,13 +369,17 @@ test_that("a carried factor with no NA level takes no encode route", {
   info <- margin_column_info(
     proxy,
     dimensions = "group",
-    carried = c("key", "passthrough"),
+    carried = c("key", "passthrough", "plain"),
     backend = grouping_backend(dtplyr::lazy_dt(data))
   )
 
   encode <- vapply(info$factors, function(x) x$encode_missing_label, logical(1))
   names(encode) <- vapply(info$factors, function(x) x$col, character(1))
-  expect_setequal(names(encode), c("group", "key", "passthrough"))
+  expect_setequal(names(encode), c("group", "key", "passthrough", "plain"))
+  # `plain` is the carried column the criterion is about: a factor with no NA
+  # level. The two that have one take the route, and the dimension is here to
+  # say that being a dimension is not what decides it.
+  expect_false(encode[["plain"]])
   expect_false(encode[["group"]])
   expect_true(encode[["key"]])
   expect_true(encode[["passthrough"]])

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -377,8 +377,7 @@ test_that("a carried factor with no NA level takes no encode route", {
   names(encode) <- vapply(info$factors, function(x) x$col, character(1))
   expect_setequal(names(encode), c("group", "key", "passthrough", "plain"))
   # `plain` is the carried column the criterion is about: a factor with no NA
-  # level. The two that have one take the route, and the dimension is here to
-  # say that being a dimension is not what decides it.
+  # level.
   expect_false(encode[["plain"]])
   expect_false(encode[["group"]])
   expect_true(encode[["key"]])


### PR DESCRIPTION
Closes #415.

A factor column carrying a declared `NA` level lost it on a dtplyr input whenever it crossed the branch union without being a Margin dimension — as a fixed `.by` key, or as a column the verb passes through — and the values that used the level became missing. #408 fixed the dimension case; `label_margin_branch()` and `restore_margin_factors()` both reached its encode-and-rebuild route from the plan's dimensions alone.

`margin_column_info()` now takes `carried`, the input columns the verb's result holds beside the dimensions, and returns `factor_info` for those too. `prototypes` stays keyed to the dimensions, which are the only columns a branch omits. No query is added: the selection proxy already holds every column for each kind that can restore factors, so this is a second read of the one snapshot ADR 0002 acquired.

Each verb states its own set rather than a word naming its kind, because only a column the result holds can be rebuilt after the union: `expand_with_margins()` carries every column, while the summary and nest verbs carry the fixed `.by` keys — a summary output may reuse an input column's name, and a nested payload column is inside a cell by the time the finalizer runs.

`margin_label_of()` is what lets the widened set be read against `margin_labels`, which stays keyed to the dimensions: `[[` on an absent name raises a subscript error rather than answering that the column is unlabelled.

## Residual

A dtplyr `nest_with_margins()` payload column still loses a declared `NA` level inside its cell. That is the same union, but the column is inside `.key` by the time the finalizer runs and nothing rebuilds it, so it is outside this ticket's Reproduction and Acceptance. Filed as #421 rather than widened into here.

## Verification

- The issue's Reproduction prints `[1] "p" NA` and `[1] "a" NA` on both backends, with `is.na()` agreeing.
- `testthat::test_local()` green with dtplyr, duckdb, arrow, data.table, DBI and tidyr installed; `test-query-policy.R`'s snapshots unchanged.
- `lintr::lint_package()` clean.