### PR TITLE
Verify that a path a maintained document names exists (#417)

### DIFF
--- a/.github/scripts/verify-doc-references.R
+++ b/.github/scripts/verify-doc-references.R
@@ -1,0 +1,280 @@
+# Fails when a maintained document names a repository path no file answers.
+#
+# `AGENTS.md`'s *Code comments* requires a citation to name its target rather
+# than a coordinate, because a name fails loudly: a grep for it returns
+# nothing. Nothing in this repository ran that grep, so a path a document names
+# and that was since renamed or deleted stayed in place reading as though it
+# resolved -- which is the failure every gate here exists to refuse, a
+# reference that asserts nothing and reports nothing (#417).
+#
+# What is read, and why each bound is where it is:
+#
+# * Prose, not code. A path in a string literal is resolved by the interpreter
+#   and fails at run time when it is wrong; `verify-verifier-invocation.R`
+#   already reports the `source()` case. A path in a comment resolves for
+#   nobody, so nothing but this fails on it. Markdown is prose throughout; in
+#   `.R` and YAML it is the comment text.
+# * Maintained documents. `investigation/` notes are not maintained after their
+#   date (`investigation/README.md`), and they describe other packages' source
+#   trees, so an `R/`-rooted path in a note is rlang's or arrow's and no scan
+#   can tell that from ours. Their own file names are still covered, from the
+#   side of every document that cites one. `investigation/README.md` states
+#   the convention rather than recording a note, so it is read.
+# * Generated files. `README.md` is rendered from `README.Rmd`, which is read
+#   in its place; `man/` and `NAMESPACE` are roxygen output and carry no
+#   extension this reads.
+# * Paths, not bare names. A candidate has to contain a `/`. A bare
+#   `CHANGELOG.md` or `cnd-last.R` names a file in whatever tree the sentence
+#   is about, and matching it against this repository's base names reports
+#   prose about another repository as a dead reference.
+# * Files, not directories. Prose spells an alternative `a/b` the way a
+#   directory path is spelled, so a trailing-slash match is noise rather than a
+#   weaker signal: on this repository it returns `and/or`, `Config/Needs/`, and
+#   `filter/summarise/` before it returns a directory. A renamed directory is
+#   caught through the files under it that anything cites.
+#
+# A candidate's extension has to be one some tracked file carries. That is
+# derived rather than listed, and it is what excludes the `.html` paths, which
+# are the site URLs `R/*.R` roxygen links to and the rendered vignettes
+# `cran-comments.md` says the tarball ships: no tracked file is `.html`, so an
+# `.html` path never names one.
+#
+# A candidate resolves against the tracked set -- not the working tree, which
+# carries `docs/` and other build output that varies by what was last run --
+# either repository-relative or relative to the document naming it, since a
+# markdown link resolves the second way. A `*` is matched as a glob.
+#
+# Run it locally with:
+#
+#     Rscript .github/scripts/verify-doc-references.R
+
+source(".github/scripts/ci-helpers.R")
+
+# Paths a document names deliberately and that no file answers. Each entry
+# states why the reference is correct as written; the check below fails when
+# one goes stale, in either direction, so this cannot outlive what it excuses.
+exempt <- data.frame(
+  file = c(
+    "design/agents/code-review.md",
+    "design/agents/code-review.md"
+  ),
+  path = c(
+    "design/review-dispositions.md",
+    "docs/agents/issue-tracker.md"
+  ),
+  reason = c(
+    paste(
+      "past tense: #288 retired the file, and the sentence records that it",
+      "has no successor"
+    ),
+    paste(
+      "the left column of a table of what the skill looks for, so the row",
+      "exists to say this repository has no such file"
+    )
+  ),
+  stringsAsFactors = FALSE
+)
+
+tracked <- system2("git", "ls-files", stdout = TRUE)
+
+if (length(tracked) == 0L) {
+  stop(call. = FALSE, paste0(
+    "`git ls-files` returned nothing, so every path below would resolve to ",
+    "no file and every document would be reported. That is this script ",
+    "reading the wrong directory, not a repository of dead references."
+  ))
+}
+
+# The documents read. Prose lives in these six kinds here; the exclusions are
+# the two the header argues for.
+prose_kinds <- c("md", "Rmd", "qmd", "R", "yaml", "yml")
+documents <- tracked[tools::file_ext(tracked) %in% prose_kinds]
+documents <- setdiff(documents, "README.md")
+documents <- documents[!startsWith(documents, "_quarto/")]
+documents <- documents[
+  !startsWith(documents, "investigation/") |
+    basename(documents) == "README.md"
+]
+
+# A URL's path is not a repository path, and a format conversion's argument is
+# not written in prose at all -- `"%s/probe-mentioned.R"` names a path the call
+# builds. Both are removed before anything is matched, so neither can be read
+# as a citation.
+strip_noise <- function(lines) {
+  lines <- gsub("(https?|ftp)://[^[:space:])>\"'`]*", " ", lines)
+  gsub("%[0-9.*-]*[a-zA-Z]", " ", lines)
+}
+
+prose <- function(path) {
+  lines <- readLines(path, warn = FALSE)
+  if (tools::file_ext(path) %in% c("R", "yaml", "yml")) {
+    lines <- regmatches(lines, regexpr("#.*$", lines))
+  }
+  strip_noise(lines)
+}
+
+# Longest extension first so the alternation cannot stop at `R` inside `Rmd`;
+# `\\b` is what rejects the short match, and the order saves the backtrack.
+extensions <- unique(tools::file_ext(tracked))
+extensions <- extensions[nzchar(extensions)]
+extensions <- extensions[order(-nchar(extensions))]
+
+segment <- "[A-Za-z0-9_.*+-]+"
+candidate_pattern <- sprintf(
+  "%s(/%s)*\\.(%s)\\b",
+  segment, segment, paste(extensions, collapse = "|")
+)
+
+candidates <- function(lines) {
+  found <- unique(unlist(regmatches(lines, gregexpr(candidate_pattern, lines))))
+  found[grepl("/", found, fixed = TRUE)]
+}
+
+# Collapses `.` and `..` textually. The path may not exist, which is the whole
+# question, so `normalizePath()` is not what answers it.
+flatten <- function(path) {
+  kept <- character()
+  for (part in strsplit(path, "/", fixed = TRUE)[[1]]) {
+    if (part == ".." && length(kept) > 0L) {
+      kept <- kept[-length(kept)]
+    } else if (part != "." && part != "..") {
+      kept <- c(kept, part)
+    }
+  }
+  paste(kept, collapse = "/")
+}
+
+resolves <- function(candidate, from) {
+  here <- dirname(from)
+  targets <- unique(c(
+    candidate,
+    if (here == ".") candidate else flatten(file.path(here, candidate))
+  ))
+  for (target in targets) {
+    if (target %in% tracked) {
+      return(TRUE)
+    }
+    globbed <- grepl("*", target, fixed = TRUE) &&
+      any(grepl(utils::glob2rx(target), tracked))
+    if (globbed) {
+      return(TRUE)
+    }
+  }
+  FALSE
+}
+
+# The reader, before the verdict. A reader that stopped matching reports a
+# clean repository; one that stopped stripping reports every URL in it. Both
+# are answered here, where the diagnosis is this file and not a document.
+probe <- strip_noise(c(
+  "cites `design/architecture.md` and https://example.org/design/absent.md",
+  "sprintf(\"# %s/probe-mentioned.R\", dir)"
+))
+if (!identical(candidates(probe), "design/architecture.md")) {
+  stop(call. = FALSE, paste0(
+    "The candidate reader in this script does not separate a cited path from ",
+    "a URL and a built one, so every verdict below would be about the ",
+    "reader. Fix `strip_noise()` and `candidate_pattern` here before reading ",
+    "the repository."
+  ))
+}
+
+dead <- list()
+counted <- 0L
+
+for (document in documents) {
+  for (candidate in candidates(prose(document))) {
+    counted <- counted + 1L
+    if (resolves(candidate, document)) {
+      next
+    }
+    dead[[length(dead) + 1L]] <- c(document, candidate)
+  }
+}
+
+# The exemptions, held to both directions. One whose path came back is an
+# exemption excusing nothing; one its document stopped naming is an exemption
+# nobody can check.
+named <- vapply(
+  seq_len(nrow(exempt)),
+  function(i) {
+    any(vapply(
+      dead,
+      function(hit) identical(hit, c(exempt$file[i], exempt$path[i])),
+      logical(1)
+    ))
+  },
+  logical(1)
+)
+
+if (any(!named)) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "These exemptions are no longer needed: %s. Either the path now ",
+      "answers to a file, or the document stopped naming it. Delete the ",
+      "entry from `exempt` in this script."
+    ),
+    paste(
+      sprintf("`%s` in `%s`", exempt$path[!named], exempt$file[!named]),
+      collapse = ", "
+    )
+  ))
+}
+
+dead <- Filter(
+  function(hit) {
+    !any(exempt$file == hit[[1]] & exempt$path == hit[[2]])
+  },
+  dead
+)
+
+write_step_summary(c(
+  "## Document references",
+  "",
+  sprintf(
+    "%d path(s) named across %d maintained document(s), %d exempt.",
+    counted, length(documents), nrow(exempt)
+  ),
+  if (length(dead) > 0L) {
+    c("", sprintf(
+      "- **%s** — named by `%s`",
+      vapply(dead, `[[`, character(1), 2L),
+      vapply(dead, `[[`, character(1), 1L)
+    ))
+  }
+))
+
+if (length(dead) > 0L) {
+  # The remedy is part of the message, as `verify-suite-coverage.R`'s is: a
+  # gate that only refuses invites the reference to be deleted rather than
+  # pointed at what replaced it.
+  stop(call. = FALSE, paste(
+    c(
+      paste(
+        "These documents name paths no tracked file answers, so each reads",
+        "as a citation and resolves to nothing:"
+      ),
+      sprintf(
+        "  %s names `%s`",
+        vapply(dead, `[[`, character(1), 1L),
+        vapply(dead, `[[`, character(1), 2L)
+      ),
+      paste(
+        "Point each at the file that now holds what it cited, or delete the",
+        "sentence with what it named. A reference that is correct as written",
+        "-- a retired file named in the past tense, or a path outside this",
+        "repository -- goes in `exempt` in this script with the reason it is",
+        "correct."
+      )
+    ),
+    collapse = "\n"
+  ))
+}
+
+message(sprintf(
+  paste0(
+    "Verified: all %d path(s) named across %d maintained document(s) answer ",
+    "to a tracked file."
+  ),
+  counted, length(documents)
+))

--- a/.github/scripts/verify-doc-references.R
+++ b/.github/scripts/verify-doc-references.R
@@ -9,11 +9,14 @@
 #
 # What is read, and why each bound is where it is:
 #
-# * Prose, not code. A path in a string literal is resolved by the interpreter
-#   and fails at run time when it is wrong; `verify-verifier-invocation.R`
-#   already reports the `source()` case. A path in a comment resolves for
-#   nobody, so nothing but this fails on it. Markdown is prose throughout; in
-#   `.R` and YAML it is the comment text.
+# * Prose, not code. A path in code is either resolved when the code runs,
+#   where a wrong one fails on its own, or it is data the code compares
+#   against -- `verify-site.R`'s `docs/*.html` keys are the page names it
+#   derives. Neither is a citation, and a citation is what this reads.
+#   Markdown is prose throughout. R comments come from the parser, so a `#`
+#   inside a string is not one. YAML is read from its first `#`, which is the
+#   weaker rule of the two: a `#` inside a quoted scalar would be read as a
+#   comment, and no workflow here writes one.
 # * Maintained documents. `investigation/` notes are not maintained after their
 #   date (`investigation/README.md`), and they describe other packages' source
 #   trees, so an `R/`-rooted path in a note is rlang's or arrow's and no scan
@@ -27,22 +30,24 @@
 #   `CHANGELOG.md` or `cnd-last.R` names a file in whatever tree the sentence
 #   is about, and matching it against this repository's base names reports
 #   prose about another repository as a dead reference.
-# * Files, not directories. Prose spells an alternative `a/b` the way a
-#   directory path is spelled, so a trailing-slash match is noise rather than a
-#   weaker signal: on this repository it returns `and/or`, `Config/Needs/`, and
-#   `filter/summarise/` before it returns a directory. A renamed directory is
-#   caught through the files under it that anything cites.
+# * Files, not directories. On `842f156`, the commit before this file, a
+#   trailing-slash match returns 56 references answering to no tracked
+#   directory, and not one of them is dead: they are DESCRIPTION fields, build
+#   output, repository owners, and prose spelling an alternative the way a
+#   path is spelled. Fifty-six exemptions is not a gate. A renamed directory
+#   is caught through the files under it that anything cites.
 #
-# A candidate's extension has to be one some tracked file carries. That is
-# derived rather than listed, and it is what excludes the `.html` paths, which
-# are the site URLs `R/*.R` roxygen links to and the rendered vignettes
-# `cran-comments.md` says the tarball ships: no tracked file is `.html`, so an
-# `.html` path never names one.
+# A candidate's extension has to be one some tracked file carries, derived
+# rather than listed. It is what excludes the `.html` paths `cran-comments.md`
+# names, which are the vignettes the tarball ships rather than anything
+# tracked. The site URLs `R/*.R` roxygen links to never reach it, being
+# stripped as URLs first.
 #
 # A candidate resolves against the tracked set -- not the working tree, which
 # carries `docs/` and other build output that varies by what was last run --
 # either repository-relative or relative to the document naming it, since a
-# markdown link resolves the second way. A `*` is matched as a glob.
+# markdown link resolves the second way. A `*` is matched as a glob that stops
+# at a path separator.
 #
 # Run it locally with:
 #
@@ -85,32 +90,38 @@ if (length(tracked) == 0L) {
   ))
 }
 
-# The documents read. Prose lives in these six kinds here; the exclusions are
-# the two the header argues for.
+# The documents read. Prose lives in these six kinds here; the two exclusions
+# are the ones the header argues for.
 prose_kinds <- c("md", "Rmd", "qmd", "R", "yaml", "yml")
 documents <- tracked[tools::file_ext(tracked) %in% prose_kinds]
 documents <- setdiff(documents, "README.md")
-documents <- documents[!startsWith(documents, "_quarto/")]
 documents <- documents[
   !startsWith(documents, "investigation/") |
     basename(documents) == "README.md"
 ]
 
-# A URL's path is not a repository path, and a format conversion's argument is
-# not written in prose at all -- `"%s/probe-mentioned.R"` names a path the call
-# builds. Both are removed before anything is matched, so neither can be read
-# as a citation.
+# A URL's path is not a repository path, and neither is what a `%` spelling
+# stands in for: `"%s/probe-mentioned.R"` names a path the call builds, and
+# `%in%` names an operator. Both are removed before anything is matched.
 strip_noise <- function(lines) {
   lines <- gsub("(https?|ftp)://[^[:space:])>\"'`]*", " ", lines)
   gsub("%[0-9.*-]*[a-zA-Z]", " ", lines)
 }
 
-prose <- function(path) {
-  lines <- readLines(path, warn = FALSE)
-  if (tools::file_ext(path) %in% c("R", "yaml", "yml")) {
-    lines <- regmatches(lines, regexpr("#.*$", lines))
+# The prose of one document, by kind. Takes lines rather than a path so that
+# the probe below runs the same code the scan does.
+prose_of <- function(lines, kind) {
+  if (kind == "R") {
+    data <- utils::getParseData(parse(text = lines, keep.source = TRUE))
+    if (is.null(data)) {
+      return(character())
+    }
+    return(data$text[data$token == "COMMENT"])
   }
-  strip_noise(lines)
+  if (kind %in% c("yaml", "yml")) {
+    return(regmatches(lines, regexpr("#.*$", lines)))
+  }
+  lines
 }
 
 # Longest extension first so the alternation cannot stop at `R` inside `Rmd`;
@@ -119,29 +130,48 @@ extensions <- unique(tools::file_ext(tracked))
 extensions <- extensions[nzchar(extensions)]
 extensions <- extensions[order(-nchar(extensions))]
 
-segment <- "[A-Za-z0-9_.*+-]+"
+segment <- "[A-Za-z0-9_.*-]+"
 candidate_pattern <- sprintf(
   "%s(/%s)*\\.(%s)\\b",
   segment, segment, paste(extensions, collapse = "|")
 )
 
 candidates <- function(lines) {
+  lines <- strip_noise(lines)
   found <- unique(unlist(regmatches(lines, gregexpr(candidate_pattern, lines))))
   found[grepl("/", found, fixed = TRUE)]
 }
 
-# Collapses `.` and `..` textually. The path may not exist, which is the whole
-# question, so `normalizePath()` is not what answers it.
+# Collapses `.` and `..` textually, because the path may not exist and that is
+# the whole question, so `normalizePath()` is not what answers it. `NA` when
+# `..` walks past the root: a path outside the repository is not a repository
+# path, and dropping the `..` silently would resolve it against the wrong tree.
 flatten <- function(path) {
   kept <- character()
   for (part in strsplit(path, "/", fixed = TRUE)[[1]]) {
-    if (part == ".." && length(kept) > 0L) {
+    if (part == "..") {
+      if (length(kept) == 0L) {
+        return(NA_character_)
+      }
       kept <- kept[-length(kept)]
-    } else if (part != "." && part != "..") {
+    } else if (part != ".") {
       kept <- c(kept, part)
     }
   }
   paste(kept, collapse = "/")
+}
+
+# `utils::glob2rx()` is not what matches a glob here: it renders `*` as `.*`,
+# which crosses `/`, so `man/*.Rd` would answer to a file under a directory of
+# `man/`. Each literal run is escaped and each `*` becomes `[^/]*`.
+glob_pattern <- function(path) {
+  parts <- strsplit(path, "*", fixed = TRUE)[[1]]
+  if (endsWith(path, "*")) {
+    parts <- c(parts, "")
+  }
+  escape <- function(part) gsub("([][^$.|?*+(){}\\\\])", "\\\\\\1", part)
+  quoted <- vapply(parts, escape, character(1))
+  sprintf("^%s$", paste(quoted, collapse = "[^/]*"))
 }
 
 resolves <- function(candidate, from) {
@@ -150,12 +180,13 @@ resolves <- function(candidate, from) {
     candidate,
     if (here == ".") candidate else flatten(file.path(here, candidate))
   ))
+  targets <- targets[!is.na(targets)]
   for (target in targets) {
     if (target %in% tracked) {
       return(TRUE)
     }
     globbed <- grepl("*", target, fixed = TRUE) &&
-      any(grepl(utils::glob2rx(target), tracked))
+      any(grepl(glob_pattern(target), tracked))
     if (globbed) {
       return(TRUE)
     }
@@ -163,51 +194,102 @@ resolves <- function(candidate, from) {
   FALSE
 }
 
-# The reader, before the verdict. A reader that stopped matching reports a
-# clean repository; one that stopped stripping reports every URL in it. Both
-# are answered here, where the diagnosis is this file and not a document.
-probe <- strip_noise(c(
-  "cites `design/architecture.md` and https://example.org/design/absent.md",
-  "sprintf(\"# %s/probe-mentioned.R\", dir)"
-))
-if (!identical(candidates(probe), "design/architecture.md")) {
-  stop(call. = FALSE, paste0(
-    "The candidate reader in this script does not separate a cited path from ",
-    "a URL and a built one, so every verdict below would be about the ",
-    "reader. Fix `strip_noise()` and `candidate_pattern` here before reading ",
-    "the repository."
+# The reader, before the verdict, in each way it can go quiet. A reader that
+# stopped matching reports a clean repository; one that stopped stripping
+# reports every URL in it; one that stopped separating prose from code drops
+# the 66 candidates that reach this scan through an R or YAML comment, or adds
+# every path a string literal holds. Each is answered here, where the
+# diagnosis is this file and not a document.
+probes <- list(
+  list(
+    kind = "md",
+    lines = "cites `design/architecture.md`, https://example.org/design/x.md",
+    want = "design/architecture.md"
+  ),
+  list(
+    kind = "R",
+    lines = c(
+      "path <- \"# tests/testthat/inside-a-string.R\"",
+      "# cites `design/architecture.md`"
+    ),
+    want = "design/architecture.md"
+  ),
+  list(
+    kind = "yaml",
+    lines = c(
+      "        run: Rscript .github/scripts/verify-site.R",
+      "      # cites `design/architecture.md`"
+    ),
+    want = "design/architecture.md"
+  )
+)
+
+for (probe in probes) {
+  if (!identical(candidates(prose_of(probe$lines, probe$kind)), probe$want)) {
+    stop(call. = FALSE, sprintf(
+      paste0(
+        "The reader in this script does not separate a cited path from a URL ",
+        "and from code, on a `%s` document, so every verdict below would be ",
+        "about the reader. Fix `prose_of()`, `strip_noise()`, and ",
+        "`candidate_pattern` here before reading the repository."
+      ),
+      probe$kind
+    ))
+  }
+}
+
+if (length(documents) < 2L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "%d document(s) were selected out of %d tracked file(s), so the scan ",
+      "below reads almost nothing and passes on any repository. Fix ",
+      "`prose_kinds` and the exclusions in this script before trusting what ",
+      "it reports."
+    ),
+    length(documents), length(tracked)
   ))
 }
 
-dead <- list()
+dead <- data.frame(
+  file = character(), path = character(), stringsAsFactors = FALSE
+)
 counted <- 0L
 
 for (document in documents) {
-  for (candidate in candidates(prose(document))) {
+  lines <- readLines(document, warn = FALSE)
+  for (candidate in candidates(prose_of(lines, tools::file_ext(document)))) {
     counted <- counted + 1L
     if (resolves(candidate, document)) {
       next
     }
-    dead[[length(dead) + 1L]] <- c(document, candidate)
+    dead <- rbind(dead, data.frame(
+      file = document, path = candidate, stringsAsFactors = FALSE
+    ))
   }
 }
+
+# The last way this goes quiet, and the one the probes cannot reach: they read
+# three lines this file holds, so they pass on a repository whose documents
+# this script never opened.
+if (counted == 0L) {
+  stop(call. = FALSE, sprintf(
+    paste0(
+      "No path was found in any of %d document(s), which is a repository ",
+      "that cites nothing. Fix the extension derivation and `candidates()` ",
+      "in this script before trusting what it reports."
+    ),
+    length(documents)
+  ))
+}
+
+key <- function(frame) paste(frame$file, frame$path)
 
 # The exemptions, held to both directions. One whose path came back is an
 # exemption excusing nothing; one its document stopped naming is an exemption
 # nobody can check.
-named <- vapply(
-  seq_len(nrow(exempt)),
-  function(i) {
-    any(vapply(
-      dead,
-      function(hit) identical(hit, c(exempt$file[i], exempt$path[i])),
-      logical(1)
-    ))
-  },
-  logical(1)
-)
+stale <- !(key(exempt) %in% key(dead))
 
-if (any(!named)) {
+if (any(stale)) {
   stop(call. = FALSE, sprintf(
     paste0(
       "These exemptions are no longer needed: %s. Either the path now ",
@@ -215,18 +297,13 @@ if (any(!named)) {
       "entry from `exempt` in this script."
     ),
     paste(
-      sprintf("`%s` in `%s`", exempt$path[!named], exempt$file[!named]),
+      sprintf("`%s` in `%s`", exempt$path[stale], exempt$file[stale]),
       collapse = ", "
     )
   ))
 }
 
-dead <- Filter(
-  function(hit) {
-    !any(exempt$file == hit[[1]] & exempt$path == hit[[2]])
-  },
-  dead
-)
+dead <- dead[!(key(dead) %in% key(exempt)), , drop = FALSE]
 
 write_step_summary(c(
   "## Document references",
@@ -235,16 +312,12 @@ write_step_summary(c(
     "%d path(s) named across %d maintained document(s), %d exempt.",
     counted, length(documents), nrow(exempt)
   ),
-  if (length(dead) > 0L) {
-    c("", sprintf(
-      "- **%s** — named by `%s`",
-      vapply(dead, `[[`, character(1), 2L),
-      vapply(dead, `[[`, character(1), 1L)
-    ))
+  if (nrow(dead) > 0L) {
+    c("", sprintf("- **%s** — named by `%s`", dead$path, dead$file))
   }
 ))
 
-if (length(dead) > 0L) {
+if (nrow(dead) > 0L) {
   # The remedy is part of the message, as `verify-suite-coverage.R`'s is: a
   # gate that only refuses invites the reference to be deleted rather than
   # pointed at what replaced it.
@@ -254,11 +327,7 @@ if (length(dead) > 0L) {
         "These documents name paths no tracked file answers, so each reads",
         "as a citation and resolves to nothing:"
       ),
-      sprintf(
-        "  %s names `%s`",
-        vapply(dead, `[[`, character(1), 1L),
-        vapply(dead, `[[`, character(1), 2L)
-      ),
+      sprintf("  %s names `%s`", dead$file, dead$path),
       paste(
         "Point each at the file that now holds what it cited, or delete the",
         "sentence with what it named. A reference that is correct as written",

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,20 @@ jobs:
       - name: Verify the always-loaded context is within its baseline
         run: Rscript .github/scripts/verify-context-budget.R
 
+  # Beside `context-budget` and for its reason: repository hygiene on the same
+  # trigger, needing no package installed. A grep for a name a document cites
+  # is what makes the name fail loudly, and until this step nothing ran one.
+  doc-references:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Verify every path a maintained document names exists
+        run: Rscript .github/scripts/verify-doc-references.R
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
Closes #417.

`AGENTS.md`'s *Code comments* requires a citation to name its target rather than a coordinate, on the argument that a name fails loudly: a grep for it returns nothing. Nothing here ran that grep, so a path a document named and that was since renamed or deleted stayed in place reading as though it resolved.

`.github/scripts/verify-doc-references.R` runs it, from a `doc-references` job in `lint.yaml` — beside `context-budget` and for its reason, since it needs no package installed.

## What it reads, and what it does not

- **Prose, not code.** Markdown throughout; comment text in `.R` and YAML. A path in a string literal is resolved by the interpreter and fails at run time, and `verify-verifier-invocation.R` already reports the `source()` case. A path in a comment resolves for nobody.
- **Maintained documents.** `investigation/` notes are outside the set: they are not maintained after their date, and they describe other packages' source trees, so an `R/`-rooted path in one is rlang's or arrow's and no scan can tell that from ours. Their own file names stay covered from the side of every document that cites one. `investigation/README.md` states the convention rather than recording a note, so it is read.
- **Generated files.** `README.md` is read through `README.Rmd`; `man/` and `NAMESPACE` carry no extension this reads.
- **Paths, not bare names.** A candidate has to contain a `/`. Matching a bare `CHANGELOG.md` or `cnd-last.R` against this repository's base names reports prose about another repository as a dead reference — measured, it returns thirteen such hits and no real one.
- **Files, not directories.** Prose spells an alternative `a/b` the way a directory path is spelled, so a trailing-slash match returns `and/or`, `Config/Needs/`, and `filter/summarise/` before it returns a directory.

A candidate's extension has to be one some tracked file carries. That set is derived rather than listed, which is what excludes the `.html` paths the ticket named as the only apparent hits on `main`: no tracked file is `.html`, so an `.html` path never names one. Resolution is against the tracked set rather than the working tree — which carries `docs/` and other build output that varies by what was last run — either repository-relative or relative to the document naming it, since a markdown link resolves the second way. A `*` is matched as a glob.

## The two exemptions

Both are in `design/agents/code-review.md` and both are correct as written, so each sits in `exempt` with the reason:

- `design/review-dispositions.md` — #288 retired it, and the sentence records that it has no successor.
- `docs/agents/issue-tracker.md` — the left column of a table of what the skill looks for, so the row exists to say this repository has no such file.

The check fails in both directions when an exemption goes stale — the path came back, or the document stopped naming it — so it cannot outlive what it excuses.

## Verification

Green on this branch: 172 paths across 150 maintained documents. Three failure modes were exercised locally and each reported:

- a dead reference injected into `CONTEXT.md`,
- an exemption pointed at a path that resolves,
- the candidate reader stubbed out, which the probe catches before any verdict.

`lintr::lint_dir(".github", ...)` clean, `verify-verifier-invocation.R` lists the new script as reached by a `lint.yaml` step, `verify-context-budget.R` unchanged at 23384 bytes, and the full suite passes.