### PR TITLE
Decide which file owns why must_error exists (#418)

### DIFF
--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,13 +24,12 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 23384L
+baseline_bytes <- 22080L
 baseline_note <- paste(
-  "#416 deleting the `must_error` implementation's three load-bearing",
-  "properties, which `inst/vignette-hooks/must-error.R` already stated at the",
-  "three sites holding them, over #295's baseline; 322 of the 1056 bytes that",
-  "removed paid for the rule that a citation names its target rather than a",
-  "line number"
+  "#418 deleting the gate's argument from *Chunks that must fail*, which",
+  "`verify-must-error.R`'s header and `release-matrix.yaml`'s already held,",
+  "together with the two reasons `inst/vignette-hooks/must-error.R` states",
+  "beside the code each is about, over #416's baseline; nothing was added"
 )
 
 entry <- "CLAUDE.md"

--- a/.github/scripts/verify-context-budget.R
+++ b/.github/scripts/verify-context-budget.R
@@ -24,12 +24,13 @@ source(".github/scripts/ci-helpers.R")
 # What the closure measured when it was last set, and the commit that set it.
 # Moving this means saying in the same commit what was added and what paid for
 # it.
-baseline_bytes <- 22080L
+baseline_bytes <- 22005L
 baseline_note <- paste(
   "#418 deleting the gate's argument from *Chunks that must fail*, which",
   "`verify-must-error.R`'s header and `release-matrix.yaml`'s already held,",
-  "together with the two reasons `inst/vignette-hooks/must-error.R` states",
-  "beside the code each is about, over #416's baseline; nothing was added"
+  "together with the reasons `inst/vignette-hooks/must-error.R` states beside",
+  "the code each is about and a claim its review found false, over #416's",
+  "baseline; nothing was added"
 )
 
 entry <- "CLAUDE.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,10 @@ offer no option for the other half, and no package supplies one
 (`investigation/requiring-a-documentation-chunk-to-fail.md`).
 
 `inst/vignette-hooks/must-error.R` therefore defines a `must_error` chunk
-option. It implies `error: true`, so the two are never set inconsistently, and
-it halts the render naming the chunk when a chunk marked with it completes
-without raising an error. Mark a chunk with it instead of `error: true`
-whenever the surrounding prose asserts that the call fails.
+option. It implies `error: true`, and it halts the render naming the chunk when
+a chunk marked with it completes without raising an error. Mark a chunk with it
+instead of `error: true` whenever the surrounding prose asserts that the call
+fails.
 
 It takes two forms. `must_error: true` accepts any error, which is what the
 option has always meant. `must_error: marginplyr_error` additionally requires
@@ -105,7 +105,7 @@ the error to carry that condition class. Prefer the class form wherever the
 prose names what refuses the call: a bare `true` passes when the call fails for
 an unrelated reason — a renamed argument, a typo, a changed column — and the
 reader is then shown a diagnostic the prose does not describe. The class form
-also matches an error a dplyr verb wrapped. Any other value halts the render.
+also matches an error a dplyr verb wrapped.
 
 The definition lives under `inst/` so that every vignette reaches it in one
 line rather than carrying a copy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,8 @@ option has always meant. `must_error: marginplyr_error` additionally requires
 the error to carry that condition class. Prefer the class form wherever the
 prose names what refuses the call: a bare `true` passes when the call fails for
 an unrelated reason — a renamed argument, a typo, a changed column — and the
-reader is then shown a diagnostic the prose does not describe. The check reads
-the `parent` chain, because a Package condition usually reaches the reader
-wrapped by the dplyr verb that raised it, and it is the wrapped class the prose
-names. Any other value halts the render rather than being ignored, since a
-header this cannot read is one whose assertion silently stopped happening.
+reader is then shown a diagnostic the prose does not describe. The class form
+also matches an error a dplyr verb wrapped. Any other value halts the render.
 
 The definition lives under `inst/` so that every vignette reaches it in one
 line rather than carrying a copy:
@@ -127,23 +124,7 @@ guard on knitr in a vignette would never fire
 (`investigation/restoring-knitr-hooks-a-vignette-installs.md`).
 
 `.github/scripts/verify-must-error.R` is the gate, run by `altdoc.yaml` and
-locally with `Rscript .github/scripts/verify-must-error.R`. It knits fixture
-documents covering each form, the guarded chunk, a malformed option value, and
-the restoration, because nothing else in the repository fails when the option
-stops working — an option that asserts nothing reports nothing, which reads
-exactly like a set of vignettes whose rejected calls are all still rejected.
-It is not a testthat test: `release-matrix.yaml`'s `backend` jobs install the
-hard dependencies plus one optional backend, so knitr is absent there — a
-vignette rebuild is what puts it in the closure, and those jobs pass
-`--ignore-vignettes` — and `verify-backend.R` fails a job for any skip that does
-not name a backend the job withheld.
-
-Its guarded-chunk fixture withholds a name no library holds, because what a
-fixture can vary is whether knitr evaluated a chunk and not why. A genuinely
-absent Suggest is covered where one is absent: `depends-only` rebuilds the
-vignettes with every Suggest withheld, and `recipes.qmd`'s `nested-aggregate`
-chunk is a `must_error` chunk behind `has_duckdb`, so an option that reported it
-fails that job.
+locally with `Rscript .github/scripts/verify-must-error.R`.
 
 ### Site verification
 

--- a/inst/vignette-hooks/must-error.R
+++ b/inst/vignette-hooks/must-error.R
@@ -1,23 +1,13 @@
 # The `must_error` chunk option, shared by every vignette.
 #
-# A vignette showing a rejected call executes it rather than quoting its error,
-# so the reader sees the diagnostic their own session would produce. Mark such a
-# chunk with this option instead of Quarto's `error: true`, which only *permits*
-# an error and so renders a success underneath prose that still claims a
-# failure.
-#
-# A vignette reaches it in one line -- a `source()` call on the `system.file()`
-# path to this file -- which is why the definition lives here rather than in a
-# setup chunk. The hidden setup chunks of `vignettes/recipes.qmd` and
-# `vignettes/get_started.qmd` show the call.
-#
 # Two forms:
 #
 #     must_error: true               any error will do
 #     must_error: marginplyr_error   the error must carry that condition class
 #
-# `AGENTS.md` is authoritative for when to mark a chunk. What a rewrite of this
-# file must keep is stated at the sites that hold it, and not here.
+# `AGENTS.md` is authoritative for what the option is for and when to mark a
+# chunk. What a rewrite of this file must keep is stated at the sites that hold
+# it, and not here.
 
 local({
   # Sourcing this twice -- two setup chunks in one document, or a second

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -263,8 +263,7 @@ cran_status_field <- "Config/marginplyr/cran-status"
 
 # Only `unpublished` and `published` can be read. Any other value stops rather
 # than being treated as either, for the reason a malformed `must_error` header
-# halts a render: a field this cannot read is a field whose assertions silently
-# stopped happening. Reading and checking are separate so that the refusal is
+# halts a render. Reading and checking are separate so that the refusal is
 # executed by a test today, rather than first attempted on release day.
 checked_cran_status <- function(status) {
   if (!isTRUE(status %in% c("unpublished", "published"))) {

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -63,9 +63,8 @@ has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
 has_dtplyr <- marginplyr_suggest_available("dtplyr")
 has_arrow <- marginplyr_suggest_available("arrow")
 
-# Chunks marked with `must_error` show a call that is meant to fail, so the
-# reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
-# authoritative for what the option does and why it exists.
+# Installs the `must_error` chunk option this document's rejected-call chunks
+# use. AGENTS.md is authoritative for what it does and why it exists.
 source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
 ```
 

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -60,9 +60,8 @@ has_dtplyr <- marginplyr_suggest_available("dtplyr")
 has_tabsets <- marginplyr_suggest_available("knitr") &&
   marginplyr_suggest_available("quartabs")
 
-# Chunks marked with `must_error` show a call that is meant to fail, so the
-# reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
-# authoritative for what the option does and why it exists.
+# Installs the `must_error` chunk option this document's rejected-call chunks
+# use. AGENTS.md is authoritative for what it does and why it exists.
 source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
 ```
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -62,9 +62,8 @@ source(system.file("suggests", "guard.R", package = "marginplyr"))
 has_duckdb <- marginplyr_suggest_available("DBI") &&
   marginplyr_suggest_available("duckdb")
 
-# Chunks marked with `must_error` show a call that is meant to fail, so the
-# reader sees the real diagnostic rather than a quotation of one. AGENTS.md is
-# authoritative for what the option does and why it exists.
+# Installs the `must_error` chunk option this document's rejected-call chunks
+# use. AGENTS.md is authoritative for what it does and why it exists.
 source(system.file("vignette-hooks", "must-error.R", package = "marginplyr"))
 ```
 


### PR DESCRIPTION
Closes #418.

`AGENTS.md` owns why the option exists. Everything about how a file works stays in that file.

## What the ticket named, and what measuring found

#418 named one duplication: the first sentence of *Chunks that must fail*, verbatim in `inst/vignette-hooks/must-error.R`'s header. Measuring found more.

The sentence is in **five** places, not two — `AGENTS.md`, the hook, and the `include: false` setup chunk of all three vignettes. Four of the five already name `AGENTS.md` as authoritative, and the two that disagree disagree about scope: the vignettes say `AGENTS.md` owns "what the option does and why it exists", while the hook says it owns only "when to mark a chunk" and then states the why itself.

The same section holds two further pairs the ticket did not name:

| `AGENTS.md` | already held by |
|---|---|
| the gate paragraph and the fixture paragraph | `verify-must-error.R`'s header and `:275-281`; the `--ignore-vignettes` clause by `release-matrix.yaml`'s header |
| the `parent`-chain reason and the malformed-value reason | `must-error.R:36-38`, `:59-64`, and `verify-must-error.R:253-254` |

A seven-word shingle scan of the whole section against the six files that touch the option confirms the inventory is complete.

## The rule applied

An author-facing rule stays in `AGENTS.md`, because it fires for anyone writing a vignette. Reasoning about how a file works stays in that file, because its audience is reading it.

That points both ways, and the split is where the two directions land:

- **Why the option exists** is what a vignette author needs before choosing to mark a chunk. `AGENTS.md` keeps it, with the citation to `investigation/requiring-a-documentation-chunk-to-fail.md`. `must-error.R` drops its copy.
- **Why the gate is a script and not a testthat test** is read by whoever opens the verifier. `verify-must-error.R` keeps it. `AGENTS.md` keeps the pointer and the local command. The general rule this derives from is already in *Release matrix*, so the derivation was the second copy.

Two sites were checked against the rule and **kept**:

- `altdoc.yaml:54-56` borrows the "reports nothing" premise, but its own decision is that the step runs *before* the render, and "failing here says which half broke" is unsupported without it. The verifier's header says nothing about step ordering.
- `AGENTS.md`'s placement paragraph cites *Dependency metadata* and then says the quarto → rmarkdown → knitr chain is which way this site falls under it. `investigation/README.md` says a note "is not maintained afterwards" and "never describes the present", so a live claim cannot be delegated to one — unlike a verifier header.

## What changed

- `AGENTS.md` — gate and fixture paragraphs reduced to the pointer; two reasons in the two-forms paragraph reduced to the facts.
- `inst/vignette-hooks/must-error.R` — header drops the why and the `inst/` placement argument, whose vignette list named two of the three documents that hold the call. Delegation line widened to "what the option is for and when to mark a chunk".
- `vignettes/{recipes,get_started,database_backends}.qmd` — setup comments state what the `source()` call installs rather than restating the argument they delegate.
- `tests/testthat/test-documentation.R` — cited the malformed-header reason and then restated it with "field" substituted for "chunk header". The restatement is deleted; the citation stays.
- `.github/scripts/verify-context-budget.R` — baseline ratcheted.

No rule was added: *Code comments* already forbids re-deriving a cited decision's argument, and #416 settled that it reaches `AGENTS.md`'s own prose.

## The budget

| | bytes |
|---|---|
| before | 23384 |
| the gate's argument and its fixture paragraph | -1076 |
| the two reasons stated beside the code each is about | -228 |
| a claim the review found false, and one more second copy | -75 |
| **baseline** | **22005** |

Nothing was added, so the ratchet is the whole of it. Note that #418 as scoped saves nothing: the 507-byte paragraph it named stays, and the savings all come from the sites measuring found.

## Review

Ran `mattpocock-skills:code-review` against `origin/main...e494d29`. Two findings, both answered by deleting in `adfbba9`; none rejected. The record is in the review comment on this pull request.

## Checks

| | |
|---|---|
| `verify-context-budget.R` | 22005 of 22005 |
| `verify-must-error.R` | 8 fixtures |
| `verify-doc-references.R` | 171 paths across 150 documents |
| `verify-verifier-invocation.R` | 9 verifiers |
| `lintr::lint_package()` | no lints |
| `test-documentation.R` | 21 pass |

`docs/` and `README.md` are unaffected: every vignette edit is a comment inside an `include: false` chunk.
