### PR TITLE
Restore an NA factor level inside a nested cell (#421)

### DIFF
--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -70,10 +70,11 @@ proxy_columns <- function(data_proxy, cols) {
 }
 
 # `carried` names the input columns that reach the result beside the Margin
-# dimensions -- a fixed `.by` key, or a column the verb passes through. They
-# cross the same branch union and lose a declared NA level in the same place,
-# so `factors` covers them too (#415). Which columns those are is settled by
-# `prepare_margin_operation()`'s `carried_columns`.
+# dimensions -- a fixed `.by` key, a column the verb passes through, or one it
+# folds into a cell. They cross the same branch union and lose a declared NA
+# level in the same place, so `factors` covers them too (#415, #421). Which
+# columns those are is settled by `prepare_margin_operation()`'s
+# `carried_columns`.
 #
 # `prototypes` stays keyed to the dimensions alone. It stands for the value a
 # branch omitting a dimension writes, and only a dimension is ever omitted.

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -412,10 +412,11 @@ label_margin_branch <- function(.data,
     function(info) info$col,
     character(1)
   )
-  # A column `factor_info` names that is not a dimension is a fixed `.by` key
-  # or one the verb passes through, so it is in every branch rather than in
-  # the ones that include it, and it is never labelled: only the encoded arm
-  # above can select it (#415).
+  # A column `factor_info` names that is not a dimension is one the verb
+  # carries -- a fixed `.by` key, one it passes through, or one it folds into a
+  # cell -- so it is in every branch rather than in the ones that include it,
+  # and it is never labelled: only the encoded arm above can select it (#415,
+  # #421).
   encoded_factors <- Filter(
     function(info) {
       present <- !(info$col %in% plan$dimensions) || info$col %in% included

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -43,9 +43,14 @@ new_margin_operation <- function(data,
 # resolves in the aggregate query alone, and dbplyr discards the ordering of
 # any query it goes on to wrap in a subquery — which labelling the omitted
 # dimensions and placing the grouping columns both do.
-new_margin_execution <- function(result, sort_id = NULL) {
+#
+# `factor_info` is the columns the finalizer can still reach, and `NULL` says
+# every column the operation named. Only an executor that puts a column
+# somewhere the finalizer cannot `mutate()` reports one: nesting folds its
+# payload into a cell and rebuilds it there (#421).
+new_margin_execution <- function(result, sort_id = NULL, factor_info = NULL) {
   structure(
-    list(result = result, sort_id = sort_id),
+    list(result = result, sort_id = sort_id, factor_info = factor_info),
     class = "marginplyr_margin_execution"
   )
 }
@@ -342,9 +347,13 @@ finalize_margin_operation <- function(operation, execution) {
   check_margin_operation(operation)
   stopifnot(inherits(execution, "marginplyr_margin_execution"))
   result <- dplyr::ungroup(execution$result)
+  factor_info <- execution$factor_info
+  if (is.null(factor_info)) {
+    factor_info <- operation$column_info$factors
+  }
   result <- restore_margin_factors(
     result,
-    factor_info = operation$column_info$factors,
+    factor_info = factor_info,
     margin_labels = operation$margin_labels,
     position = operation$margin_label_position
   )

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -267,14 +267,6 @@ nest_margin_pipeline <- function(.data,
     .key = .key,
     .keep = .keep
   )
-  # The payload columns are inside a cell by now and rebuilt already, so the
-  # finalizer is handed the columns it can still reach. `mutate()` on one of
-  # the others would name a column the result no longer has.
-  outer_cols <- c(operation$plan$by, operation$plan$dimensions)
-  operation$column_info$factors <- Filter(
-    function(info) info$col %in% outer_cols,
-    operation$column_info$factors
-  )
   finalize_margin_operation(operation, execution)
 }
 
@@ -362,16 +354,22 @@ execute_margin_nest <- function(operation, .key, .keep) {
       # own; the identifier is retained past the nest and dropped once the
       # finalizer has ordered by it.
       sorting <- margin_sorting(operation)
+      # One split, read by both halves: what is folded into a cell is rebuilt
+      # here, and what stays a column of its own is what the finalizer is left.
+      # Deriving the two separately would let them drift into a finalizer that
+      # rebuilds a column the fold has taken away, or skips one it kept.
+      folded <- vapply(
+        column_info$factors,
+        function(info) !(info$col %in% group_cols),
+        logical(1)
+      )
       # Before the fold, because that is the last point a payload column is a
       # column. The union has already turned the values on a declared NA level
       # into missing, so rebuilding inside the cell would restore the level
       # with nothing left on it (#421).
       expanded <- restore_margin_factors(
         expanded,
-        factor_info = Filter(
-          function(info) !(info$col %in% group_cols),
-          column_info$factors
-        ),
+        factor_info = column_info$factors[folded],
         margin_labels = operation$margin_labels,
         position = operation$margin_label_position
       )
@@ -385,7 +383,8 @@ execute_margin_nest <- function(operation, .key, .keep) {
           .keep = .keep,
           drop_set_col = is.null(operation$set_id_name) && !sorting
         ),
-        sort_id = if (sorting) set_col else NULL
+        sort_id = if (sorting) set_col else NULL,
+        factor_info = column_info$factors[!folded]
       )
     },
     call = operation$call

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -254,11 +254,11 @@ nest_margin_pipeline <- function(.data,
     .duplicates = .duplicates,
     .sort = .sort,
     duplicates_choices = nest_duplicates_choices,
-    # Nesting expands every column and then folds all but the grouping columns
-    # into `.key`, so the fixed `.by` keys are what the result carries as
-    # columns of its own. A payload column is inside a cell by the time the
-    # finalizer runs, where nothing rebuilds it.
-    carried_columns = function(data_vars, plan) plan$by,
+    # Nesting folds all but the grouping columns into `.key`, so every input
+    # column reaches the result -- as a column of its own, or inside a cell
+    # (#421). `execute_margin_nest()` rebuilds the second kind before folding
+    # it, which is the half of the route that lets this name them all.
+    carried_columns = function(data_vars, plan) data_vars,
     .id = .id,
     call = call
   )
@@ -266,6 +266,14 @@ nest_margin_pipeline <- function(.data,
     operation,
     .key = .key,
     .keep = .keep
+  )
+  # The payload columns are inside a cell by now and rebuilt already, so the
+  # finalizer is handed the columns it can still reach. `mutate()` on one of
+  # the others would name a column the result no longer has.
+  outer_cols <- c(operation$plan$by, operation$plan$dimensions)
+  operation$column_info$factors <- Filter(
+    function(info) info$col %in% outer_cols,
+    operation$column_info$factors
   )
   finalize_margin_operation(operation, execution)
 }
@@ -312,10 +320,30 @@ execute_margin_nest <- function(operation, .key, .keep) {
         character()
       }
       data <- operation$data
+      column_info <- operation$column_info
       if (length(keep_cols) > 0L) {
         keep_exprs <- lapply(group_cols, margin_column_pronoun)
         names(keep_exprs) <- unname(keep_cols)
         data <- dplyr::mutate(data, !!!keep_exprs)
+        # A `.keep` copy is made here, after `prepare_margin_operation()` read
+        # the input's schema, so no `factor_info` entry names it and the encode
+        # arm would not see it. The copy holds the source column's values, so
+        # the source column's entry describes it under the internal name. It
+        # carries no Margin label, which is what puts it on the same route as a
+        # payload column: rebuilt on its declared levels with none appended.
+        column_info$factors <- c(
+          column_info$factors,
+          lapply(
+            Filter(
+              function(info) info$col %in% names(keep_cols),
+              column_info$factors
+            ),
+            function(info) {
+              info$col <- unname(keep_cols[[info$col]])
+              info
+            }
+          )
+        )
       }
 
       validate_margin_operation(operation)
@@ -324,7 +352,7 @@ execute_margin_nest <- function(operation, .key, .keep) {
         data,
         plan = plan,
         margin_labels = operation$margin_labels,
-        column_info = operation$column_info,
+        column_info = column_info,
         backend = operation$backend,
         set_id_name = set_col
       )
@@ -334,6 +362,19 @@ execute_margin_nest <- function(operation, .key, .keep) {
       # own; the identifier is retained past the nest and dropped once the
       # finalizer has ordered by it.
       sorting <- margin_sorting(operation)
+      # Before the fold, because that is the last point a payload column is a
+      # column. The union has already turned the values on a declared NA level
+      # into missing, so rebuilding inside the cell would restore the level
+      # with nothing left on it (#421).
+      expanded <- restore_margin_factors(
+        expanded,
+        factor_info = Filter(
+          function(info) !(info$col %in% group_cols),
+          column_info$factors
+        ),
+        margin_labels = operation$margin_labels,
+        position = operation$margin_label_position
+      )
       new_margin_execution(
         nest_expanded_margins(
           expanded,

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -387,6 +387,152 @@ test_that("a carried factor with no NA level takes no encode route", {
   expect_identical(names(info$prototypes), "group")
 })
 
+# A nesting verb folds every column but the grouping columns into a cell, so a
+# carried column crosses the union like any other and is inside the cell by the
+# time the finalizer runs (#421). `.keep = TRUE` adds a second site: it copies
+# each grouping column under an internal name before the union, so the outer
+# column and its own nested copy can disagree about the level.
+#
+# A fixture of its own rather than `na_level_carried_data()`, which holds a
+# column named `key`: a cell is built by `pick(everything())`, which dtplyr
+# translates to a `data.table()` call, so that name arrives as that function's
+# `key` argument and the call fails. Nothing here is marginplyr's -- the same
+# `summarize(list(pick(everything())))` on a bare `lazy_dt()` fails the same
+# way -- and it is filed as #424.
+na_level_nested_data <- function(ordered = FALSE, na_level_group = FALSE) {
+  carried_class <- if (ordered) c("ordered", "factor") else "factor"
+  data.frame(
+    group = if (na_level_group) {
+      structure(c(1L, 2L), levels = c("g1", NA_character_), class = "factor")
+    } else {
+      factor(c("g1", "g2"))
+    },
+    passthrough = structure(
+      c(1L, 2L),
+      levels = c("a", NA_character_),
+      class = carried_class
+    ),
+    plain = factor(c("q", "r")),
+    value = 1:2
+  )
+}
+
+# Rows are one per Grouping set member and ADR 0018 leaves their order to the
+# backend, so the cells are paired by the outer column's integer code, which is
+# distinct per row in every case below. Reading the code rather than the
+# displayed value is also what keeps a value on the NA level apart from a
+# margin row's typed missing, which `as.character()` spells the same way.
+nest_cells <- function(result, outer, .key = "data") {
+  lapply(result[[.key]][order(as.integer(result[[outer]]))], as.data.frame)
+}
+
+# By integer code for the reason `expect_passthrough_agrees()` gives, with
+# `na.last` because `sort()` drops the missing a lost level leaves behind --
+# the one difference the assertion exists to catch.
+expect_cell_column_agrees <- function(result,
+                                      expected,
+                                      outer,
+                                      col,
+                                      expected_levels) {
+  result_cells <- nest_cells(result, outer)
+  expected_cells <- nest_cells(expected, outer)
+  expect_identical(length(result_cells), length(expected_cells))
+  for (i in seq_along(result_cells)) {
+    got <- result_cells[[i]][[col]]
+    want <- expected_cells[[i]][[col]]
+    expect_identical(levels(got), expected_levels, info = as.character(i))
+    expect_identical(levels(got), levels(want), info = as.character(i))
+    expect_identical(
+      sort(as.integer(got), na.last = TRUE),
+      sort(as.integer(want), na.last = TRUE),
+      info = as.character(i)
+    )
+  }
+}
+
+test_that("dtplyr keeps a used NA level on a nested payload column", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_nested_data()
+  operation <- function(input) {
+    nest_with_margins(input, .grouping = rollup(group))
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  expect_cell_column_agrees(
+    result,
+    expected,
+    "group",
+    "passthrough",
+    c("a", NA)
+  )
+  # `plain` is the payload column with no NA level: rebuilding it takes nothing
+  # away, which is what keeps the widened route from costing the common case.
+  expect_cell_column_agrees(result, expected, "group", "plain", c("q", "r"))
+})
+
+test_that("a nested payload ordered factor keeps its ordering", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_nested_data(ordered = TRUE)
+  operation <- function(input) {
+    nest_with_margins(input, .grouping = rollup(group))
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  expect_s3_class(nest_cells(result, "group")[[1L]]$passthrough, "ordered")
+  expect_cell_column_agrees(
+    result,
+    expected,
+    "group",
+    "passthrough",
+    c("a", NA)
+  )
+})
+
+test_that("nest_by_with_margins keeps a used NA level in its cell", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_nested_data()
+  operation <- function(input) {
+    nest_by_with_margins(input, .grouping = rollup(group))
+  }
+
+  # `nest_by_with_margins()` collects, so both results are already local.
+  result <- operation(dtplyr::lazy_dt(data))
+  expected <- operation(data)
+  expect_cell_column_agrees(
+    result,
+    expected,
+    "group",
+    "passthrough",
+    c("a", NA)
+  )
+})
+
+test_that(".keep = TRUE keeps a used NA level on a nested grouping copy", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_nested_data(na_level_group = TRUE)
+  operation <- function(input) {
+    nest_with_margins(input, .grouping = rollup(group), .keep = TRUE)
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  # The outer column takes the Margin label. Its nested copy holds the source
+  # value the branch was built from, so it takes none and is rebuilt on the
+  # levels the input declared.
+  expect_identical(levels(result$group), c("g1", NA, "Total"))
+  expect_identical(levels(result$group), levels(expected$group))
+  expect_cell_column_agrees(result, expected, "group", "group", c("g1", NA))
+  expect_cell_column_agrees(
+    result,
+    expected,
+    "group",
+    "passthrough",
+    c("a", NA)
+  )
+})
+
 test_that("NA factor levels stay structural when collision checks are off", {
   with_na_level <- factor_contract_data(
     has_na_level = TRUE,

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -418,17 +418,26 @@ na_level_nested_data <- function(ordered = FALSE, na_level_group = FALSE) {
 }
 
 # Rows are one per Grouping set member and ADR 0018 leaves their order to the
-# backend, so the cells are paired by the outer column's integer code, which is
-# distinct per row in every case below. Reading the code rather than the
-# displayed value is also what keeps a value on the NA level apart from a
-# margin row's typed missing, which `as.character()` spells the same way.
+# backend, so the cells are paired by the integer codes of `outer`, which name
+# together as many columns as it takes for the tuple to be distinct per row.
+# Reading the code rather than the displayed value is also what keeps a value
+# on the NA level apart from a margin row's typed missing, which
+# `as.character()` spells the same way.
 nest_cells <- function(result, outer, .key = "data") {
-  lapply(result[[.key]][order(as.integer(result[[outer]]))], as.data.frame)
+  keys <- lapply(outer, function(col) as.integer(result[[col]]))
+  lapply(result[[.key]][do.call(order, keys)], as.data.frame)
 }
 
-# By integer code for the reason `expect_passthrough_agrees()` gives, with
-# `na.last` because `sort()` drops the missing a lost level leaves behind --
-# the one difference the assertion exists to catch.
+# Rows within a cell are put in `value` order, which is distinct per source row
+# in every fixture here, so the codes are compared position by position rather
+# than as a multiset: what is asserted is which row lost the level and not how
+# many did. The order a backend returns rows in is its own (ADR 0018), so
+# sorting by a column of the data is what makes the comparison meaningful.
+#
+# The integer code for the reason `expect_passthrough_agrees()` gives, and it
+# is strictly stronger than comparing `is.na()`: a value on the NA level has a
+# code and a typed missing has none, so code identity carries the missingness
+# pattern and separates the two readings `as.character()` spells alike.
 expect_cell_column_agrees <- function(result,
                                       expected,
                                       outer,
@@ -438,15 +447,13 @@ expect_cell_column_agrees <- function(result,
   expected_cells <- nest_cells(expected, outer)
   expect_identical(length(result_cells), length(expected_cells))
   for (i in seq_along(result_cells)) {
-    got <- result_cells[[i]][[col]]
-    want <- expected_cells[[i]][[col]]
+    got <- result_cells[[i]]
+    want <- expected_cells[[i]]
+    got <- got[order(got$value), ][[col]]
+    want <- want[order(want$value), ][[col]]
     expect_identical(levels(got), expected_levels, info = as.character(i))
     expect_identical(levels(got), levels(want), info = as.character(i))
-    expect_identical(
-      sort(as.integer(got), na.last = TRUE),
-      sort(as.integer(want), na.last = TRUE),
-      info = as.character(i)
-    )
+    expect_identical(as.integer(got), as.integer(want), info = as.character(i))
   }
 }
 
@@ -528,6 +535,55 @@ test_that(".keep = TRUE keeps a used NA level on a nested grouping copy", {
     result,
     expected,
     "group",
+    "passthrough",
+    c("a", NA)
+  )
+})
+
+test_that("nest_by_with_margins keeps a used NA level with .keep = TRUE", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_nested_data(na_level_group = TRUE)
+  operation <- function(input) {
+    nest_by_with_margins(input, .grouping = rollup(group), .keep = TRUE)
+  }
+
+  result <- operation(dtplyr::lazy_dt(data))
+  expected <- operation(data)
+  expect_identical(levels(result$group), c("g1", NA, "Total"))
+  expect_cell_column_agrees(result, expected, "group", "group", c("g1", NA))
+  expect_cell_column_agrees(
+    result,
+    expected,
+    "group",
+    "passthrough",
+    c("a", NA)
+  )
+})
+
+test_that(".keep = TRUE keeps a used NA level on a nested .by key copy", {
+  skip_if_suggest_absent("dtplyr")
+  data <- na_level_nested_data()
+  operation <- function(input) {
+    nest_with_margins(
+      input,
+      .by = passthrough,
+      .grouping = rollup(group),
+      .keep = TRUE
+    )
+  }
+
+  result <- dplyr::collect(operation(dtplyr::lazy_dt(data)))
+  expected <- operation(data)
+  # A fixed `.by` key is a grouping column, so the payload rebuild passes it
+  # over and it reaches the cell through the `.keep` copy instead -- the one
+  # route the tests above leave to the dimension case. It takes no Margin label
+  # at either site.
+  expect_identical(levels(result$passthrough), c("a", NA))
+  expect_identical(levels(result$passthrough), levels(expected$passthrough))
+  expect_cell_column_agrees(
+    result,
+    expected,
+    c("passthrough", "group"),
     "passthrough",
     c("a", NA)
   )


### PR DESCRIPTION
Closes #421.

A factor column carrying a declared `NA` level lost it on a dtplyr input
whenever a nesting verb folded it into `.key`, so the nested column's domain
differed by backend with no diagnostic. `.keep = TRUE` carried a second case the
issue did not name: an NA-level *grouping* column was restored on the outer
column and lost inside the cell of the same result.

The measurements that settled the fix's shape are in
https://github.com/sayuks/marginplyr/issues/421#issuecomment-5536247881. The
decisive one is that dtplyr's union turns the values on the level into genuine
missing before anything folds a cell, so the rebuild has to happen while the
payload is still a column — an in-cell rebuild would restore the level with
nothing left on it.

`#424` was filed from this branch's test work: a column named `key` breaks
nesting under dtplyr, because `pick(everything())` translates to a
`data.table()` call whose `key` formal swallows it. Not marginplyr's, and the
fixture here avoids the name and says why.

Full suite green, `lintr::lint_package()` clean. No generated file changed.
