### PR TITLE
Read a named data-frame summary for its name alone

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -148,6 +148,14 @@
   evaluated to know what it calls — `get("pick")(units)` — is an ordinary call
   as it was.
   See *Relationship to dplyr summaries* in `?summarize_with_margins`.
+* A data-frame-valued summary you gave a name to is no longer read for the
+  names it packs. `s = tibble(group = sum(value))`, `s = across(value, mean,
+  .names = "group")`, and `s = pick(value)` each produce one column called `s`,
+  because dplyr packs a named data-frame result rather than unpacking it, so
+  the argument names inside them cannot overwrite a grouping column or collide
+  with `.id`; they were refused for those collisions anyway. `across(.unpack =)`
+  renames within the packed column and is reached the same way. The unnamed
+  forms are unpacked to the top level and stay refused.
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/NEWS.md
+++ b/NEWS.md
@@ -155,7 +155,10 @@
   the argument names inside them cannot overwrite a grouping column or collide
   with `.id`; they were refused for those collisions anyway. `across(.unpack =)`
   renames within the packed column and is reached the same way. The unnamed
-  forms are unpacked to the top level and stay refused.
+  forms are unpacked to the top level and stay refused, as is a named one
+  colliding by its own name. A backend that unpacks a named result rather than
+  packing it — Arrow, for `across()` — is refused after its branch runs, with
+  the diagnostic the local backend gives.
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -380,8 +380,10 @@
 #' which it is omitted.
 #'
 #' Summary results may not overwrite a fixed key or grouping dimension,
-#' including through a data-frame-valued summary. The local dplyr backend can
-#' overwrite an existing variable and reuse a newly created summary in a
+#' including through an unnamed data-frame-valued summary, whose columns dplyr
+#' unpacks to the top level. A named one packs its columns into the single
+#' column its name gives, which collides with nothing. The local dplyr backend
+#' can overwrite an existing variable and reuse a newly created summary in a
 #' later expression, but other backends may not. marginplyr rejects grouping
 #' key overwrites so that grouping identity and behavior stay portable.
 #' Use a new summary name, or rename the grouping column before this call.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -381,11 +381,12 @@
 #'
 #' Summary results may not overwrite a fixed key or grouping dimension,
 #' including through an unnamed data-frame-valued summary, whose columns dplyr
-#' unpacks to the top level. A named one packs its columns into the single
-#' column its name gives, which collides with nothing. The local dplyr backend
-#' can overwrite an existing variable and reuse a newly created summary in a
-#' later expression, but other backends may not. marginplyr rejects grouping
-#' key overwrites so that grouping identity and behavior stay portable.
+#' unpacks to the top level. A named one is checked by its own name alone,
+#' because dplyr packs its columns into the single column that name gives.
+#' The local dplyr backend can overwrite an existing variable and reuse a newly
+#' created summary in a later expression, but other backends may not.
+#' marginplyr rejects grouping key overwrites so that grouping identity and
+#' behavior stay portable.
 #' Use a new summary name, or rename the grouping column before this call.
 #'
 #' [dplyr::cur_group()], [dplyr::cur_group_id()],

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -628,12 +628,12 @@ summary_all_of_expr <- function(selected, data_proxy) {
 }
 
 known_summary_output_names <- function(dots, data_proxy) {
-  # A dot carrying its own name produces that one column and nothing else:
-  # dplyr packs a data-frame result under the name rather than unpacking it, so
-  # the argument names inside a named `tibble()`, `data.frame()`, `across()`,
-  # or `pick()` never reach the result's top level -- including under
-  # `across(.unpack =)`, which renames within the packed column. The caller
-  # contributes the name itself from `names(dots)` (#431).
+  # A dot carrying its own name is not read for what it packs: dplyr packs a
+  # data-frame result under that name rather than unpacking it, so the argument
+  # names inside such a dot are not top-level outputs, and `names(dots)` at the
+  # caller already holds the one that is (#431). A backend that unpacks anyway
+  # is what the adapters' `check_summary_output_names()` reads the branch
+  # result for -- Arrow's `across()` is that case.
   named <- nzchar(rlang::names2(dots))
 
   unlist(

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -628,9 +628,17 @@ summary_all_of_expr <- function(selected, data_proxy) {
 }
 
 known_summary_output_names <- function(dots, data_proxy) {
+  # A dot carrying its own name produces that one column and nothing else:
+  # dplyr packs a data-frame result under the name rather than unpacking it, so
+  # the argument names inside a named `tibble()`, `data.frame()`, `across()`,
+  # or `pick()` never reach the result's top level -- including under
+  # `across(.unpack =)`, which renames within the packed column. The caller
+  # contributes the name itself from `names(dots)` (#431).
+  named <- nzchar(rlang::names2(dots))
+
   unlist(
     lapply(
-      dots,
+      dots[!named],
       function(dot) {
         expr <- rlang::quo_get_expr(dot)
         env <- rlang::quo_get_env(dot)

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -435,8 +435,10 @@ every branch: a dimension remains excluded even in a grouping set from
 which it is omitted.
 
 Summary results may not overwrite a fixed key or grouping dimension,
-including through a data-frame-valued summary. The local dplyr backend can
-overwrite an existing variable and reuse a newly created summary in a
+including through an unnamed data-frame-valued summary, whose columns dplyr
+unpacks to the top level. A named one packs its columns into the single
+column its name gives, which collides with nothing. The local dplyr backend
+can overwrite an existing variable and reuse a newly created summary in a
 later expression, but other backends may not. marginplyr rejects grouping
 key overwrites so that grouping identity and behavior stay portable.
 Use a new summary name, or rename the grouping column before this call.

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -436,11 +436,12 @@ which it is omitted.
 
 Summary results may not overwrite a fixed key or grouping dimension,
 including through an unnamed data-frame-valued summary, whose columns dplyr
-unpacks to the top level. A named one packs its columns into the single
-column its name gives, which collides with nothing. The local dplyr backend
-can overwrite an existing variable and reuse a newly created summary in a
-later expression, but other backends may not. marginplyr rejects grouping
-key overwrites so that grouping identity and behavior stay portable.
+unpacks to the top level. A named one is checked by its own name alone,
+because dplyr packs its columns into the single column that name gives.
+The local dplyr backend can overwrite an existing variable and reuse a newly
+created summary in a later expression, but other backends may not.
+marginplyr rejects grouping key overwrites so that grouping identity and
+behavior stay portable.
 Use a new summary name, or rename the grouping column before this call.
 
 \code{\link[dplyr:cur_group]{dplyr::cur_group()}}, \code{\link[dplyr:cur_group_id]{dplyr::cur_group_id()}},

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -1355,6 +1355,38 @@ test_that("native adapters reject summary outputs on their own columns", {
   expect_s3_class(id_error, "marginplyr_error")
 })
 
+test_that("Arrow's unpacked named across is caught after the branch runs", {
+  skip_if_suggest_absent("arrow")
+
+  # `known_summary_output_names()` skips a named dot because dplyr packs a
+  # data-frame result under the name (#431). Arrow does not: it returns a
+  # top-level `group` here and discards `s`, so the pre-execution check sees
+  # only `s` and the adapter's result-name check is the whole of what refuses
+  # this. The local answer is the contract, so it is read here rather than
+  # restated.
+  data <- shadowed_summary_data()
+  local_error <- expect_error(
+    summarize_with_margins(
+      data,
+      dplyr::across(value, mean, .names = "group"),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  arrow_error <- expect_error(
+    summarize_with_margins(
+      arrow::as_arrow_table(data),
+      s = dplyr::across(value, mean, .names = "group"),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_identical(
+    conditionMessage(arrow_error),
+    conditionMessage(local_error)
+  )
+})
+
 test_that("native adapters keep unpredictable names that collide with none", {
   data <- shadowed_summary_data()
   dots <- unpredictable_summary_dots("total", .names = NULL)

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1198,10 +1198,8 @@ test_that("data-frame summaries cannot overwrite grouping columns", {
 test_that("a named data-frame summary keeps its packed names to itself", {
   data <- data.frame(group = c("a", "a", "b"), value = 1:3)
 
-  # dplyr packs a data-frame result into the one column its name gives, so the
-  # argument names inside these calls are not top-level outputs and cannot
-  # collide with anything (#431). The unnamed forms, refused by the test above,
-  # are unpacked instead.
+  # The unnamed forms of these calls are the test above; dplyr unpacks those
+  # and packs these (#431).
   from_tibble <- summarize_with_margins(
     data,
     s = tibble::tibble(group = sum(value)),
@@ -1220,7 +1218,7 @@ test_that("a named data-frame summary keeps its packed names to itself", {
   expect_equal(from_across$s$group, c(1.5, 3, 2))
 
   # `.unpack` renames inside the packed column rather than out of it, so a
-  # template that produces a grouping column's name is no collision either.
+  # template producing a grouping column's name reaches no top level.
   group_frame <- function(x) data.frame(group = min(x))
   unpacked <- summarize_with_margins(
     data,
@@ -1230,8 +1228,8 @@ test_that("a named data-frame summary keeps its packed names to itself", {
   expect_equal(names(unpacked), c("group", "s"))
   expect_equal(unpacked$s$group, c(1L, 3L, 1L))
 
-  # `pick()` cannot rename, so what it packs is always input column names; the
-  # name still keeps them off the top level.
+  # `pick()` cannot rename -- `pick(c(a = b))` is a tidyselect error -- so what
+  # it packs is always input column names.
   picked <- summarize_with_margins(
     data.frame(group = c("a", "b"), value = c(1, 2)),
     s = dplyr::pick(value),
@@ -1239,6 +1237,30 @@ test_that("a named data-frame summary keeps its packed names to itself", {
   )
   expect_equal(names(picked), c("group", "s"))
   expect_equal(picked$s$value, c(1, 2))
+})
+
+test_that("a named data-frame summary is still checked by its own name", {
+  data <- data.frame(group = c("a", "a", "b"), value = 1:3)
+
+  # What the skip above leaves to `names(dots)`. Without this the skip could
+  # widen to the whole dot and every test above would still pass.
+  expect_error(
+    summarize_with_margins(
+      data,
+      group = tibble::tibble(x = sum(value)),
+      .grouping = rollup(group)
+    ),
+    "cannot overwrite grouping column.*`group`"
+  )
+  expect_error(
+    summarize_with_margins(
+      data,
+      a = tibble::tibble(x = sum(value)),
+      .grouping = rollup(group),
+      .id = "a"
+    ),
+    "`\\.id` \\(`a`\\) conflicts with a summary output"
+  )
 })
 
 test_that("a named data-frame summary does not collide with `.id`", {

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1195,6 +1195,65 @@ test_that("data-frame summaries cannot overwrite grouping columns", {
   )
 })
 
+test_that("a named data-frame summary keeps its packed names to itself", {
+  data <- data.frame(group = c("a", "a", "b"), value = 1:3)
+
+  # dplyr packs a data-frame result into the one column its name gives, so the
+  # argument names inside these calls are not top-level outputs and cannot
+  # collide with anything (#431). The unnamed forms, refused by the test above,
+  # are unpacked instead.
+  from_tibble <- summarize_with_margins(
+    data,
+    s = tibble::tibble(group = sum(value)),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(from_tibble), c("group", "s"))
+  expect_equal(from_tibble$group, c("a", "b", "Total"))
+  expect_equal(from_tibble$s$group, c(3L, 3L, 6L))
+
+  from_across <- summarize_with_margins(
+    data,
+    s = dplyr::across(value, mean, .names = "group"),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(from_across), c("group", "s"))
+  expect_equal(from_across$s$group, c(1.5, 3, 2))
+
+  # `.unpack` renames inside the packed column rather than out of it, so a
+  # template that produces a grouping column's name is no collision either.
+  group_frame <- function(x) data.frame(group = min(x))
+  unpacked <- summarize_with_margins(
+    data,
+    s = dplyr::across(value, group_frame, .unpack = "{inner}"),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(unpacked), c("group", "s"))
+  expect_equal(unpacked$s$group, c(1L, 3L, 1L))
+
+  # `pick()` cannot rename, so what it packs is always input column names; the
+  # name still keeps them off the top level.
+  picked <- summarize_with_margins(
+    data.frame(group = c("a", "b"), value = c(1, 2)),
+    s = dplyr::pick(value),
+    .by = group
+  )
+  expect_equal(names(picked), c("group", "s"))
+  expect_equal(picked$s$value, c(1, 2))
+})
+
+test_that("a named data-frame summary does not collide with `.id`", {
+  data <- data.frame(group = c("a", "a", "b"), value = 1:3)
+
+  result <- summarize_with_margins(
+    data,
+    s = tibble::tibble(a = sum(value)),
+    .grouping = rollup(group),
+    .id = "a"
+  )
+  expect_true(all(c("a", "s") %in% names(result)))
+  expect_equal(result$s$a, c(3L, 3L, 6L))
+})
+
 test_that("branch-local dplyr group context helpers are rejected", {
   data <- data.frame(group = c("a", "a", "b"), value = 1:3)
 


### PR DESCRIPTION
Closes #431.

`known_summary_output_names()` read the argument names of every `tibble()`,
`data.frame()`, `across()`, and `pick()` call in `...` regardless of whether
the dot itself carried a name. dplyr packs a named data-frame result into the
one column its name gives, so those argument names never reach the result's
top level, and the pre-execution checks in `execute_margin_summary()` refused
calls for collisions the result never had — both the grouping-column check and
the `.id` check.

The predictor now skips a dot whose own name is non-empty. `names(dots)`
already contributes that name, which is the dot's whole output. The unnamed
path is untouched, and the unnamed forms stay refused: dplyr unpacks those, so
`tibble(g = sum(v))` with no name really does produce a top-level `g`.

The issue left two shapes unmeasured. Both are measured and covered by tests:

- `across(.unpack = "{inner}")` renames *within* the packed column, so a
  template producing a grouping column's name is still no top-level name.
- `pick()` cannot rename at all — `pick(c(g = v))` is a tidyselect error — so
  what it packs is always input column names.

Review record: see the review comment on this pull request.