### PR TITLE
Build a nested cell without spreading columns into a callee's formals (#424)

### DIFF
--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -151,7 +151,7 @@ nest_by_with_margins <- function(.data,
     result <- dplyr::summarize(
       empty_data,
       "{.key}" := list(
-        !!nest_cell_expr(colnames(empty_data), colnames(empty_data))
+        !!nest_cell_expr(rlang::set_names(colnames(empty_data)))
       )
     )
     if (!is.null(.id)) {

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -151,7 +151,13 @@ nest_by_with_margins <- function(.data,
     result <- dplyr::summarize(
       empty_data,
       "{.key}" := list(
-        !!nest_cell_expr(rlang::set_names(colnames(empty_data)), "local")
+        !!nest_cell_expr(
+          rlang::set_names(colnames(empty_data)),
+          # The kind of the input, not of `empty_data`: this rebuilds what the
+          # pipeline returned for it, so its cell is the one every other cell
+          # from this input is.
+          grouping_backend(.data)$kind
+        )
       )
     )
     if (!is.null(.id)) {

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -151,7 +151,7 @@ nest_by_with_margins <- function(.data,
     result <- dplyr::summarize(
       empty_data,
       "{.key}" := list(
-        !!nest_cell_expr(rlang::set_names(colnames(empty_data)))
+        !!nest_cell_expr(rlang::set_names(colnames(empty_data)), "local")
       )
     )
     if (!is.null(.id)) {

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -151,7 +151,7 @@ nest_by_with_margins <- function(.data,
     result <- dplyr::summarize(
       empty_data,
       "{.key}" := list(
-        !!nest_cell_expr(empty_payload = ncol(empty_data) == 0L)
+        !!nest_cell_expr(colnames(empty_data), colnames(empty_data))
       )
     )
     if (!is.null(.id)) {

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -51,10 +51,11 @@
 #'
 #' The list column is a regular list of data frames; its exact `vctrs_list_of`
 #' subclass is not part of the API. Neither is the class of its elements,
-#' which follows what the backend made of the cell expression and is tibbles
-#' on both today. Only their being data frames holding the input's non-key
-#' columns is promised, so `lapply(result$data, tibble::as_tibble)` is what a
-#' caller who needs the class itself writes. [nest_with_margins()] follows
+#' which follows whichever backend produced them: tibbles for a local input,
+#' and data tables under `dtplyr`, which is what [tidyr::nest()] on the same
+#' input gives. Only their being data frames holding the input's non-key
+#' columns is promised. Call `lapply(result$data, tibble::as_tibble)` when one
+#' element class is needed across backends. [nest_with_margins()] follows
 #' [tidyr::nest()] for an empty ungrouped input and returns zero outer rows.
 #' [nest_by_with_margins()] follows [dplyr::nest_by()] and returns one row
 #' containing the empty input when there are no grouping keys.
@@ -62,18 +63,19 @@
 #' When nesting leaves no payload column — every input column is a fixed key or
 #' a grouping dimension, and `.keep` does not put them back — each nested data
 #' frame still has one row per source row it stands for, as [dplyr::nest_by()]
-#' does. That row count is promised; the class of such a cell is described
-#' rather than promised, as every element class is.
+#' does. That row count is promised. The class of such a cell is described
+#' rather than promised, as every element class is: on both backends it is what
+#' [dplyr::tibble()] produced, because a `data.table` cannot hold rows without
+#' columns at all.
 #'
-#' A `data.table` cannot hold rows without columns at all, which is a limit on
-#' what an input can carry into `dtplyr` rather than anything nesting does: a
-#' data frame with rows and no columns loses its rows on the way in, so
-#' `dtplyr::lazy_dt(data.frame(row.names = 1:3))` is already empty before
-#' marginplyr reads it and no behavior here can restore the three rows. Nest
-#' an input that has rows and no columns locally when its row count matters.
-#' This is the whole of the difference: a column-less input that reaches the
-#' backend with the rows it had -- one with no rows either -- nests to the
-#' same result on both backends.
+#' That last point is also a limit on what an input can carry into `dtplyr`,
+#' rather than anything nesting does: a data frame with rows and no columns
+#' loses its rows on the way in, so `dtplyr::lazy_dt(data.frame(row.names =
+#' 1:3))` is already empty before marginplyr reads it and no behavior here can
+#' restore the three rows. Nest an input that has rows and no columns locally
+#' when its row count matters. This is the whole of the difference: a
+#' column-less input that reaches the backend with the rows it had -- one with
+#' no rows either -- nests to the same result on both backends.
 #'
 #' No input column name is reserved for internal bookkeeping. Temporary
 #' grouping-set and `.keep` columns are generated collision-free and removed
@@ -378,6 +380,7 @@ execute_margin_nest <- function(operation, .key, .keep) {
           set_col = set_col,
           keep_cols = keep_cols,
           .key = .key,
+          kind = operation$backend$kind,
           drop_set_col = is.null(operation$set_id_name) && !sorting
         ),
         sort_id = if (sorting) set_col else NULL,
@@ -388,11 +391,12 @@ execute_margin_nest <- function(operation, .key, .keep) {
   )
 }
 
-# The expression building one cell, given the columns it is to hold: a named
-# character vector whose names are the names the cell's columns take and whose
-# values are the columns of the expanded step they read. An empty one is a
-# nesting that has no payload column left.
-nest_cell_expr <- function(cell_cols) {
+# The expression building one cell, given the columns it is to hold and the
+# backend kind that will evaluate it. `cell_cols` is a named character vector
+# whose names are the names the cell's columns take and whose values are the
+# columns of the expanded step they read; an empty one is a nesting that has
+# no payload column left.
+nest_cell_expr <- function(cell_cols, kind) {
   if (length(cell_cols) == 0L) {
     # A nesting that removes every payload column still stands for a known
     # number of source rows per cell, and once the columns are gone the count
@@ -401,20 +405,27 @@ nest_cell_expr <- function(cell_cols) {
     # is a tibble on either, because a `data.table` cannot hold rows without
     # columns — `dim()` reads its row count from its first column, so a
     # column-less one is always empty.
-    quote(dplyr::tibble(.rows = dplyr::n()))
+    return(quote(dplyr::tibble(.rows = dplyr::n())))
+  }
+
+  # `list()`, whose only formal is `...`, because dtplyr translates a `pick()`
+  # standing where a value stands into a literal `data.table()` call carrying
+  # one named argument per column: a column named for one of that function's
+  # formals is taken as that argument, so `key` and `check.names` raise and
+  # `keep.rownames` and `stringsAsFactors` are absorbed and leave the column
+  # out of every cell (#424). The conversion is a step of its own for the same
+  # reason, each converter having formals a column could be named for.
+  columns <- rlang::set_names(
+    lapply(unname(cell_cols), rlang::sym),
+    names(cell_cols)
+  )
+  # The converter is the one place the backends differ, and it is what keeps
+  # the element class the backend's own (ADR 0016): `tidyr::nest()` on a
+  # `dtplyr` step translates to `.SD` and yields a `data.table`, which is what
+  # a caller nesting the same input without marginplyr gets.
+  if (identical(kind, "dtplyr")) {
+    rlang::expr(data.table::as.data.table(list(!!!columns)))
   } else {
-    # `list()`, whose only formal is `...`, because dtplyr translates a
-    # `pick()` standing where a value stands into a literal `data.table()`
-    # call carrying one named argument per column: a column named for one of
-    # that function's formals is taken as that argument, so `key` and
-    # `check.names` raise and `keep.rownames` and `stringsAsFactors` are
-    # absorbed and leave the column out of every cell (#424). The conversion
-    # is a step of its own for the same reason, `tibble()` having formals a
-    # column could be named for too.
-    columns <- rlang::set_names(
-      lapply(unname(cell_cols), rlang::sym),
-      names(cell_cols)
-    )
     rlang::expr(dplyr::as_tibble(list(!!!columns)))
   }
 }
@@ -424,6 +435,7 @@ nest_expanded_margins <- function(.data,
                                   set_col,
                                   keep_cols,
                                   .key,
+                                  kind,
                                   drop_set_col = TRUE) {
   outer_cols <- c(group_cols, set_col)
   # `get_col_names()` rather than `colnames()`, which reads `dimnames()` and
@@ -451,7 +463,7 @@ nest_expanded_margins <- function(.data,
 
   result <- dplyr::summarize(
     .data,
-    "{.key}" := list(!!nest_cell_expr(cell_cols)),
+    "{.key}" := list(!!nest_cell_expr(cell_cols, kind)),
     .by = dplyr::all_of(outer_cols)
   )
 

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -51,10 +51,10 @@
 #'
 #' The list column is a regular list of data frames; its exact `vctrs_list_of`
 #' subclass is not part of the API. Neither is the class of its elements,
-#' which follows whichever backend produced them and is tibbles on both today.
-#' Only their being data frames holding the input's non-key columns is
-#' promised. Call `lapply(result$data, tibble::as_tibble)` when one element
-#' class is needed across backends. [nest_with_margins()] follows
+#' which follows what the backend made of the cell expression and is tibbles
+#' on both today. Only their being data frames holding the input's non-key
+#' columns is promised, so `lapply(result$data, tibble::as_tibble)` is what a
+#' caller who needs the class itself writes. [nest_with_margins()] follows
 #' [tidyr::nest()] for an empty ungrouped input and returns zero outer rows.
 #' [nest_by_with_margins()] follows [dplyr::nest_by()] and returns one row
 #' containing the empty input when there are no grouping keys.
@@ -388,31 +388,33 @@ execute_margin_nest <- function(operation, .key, .keep) {
   )
 }
 
-# A nesting that removes every payload column still stands for a known number
-# of source rows per cell, and once the columns are gone the count is the only
-# thing left to carry it. `pick()` cannot: with an empty selection it answers a
-# one-row frame locally and an empty `data.table` under dtplyr, so each cell
-# reports a cardinality no source row produced, and the two backends disagree
-# besides. `n()` is that count, and dtplyr translates it to `.N`, so one
-# expression serves both. The cell is a tibble on either backend, because a
-# `data.table` cannot hold rows without columns — `dim()` reads its row count
-# from its first column, so a column-less one is always empty — and the element
-# class is documented as whatever the backend produced rather than promised.
-#
-# The other branch names its columns into `list()`, whose only formal is `...`.
-# A `pick()` there would read the same columns, but dtplyr translates a `pick()`
-# standing where a value stands into a literal `data.table()` call carrying one
-# named argument per column, so a column named for one of that function's
-# formals is taken as that argument: `key` and `check.names` raise, and
-# `keep.rownames` and `stringsAsFactors` are absorbed and leave the column out
-# of every cell (#424). The conversion is a step of its own rather than a
-# `tibble()` call naming the columns, because that function has formals a
-# column could be named for too.
-nest_cell_expr <- function(payload_cols, out_names) {
-  if (length(payload_cols) == 0L) {
+# The expression building one cell, given the columns it is to hold: a named
+# character vector whose names are the names the cell's columns take and whose
+# values are the columns of the expanded step they read. An empty one is a
+# nesting that has no payload column left.
+nest_cell_expr <- function(cell_cols) {
+  if (length(cell_cols) == 0L) {
+    # A nesting that removes every payload column still stands for a known
+    # number of source rows per cell, and once the columns are gone the count
+    # is the only thing left to carry it. `n()` is that count, and dtplyr
+    # translates it to `.N`, so one expression serves both backends. The cell
+    # is a tibble on either, because a `data.table` cannot hold rows without
+    # columns — `dim()` reads its row count from its first column, so a
+    # column-less one is always empty.
     quote(dplyr::tibble(.rows = dplyr::n()))
   } else {
-    columns <- rlang::set_names(lapply(payload_cols, rlang::sym), out_names)
+    # `list()`, whose only formal is `...`, because dtplyr translates a
+    # `pick()` standing where a value stands into a literal `data.table()`
+    # call carrying one named argument per column: a column named for one of
+    # that function's formals is taken as that argument, so `key` and
+    # `check.names` raise and `keep.rownames` and `stringsAsFactors` are
+    # absorbed and leave the column out of every cell (#424). The conversion
+    # is a step of its own for the same reason, `tibble()` having formals a
+    # column could be named for too.
+    columns <- rlang::set_names(
+      lapply(unname(cell_cols), rlang::sym),
+      names(cell_cols)
+    )
     rlang::expr(dplyr::as_tibble(list(!!!columns)))
   }
 }
@@ -427,30 +429,29 @@ nest_expanded_margins <- function(.data,
   # `get_col_names()` rather than `colnames()`, which reads `dimnames()` and
   # so answers `NULL` for a `dtplyr` step — every payload column would then
   # look absent and be dropped from every cell.
-  payload_cols <- setdiff(
-    get_col_names(.data, dplyr::everything()),
-    outer_cols
+  cell_cols <- rlang::set_names(
+    setdiff(get_col_names(.data, dplyr::everything()), outer_cols)
   )
-  out_names <- payload_cols
   if (length(keep_cols) > 0L) {
     # `.keep = TRUE` nests a copy of each grouping column, made upstream under
     # an internal name so that the outer key and the copy can disagree. The
     # cell gives each copy back the name the caller wrote, and the grouping
     # columns lead it, which is what `.keep` promises. `order()` is stable, so
     # the rest keep the order the input gave them.
-    restored <- match(payload_cols, unname(keep_cols))
+    restored <- match(unname(cell_cols), unname(keep_cols))
     named <- !is.na(restored)
-    out_names[named] <- names(keep_cols)[restored[named]]
-    leading <- order(
-      match(out_names, group_cols, nomatch = length(out_names) + 1L)
+    names(cell_cols)[named] <- names(keep_cols)[restored[named]]
+    leading <- match(
+      names(cell_cols),
+      group_cols,
+      nomatch = length(cell_cols) + 1L
     )
-    payload_cols <- payload_cols[leading]
-    out_names <- out_names[leading]
+    cell_cols <- cell_cols[order(leading)]
   }
 
   result <- dplyr::summarize(
     .data,
-    "{.key}" := list(!!nest_cell_expr(payload_cols, out_names)),
+    "{.key}" := list(!!nest_cell_expr(cell_cols)),
     .by = dplyr::all_of(outer_cols)
   )
 

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -392,10 +392,10 @@ execute_margin_nest <- function(operation, .key, .keep) {
 }
 
 # The expression building one cell, given the columns it is to hold and the
-# backend kind that will evaluate it. `cell_cols` is a named character vector
-# whose names are the names the cell's columns take and whose values are the
-# columns of the expanded step they read; an empty one is a nesting that has
-# no payload column left.
+# backend kind whose converter it names. `cell_cols` is a named character
+# vector whose names are the names the cell's columns take and whose values
+# are the columns of the expanded step they read; an empty one is a nesting
+# that has no payload column left.
 nest_cell_expr <- function(cell_cols, kind) {
   if (length(cell_cols) == 0L) {
     # A nesting that removes every payload column still stands for a known
@@ -450,8 +450,8 @@ nest_expanded_margins <- function(.data,
     # `.keep = TRUE` nests a copy of each grouping column, made upstream under
     # an internal name so that the outer key and the copy can disagree. The
     # cell gives each copy back the name the caller wrote, and the grouping
-    # columns lead it, which is what `.keep` promises. `order()` is stable, so
-    # the rest keep the order the input gave them.
+    # columns lead it. `order()` is stable, so the rest keep the order the
+    # input gave them.
     restored <- match(unname(cell_cols), unname(keep_cols))
     named <- !is.na(restored)
     names(cell_cols)[named] <- names(keep_cols)[restored[named]]

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -52,10 +52,10 @@
 #' The list column is a regular list of data frames; its exact `vctrs_list_of`
 #' subclass is not part of the API. Neither is the class of its elements,
 #' which follows whichever backend produced them: tibbles for a local input,
-#' and data tables under `dtplyr`, which is what [tidyr::nest()] on the same
-#' input gives. Only their being data frames holding the input's non-key
-#' columns is promised. Call `lapply(result$data, tibble::as_tibble)` when one
-#' element class is needed across backends. [nest_with_margins()] follows
+#' and data tables under `dtplyr`. Only their being data frames holding the
+#' input's non-key columns is promised. Call
+#' `lapply(result$data, tibble::as_tibble)` when one element class is needed
+#' across backends. [nest_with_margins()] follows
 #' [tidyr::nest()] for an empty ungrouped input and returns zero outer rows.
 #' [nest_by_with_margins()] follows [dplyr::nest_by()] and returns one row
 #' containing the empty input when there are no grouping keys.
@@ -415,14 +415,16 @@ nest_cell_expr <- function(cell_cols, kind) {
   # `keep.rownames` and `stringsAsFactors` are absorbed and leave the column
   # out of every cell (#424). The conversion is a step of its own for the same
   # reason, each converter having formals a column could be named for.
+  #
+  # `margin_column_pronoun()` rather than a bare symbol, because dtplyr folds a
+  # symbol named `T` or `F` to the logical constant before it looks at the
+  # step's columns, which would put that constant in the cell in place of the
+  # column and report nothing.
   columns <- rlang::set_names(
-    lapply(unname(cell_cols), rlang::sym),
+    lapply(unname(cell_cols), margin_column_pronoun),
     names(cell_cols)
   )
-  # The converter is the one place the backends differ, and it is what keeps
-  # the element class the backend's own (ADR 0016): `tidyr::nest()` on a
-  # `dtplyr` step translates to `.SD` and yields a `data.table`, which is what
-  # a caller nesting the same input without marginplyr gets.
+  # Per backend (ADR 0016).
   if (identical(kind, "dtplyr")) {
     rlang::expr(data.table::as.data.table(list(!!!columns)))
   } else {

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -51,10 +51,9 @@
 #'
 #' The list column is a regular list of data frames; its exact `vctrs_list_of`
 #' subclass is not part of the API. Neither is the class of its elements,
-#' which follows whichever backend produced them: tibbles for a local input,
-#' because that is what [dplyr::pick()] returns, and data tables under
-#' `dtplyr`. Only their being data frames holding the input's non-key columns
-#' is promised. Call `lapply(result$data, tibble::as_tibble)` when one element
+#' which follows whichever backend produced them and is tibbles on both today.
+#' Only their being data frames holding the input's non-key columns is
+#' promised. Call `lapply(result$data, tibble::as_tibble)` when one element
 #' class is needed across backends. [nest_with_margins()] follows
 #' [tidyr::nest()] for an empty ungrouped input and returns zero outer rows.
 #' [nest_by_with_margins()] follows [dplyr::nest_by()] and returns one row
@@ -63,19 +62,18 @@
 #' When nesting leaves no payload column — every input column is a fixed key or
 #' a grouping dimension, and `.keep` does not put them back — each nested data
 #' frame still has one row per source row it stands for, as [dplyr::nest_by()]
-#' does. That row count is promised. The class of such a cell is described
-#' rather than promised, as every element class is: on both backends it is what
-#' [dplyr::tibble()] produced, because a `data.table` cannot hold rows without
-#' columns at all.
+#' does. That row count is promised; the class of such a cell is described
+#' rather than promised, as every element class is.
 #'
-#' That last point is also a limit on what an input can carry into `dtplyr`,
-#' rather than anything nesting does: a data frame with rows and no columns
-#' loses its rows on the way in, so `dtplyr::lazy_dt(data.frame(row.names =
-#' 1:3))` is already empty before marginplyr reads it and no behavior here can
-#' restore the three rows. Nest an input that has rows and no columns locally
-#' when its row count matters. This is the whole of the difference: a
-#' column-less input that reaches the backend with the rows it had -- one with
-#' no rows either -- nests to the same result on both backends.
+#' A `data.table` cannot hold rows without columns at all, which is a limit on
+#' what an input can carry into `dtplyr` rather than anything nesting does: a
+#' data frame with rows and no columns loses its rows on the way in, so
+#' `dtplyr::lazy_dt(data.frame(row.names = 1:3))` is already empty before
+#' marginplyr reads it and no behavior here can restore the three rows. Nest
+#' an input that has rows and no columns locally when its row count matters.
+#' This is the whole of the difference: a column-less input that reaches the
+#' backend with the rows it had -- one with no rows either -- nests to the
+#' same result on both backends.
 #'
 #' No input column name is reserved for internal bookkeeping. Temporary
 #' grouping-set and `.keep` columns are generated collision-free and removed
@@ -380,7 +378,6 @@ execute_margin_nest <- function(operation, .key, .keep) {
           set_col = set_col,
           keep_cols = keep_cols,
           .key = .key,
-          .keep = .keep,
           drop_set_col = is.null(operation$set_id_name) && !sorting
         ),
         sort_id = if (sorting) set_col else NULL,
@@ -402,14 +399,21 @@ execute_margin_nest <- function(operation, .key, .keep) {
 # from its first column, so a column-less one is always empty — and the element
 # class is documented as whatever the backend produced rather than promised.
 #
-# Both call sites spell `empty_payload` out, because the two expressions this
-# returns differ in what they read rather than in degree, and a bare `TRUE` at
-# a call site would not say which one it asked for.
-nest_cell_expr <- function(empty_payload) {
-  if (empty_payload) {
+# The other branch names its columns into `list()`, whose only formal is `...`.
+# A `pick()` there would read the same columns, but dtplyr translates a `pick()`
+# standing where a value stands into a literal `data.table()` call carrying one
+# named argument per column, so a column named for one of that function's
+# formals is taken as that argument: `key` and `check.names` raise, and
+# `keep.rownames` and `stringsAsFactors` are absorbed and leave the column out
+# of every cell (#424). The conversion is a step of its own rather than a
+# `tibble()` call naming the columns, because that function has formals a
+# column could be named for too.
+nest_cell_expr <- function(payload_cols, out_names) {
+  if (length(payload_cols) == 0L) {
     quote(dplyr::tibble(.rows = dplyr::n()))
   } else {
-    quote(dplyr::pick(dplyr::everything()))
+    columns <- rlang::set_names(lapply(payload_cols, rlang::sym), out_names)
+    rlang::expr(dplyr::as_tibble(list(!!!columns)))
   }
 }
 
@@ -418,46 +422,37 @@ nest_expanded_margins <- function(.data,
                                   set_col,
                                   keep_cols,
                                   .key,
-                                  .keep,
                                   drop_set_col = TRUE) {
-  # `.keep = TRUE` with grouping columns nests them, so that branch always has
-  # a payload column and needs no count of its own.
-  if (.keep && length(group_cols) > 0L) {
-    # `rename()` and `relocate()` run inside a data-masked summary expression,
-    # so their tidyselect resolves `keep_cols` and `group_cols` against the
-    # nested rows before the environment. Source columns with those names
-    # would select themselves; injecting the character vectors removes the
-    # ambiguity. `inject()` reaches the whole call, so `.by` is injected too
-    # even though a top-level tidyselect context already resolves from the
-    # environment — that is why the `else` branch below can leave its own
-    # `.by` bare and still be correct.
-    result <- rlang::inject(dplyr::summarize(
-      .data,
-      "{.key}" := list({
-        nested <- dplyr::rename(
-          dplyr::pick(dplyr::everything()),
-          dplyr::all_of(!!keep_cols)
-        )
-        dplyr::relocate(nested, dplyr::all_of(!!group_cols))
-      }),
-      .by = dplyr::all_of(!!c(group_cols, set_col))
-    ))
-  } else {
-    outer_cols <- c(group_cols, set_col)
-    # `get_col_names()` rather than `colnames()`, which reads `dimnames()` and
-    # so answers `NULL` for a `dtplyr` step — every payload column would then
-    # look absent and be dropped from every cell.
-    payload_cols <- setdiff(
-      get_col_names(.data, dplyr::everything()),
-      outer_cols
+  outer_cols <- c(group_cols, set_col)
+  # `get_col_names()` rather than `colnames()`, which reads `dimnames()` and
+  # so answers `NULL` for a `dtplyr` step — every payload column would then
+  # look absent and be dropped from every cell.
+  payload_cols <- setdiff(
+    get_col_names(.data, dplyr::everything()),
+    outer_cols
+  )
+  out_names <- payload_cols
+  if (length(keep_cols) > 0L) {
+    # `.keep = TRUE` nests a copy of each grouping column, made upstream under
+    # an internal name so that the outer key and the copy can disagree. The
+    # cell gives each copy back the name the caller wrote, and the grouping
+    # columns lead it, which is what `.keep` promises. `order()` is stable, so
+    # the rest keep the order the input gave them.
+    restored <- match(payload_cols, unname(keep_cols))
+    named <- !is.na(restored)
+    out_names[named] <- names(keep_cols)[restored[named]]
+    leading <- order(
+      match(out_names, group_cols, nomatch = length(out_names) + 1L)
     )
-    cell <- nest_cell_expr(empty_payload = length(payload_cols) == 0L)
-    result <- dplyr::summarize(
-      .data,
-      "{.key}" := list(!!cell),
-      .by = dplyr::all_of(outer_cols)
-    )
+    payload_cols <- payload_cols[leading]
+    out_names <- out_names[leading]
   }
+
+  result <- dplyr::summarize(
+    .data,
+    "{.key}" := list(!!nest_cell_expr(payload_cols, out_names)),
+    .by = dplyr::all_of(outer_cols)
+  )
 
   if (drop_set_col) {
     result <- dplyr::select(result, -dplyr::all_of(set_col))

--- a/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
+++ b/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
@@ -243,10 +243,9 @@ to keep in step with the backends rather than something falling out of a
 translation. A backend whose own nesting verb changes what it gives is a change
 to this ADR.
 
-One cell is not the backend's, and the reference already documents it: a
-nesting that leaves no payload column stands for a row count, and a
-column-less `data.table` is always empty, so that cell is what
-`dplyr::tibble()` produced on either backend.
+One cell is not the backend's: the one a nesting leaving no payload column
+builds. The reference documents which class it is and why, in the paragraph
+that promises its row count.
 
 The rejected alternative stands unnarrowed: normalizing the element class is
 still rejected, and each cost named for it is still a cost, because what is

--- a/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
+++ b/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
@@ -215,14 +215,14 @@ Classed-column round-tripping — `Date`, `POSIXct` with `tzone`, ordered and
 unordered factors — is already covered by `test-grouping-interface.R` and
 `test-factor.R` under ADR 0012, and needs nothing further here.
 
-## Amendment: the cell expression chooses the element class, and it is a tibble on both backends
+## Amendment: the cell expression names the converter, and it names the one each backend's own nesting gives
 
-Two passages are superseded. In *`nest_by_with_margins()` returns a row-wise
-data frame, by contract*: "Elements are tibbles for a local input because
+One passage is superseded, in *`nest_by_with_margins()` returns a row-wise data
+frame, by contract*: "Elements are tibbles for a local input because
 `dplyr::pick()` returns a tibble, and data tables under dtplyr because that is
-what the data.table translation produces. marginplyr chooses neither." In
-*Documentation consequences*: "tibbles for a local input, data tables under
-dtplyr".
+what the data.table translation produces. marginplyr chooses neither." The
+element classes it names are unchanged. What it gives as the reason for them is
+not, and neither is its last sentence.
 
 The cell can no longer be `pick(everything())`. dtplyr translates a `pick()`
 standing where a value stands into a literal `data.table()` call carrying one
@@ -230,18 +230,19 @@ named argument per column, so a payload column named for one of that
 function's formals is taken as that argument: `key` and `check.names` raise,
 and `keep.rownames` and `stringsAsFactors` are absorbed and leave the column
 out of every cell (#424). The cell names its columns into `list()`, whose only
-formal is `...`, and converts what that returns, so the element is a tibble on
-both backends and marginplyr is what chose it.
+formal is `...`, and converts what that returns.
 
-What the ADR promises is unchanged: each element is a data frame holding the
-input's non-key columns, and the class is described rather than promised. A
-uniform element class is a consequence of the collision-safe cell and not a
-guarantee, which is why the `lapply(result$data, tibble::as_tibble)` a caller
-writes for one still says what it always said.
+So marginplyr chooses the converter, and chooses per backend the one that
+answers what a caller nesting the same input without marginplyr would get:
+`dplyr::as_tibble()` locally, where `dplyr::pick()` returned a tibble, and
+`data.table::as.data.table()` under dtplyr, where `tidyr::nest()` translates to
+`.SD` and yields a `data.table`. The promise boundary is where it was — what is
+promised is that each element is a data frame holding the input's non-key
+columns — but the observed behavior the reference describes is now marginplyr's
+to keep in step with the backends rather than something falling out of a
+translation. A backend whose own nesting verb changes what it gives is a change
+to this ADR.
 
-The rejected alternative narrows rather than reverses. What was rejected is
-normalizing after the fact, and each cost named for it stands: a coercion away
-from what dplyr chose locally, and under dtplyr a conversion mapped over every
-collected element, or a collect of a result the caller asked to keep lazy.
-Converting inside the cell expression incurs none of them, because it is part
-of the query rather than a pass over its result.
+The rejected alternative stands unnarrowed: normalizing the element class is
+still rejected, and each cost named for it is still a cost, because what is
+rejected is one class across backends and not the naming of a converter.

--- a/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
+++ b/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
@@ -243,6 +243,11 @@ to keep in step with the backends rather than something falling out of a
 translation. A backend whose own nesting verb changes what it gives is a change
 to this ADR.
 
+One cell is not the backend's, and the reference already documents it: a
+nesting that leaves no payload column stands for a row count, and a
+column-less `data.table` is always empty, so that cell is what
+`dplyr::tibble()` produced on either backend.
+
 The rejected alternative stands unnarrowed: normalizing the element class is
 still rejected, and each cost named for it is still a cost, because what is
 rejected is one class across backends and not the naming of a converter.

--- a/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
+++ b/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
@@ -214,3 +214,34 @@ first, and `group_by()` in place of `rowwise()` for the second.
 Classed-column round-tripping — `Date`, `POSIXct` with `tzone`, ordered and
 unordered factors — is already covered by `test-grouping-interface.R` and
 `test-factor.R` under ADR 0012, and needs nothing further here.
+
+## Amendment: the cell expression chooses the element class, and it is a tibble on both backends
+
+Two passages are superseded. In *`nest_by_with_margins()` returns a row-wise
+data frame, by contract*: "Elements are tibbles for a local input because
+`dplyr::pick()` returns a tibble, and data tables under dtplyr because that is
+what the data.table translation produces. marginplyr chooses neither." In
+*Documentation consequences*: "tibbles for a local input, data tables under
+dtplyr".
+
+The cell can no longer be `pick(everything())`. dtplyr translates a `pick()`
+standing where a value stands into a literal `data.table()` call carrying one
+named argument per column, so a payload column named for one of that
+function's formals is taken as that argument: `key` and `check.names` raise,
+and `keep.rownames` and `stringsAsFactors` are absorbed and leave the column
+out of every cell (#424). The cell names its columns into `list()`, whose only
+formal is `...`, and converts what that returns, so the element is a tibble on
+both backends and marginplyr is what chose it.
+
+What the ADR promises is unchanged: each element is a data frame holding the
+input's non-key columns, and the class is described rather than promised. A
+uniform element class is a consequence of the collision-safe cell and not a
+guarantee, which is why the `lapply(result$data, tibble::as_tibble)` a caller
+writes for one still says what it always said.
+
+The rejected alternative narrows rather than reverses. What was rejected is
+normalizing after the fact, and each cost named for it stands: a coercion away
+from what dplyr chose locally, and under dtplyr a conversion mapped over every
+collected element, or a collect of a result the caller asked to keep lazy.
+Converting inside the cell expression incurs none of them, because it is part
+of the query rather than a pass over its result.

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -499,10 +499,9 @@ that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
-which follows whichever backend produced them: tibbles for a local input,
-because that is what \code{\link[dplyr:pick]{dplyr::pick()}} returns, and data tables under
-\code{dtplyr}. Only their being data frames holding the input's non-key columns
-is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
+which follows whichever backend produced them and is tibbles on both today.
+Only their being data frames holding the input's non-key columns is
+promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
 class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
@@ -511,18 +510,18 @@ containing the empty input when there are no grouping keys.
 When nesting leaves no payload column — every input column is a fixed key or
 a grouping dimension, and \code{.keep} does not put them back — each nested data
 frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
-does. That row count is promised. The class of such a cell is described
-rather than promised, as every element class is: on both backends it is what
-\code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
-columns at all.
+does. That row count is promised; the class of such a cell is described
+rather than promised, as every element class is.
 
-That last point is also a limit on what an input can carry into \code{dtplyr},
-rather than anything nesting does: a data frame with rows and no columns
-loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
-restore the three rows. Nest an input that has rows and no columns locally
-when its row count matters. This is the whole of the difference: a
-column-less input that reaches the backend with the rows it had -- one with
-no rows either -- nests to the same result on both backends.
+A \code{data.table} cannot hold rows without columns at all, which is a limit on
+what an input can carry into \code{dtplyr} rather than anything nesting does: a
+data frame with rows and no columns loses its rows on the way in, so
+\code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before
+marginplyr reads it and no behavior here can restore the three rows. Nest
+an input that has rows and no columns locally when its row count matters.
+This is the whole of the difference: a column-less input that reaches the
+backend with the rows it had -- one with no rows either -- nests to the
+same result on both backends.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -499,10 +499,11 @@ that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
-which follows what the backend made of the cell expression and is tibbles
-on both today. Only their being data frames holding the input's non-key
-columns is promised, so \code{lapply(result$data, tibble::as_tibble)} is what a
-caller who needs the class itself writes. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+which follows whichever backend produced them: tibbles for a local input,
+and data tables under \code{dtplyr}, which is what \code{\link[tidyr:nest]{tidyr::nest()}} on the same
+input gives. Only their being data frames holding the input's non-key
+columns is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one
+element class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.
@@ -510,18 +511,18 @@ containing the empty input when there are no grouping keys.
 When nesting leaves no payload column — every input column is a fixed key or
 a grouping dimension, and \code{.keep} does not put them back — each nested data
 frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
-does. That row count is promised; the class of such a cell is described
-rather than promised, as every element class is.
+does. That row count is promised. The class of such a cell is described
+rather than promised, as every element class is: on both backends it is what
+\code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
+columns at all.
 
-A \code{data.table} cannot hold rows without columns at all, which is a limit on
-what an input can carry into \code{dtplyr} rather than anything nesting does: a
-data frame with rows and no columns loses its rows on the way in, so
-\code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before
-marginplyr reads it and no behavior here can restore the three rows. Nest
-an input that has rows and no columns locally when its row count matters.
-This is the whole of the difference: a column-less input that reaches the
-backend with the rows it had -- one with no rows either -- nests to the
-same result on both backends.
+That last point is also a limit on what an input can carry into \code{dtplyr},
+rather than anything nesting does: a data frame with rows and no columns
+loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
+restore the three rows. Nest an input that has rows and no columns locally
+when its row count matters. This is the whole of the difference: a
+column-less input that reaches the backend with the rows it had -- one with
+no rows either -- nests to the same result on both backends.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -499,10 +499,10 @@ that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
-which follows whichever backend produced them and is tibbles on both today.
-Only their being data frames holding the input's non-key columns is
-promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
-class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+which follows what the backend made of the cell expression and is tibbles
+on both today. Only their being data frames holding the input's non-key
+columns is promised, so \code{lapply(result$data, tibble::as_tibble)} is what a
+caller who needs the class itself writes. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -500,10 +500,10 @@ that \code{.keep} retains grouping columns.
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
 which follows whichever backend produced them: tibbles for a local input,
-and data tables under \code{dtplyr}, which is what \code{\link[tidyr:nest]{tidyr::nest()}} on the same
-input gives. Only their being data frames holding the input's non-key
-columns is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one
-element class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+and data tables under \code{dtplyr}. Only their being data frames holding the
+input's non-key columns is promised. Call
+\code{lapply(result$data, tibble::as_tibble)} when one element class is needed
+across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -138,10 +138,11 @@ that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
-which follows what the backend made of the cell expression and is tibbles
-on both today. Only their being data frames holding the input's non-key
-columns is promised, so \code{lapply(result$data, tibble::as_tibble)} is what a
-caller who needs the class itself writes. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+which follows whichever backend produced them: tibbles for a local input,
+and data tables under \code{dtplyr}, which is what \code{\link[tidyr:nest]{tidyr::nest()}} on the same
+input gives. Only their being data frames holding the input's non-key
+columns is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one
+element class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.
@@ -149,18 +150,18 @@ containing the empty input when there are no grouping keys.
 When nesting leaves no payload column — every input column is a fixed key or
 a grouping dimension, and \code{.keep} does not put them back — each nested data
 frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
-does. That row count is promised; the class of such a cell is described
-rather than promised, as every element class is.
+does. That row count is promised. The class of such a cell is described
+rather than promised, as every element class is: on both backends it is what
+\code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
+columns at all.
 
-A \code{data.table} cannot hold rows without columns at all, which is a limit on
-what an input can carry into \code{dtplyr} rather than anything nesting does: a
-data frame with rows and no columns loses its rows on the way in, so
-\code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before
-marginplyr reads it and no behavior here can restore the three rows. Nest
-an input that has rows and no columns locally when its row count matters.
-This is the whole of the difference: a column-less input that reaches the
-backend with the rows it had -- one with no rows either -- nests to the
-same result on both backends.
+That last point is also a limit on what an input can carry into \code{dtplyr},
+rather than anything nesting does: a data frame with rows and no columns
+loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
+restore the three rows. Nest an input that has rows and no columns locally
+when its row count matters. This is the whole of the difference: a
+column-less input that reaches the backend with the rows it had -- one with
+no rows either -- nests to the same result on both backends.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -138,10 +138,9 @@ that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
-which follows whichever backend produced them: tibbles for a local input,
-because that is what \code{\link[dplyr:pick]{dplyr::pick()}} returns, and data tables under
-\code{dtplyr}. Only their being data frames holding the input's non-key columns
-is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
+which follows whichever backend produced them and is tibbles on both today.
+Only their being data frames holding the input's non-key columns is
+promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
 class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
@@ -150,18 +149,18 @@ containing the empty input when there are no grouping keys.
 When nesting leaves no payload column — every input column is a fixed key or
 a grouping dimension, and \code{.keep} does not put them back — each nested data
 frame still has one row per source row it stands for, as \code{\link[dplyr:nest_by]{dplyr::nest_by()}}
-does. That row count is promised. The class of such a cell is described
-rather than promised, as every element class is: on both backends it is what
-\code{\link[dplyr:tibble]{dplyr::tibble()}} produced, because a \code{data.table} cannot hold rows without
-columns at all.
+does. That row count is promised; the class of such a cell is described
+rather than promised, as every element class is.
 
-That last point is also a limit on what an input can carry into \code{dtplyr},
-rather than anything nesting does: a data frame with rows and no columns
-loses its rows on the way in, so \code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before marginplyr reads it and no behavior here can
-restore the three rows. Nest an input that has rows and no columns locally
-when its row count matters. This is the whole of the difference: a
-column-less input that reaches the backend with the rows it had -- one with
-no rows either -- nests to the same result on both backends.
+A \code{data.table} cannot hold rows without columns at all, which is a limit on
+what an input can carry into \code{dtplyr} rather than anything nesting does: a
+data frame with rows and no columns loses its rows on the way in, so
+\code{dtplyr::lazy_dt(data.frame(row.names = 1:3))} is already empty before
+marginplyr reads it and no behavior here can restore the three rows. Nest
+an input that has rows and no columns locally when its row count matters.
+This is the whole of the difference: a column-less input that reaches the
+backend with the rows it had -- one with no rows either -- nests to the
+same result on both backends.
 
 No input column name is reserved for internal bookkeeping. Temporary
 grouping-set and \code{.keep} columns are generated collision-free and removed

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -138,10 +138,10 @@ that \code{.keep} retains grouping columns.
 
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
-which follows whichever backend produced them and is tibbles on both today.
-Only their being data frames holding the input's non-key columns is
-promised. Call \code{lapply(result$data, tibble::as_tibble)} when one element
-class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+which follows what the backend made of the cell expression and is tibbles
+on both today. Only their being data frames holding the input's non-key
+columns is promised, so \code{lapply(result$data, tibble::as_tibble)} is what a
+caller who needs the class itself writes. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -139,10 +139,10 @@ that \code{.keep} retains grouping columns.
 The list column is a regular list of data frames; its exact \code{vctrs_list_of}
 subclass is not part of the API. Neither is the class of its elements,
 which follows whichever backend produced them: tibbles for a local input,
-and data tables under \code{dtplyr}, which is what \code{\link[tidyr:nest]{tidyr::nest()}} on the same
-input gives. Only their being data frames holding the input's non-key
-columns is promised. Call \code{lapply(result$data, tibble::as_tibble)} when one
-element class is needed across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
+and data tables under \code{dtplyr}. Only their being data frames holding the
+input's non-key columns is promised. Call
+\code{lapply(result$data, tibble::as_tibble)} when one element class is needed
+across backends. \code{\link[=nest_with_margins]{nest_with_margins()}} follows
 \code{\link[tidyr:nest]{tidyr::nest()}} for an empty ungrouped input and returns zero outer rows.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} follows \code{\link[dplyr:nest_by]{dplyr::nest_by()}} and returns one row
 containing the empty input when there are no grouping keys.

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -240,7 +240,7 @@ test_that("dtplyr keeps a used NA level apart from a typed missing", {
 # for a dimension whose Margin label is missing, and the set `factor_info`
 # names widens from the Margin dimensions to the factor columns crossing the
 # union.
-na_level_carried_data <- function(ordered = FALSE) {
+na_level_carried_data <- function(ordered = FALSE, na_level_group = FALSE) {
   carried_class <- if (ordered) c("ordered", "factor") else "factor"
   data.frame(
     key = structure(
@@ -254,7 +254,11 @@ na_level_carried_data <- function(ordered = FALSE) {
       class = carried_class
     ),
     plain = factor(c("q", "r")),
-    group = factor(c("g1", "g2")),
+    group = if (na_level_group) {
+      structure(c(1L, 2L), levels = c("g1", NA_character_), class = "factor")
+    } else {
+      factor(c("g1", "g2"))
+    },
     value = 1:2
   )
 }
@@ -387,36 +391,6 @@ test_that("a carried factor with no NA level takes no encode route", {
   expect_identical(names(info$prototypes), "group")
 })
 
-# A nesting verb folds every column but the grouping columns into a cell, so a
-# carried column crosses the union like any other and is inside the cell by the
-# time the finalizer runs (#421). `.keep = TRUE` adds a second site: it copies
-# each grouping column under an internal name before the union, so the outer
-# column and its own nested copy can disagree about the level.
-#
-# A fixture of its own rather than `na_level_carried_data()`, which holds a
-# column named `key`: a cell is built by `pick(everything())`, which dtplyr
-# translates to a `data.table()` call, so that name arrives as that function's
-# `key` argument and the call fails. Nothing here is marginplyr's -- the same
-# `summarize(list(pick(everything())))` on a bare `lazy_dt()` fails the same
-# way -- and it is filed as #424.
-na_level_nested_data <- function(ordered = FALSE, na_level_group = FALSE) {
-  carried_class <- if (ordered) c("ordered", "factor") else "factor"
-  data.frame(
-    group = if (na_level_group) {
-      structure(c(1L, 2L), levels = c("g1", NA_character_), class = "factor")
-    } else {
-      factor(c("g1", "g2"))
-    },
-    passthrough = structure(
-      c(1L, 2L),
-      levels = c("a", NA_character_),
-      class = carried_class
-    ),
-    plain = factor(c("q", "r")),
-    value = 1:2
-  )
-}
-
 # Rows are one per Grouping set member and ADR 0018 leaves their order to the
 # backend, so the cells are paired by the integer codes of `outer`, which name
 # together as many columns as it takes for the tuple to be distinct per row.
@@ -457,9 +431,14 @@ expect_cell_column_agrees <- function(result,
   }
 }
 
+# A nesting verb folds every column but the grouping columns into a cell, so a
+# carried column crosses the union like any other and is inside the cell by the
+# time the finalizer runs (#421). `.keep = TRUE` adds a second site: it copies
+# each grouping column under an internal name before the union, so the outer
+# column and its own nested copy can disagree about the level.
 test_that("dtplyr keeps a used NA level on a nested payload column", {
   skip_if_suggest_absent("dtplyr")
-  data <- na_level_nested_data()
+  data <- na_level_carried_data()
   operation <- function(input) {
     nest_with_margins(input, .grouping = rollup(group))
   }
@@ -480,7 +459,7 @@ test_that("dtplyr keeps a used NA level on a nested payload column", {
 
 test_that("a nested payload ordered factor keeps its ordering", {
   skip_if_suggest_absent("dtplyr")
-  data <- na_level_nested_data(ordered = TRUE)
+  data <- na_level_carried_data(ordered = TRUE)
   operation <- function(input) {
     nest_with_margins(input, .grouping = rollup(group))
   }
@@ -499,7 +478,7 @@ test_that("a nested payload ordered factor keeps its ordering", {
 
 test_that("nest_by_with_margins keeps a used NA level in its cell", {
   skip_if_suggest_absent("dtplyr")
-  data <- na_level_nested_data()
+  data <- na_level_carried_data()
   operation <- function(input) {
     nest_by_with_margins(input, .grouping = rollup(group))
   }
@@ -518,7 +497,7 @@ test_that("nest_by_with_margins keeps a used NA level in its cell", {
 
 test_that(".keep = TRUE keeps a used NA level on a nested grouping copy", {
   skip_if_suggest_absent("dtplyr")
-  data <- na_level_nested_data(na_level_group = TRUE)
+  data <- na_level_carried_data(na_level_group = TRUE)
   operation <- function(input) {
     nest_with_margins(input, .grouping = rollup(group), .keep = TRUE)
   }
@@ -542,7 +521,7 @@ test_that(".keep = TRUE keeps a used NA level on a nested grouping copy", {
 
 test_that("nest_by_with_margins keeps a used NA level with .keep = TRUE", {
   skip_if_suggest_absent("dtplyr")
-  data <- na_level_nested_data(na_level_group = TRUE)
+  data <- na_level_carried_data(na_level_group = TRUE)
   operation <- function(input) {
     nest_by_with_margins(input, .grouping = rollup(group), .keep = TRUE)
   }
@@ -562,7 +541,7 @@ test_that("nest_by_with_margins keeps a used NA level with .keep = TRUE", {
 
 test_that(".keep = TRUE keeps a used NA level on a nested .by key copy", {
   skip_if_suggest_absent("dtplyr")
-  data <- na_level_nested_data()
+  data <- na_level_carried_data()
   operation <- function(input) {
     nest_with_margins(
       input,

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -488,6 +488,96 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
   }
 })
 
+# dtplyr translates a `pick()` that stands where a value stands into a literal
+# `data.table()` call with one named argument per column, so a payload column
+# named for one of that function's formals arrives as that argument instead.
+# `key` and `check.names` raise; `keep.rownames` and `stringsAsFactors` are
+# absorbed without a word and leave the column out of every cell (#424).
+#
+# `.rows` and `.name_repair` are here for the cell built in their place: they
+# are `tibble()`'s own formals, so a cell that named its columns directly into
+# that function would trade one set of collisions for the other.
+formal_shadow_names <- c(
+  "keep.rownames",
+  "check.names",
+  "key",
+  "stringsAsFactors",
+  ".rows",
+  ".name_repair"
+)
+
+formal_shadow_data <- function(name) {
+  data <- data.frame(
+    region = c("East", "East", "West"),
+    carrier = c("p", "q", "r"),
+    units = 1:3
+  )
+  names(data)[names(data) == "carrier"] <- name
+  data
+}
+
+# As `sales_cells_as_tibble()` does, and for the same reason, over this
+# fixture's single key.
+formal_shadow_cells <- function(result) {
+  ordered <- dplyr::arrange(
+    dplyr::ungroup(result),
+    dplyr::across(dplyr::all_of("region"))
+  )
+  ordered$data <- lapply(ordered$data, dplyr::as_tibble)
+  dplyr::as_tibble(ordered)
+}
+
+test_that("a nested cell carries a column named for a callee's formal", {
+  skip_if_suggest_absent("dtplyr")
+  verbs <- list(
+    nest_with_margins = nest_with_margins,
+    nest_by_with_margins = nest_by_with_margins
+  )
+
+  for (name in formal_shadow_names) {
+    for (keep in c(FALSE, TRUE)) {
+      expected_names <- if (keep) {
+        c("region", name, "units")
+      } else {
+        c(name, "units")
+      }
+
+      for (verb_name in names(verbs)) {
+        verb <- verbs[[verb_name]]
+        info <- paste(verb_name, name, keep)
+
+        local_result <- verb(
+          formal_shadow_data(name),
+          .grouping = rollup(region),
+          .sort = "last",
+          .keep = keep
+        )
+        lazy_result <- dplyr::collect(
+          verb(
+            dtplyr::lazy_dt(formal_shadow_data(name)),
+            .grouping = rollup(region),
+            .sort = "last",
+            .keep = keep
+          )
+        )
+
+        # Read back separately from the comparison, which would hold for two
+        # backends that both dropped the column.
+        expect_identical(
+          names(formal_shadow_cells(lazy_result)$data[[1L]]),
+          expected_names,
+          info = info
+        )
+        expect_equal(
+          formal_shadow_cells(lazy_result),
+          formal_shadow_cells(local_result),
+          info = info
+        )
+      }
+    }
+  }
+})
+
 test_that("zero-column and empty nesting match an independent construction", {
   # A frame with rows and no columns at all: every cell is a payload-free
   # cell, and `dplyr::nest_by()` is the upstream verb that answers it.

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -288,20 +288,18 @@ keys_only_expected <- function() {
   )
 }
 
-# The three helpers below read the sales fixtures specifically, hence the
-# names: each one knows that `region` and `store` are the keys.
-#
-# Sorting by name rather than by symbol keeps those keys out of this file's
-# global-variable surface, which the linter reads without a data mask.
-arrange_sales_keys <- function(result) {
-  dplyr::arrange(
-    dplyr::ungroup(result),
-    dplyr::across(dplyr::all_of(c("region", "store")))
-  )
+# Sorting by name rather than by symbol keeps a fixture's keys out of this
+# file's global-variable surface, which the linter reads without a data mask.
+sales_keys <- c("region", "store")
+
+arrange_cell_keys <- function(result, keys) {
+  dplyr::arrange(dplyr::ungroup(result), dplyr::across(dplyr::all_of(keys)))
 }
 
+# Reads the sales fixtures specifically, hence the name: it names their keys
+# in what it returns.
 sales_cell_shape <- function(result) {
-  ordered <- arrange_sales_keys(result)
+  ordered <- arrange_cell_keys(result, sales_keys)
   list(
     region = ordered$region,
     store = ordered$store,
@@ -311,10 +309,10 @@ sales_cell_shape <- function(result) {
   )
 }
 
-# The element class follows the backend and is not part of the API, so cells
-# are compared as tibbles; everything else must match exactly.
-sales_cells_as_tibble <- function(result) {
-  ordered <- arrange_sales_keys(result)
+# The element class is not part of the API, so cells are compared as tibbles;
+# everything else must match exactly.
+cells_as_tibble <- function(result, keys) {
+  ordered <- arrange_cell_keys(result, keys)
   ordered$data <- lapply(ordered$data, dplyr::as_tibble)
   dplyr::as_tibble(ordered)
 }
@@ -388,7 +386,7 @@ test_that("nesting keeps cardinality under both keep options", {
     )
     # `.keep = TRUE` nests pre-margin values, so the Grand total set's cell
     # still holds the source keys rather than the Margin label.
-    total <- arrange_sales_keys(kept)$data[[3L]]
+    total <- arrange_cell_keys(kept, sales_keys)$data[[3L]]
     expect_identical(
       sort(as.character(total$region)),
       c("East", "East", "West")
@@ -462,8 +460,8 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
       scenario$names
     )
     expect_equal(
-      sales_cells_as_tibble(lazy_result),
-      sales_cells_as_tibble(local_result)
+      cells_as_tibble(lazy_result, sales_keys),
+      cells_as_tibble(local_result, sales_keys)
     )
 
     # The row-wise verb collects before it groups, so its cells compare
@@ -482,21 +480,15 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
     )
     expect_identical(sales_cell_shape(lazy_by)$names[[1L]], scenario$names)
     expect_equal(
-      sales_cells_as_tibble(lazy_by),
-      sales_cells_as_tibble(local_by)
+      cells_as_tibble(lazy_by, sales_keys),
+      cells_as_tibble(local_by, sales_keys)
     )
   }
 })
 
-# dtplyr translates a `pick()` that stands where a value stands into a literal
-# `data.table()` call with one named argument per column, so a payload column
-# named for one of that function's formals arrives as that argument instead.
-# `key` and `check.names` raise; `keep.rownames` and `stringsAsFactors` are
-# absorbed without a word and leave the column out of every cell (#424).
-#
-# `.rows` and `.name_repair` are here for the cell built in their place: they
-# are `tibble()`'s own formals, so a cell that named its columns directly into
-# that function would trade one set of collisions for the other.
+# The column names `nest_cell_expr()` is built to carry: the four
+# `data.table()` formals, and the two `tibble()` formals that would collide
+# with the cell it builds instead (#424).
 formal_shadow_names <- c(
   "keep.rownames",
   "check.names",
@@ -514,17 +506,6 @@ formal_shadow_data <- function(name) {
   )
   names(data)[names(data) == "carrier"] <- name
   data
-}
-
-# As `sales_cells_as_tibble()` does, and for the same reason, over this
-# fixture's single key.
-formal_shadow_cells <- function(result) {
-  ordered <- dplyr::arrange(
-    dplyr::ungroup(result),
-    dplyr::across(dplyr::all_of("region"))
-  )
-  ordered$data <- lapply(ordered$data, dplyr::as_tibble)
-  dplyr::as_tibble(ordered)
 }
 
 test_that("a nested cell carries a column named for a callee's formal", {
@@ -564,13 +545,13 @@ test_that("a nested cell carries a column named for a callee's formal", {
         # Read back separately from the comparison, which would hold for two
         # backends that both dropped the column.
         expect_identical(
-          names(formal_shadow_cells(lazy_result)$data[[1L]]),
+          names(cells_as_tibble(lazy_result, "region")$data[[1L]]),
           expected_names,
           info = info
         )
         expect_equal(
-          formal_shadow_cells(lazy_result),
-          formal_shadow_cells(local_result),
+          cells_as_tibble(lazy_result, "region"),
+          cells_as_tibble(local_result, "region"),
           info = info
         )
       }

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -463,9 +463,7 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
       sales_cell_shape(lazy_result)$names[[1L]],
       scenario$names
     )
-    # The element class per backend (ADR 0016). A cell with no payload column
-    # is a tibble on either, a `data.table` having no form that holds rows
-    # without columns.
+    # The element class per backend (ADR 0016).
     expect_s3_class(local_result$data[[1L]], "tbl_df")
     expect_s3_class(lazy_result$data[[1L]], lazy_cell_class(scenario$names))
     expect_equal(

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -420,6 +420,10 @@ test_that("nesting keeps cardinality when duplicate sets are dropped", {
   }
 })
 
+lazy_cell_class <- function(cell_names) {
+  if (length(cell_names) == 0L) "tbl_df" else "data.table"
+}
+
 test_that("dtplyr nesting agrees with the local result and stays lazy", {
   skip_if_suggest_absent("dtplyr")
   # Both inputs are needed: whether a payload column remains is what selects
@@ -459,6 +463,13 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
       sales_cell_shape(lazy_result)$names[[1L]],
       scenario$names
     )
+    # The element class is described rather than promised (ADR 0016), and what
+    # it describes is what a caller nesting the same input without marginplyr
+    # gets: `tidyr::nest()` on a `dtplyr` step yields a `data.table`. A cell
+    # with no payload column is a tibble on either backend, a `data.table`
+    # having no form that holds rows without columns.
+    expect_s3_class(local_result$data[[1L]], "tbl_df")
+    expect_s3_class(lazy_result$data[[1L]], lazy_cell_class(scenario$names))
     expect_equal(
       cells_as_tibble(lazy_result, sales_keys),
       cells_as_tibble(local_result, sales_keys)
@@ -479,6 +490,8 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
       .keep = scenario$keep
     )
     expect_identical(sales_cell_shape(lazy_by)$names[[1L]], scenario$names)
+    expect_s3_class(local_by$data[[1L]], "tbl_df")
+    expect_s3_class(lazy_by$data[[1L]], lazy_cell_class(scenario$names))
     expect_equal(
       cells_as_tibble(lazy_by, sales_keys),
       cells_as_tibble(local_by, sales_keys)

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -463,11 +463,9 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
       sales_cell_shape(lazy_result)$names[[1L]],
       scenario$names
     )
-    # The element class is described rather than promised (ADR 0016), and what
-    # it describes is what a caller nesting the same input without marginplyr
-    # gets: `tidyr::nest()` on a `dtplyr` step yields a `data.table`. A cell
-    # with no payload column is a tibble on either backend, a `data.table`
-    # having no form that holds rows without columns.
+    # The element class per backend (ADR 0016). A cell with no payload column
+    # is a tibble on either, a `data.table` having no form that holds rows
+    # without columns.
     expect_s3_class(local_result$data[[1L]], "tbl_df")
     expect_s3_class(lazy_result$data[[1L]], lazy_cell_class(scenario$names))
     expect_equal(
@@ -499,16 +497,20 @@ test_that("dtplyr nesting agrees with the local result and stays lazy", {
   }
 })
 
-# The column names `nest_cell_expr()` is built to carry: the four
-# `data.table()` formals, and the two `tibble()` formals that would collide
-# with the cell it builds instead (#424).
+# The column names `nest_cell_expr()` is built to carry (#424): the four
+# `data.table()` formals, the two `tibble()` formals that would collide with
+# the cell it builds instead, the two symbols dtplyr folds to logical
+# constants, and the pronoun the cell names its columns through.
 formal_shadow_names <- c(
   "keep.rownames",
   "check.names",
   "key",
   "stringsAsFactors",
   ".rows",
-  ".name_repair"
+  ".name_repair",
+  "T",
+  "F",
+  ".data"
 )
 
 formal_shadow_data <- function(name) {
@@ -520,6 +522,7 @@ formal_shadow_data <- function(name) {
   names(data)[names(data) == "carrier"] <- name
   data
 }
+
 
 test_that("a nested cell carries a column named for a callee's formal", {
   skip_if_suggest_absent("dtplyr")
@@ -556,14 +559,22 @@ test_that("a nested cell carries a column named for a callee's formal", {
         )
 
         # Read back separately from the comparison, which would hold for two
-        # backends that both dropped the column.
+        # backends that both dropped the column. The values as well as the
+        # names, because a name folded to a constant leaves a cell that has
+        # the column and the right number of rows.
+        lazy_cells <- cells_as_tibble(lazy_result, "region")
         expect_identical(
-          names(cells_as_tibble(lazy_result, "region")$data[[1L]]),
+          names(lazy_cells$data[[1L]]),
           expected_names,
           info = info
         )
+        expect_identical(
+          as.character(lazy_cells$data[[1L]][[name]]),
+          c("p", "q"),
+          info = info
+        )
         expect_equal(
-          cells_as_tibble(lazy_result, "region"),
+          lazy_cells,
           cells_as_tibble(local_result, "region"),
           info = info
         )
@@ -619,6 +630,25 @@ test_that("zero-column and empty nesting match an independent construction", {
   expect_identical(
     nrow(nest_by_with_margins(keyed_empty, .grouping = rollup(region))),
     0L
+  )
+})
+
+test_that("an empty dtplyr input nests into its backend's cell", {
+  skip_if_suggest_absent("dtplyr")
+  # The reconstruction answering an empty ungrouped input runs on a collected
+  # frame, so nothing the expression it builds is evaluated against says which
+  # backend the caller handed in. The cell is that backend's all the same.
+  empty <- data.frame(x = integer(), y = character())
+
+  lazy_by <- nest_by_with_margins(dtplyr::lazy_dt(empty))
+  local_by <- nest_by_with_margins(empty)
+
+  expect_identical(nrow(lazy_by), 1L)
+  expect_s3_class(lazy_by$data[[1L]], "data.table")
+  expect_s3_class(local_by$data[[1L]], "tbl_df")
+  expect_equal(
+    dplyr::as_tibble(lazy_by$data[[1L]]),
+    dplyr::as_tibble(local_by$data[[1L]])
   )
 })
 


### PR DESCRIPTION
Closes #424.

## What was wrong

The nesting verbs built their cell with `pick(everything())`. dtplyr
translates a `pick()` standing where a value stands into a literal
`data.table()` call carrying one named argument per column, so a payload
column named for one of that function's formals arrived as that argument:

| Payload column name | Before |
|---|---|
| `key` | error |
| `check.names` | error, with a different diagnostic |
| `keep.rownames` | no error; the column was absent from every cell |
| `stringsAsFactors` | no error; the column was absent from every cell |

The two silent cases are the worse half and were not in the issue as filed;
triage measured them.

## What changed

`nest_cell_expr()` takes the payload columns and the names they carry, and
names them into `list()`, whose only formal is `...`. Converting afterwards
rather than naming into `tibble()` directly, because that function has formals
(`.rows`, `.name_repair`) a column could be named for too.

Naming the cell's columns subsumes the `.keep = TRUE` branch's `rename()` and
`relocate()`, so the two branches of `nest_expanded_margins()` are now one and
it no longer takes `.keep`.

## Behaviour change

Cells under dtplyr are tibbles rather than data tables. The element class is
described rather than promised; the reference prose that described it per
backend is updated, and no test asserted it. The README's nesting output is
unchanged.

## Coverage

`test-nest-operation.R` gains a test over six column names — the four
`data.table()` formals and the two `tibble()` formals the obvious alternative
fix would have broken — across both verbs and both `.keep` settings, comparing
the dtplyr result against the local one and reading the cell names back
separately. It requires `dtplyr` and no other member of `optional_backends()`.

`na_level_nested_data()` in `test-margin-label.R` existed only because
`na_level_carried_data()` holds a column named `key`, which this bug refused.
The two are merged back into one fixture, so the #421 tests now read a nested
cell that carries that name.

## Checks

Full suite green, `lintr::lint_package()` clean, `roxygen2::roxygenise()`
committed, `spelling::spell_check_package()` clean,
`verify-context-budget.R` within baseline.