### PR TITLE
Name an unnamed summary from the caller's own expression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -148,6 +148,20 @@
   evaluated to know what it calls — `get("pick")(units)` — is an ordinary call
   as it was.
   See *Relationship to dplyr summaries* in `?summarize_with_margins`.
+* An unnamed summary now takes its column name from the expression you wrote
+  rather than from the one marginplyr rewrote it into. `...` is documented as
+  `dplyr::summarize()`'s name-value pairs, and the rewrite ran first: a
+  `grouping_bit()` or `grouping_id()` became the branch's own `0L` or `1L`, so
+  `sum(v) + grouping_bit(a)` named a different column in each Grouping-set
+  branch — which stopped the operation inside an internal invariant on every
+  backend taking the portable `UNION ALL` path, and named the column after a
+  SQL literal on the backends running `GROUP BY GROUPING SETS`. A selection
+  helper became a qualified `all_of()` literal, so `nrow(pick(v, w))` named its
+  column `nrow(dplyr::pick(dplyr::all_of(c("v", "w"))))`. Both are now named
+  after the caller's own expression, identically on every backend. A summary no
+  rewrite reaches is named by dplyr exactly as before, and a data-frame-valued
+  summary still expands its columns into the result rather than packing them
+  into one column under a name (#430).
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/NEWS.md
+++ b/NEWS.md
@@ -159,9 +159,15 @@
   helper became a qualified `all_of()` literal, so `nrow(pick(v, w))` named its
   column `nrow(dplyr::pick(dplyr::all_of(c("v", "w"))))`. Both are now named
   after the caller's own expression, identically on every backend. A summary no
-  rewrite reaches is named by dplyr exactly as before, and a data-frame-valued
-  summary still expands its columns into the result rather than packing them
-  into one column under a name (#430).
+  rewrite reaches is named by dplyr exactly as before, and so is a summary
+  written as `across()` or `pick()` itself, so both go on expanding a
+  data-frame value's columns into the result. A data-frame-valued summary a
+  rewrite *does* reach is now named, and dplyr packs a named one:
+  `range_frame(pick(x))` returned `lo` and `hi` and now returns one
+  data-frame column named after the call. Telling that summary from
+  `nrow(pick(v, w))` is a question about the value's type rather than about how
+  it is spelled, so give either one a name of your own where you want the
+  columns expanded or packed regardless (#430).
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/NEWS.md
+++ b/NEWS.md
@@ -167,7 +167,7 @@
   data-frame column named after the call. Telling that summary from
   `nrow(pick(v, w))` is a question about the value's type rather than about how
   it is spelled, so give either one a name of your own where you want the
-  columns expanded or packed regardless (#430).
+  columns expanded or packed regardless (#430, #435).
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -208,6 +208,29 @@ grouping_helper_name <- function(expr) {
   static_spelling_name(expr, "grouping")
 }
 
+# Whether `rewrite_grouping_dots()` would replace anything in this expression.
+# One reader needs it: an unnamed summary carrying a Grouping helper is named
+# before the rewrite runs, because the rewrite is what leaves each branch a
+# different expression to deparse (#430).
+#
+# The walk is `find_summary_context_helpers()`'s rather than the rewrite's own,
+# for the reason that function gives: a helper the caller quoted is language
+# data, and `rewrite_grouping_expr()` descends past it without rewriting it, so
+# a search that read it would answer for a summary nothing rewrites.
+contains_grouping_helper <- function(expr) {
+  if (!rlang::is_call(expr)) {
+    return(FALSE)
+  }
+  if (!is.null(grouping_helper_name(expr))) {
+    return(TRUE)
+  }
+  any(vapply(
+    searched_call_parts(expr),
+    contains_grouping_helper,
+    logical(1)
+  ))
+}
+
 grouping_helper_vars <- function(args, helper, plan) {
   # Each argument is read as a value rather than bound to a name, for the reason
   # `static_call_args()` gives: one of them may be R's empty argument, which is

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -320,7 +320,7 @@ new_summary_arguments <- function(dots,
 # data-frame-valued expression the static reading does not recognize, and no
 # reading separates it from a scalar one: `nrow(pick(v, w))` has to be named
 # and `range_frame(pick(v))` has to not be, which is a question about the
-# value's type.
+# value's type. #435 holds what that costs and what answering it would take.
 #
 # `rlang::as_label()` is `rlang::quos_auto_name()`'s own labeller, so the name
 # is dplyr's up to the width at which rlang abbreviates a long expression:

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -306,17 +306,21 @@ new_summary_arguments <- function(dots,
 # rewrite. `...` is documented as `dplyr::summarize()`'s name-value pairs, so
 # the name is settled from the caller's own expression here instead (#430).
 #
-# Only a rewritten summary is named, and that bound is what keeps the fix from
-# reaching a summary whose value is a data frame: dplyr expands such a
-# summary's columns into the result while it is unnamed and packs them into one
-# column under any name, and a one-row data frame returned by a function of the
-# caller's own is an ordinary way to write several columns at once. Nothing
-# rewrites that call, so nothing here names it.
+# Only a rewritten summary is named, which is what keeps the fix away from a
+# summary dplyr expands rather than names: a data-frame-valued summary's
+# columns go into the result while it is unnamed and are packed into one column
+# under any name, and returning a one-row data frame is an ordinary way to
+# write several columns at once. One no rewrite reaches goes on expanding.
 #
-# The two recognized data-frame-valued shapes are rewritten, so they need the
-# exclusion stated: `across()` and `pick()` are selection helpers, and
-# `tibble()` beside one carries the rewrite up. They also need no fix, each
-# naming its own outputs whatever a branch rewrote inside it.
+# One a rewrite does reach is named, and is then packed. The recognized
+# data-frame-valued shapes are excluded here rather than left to that, because
+# they are the ones a static reading reaches: `across()` and `pick()` are
+# selection helpers and `tibble()` beside one carries the rewrite up, and each
+# names its own outputs whatever a branch rewrote inside it. What is left is a
+# data-frame-valued expression the static reading does not recognize, and no
+# reading separates it from a scalar one: `nrow(pick(v, w))` has to be named
+# and `range_frame(pick(v))` has to not be, which is a question about the
+# value's type.
 #
 # `rlang::as_label()` is `rlang::quos_auto_name()`'s own labeller, so the name
 # is dplyr's up to the width at which rlang abbreviates a long expression:
@@ -695,7 +699,7 @@ known_summary_output_names <- function(dots, data_proxy) {
 # Which data-frame-valued shape a summary is written as, or `NULL` for one that
 # is not recognized as any. Two readers need the recognition and each needs a
 # different half of it: `known_data_frame_output_names()` reads which outputs
-# the shape produces, and `name_unnamed_summary_dots()` reads that dplyr
+# the shape produces, and `name_rewritten_summary_dots()` reads that dplyr
 # expands them rather than naming one column for the summary. Answering both
 # from here is what keeps a shape added for one from being invisible to the
 # other.
@@ -754,7 +758,14 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     return(names(resolve_summary_selection(selection, env, data_proxy)))
   }
 
-  known_across_output_names(expr, env, data_proxy)
+  if (identical(kind, "across")) {
+    return(known_across_output_names(expr, env, data_proxy))
+  }
+
+  # A kind the classifier answers and this does not. Both are in this file and
+  # nothing outside it names a kind, so no call reaches this and it stays a
+  # bare `stop()` (ADR 0015).
+  stop("Unhandled data-frame-valued summary kind: ", kind, call. = FALSE)
 }
 
 known_injected_argument_name <- function(expr) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -294,6 +294,50 @@ new_summary_arguments <- function(dots,
   list(dots = dots, labels = labels)
 }
 
+# The name dplyr would have given each unnamed summary marginplyr rewrites,
+# read from what the caller wrote rather than from the rewrite.
+#
+# dplyr names an unnamed summary by deparsing the expression it receives, and
+# what a rewritten one hands it is marginplyr's spelling: a branch-local `0L`
+# or `1L` where the caller wrote `grouping_bit()` or `grouping_id()`, and a
+# qualified `all_of()` literal where they wrote a selection helper. The first
+# spelled a different column name in each Grouping-set branch, which is what
+# the union's column invariant refused; the second named the column after the
+# rewrite. `...` is documented as `dplyr::summarize()`'s name-value pairs, so
+# the name is settled from the caller's own expression here instead (#430).
+#
+# Only a rewritten summary is named, and that bound is what keeps the fix from
+# reaching a summary whose value is a data frame: dplyr expands such a
+# summary's columns into the result while it is unnamed and packs them into one
+# column under any name, and a one-row data frame returned by a function of the
+# caller's own is an ordinary way to write several columns at once. Nothing
+# rewrites that call, so nothing here names it.
+#
+# The two recognized data-frame-valued shapes are rewritten, so they need the
+# exclusion stated: `across()` and `pick()` are selection helpers, and
+# `tibble()` beside one carries the rewrite up. They also need no fix, each
+# naming its own outputs whatever a branch rewrote inside it.
+#
+# `rlang::as_label()` is `rlang::quos_auto_name()`'s own labeller, so the name
+# is dplyr's up to the width at which rlang abbreviates a long expression:
+# dplyr asks rlang for a variant spelling of that abbreviation through an
+# internal option, and neither spelling stands for an expression the caller
+# could read back.
+name_rewritten_summary_dots <- function(original, resolved) {
+  stopifnot(length(original) == length(resolved))
+  arg_names <- rlang::names2(resolved)
+  for (i in which(!nzchar(arg_names))) {
+    expr <- rlang::quo_get_expr(original[[i]])
+    rewritten <- !identical(expr, rlang::quo_get_expr(resolved[[i]])) ||
+      contains_grouping_helper(expr)
+    if (!rewritten || !is.null(data_frame_valued_summary_kind(expr))) {
+      next
+    }
+    arg_names[[i]] <- rlang::as_label(expr)
+  }
+  stats::setNames(resolved, arg_names)
+}
+
 plan_summary_expressions <- function(dots,
                                      data_proxy,
                                      data_vars,
@@ -307,6 +351,7 @@ plan_summary_expressions <- function(dots,
   # the caller's own labels: every rewrite below runs after this line, and ADR
   # 0007 has already captured the dots at the public verb.
   caller_labels <- summary_argument_labels(dots)
+  original_dots <- dots
   selection_proxy <- dplyr::select(
     data_proxy,
     dplyr::all_of(setdiff(
@@ -322,6 +367,12 @@ plan_summary_expressions <- function(dots,
     normalize_across_names = FALSE,
     skip_shares = TRUE
   )
+  # Against the dots this rewrite received, and before share planning moves
+  # one: a share summary carries an output name already, and every rewrite
+  # below this either answers a named dot or is one of those moves. The labels
+  # above are read first because they are the caller's spelling for a Condition
+  # context, which a name assigned here would spell `sum(v) = sum(v)`.
+  dots <- name_rewritten_summary_dots(original_dots, dots)
   summary_plan <- plan_share_expressions(
     dots,
     selection_proxy = selection_proxy,
@@ -641,18 +692,42 @@ known_summary_output_names <- function(dots, data_proxy) {
   )
 }
 
-known_data_frame_output_names <- function(expr, env, data_proxy) {
+# Which data-frame-valued shape a summary is written as, or `NULL` for one that
+# is not recognized as any. Two readers need the recognition and each needs a
+# different half of it: `known_data_frame_output_names()` reads which outputs
+# the shape produces, and `name_unnamed_summary_dots()` reads that dplyr
+# expands them rather than naming one column for the summary. Answering both
+# from here is what keeps a shape added for one from being invisible to the
+# other.
+#
+# Two frame families rather than one, because the owner differs and the owner
+# is what recognition tests: tibble owns `tibble()` and `data_frame()`, base
+# owns `data.frame()`. Neither is a Contextual helper -- nothing rewrites them,
+# and a caller who binds `tibble` gets their own function -- so what is read
+# here is only which output names the summary is going to produce (ADR 0019).
+data_frame_valued_summary_kind <- function(expr) {
   if (!rlang::is_call(expr)) {
+    return(NULL)
+  }
+  if (is_any_static_spelling_call(expr, c("tibble_frame", "base_frame"))) {
+    return("frame")
+  }
+  if (is_static_spelling_call(expr, "selection", "pick")) {
+    return("pick")
+  }
+  if (is_static_spelling_call(expr, "selection", "across")) {
+    return("across")
+  }
+  NULL
+}
+
+known_data_frame_output_names <- function(expr, env, data_proxy) {
+  kind <- data_frame_valued_summary_kind(expr)
+  if (is.null(kind)) {
     return(character())
   }
 
-  # Two families rather than one, because the owner differs and the owner is
-  # what recognition tests: tibble owns `tibble()` and `data_frame()`, base
-  # owns `data.frame()`. Neither is a Contextual helper -- nothing rewrites
-  # them, and a caller who binds `tibble` gets their own function -- so what is
-  # read here is only which output names the summary is going to produce
-  # (ADR 0019).
-  if (is_any_static_spelling_call(expr, c("tibble_frame", "base_frame"))) {
+  if (identical(kind, "frame")) {
     call_args <- static_call_args(expr)
     arg_names <- names(call_args)
     if (is.null(arg_names)) {
@@ -669,7 +744,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     ))
   }
 
-  if (is_static_spelling_call(expr, "selection", "pick")) {
+  if (identical(kind, "pick")) {
     call_args <- static_call_args(expr)
     selection <- if (length(call_args) == 0L) {
       rlang::expr(dplyr::everything())
@@ -679,11 +754,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
     return(names(resolve_summary_selection(selection, env, data_proxy)))
   }
 
-  if (is_static_spelling_call(expr, "selection", "across")) {
-    return(known_across_output_names(expr, env, data_proxy))
-  }
-
-  character()
+  known_across_output_names(expr, env, data_proxy)
 }
 
 known_injected_argument_name <- function(expr) {

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -135,15 +135,19 @@ native_translation_failure <- function() {
   # nolint end
 }
 
-# The same failure under two unnamed dots the caller spelled differently. Both
-# collapse to one label, so the span says which expression raised the error but
-# not which argument did.
+# The same failure under two dots the caller spelled differently and named the
+# same. Both collapse to one label, so the span says which expression raised
+# the error but not which argument did.
+#
+# The name is what makes the two collide, unnamed dots no longer being able to:
+# each carries the caller's own expression as its name since #430, so two dots
+# the caller spelled differently label differently as well.
 native_shared_label_failure <- function() {
   # nolint start: object_usage_linter.
   summarize_with_margins(
     native_grouping_sets_input(),
-    grouping_bit(a) + no_such_column,
-    grouping_bit(a) + value,
+    x = grouping_bit(a) + no_such_column,
+    x = grouping_bit(a) + value,
     .grouping = rollup(a)
   )
   # nolint end
@@ -762,7 +766,7 @@ test_that("a native label two dots share is left as dplyr wrote it", {
   # drops the entry, so dplyr's own quotation stands.
   expect_match(
     conditionMessage(error),
-    "In argument: `+...`",
+    "In argument: `x = +...`",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1174,6 +1174,85 @@ test_that("column-wise summaries preserve names and unpacked outputs", {
   expect_equal(names(unpacked), c("group", "x_lo", "x_hi"))
 })
 
+# #430. dplyr names an unnamed summary by deparsing the expression it is given,
+# and marginplyr rewrites that expression before dplyr sees it: the branch's own
+# `0L` or `1L` for a Grouping helper, and a qualified `all_of()` literal for a
+# selection helper. The first left each branch a different column name, which
+# the union adapter's column invariant refused and the native adapter did not
+# notice; the second named the column after the rewrite.
+#
+# Both adapters are asserted, the native one over a simulated connection so that
+# the case runs wherever the suite does. The values are asserted beside the
+# names on the local path, because a Grouping helper naming a column correctly
+# in every branch is what the union combines, and the combined column is what
+# says the branches agreed about more than their names.
+test_that("an unnamed summary is named from the caller's own expression", {
+  data <- data.frame(a = c("x", "y"), v = c(1, 2))
+
+  result <- summarize_with_margins(
+    data,
+    sum(v) + grouping_bit(a),
+    .grouping = rollup(a)
+  )
+  expect_equal(names(result), c("a", "sum(v) + grouping_bit(a)"))
+  expect_equal(result[["sum(v) + grouping_bit(a)"]], c(1, 2, 4))
+
+  native <- summarize_with_margins(
+    dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres()),
+    sum(v) + grouping_bit(a),
+    .grouping = rollup(a)
+  )
+  expect_true("sum(v) + grouping_bit(a)" %in% colnames(native))
+})
+
+test_that("an unnamed summary is named before a selection is resolved", {
+  data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
+
+  result <- summarize_with_margins(
+    data,
+    ncol(dplyr::pick(x, y)),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(result), c("group", "ncol(dplyr::pick(x, y))"))
+  expect_equal(result[["ncol(dplyr::pick(x, y))"]], rep(2L, 3L))
+})
+
+# The bound the fix is written to: only a summary marginplyr rewrites is named,
+# because a name is not only a label for a data-frame-valued summary. dplyr
+# expands such a summary's columns into the result while it is unnamed and packs
+# them into one column under any name, and returning a one-row data frame from a
+# function of the caller's own is an ordinary way to write several columns at
+# once. Nothing rewrites that call, and nothing may name it.
+test_that("an unnamed summary no rewrite reaches keeps dplyr's own naming", {
+  data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
+  range_frame <- function(value) {
+    data.frame(lo = min(value), hi = max(value))
+  }
+
+  expect_equal(
+    names(summarize_with_margins(data, sum(x), .grouping = rollup(group))),
+    c("group", "sum(x)")
+  )
+  expect_equal(
+    names(summarize_with_margins(
+      data,
+      range_frame(x),
+      .grouping = rollup(group)
+    )),
+    c("group", "lo", "hi")
+  )
+  # A recognized data-frame-valued summary is rewritten, so it is the exclusion
+  # rather than the bound that keeps this one expanding.
+  expect_equal(
+    names(summarize_with_margins(
+      data,
+      dplyr::across(c(x, y), mean),
+      .grouping = rollup(group)
+    )),
+    c("group", "x", "y")
+  )
+})
+
 test_that("data-frame summaries cannot overwrite grouping columns", {
   data <- data.frame(group = c("a", "a", "b"), value = 1:3)
 

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1260,7 +1260,7 @@ test_that("an unnamed summary no rewrite reaches keeps dplyr's own naming", {
 # Telling them from `nrow(pick(x, y))` above, which #430 requires be named, is a
 # question about the value's type, and ADR 0019 reads spellings. So this is the
 # assertion that says the two recognized shapes are excluded by name because a
-# static reading reaches them and not because the exclusion is complete.
+# static reading reaches them and not because the exclusion is complete (#435).
 test_that("a rewritten data-frame-valued summary is named and packed", {
   data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
   range_frame <- function(columns) {

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1222,7 +1222,7 @@ test_that("an unnamed summary is named before a selection is resolved", {
 # expands such a summary's columns into the result while it is unnamed and packs
 # them into one column under any name, and returning a one-row data frame from a
 # function of the caller's own is an ordinary way to write several columns at
-# once. Nothing rewrites that call, and nothing may name it.
+# once. Nothing rewrites `range_frame(x)`, so nothing names it.
 test_that("an unnamed summary no rewrite reaches keeps dplyr's own naming", {
   data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
   range_frame <- function(value) {
@@ -1251,6 +1251,39 @@ test_that("an unnamed summary no rewrite reaches keeps dplyr's own naming", {
     )),
     c("group", "x", "y")
   )
+})
+
+# What that bound costs, pinned here rather than left to be found: a
+# data-frame-valued summary a rewrite *does* reach is named, and dplyr packs a
+# named one into a single column. Both shapes below expanded before #430.
+#
+# Telling them from `nrow(pick(x, y))` above, which #430 requires be named, is a
+# question about the value's type, and ADR 0019 reads spellings. So this is the
+# assertion that says the two recognized shapes are excluded by name because a
+# static reading reaches them and not because the exclusion is complete.
+test_that("a rewritten data-frame-valued summary is named and packed", {
+  data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
+  range_frame <- function(columns) {
+    data.frame(lo = min(columns[[1L]]), hi = max(columns[[1L]]))
+  }
+  totals <- function(value, bit) {
+    data.frame(sum = sum(value), margin = bit)
+  }
+
+  selected <- summarize_with_margins(
+    data,
+    range_frame(dplyr::pick(x)),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(selected), c("group", "range_frame(dplyr::pick(x))"))
+  expect_s3_class(selected[["range_frame(dplyr::pick(x))"]], "data.frame")
+
+  helped <- summarize_with_margins(
+    data,
+    totals(x, grouping_bit(group)),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(helped), c("group", "totals(x, grouping_bit(group))"))
 })
 
 test_that("data-frame summaries cannot overwrite grouping columns", {


### PR DESCRIPTION
Closes #430.

## What changed

An unnamed summary was handed to `dplyr::summarize()` after marginplyr had
rewritten it, so dplyr named the column by deparsing the rewrite. A Grouping
helper became the branch's own `0L` or `1L`, so `sum(v) + grouping_bit(a)`
named a different column in each Grouping-set branch: the union adapter's
column invariant refused it — a bare `stop()` ADR 0015 reserves for a defect,
reached by valid caller input — and the native adapter named the column after a
SQL literal's deparse instead. A selection helper became a qualified `all_of()`
literal, so `nrow(pick(v, w))` named its column after the rewrite.

`plan_summary_expressions()` now names an unnamed dot from the expression the
caller wrote, after the labels a Condition context reads and before share
planning moves one.

Only a summary marginplyr rewrites is named. #430's *Fix direction* proposed
`rlang::quos_auto_name()` over every dot before rewriting; that also names the
data-frame-valued summaries dplyr expands only while they are unnamed, so
`across(c(x, y), mean)` and a caller's own one-row-frame function would have
come back packed into one column. The bound keeps both expanding.

`known_data_frame_output_names()`'s recognition moves into
`data_frame_valued_summary_kind()`, which both readers share.

## The one behaviour change that is not the fix

A data-frame-valued summary a rewrite *does* reach is named, and is then
packed: `range_frame(pick(x))` returned `lo` and `hi` and now returns one
data-frame column. Separating it from `nrow(pick(v, w))`, which #430 requires
be named, is a question about the value's type, which ADR 0019's static reading
does not answer. #435 holds it, `NEWS.md` states it, and
*a rewritten data-frame-valued summary is named and packed* asserts it.

## Verification

`testthat::test_local()` green with every optional backend installed;
`lintr::lint_package()` reports no lints; `roxygen2::roxygenise()` produces no
diff. The two reproductions in #430 were checked on local, dtplyr, Arrow,
DuckDB, and a simulated Postgres connection, which name the column identically.