### PR TITLE
Give a summary branch with nothing to select a column (#428)

### DIFF
--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -276,23 +276,23 @@ abort_absorbed_summary <- function(labels) {
 # maintainer's signal is `test-query-policy.R`, which fails when a read
 # happens at all.
 #
-# `seed_name` names one column the branch summarizes for itself. Only a caller
-# whose branch would otherwise select nothing at all passes one, and
+# `placeholder_name` names one column the branch summarizes for itself. Only a
+# caller whose branch would otherwise select nothing at all passes one, and
 # `summarize_margin_union()` is where that is decided and where the column is
 # dropped again.
 summarize_margin_branch <- function(.data,
                                     ...,
                                     .by,
                                     caller_labels,
-                                    seed_name = NULL) {
+                                    placeholder_name = NULL) {
   dots <- rlang::enquos(...)
 
-  # The seed joins what dplyr is handed and not `dots`, which stays the
+  # The placeholder joins what dplyr is handed and not `dots`, which stays the
   # caller's: the handler below places a blamed expression in it by position,
   # and a column the caller did not write has no label to be blamed under.
   summarize_dots <- dots
-  if (!is.null(seed_name)) {
-    summarize_dots[[seed_name]] <- rlang::quo(dplyr::n())
+  if (!is.null(placeholder_name)) {
+    summarize_dots[[placeholder_name]] <- rlang::quo(dplyr::n())
   }
 
   result <- withCallingHandlers(
@@ -405,17 +405,17 @@ summarize_margin_union <- function(.data,
   # A branch that summarizes nothing and groups by nothing selects no columns
   # at all, and the label and identifier `mutate()`s layered on that query give
   # dbplyr a `lazy_select_query` whose star expansion has no column to read
-  # (#428). Such a branch carries a column of its own instead, dropped once the
-  # columns the result keeps are in place.
+  # (#428). Such a branch summarizes a column of its own to stand in the
+  # result's place, dropped once the columns the result keeps are there.
   #
-  # `n()` and not a literal, because the seed has to aggregate: a constant in a
-  # `summarize()` over no groups renders as `SELECT 1 AS seed FROM t`, one row
-  # per source row, where `COUNT(*)` is the single Grand total row the branch
-  # stands for.
-  seed_name <- new_margin_internal_names(
+  # `n()` and not a literal, because the placeholder has to aggregate: a
+  # constant in a `summarize()` over no groups renders as `SELECT 1 AS x FROM
+  # t`, one row per source row, where `COUNT(*)` is the single Grand total row
+  # the branch stands for.
+  placeholder_name <- new_margin_internal_names(
     1L,
     used_names = c(reserved_names, unname(key_names)),
-    prefix = "..marginplyr_seed_"
+    prefix = "..marginplyr_placeholder_"
   )
 
   conditions <- new_branch_conditions(
@@ -436,8 +436,9 @@ summarize_margin_union <- function(.data,
         grouping_set = grouping_set,
         sql = FALSE
       )
-      needs_seed <- length(branch_dots) == 0L && length(grouping_set) == 0L
-      branch_seed <- if (needs_seed) seed_name else NULL
+      selects_nothing <- length(branch_dots) == 0L &&
+        length(grouping_set) == 0L
+      placeholder <- if (selects_nothing) placeholder_name else NULL
 
       # Only the caller's expressions are wrapped. The checks and the branch
       # builders below raise Package conditions, which carry their own context
@@ -452,16 +453,16 @@ summarize_margin_union <- function(.data,
           !!!branch_dots,
           .by = unname(key_names[grouping_set]),
           caller_labels = summaries$labels,
-          seed_name = branch_seed
+          placeholder_name = placeholder
         ),
         conditions = conditions,
         restatements = branch_argument_map(branch_dots, summaries$labels)
       )
 
-      # Without the seed: every question below is asked of the names the
-      # summary produced, and that column is this adapter's own.
+      # Without the placeholder: what this asks about is the names the summary
+      # produced, and that column is the adapter's own.
       check_summary_output_names(
-        setdiff(get_col_names(result, dplyr::everything()), branch_seed),
+        setdiff(get_col_names(result, dplyr::everything()), placeholder),
         group_vars = group_vars,
         internal_names = unname(key_names[setdiff(group_vars, grouping_set)]),
         set_id_name = set_id_name,
@@ -486,13 +487,10 @@ summarize_margin_union <- function(.data,
       )
 
       # A summary branch holds one row per group rather than one per source
-      # row, and the seed above leaves it holding a column whichever branch
-      # this is, so no identifier column materialises a row and nothing is
-      # counted. What a `data.table` still cannot represent is the result once
-      # every column goes away again -- a one-row, zero-column table -- which
-      # is dtplyr's own answer to such a summary rather than something this
-      # attachment decides, and is documented as a limit on
-      # `summarize_with_margins()` where a caller meets it.
+      # row, and the placeholder above leaves every branch holding a column, so
+      # no identifier column materialises a row and nothing is counted. The
+      # result a `data.table` still cannot hold once every column goes away
+      # again is a documented limit on `summarize_with_margins()`.
       result <- add_grouping_set_id(
         result,
         set_id_name,
@@ -503,10 +501,10 @@ summarize_margin_union <- function(.data,
       # Last, so that the columns the result keeps are all in place before the
       # branch gives up the only one it had: dropping ahead of the identifier
       # would hand the same zero-column query to the same `mutate()`.
-      if (is.null(branch_seed)) {
+      if (is.null(placeholder)) {
         result
       } else {
-        dplyr::select(result, -dplyr::all_of(branch_seed))
+        dplyr::select(result, -dplyr::all_of(placeholder))
       }
     },
     plan$sets,

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -275,16 +275,30 @@ abort_absorbed_summary <- function(labels) {
 # Which way each falls is on the guard itself, and ADR 0025 records both. The
 # maintainer's signal is `test-query-policy.R`, which fails when a read
 # happens at all.
+#
+# `seed_name` names one column the branch summarizes for itself. Only a caller
+# whose branch would otherwise select nothing at all passes one, and
+# `summarize_margin_union()` is where that is decided and where the column is
+# dropped again.
 summarize_margin_branch <- function(.data,
                                     ...,
                                     .by,
-                                    caller_labels) {
+                                    caller_labels,
+                                    seed_name = NULL) {
   dots <- rlang::enquos(...)
+
+  # The seed joins what dplyr is handed and not `dots`, which stays the
+  # caller's: the handler below places a blamed expression in it by position,
+  # and a column the caller did not write has no label to be blamed under.
+  summarize_dots <- dots
+  if (!is.null(seed_name)) {
+    summarize_dots[[seed_name]] <- rlang::quo(dplyr::n())
+  }
 
   result <- withCallingHandlers(
     rlang::inject(dplyr::summarize(
       .data = .data,
-      !!!dots,
+      !!!summarize_dots,
       .by = dplyr::all_of(.by)
     )),
     warning = function(cnd) {
@@ -388,6 +402,22 @@ summarize_margin_union <- function(.data,
     .data <- dplyr::mutate(.data, !!!key_exprs)
   }
 
+  # A branch that summarizes nothing and groups by nothing selects no columns
+  # at all, and the label and identifier `mutate()`s layered on that query give
+  # dbplyr a `lazy_select_query` whose star expansion has no column to read
+  # (#428). Such a branch carries a column of its own instead, dropped once the
+  # columns the result keeps are in place.
+  #
+  # `n()` and not a literal, because the seed has to aggregate: a constant in a
+  # `summarize()` over no groups renders as `SELECT 1 AS seed FROM t`, one row
+  # per source row, where `COUNT(*)` is the single Grand total row the branch
+  # stands for.
+  seed_name <- new_margin_internal_names(
+    1L,
+    used_names = c(reserved_names, unname(key_names)),
+    prefix = "..marginplyr_seed_"
+  )
+
   conditions <- new_branch_conditions(
     keys = rlang::set_names(names(key_names), unname(key_names)),
     call = call
@@ -406,6 +436,8 @@ summarize_margin_union <- function(.data,
         grouping_set = grouping_set,
         sql = FALSE
       )
+      needs_seed <- length(branch_dots) == 0L && length(grouping_set) == 0L
+      branch_seed <- if (needs_seed) seed_name else NULL
 
       # Only the caller's expressions are wrapped. The checks and the branch
       # builders below raise Package conditions, which carry their own context
@@ -419,14 +451,17 @@ summarize_margin_union <- function(.data,
           .data = .data,
           !!!branch_dots,
           .by = unname(key_names[grouping_set]),
-          caller_labels = summaries$labels
+          caller_labels = summaries$labels,
+          seed_name = branch_seed
         ),
         conditions = conditions,
         restatements = branch_argument_map(branch_dots, summaries$labels)
       )
 
+      # Without the seed: every question below is asked of the names the
+      # summary produced, and that column is this adapter's own.
       check_summary_output_names(
-        get_col_names(result, dplyr::everything()),
+        setdiff(get_col_names(result, dplyr::everything()), branch_seed),
         group_vars = group_vars,
         internal_names = unname(key_names[setdiff(group_vars, grouping_set)]),
         set_id_name = set_id_name,
@@ -451,20 +486,28 @@ summarize_margin_union <- function(.data,
       )
 
       # A summary branch holds one row per group rather than one per source
-      # row, and a column-less summary branch is reachable only with no keys
-      # and no summaries: one group, the Grand total. The row `mutate()`
-      # materialises there while the identifier column lasts is that group's,
-      # so nothing is counted. What a `data.table` still cannot represent is
-      # the result once the column goes away again -- a one-row, zero-column
-      # table -- which is dtplyr's own answer to such a summary rather than
-      # something this attachment decides, and is documented as a limit on
+      # row, and the seed above leaves it holding a column whichever branch
+      # this is, so no identifier column materialises a row and nothing is
+      # counted. What a `data.table` still cannot represent is the result once
+      # every column goes away again -- a one-row, zero-column table -- which
+      # is dtplyr's own answer to such a summary rather than something this
+      # attachment decides, and is documented as a limit on
       # `summarize_with_margins()` where a caller meets it.
-      add_grouping_set_id(
+      result <- add_grouping_set_id(
         result,
         set_id_name,
         set_id,
         count_branch_rows = FALSE
       )
+
+      # Last, so that the columns the result keeps are all in place before the
+      # branch gives up the only one it had: dropping ahead of the identifier
+      # would hand the same zero-column query to the same `mutate()`.
+      if (is.null(branch_seed)) {
+        result
+      } else {
+        dplyr::select(result, -dplyr::all_of(branch_seed))
+      }
     },
     plan$sets,
     plan$set_ids

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -107,14 +107,16 @@
 #' [summarize_with_margins()] and [summarise_with_margins()] are synonyms,
 #' following [dplyr::summarize()] and [dplyr::summarise()].
 #'
-#' One result a `dtplyr` input cannot carry back is a summary with no columns
-#' in it: asked for no summaries and given no fixed key or grouping dimension,
-#' the answer is one row holding nothing, whatever the input held, and a
-#' `data.table` reads its row count from its first column. Such a call
-#' collects to zero rows where a local data frame returns one, as
-#' [dplyr::summarize()] itself does for that lazy input. Anything that puts a
-#' column in the result -- one summary, one fixed key, one grouping dimension,
-#' or `.id` -- ends the difference.
+#' One result no lazy backend can carry back is a summary with no columns in
+#' it: asked for no summaries and given no fixed key or grouping dimension,
+#' the answer is one row holding nothing, whatever the input held. A
+#' `data.table` reads its row count from its first column, so a `dtplyr` input
+#' collects to zero rows where a local data frame returns one; a SQL table of
+#' no columns cannot be written at all, so a database input raises the error
+#' dbplyr renders one with. Each is what [dplyr::summarize()] itself answers
+#' for that lazy input, and anything that puts a column in the result -- one
+#' summary, one fixed key, one grouping dimension, or `.id` -- ends the
+#' difference.
 #'
 #' One summary an Arrow table or record batch cannot carry -- or a query built
 #' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -107,16 +107,16 @@
 #' [summarize_with_margins()] and [summarise_with_margins()] are synonyms,
 #' following [dplyr::summarize()] and [dplyr::summarise()].
 #'
-#' One result no lazy backend can carry back is a summary with no columns in
-#' it: asked for no summaries and given no fixed key or grouping dimension,
-#' the answer is one row holding nothing, whatever the input held. A
-#' `data.table` reads its row count from its first column, so a `dtplyr` input
-#' collects to zero rows where a local data frame returns one; a SQL table of
-#' no columns cannot be written at all, so a database input raises the error
-#' dbplyr renders one with. Each is what [dplyr::summarize()] itself answers
-#' for that lazy input, and anything that puts a column in the result -- one
-#' summary, one fixed key, one grouping dimension, or `.id` -- ends the
-#' difference.
+#' Two lazy inputs cannot carry back a summary with no columns in it: asked
+#' for no summaries and given no fixed key or grouping dimension, the answer
+#' is one row holding nothing, whatever the input held. A `data.table` reads
+#' its row count from its first column, so a `dtplyr` input collects to zero
+#' rows where a local data frame returns one, and a SQL table of no columns
+#' cannot be written at all, so a database input raises the error dbplyr
+#' renders one with. Each is what [dplyr::summarize()] itself answers for that
+#' lazy input; an Arrow input answers as a local one does. Anything that puts
+#' a column in the result -- one summary, one fixed key, one grouping
+#' dimension, or `.id` -- ends the difference.
 #'
 #' One summary an Arrow table or record batch cannot carry -- or a query built
 #' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -153,14 +153,16 @@ backends use a portable \verb{UNION ALL} adapter with the same semantics.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} and \code{\link[=summarise_with_margins]{summarise_with_margins()}} are synonyms,
 following \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[dplyr:summarise]{dplyr::summarise()}}.
 
-One result a \code{dtplyr} input cannot carry back is a summary with no columns
-in it: asked for no summaries and given no fixed key or grouping dimension,
-the answer is one row holding nothing, whatever the input held, and a
-\code{data.table} reads its row count from its first column. Such a call
-collects to zero rows where a local data frame returns one, as
-\code{\link[dplyr:summarize]{dplyr::summarize()}} itself does for that lazy input. Anything that puts a
-column in the result -- one summary, one fixed key, one grouping dimension,
-or \code{.id} -- ends the difference.
+One result no lazy backend can carry back is a summary with no columns in
+it: asked for no summaries and given no fixed key or grouping dimension,
+the answer is one row holding nothing, whatever the input held. A
+\code{data.table} reads its row count from its first column, so a \code{dtplyr} input
+collects to zero rows where a local data frame returns one; a SQL table of
+no columns cannot be written at all, so a database input raises the error
+dbplyr renders one with. Each is what \code{\link[dplyr:summarize]{dplyr::summarize()}} itself answers
+for that lazy input, and anything that puts a column in the result -- one
+summary, one fixed key, one grouping dimension, or \code{.id} -- ends the
+difference.
 
 One summary an Arrow table or record batch cannot carry -- or a query built
 on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -153,16 +153,16 @@ backends use a portable \verb{UNION ALL} adapter with the same semantics.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} and \code{\link[=summarise_with_margins]{summarise_with_margins()}} are synonyms,
 following \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[dplyr:summarise]{dplyr::summarise()}}.
 
-One result no lazy backend can carry back is a summary with no columns in
-it: asked for no summaries and given no fixed key or grouping dimension,
-the answer is one row holding nothing, whatever the input held. A
-\code{data.table} reads its row count from its first column, so a \code{dtplyr} input
-collects to zero rows where a local data frame returns one; a SQL table of
-no columns cannot be written at all, so a database input raises the error
-dbplyr renders one with. Each is what \code{\link[dplyr:summarize]{dplyr::summarize()}} itself answers
-for that lazy input, and anything that puts a column in the result -- one
-summary, one fixed key, one grouping dimension, or \code{.id} -- ends the
-difference.
+Two lazy inputs cannot carry back a summary with no columns in it: asked
+for no summaries and given no fixed key or grouping dimension, the answer
+is one row holding nothing, whatever the input held. A \code{data.table} reads
+its row count from its first column, so a \code{dtplyr} input collects to zero
+rows where a local data frame returns one, and a SQL table of no columns
+cannot be written at all, so a database input raises the error dbplyr
+renders one with. Each is what \code{\link[dplyr:summarize]{dplyr::summarize()}} itself answers for that
+lazy input; an Arrow input answers as a local one does. Anything that puts
+a column in the result -- one summary, one fixed key, one grouping
+dimension, or \code{.id} -- ends the difference.
 
 One summary an Arrow table or record batch cannot carry -- or a query built
 on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -321,6 +321,82 @@ test_that("a column-less dtplyr summary keeps dtplyr's own empty answer", {
   )
 })
 
+# The Grand total branch of a summary with nothing to summarize groups by
+# nothing and selects nothing, and the label and identifier `mutate()`s layered
+# on that query gave dbplyr a `lazy_select_query` it could not render: the
+# collect failed inside dbplyr's own star expansion, naming neither the
+# caller's call nor any marginplyr function (#428). Every call here has a
+# column in its result, which is what the documented promise turns on, so what
+# each is held to is the local answer.
+test_that("a summary with no summaries renders on a SQL backend", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  data <- data.frame(a = c("x", "x", "y", NA), b = c("u", "u", "v", "v"))
+  dplyr::copy_to(con, data, "no_summary", temporary = TRUE)
+  remote <- dplyr::tbl(con, "no_summary")
+
+  # The reported call, then three neighbours of it: a second dropped dimension,
+  # an identifier column added over the branch, and a Margin label of `NULL`,
+  # which fills a dropped dimension with a missing value instead of a label.
+  calls <- list(
+    function(input) summarize_with_margins(input, .grouping = rollup(a)),
+    function(input) summarize_with_margins(input, .grouping = rollup(a, b)),
+    function(input) {
+      summarize_with_margins(input, .grouping = rollup(a), .id = "s")
+    },
+    function(input) {
+      summarize_with_margins(input, .grouping = rollup(a), .margin_label = NULL)
+    }
+  )
+  ordered <- function(result) {
+    dplyr::arrange(
+      dplyr::as_tibble(result),
+      dplyr::across(dplyr::everything())
+    )
+  }
+
+  for (build in calls) {
+    expect_equal(
+      ordered(dplyr::collect(build(remote))),
+      ordered(build(data))
+    )
+  }
+})
+
+# The boundary the branch above stops at, and dbplyr's rather than this
+# package's: with no dimension and no identifier there is no column left to put
+# the Grand total row on, and a SQL table of no columns cannot be written. It
+# is compared against what `dplyr::summarize()` answers for the same input, as
+# the `dtplyr` half of the same limit is, so a dbplyr that gained the shape
+# reports here and the documented promise is what changes.
+test_that("a column-less SQL summary keeps dbplyr's own refusal", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  data <- data.frame(a = c("x", "x", "y"), v = 1:3)
+  dplyr::copy_to(con, data, "column_less", temporary = TRUE)
+  remote <- dplyr::tbl(con, "column_less")
+
+  upstream <- expect_error(dplyr::collect(dplyr::summarize(remote)))
+  expect_error(
+    dplyr::collect(summarize_with_margins(remote)),
+    conditionMessage(upstream),
+    fixed = TRUE
+  )
+
+  # The local answer is `dplyr::summarize()`'s there too, and it is one row.
+  expect_identical(
+    dim(summarize_with_margins(data)),
+    dim(dplyr::summarize(data))
+  )
+  expect_identical(nrow(dplyr::summarize(data)), 1L)
+})
+
 # The count-preserving attachment is asked for only where a backend needs it,
 # because `n()` in a `mutate()` is a window function on SQL and an unsupported
 # expression on arrow, where it warns and pulls the data into R. Arrow is the

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -342,12 +342,16 @@ test_that("a summary with no summaries renders on a SQL backend", {
   # an identifier column added over the branch, and a Margin label of `NULL`,
   # which fills a dropped dimension with a missing value instead of a label.
   calls <- list(
-    function(input) summarize_with_margins(input, .grouping = rollup(a)),
-    function(input) summarize_with_margins(input, .grouping = rollup(a, b)),
-    function(input) {
+    "rollup(a)" = function(input) {
+      summarize_with_margins(input, .grouping = rollup(a))
+    },
+    "rollup(a, b)" = function(input) {
+      summarize_with_margins(input, .grouping = rollup(a, b))
+    },
+    "rollup(a) with .id" = function(input) {
       summarize_with_margins(input, .grouping = rollup(a), .id = "s")
     },
-    function(input) {
+    "rollup(a) with a NULL label" = function(input) {
       summarize_with_margins(input, .grouping = rollup(a), .margin_label = NULL)
     }
   )
@@ -358,12 +362,43 @@ test_that("a summary with no summaries renders on a SQL backend", {
     )
   }
 
-  for (build in calls) {
+  for (label in names(calls)) {
+    build <- calls[[label]]
     expect_equal(
       ordered(dplyr::collect(build(remote))),
-      ordered(build(data))
+      ordered(build(data)),
+      info = label
     )
   }
+})
+
+# The same branch, reached on a backend that has `GROUPING SETS` and is routed
+# off them: a repeated grouping set kept under a Grouping set identifier is
+# what `stage_margin_summaries()` sends to the union adapter instead, so a
+# backend the native path covers meets the branch anyway. #428 names this call.
+test_that("a no-summary union branch renders off the native path", {
+  skip_if_suggest_absent("duckdb", "DBI")
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  data <- data.frame(a = c("x", "x", "y", NA))
+  dplyr::copy_to(con, data, "off_native", temporary = TRUE)
+  remote <- dplyr::tbl(con, "off_native")
+
+  build <- function(input) {
+    summarize_with_margins(
+      input,
+      .grouping = grouping_sets(rollup(a), grouping_set()),
+      .duplicates = "keep",
+      .id = "s"
+    )
+  }
+  ordered <- function(result) {
+    dplyr::arrange(dplyr::as_tibble(result), a, s)
+  }
+
+  expect_equal(ordered(dplyr::collect(build(remote))), ordered(build(data)))
 })
 
 # The boundary the branch above stops at, and dbplyr's rather than this


### PR DESCRIPTION
Fixes #428.

## What was wrong

`summarize_with_margins()` asked for no summaries and given no fixed key
built a Grand total branch that summarizes nothing and groups by nothing,
so the branch query selected no columns at all. The margin label and the
Grouping set identifier are layered on with `mutate()`, and over a
zero-column lazy query that produces a `lazy_select_query` dbplyr cannot
render: collecting failed inside dbplyr's own star expansion, naming
neither the caller's call nor any marginplyr function.

The database backends on the `UNION ALL` path were the ones affected. The
other two lazy backends on it were not: an Arrow input already collected
the local answer, and a `dtplyr` one already tolerated the zero-column
step. The local path and the native `GROUPING SETS` path both returned
the distinct keys for the same input.

## The fix

Such a branch now summarizes `n()` into a placeholder column of its own,
dropped again once the columns the result keeps are in place -- last, so
the identifier `mutate()` is not handed the zero-column query the label
one was. `n()` rather than a literal, because the placeholder has to
aggregate: a constant in a `summarize()` over no groups renders
`SELECT 1 AS x FROM t`, one row per source row, where `COUNT(*)` is the
single row the branch stands for.

## The shape left over

The remaining zero-column shape is the one whose whole *result* has no
columns -- no summaries, no key, no dimension, no `.id` -- which no
adapter can fix, since a SQL table of no columns cannot be written. That
is what `dplyr::summarize()` answers for the same input, as the `dtplyr`
half of the limit already was, so the documented limit on
`summarize_with_margins()` now names both inputs rather than dtplyr
alone, and says what an Arrow input answers.

## Verification

- `tests/testthat/test-branch-union.R` gains three tests, each on one
  optional backend: the reported call and three named neighbours held to
  the local answer, the reproduction #428 names for a backend routed off
  the native path, and the leftover shape held to `dplyr::summarize()`'s
  own refusal.
- Full suite, `NOT_CRAN=true`: FAIL 0 | SKIP 0 | PASS 6690.
- `lintr::lint_package()`: no lints.
- `Rscript .github/scripts/verify-context-budget.R`: within budget.