### PR TITLE
Write a dtplyr margin label full-size on every dimension type (#427)

### DIFF
--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -460,13 +460,14 @@ label_margin_branch <- function(.data,
       dplyr::across(dplyr::all_of(labelled_as_character), as.character)
     )
   }
-  # dtplyr renders a scalar overwrite as data.table `:=`. On a multi-row
-  # column, data.table recycles the scalar and coerces it to the column's own
-  # type rather than replacing the column, so the omitted branch reaches
-  # `funion()` in the type it had: an ordered factor opposite the character
-  # branch, and an integer holding `NA` where the label was (#427). A full-size
-  # value replaces the column, which is what makes the labelled branch match
-  # the `as.character()` the included ones took above.
+  # dtplyr renders a scalar overwrite as data.table `:=`, which recycles the
+  # value and coerces it to the column's own type rather than replacing the
+  # column. The omitted branch then reaches `funion()` as the ordered factor or
+  # the integer it started as, holding the `NA` a character label coerced to,
+  # while the included branches are character (#427). A full-size value
+  # replaces the column. Every labelled dimension takes it rather than only the
+  # ones that are not character already, for which it replaces the column with
+  # itself.
   dtplyr_full_size_label <- inherits(.data, "dtplyr_step")
   values <- lapply(
     omitted,
@@ -483,7 +484,9 @@ label_margin_branch <- function(.data,
         # branches spell one. `as.character()` of the prototype cannot: it is
         # `NA`, which is also what a value on the NA level becomes, and the
         # union is where the two would stop being distinguishable (ADR 0012).
-        # Full size for the reason the labelled arm above is.
+        # Full size for the reason the labelled arm above is, and with no
+        # backend test because `drops_na_factor_level_on_union`, which
+        # `missing_label_encoded` requires, is dtplyr's alone.
         return(rlang::expr(rep(!!sentinels[[col]], dplyr::n())))
       }
       value <- prototypes[[col]]

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -460,21 +460,20 @@ label_margin_branch <- function(.data,
       dplyr::across(dplyr::all_of(labelled_as_character), as.character)
     )
   }
-  # dtplyr renders a scalar overwrite as data.table `:=`. On a multi-row factor
-  # column, data.table recycles it without replacing the column class, leaving
-  # an ordered factor opposite the character branch at `funion()`. A full-size
-  # value replaces the column so factor restoration remains after the union.
-  dtplyr_factor_cols <- if (inherits(.data, "dtplyr_step")) {
-    vapply(factor_info, function(info) info$col, character(1))
-  } else {
-    character()
-  }
+  # dtplyr renders a scalar overwrite as data.table `:=`. On a multi-row
+  # column, data.table recycles the scalar and coerces it to the column's own
+  # type rather than replacing the column, so the omitted branch reaches
+  # `funion()` in the type it had: an ordered factor opposite the character
+  # branch, and an integer holding `NA` where the label was (#427). A full-size
+  # value replaces the column, which is what makes the labelled branch match
+  # the `as.character()` the included ones took above.
+  dtplyr_full_size_label <- inherits(.data, "dtplyr_step")
   values <- lapply(
     omitted,
     function(col) {
       label <- margin_labels[[col]]
       if (!is_missing_margin_label(label)) {
-        if (col %in% dtplyr_factor_cols) {
+        if (dtplyr_full_size_label) {
           return(rlang::expr(rep(!!label, dplyr::n())))
         }
         return(label)

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -996,12 +996,12 @@ test_that("dtplyr expansion verbs restore ordered factor dimensions", {
   }
 })
 
-test_that("dtplyr expansion verbs label a dimension of any type", {
+test_that("dtplyr expansion verbs label a non-character dimension", {
   skip_if_suggest_absent("dtplyr")
   # Two rows are load-bearing for the reason the ordered-factor test above
-  # gives, and the types are what generalise it: data.table coerces a recycled
-  # scalar to the column's own type, so an integer dimension takes `NA` from
-  # its label where a factor kept its class (#427).
+  # gives, and these four types are what generalise it: data.table coerces a
+  # recycled scalar to the column's own type, so an integer dimension takes
+  # `NA` from its label where a factor kept its class (#427).
   dimensions <- list(
     integer = c(1L, 2L),
     double = c(1.5, 2.5),
@@ -1019,6 +1019,9 @@ test_that("dtplyr expansion verbs label a dimension of any type", {
       ),
       nest_with_margins = nest_with_margins(source, .grouping = rollup(group))
     )
+    for (verb in names(lazy)) {
+      expect_s3_class(lazy[[verb]], "dtplyr_step")
+    }
     results <- lapply(lazy, dplyr::collect)
     results$nest_by_with_margins <- nest_by_with_margins(
       source,
@@ -1027,10 +1030,14 @@ test_that("dtplyr expansion verbs label a dimension of any type", {
 
     for (verb in names(results)) {
       info <- paste(type, verb)
-      expect_identical(typeof(results[[verb]]$group), "character", info = info)
-      expect_setequal(
-        results[[verb]]$group,
-        c(as.character(values), "Total")
+      got <- results[[verb]]$group
+      expect_identical(typeof(got), "character", info = info)
+      # `expect_setequal()` takes no `info`, and a bare set failure would name
+      # neither the type nor the verb that produced it.
+      expect_identical(
+        sort(unique(got)),
+        sort(c(as.character(values), "Total")),
+        info = info
       )
     }
   }

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -996,6 +996,46 @@ test_that("dtplyr expansion verbs restore ordered factor dimensions", {
   }
 })
 
+test_that("dtplyr expansion verbs label a dimension of any type", {
+  skip_if_suggest_absent("dtplyr")
+  # Two rows are load-bearing for the reason the ordered-factor test above
+  # gives, and the types are what generalise it: data.table coerces a recycled
+  # scalar to the column's own type, so an integer dimension takes `NA` from
+  # its label where a factor kept its class (#427).
+  dimensions <- list(
+    integer = c(1L, 2L),
+    double = c(1.5, 2.5),
+    Date = as.Date(c("2024-01-01", "2024-01-02")),
+    logical = c(TRUE, FALSE)
+  )
+
+  for (type in names(dimensions)) {
+    values <- dimensions[[type]]
+    source <- dtplyr::lazy_dt(data.frame(group = values, value = 1:2))
+    lazy <- list(
+      expand_with_margins = expand_with_margins(
+        source,
+        .grouping = rollup(group)
+      ),
+      nest_with_margins = nest_with_margins(source, .grouping = rollup(group))
+    )
+    results <- lapply(lazy, dplyr::collect)
+    results$nest_by_with_margins <- nest_by_with_margins(
+      source,
+      .grouping = rollup(group)
+    )
+
+    for (verb in names(results)) {
+      info <- paste(type, verb)
+      expect_identical(typeof(results[[verb]]$group), "character", info = info)
+      expect_setequal(
+        results[[verb]]$group,
+        c(as.character(values), "Total")
+      )
+    }
+  }
+})
+
 test_that("Arrow applies mixed named labels lazily with typed missing values", {
   skip_if_suggest_absent("arrow")
   data <- data.frame(


### PR DESCRIPTION
Fixes #427.

`expand_with_margins()`, `nest_with_margins()`, and `nest_by_with_margins()`
failed on a `dtplyr` input whenever a Margin dimension was `integer`, `double`,
`Date`, or `logical` and the margin label was a non-missing string. The same
call through the local `data.frame` backend succeeded, and the error came from
data.table naming nothing the caller wrote.

## Cause

`label_margin_branch()` wrote the label into an omitted dimension as a scalar
in `dplyr::mutate()`. dtplyr renders a scalar overwrite as data.table `:=`,
which recycles the value and coerces it to the column's *existing* type rather
than replacing the column. The omitted branch therefore kept `integer` --
holding `NA` where the label was -- while the included branches carried
`character`, and `funion()` refused the pair.

The factor arm already carried the fix for its own case with
`rep(label, n())`; the mechanism its comment names is the same one every other
non-character type meets.

## Change

The full-size form is now selected by the backend rather than by the column
set: on a `dtplyr_step`, every labelled omitted dimension is written
`rep(label, n())`. A full-size value replaces the column, which is what makes
the labelled branch match the `as.character()` the included branches took. A
character dimension is unaffected either way, so no schema read is needed to
decide.

## Test

`tests/testthat/test-margin-label.R` gains a test generalising the existing
ordered-factor case over the four types that failed -- `integer`, `double`,
`Date`, `logical` -- across all three expansion verbs. It requires only
`dtplyr`, so the one-backend-per-test policy holds.

Full suite green with `NOT_CRAN` set; `lintr::lint_package()` reports no lints.