### PR TITLE
Blame the Margin verb on the native adapter's translation error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -252,9 +252,12 @@
   whose own text spells the line dplyr writes to point at
   `dplyr::last_dplyr_warnings()`, while warnings that differ from each other
   are still reported one by one. Only that context changes: the class, the
-  diagnostic, and the cause you receive are the ones raised. A lazy input is
-  unaffected, because its summary expressions run when you collect the result
-  rather than while the verb runs (#141, #108).
+  diagnostic, and the cause you receive are the ones raised. A lazy input
+  raises most of these when you collect the result rather than while the verb
+  runs, so they are yours to receive and not the verb's to restate; the one
+  exception is an expression the database cannot be given at all, which is
+  refused while the verb runs and is quoted and blamed the same way
+  (#141, #108, #411, #432).
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns. `.keep = TRUE` retains original pre-margin key values,
   and nesting rejects duplicate sets with `.duplicates = "keep"` because

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -2,17 +2,19 @@
 # header gives, and read here for its labels as well as its dots.
 #
 # `call` is the Margin verb a Condition context is owed instead of the internal
-# `summarize()` this adapter issues; a caller that reaches this directly has
-# none to name and leaves the blamed call alone, as `summarize_margin_union()`
-# does.
+# `summarize()` this adapter issues. It has no default, unlike
+# `summarize_margin_union()`'s, because the executor is this adapter's only
+# caller: a default would stand for a caller that does not exist, and an
+# optional argument nothing omits is one the reader has to establish is never
+# omitted.
 summarize_margin_native <- function(.data,
                                     summaries,
                                     plan,
                                     margin_labels,
                                     reserved_names,
+                                    call,
                                     set_id_name = NULL,
-                                    set_id_is_internal = FALSE,
-                                    call = NULL) {
+                                    set_id_is_internal = FALSE) {
   con <- dbplyr::remote_con(.data)
   dots <- rewrite_grouping_dots(
     summaries$dots,
@@ -70,14 +72,12 @@ summarize_margin_native <- function(.data,
   # The blamed call is rewritten alongside the argument, both being parts of
   # one Condition context (CONTEXT.md). It is assigned after the restatement
   # rather than inside it, because that function returns the condition
-  # untouched when the map is empty.
+  # untouched when the map is empty, and this half is owed either way.
   output_names <- tryCatch(
     native_summary_output_names(.data, dots),
     error = function(cnd) {
       cnd <- restate_condition_arguments(cnd, restatements)
-      if (!is.null(call)) {
-        cnd$call <- call
-      }
+      cnd$call <- call
       stop(cnd)
     }
   )

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -1,12 +1,18 @@
 # `summaries` is `stage_margin_summaries()`'s, taken whole for the reason its
 # header gives, and read here for its labels as well as its dots.
+#
+# `call` is the Margin verb a Condition context is owed instead of the internal
+# `summarize()` this adapter issues; a caller that reaches this directly has
+# none to name and leaves the blamed call alone, as `summarize_margin_union()`
+# does.
 summarize_margin_native <- function(.data,
                                     summaries,
                                     plan,
                                     margin_labels,
                                     reserved_names,
                                     set_id_name = NULL,
-                                    set_id_is_internal = FALSE) {
+                                    set_id_is_internal = FALSE,
+                                    call = NULL) {
   con <- dbplyr::remote_con(.data)
   dots <- rewrite_grouping_dots(
     summaries$dots,
@@ -60,10 +66,19 @@ summarize_margin_native <- function(.data,
   # error is the whole of what ADR 0022 restates in this adapter. The call is
   # forced out of the check's lazy argument so that the check's own Package
   # conditions stay outside the catch.
+  #
+  # The blamed call is rewritten alongside the argument, both being parts of
+  # one Condition context (CONTEXT.md). It is assigned after the restatement
+  # rather than inside it, because that function returns the condition
+  # untouched when the map is empty.
   output_names <- tryCatch(
     native_summary_output_names(.data, dots),
     error = function(cnd) {
-      stop(restate_condition_arguments(cnd, restatements))
+      cnd <- restate_condition_arguments(cnd, restatements)
+      if (!is.null(call)) {
+        cnd$call <- call
+      }
+      stop(cnd)
     }
   )
   check_summary_output_names(

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1034,9 +1034,9 @@ stage_margin_summaries <- function(operation,
           plan = plan,
           margin_labels = operation$margin_labels,
           reserved_names = reserved_names,
+          call = operation$call,
           set_id_name = set_id_name,
-          set_id_is_internal = set_id_is_internal,
-          call = operation$call
+          set_id_is_internal = set_id_is_internal
         )
       } else {
         summarize_margin_union(

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1035,7 +1035,8 @@ stage_margin_summaries <- function(operation,
           margin_labels = operation$margin_labels,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
-          set_id_is_internal = set_id_is_internal
+          set_id_is_internal = set_id_is_internal,
+          call = operation$call
         )
       } else {
         summarize_margin_union(

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -243,9 +243,12 @@ call runs first, so it is the one dbplyr translates and the one that raises.
 Which of the two dbplyr reaches first is not a contract, and nothing here rests
 on it being permanent: the tests assert the restored spelling through the verb,
 so a dbplyr that moved the translation to the grouped call fails them rather
-than dropping the restatement silently. Nothing else about the adapter moves,
-beyond forcing that call out of the check's lazy argument, which keeps the
-check's own Package conditions outside the catch.
+than dropping the restatement silently. #432 searched seventeen expression shapes
+for one the grouped call refuses and the ungrouped call accepts, and found
+none: `investigation/which-native-summarize-raises-a-translation-error.md`.
+The only other thing that moves in #411 is forcing that call out of the check's
+lazy argument, which keeps the check's own Package conditions outside the
+catch.
 
 Errors only. A branch `summarize()` on a lazy backend still builds a query
 without evaluating the caller's expression, so everything the original reasoning
@@ -282,3 +285,31 @@ citation, as a comment saying no condition is raised while the verb runs. It was
 false on the day it was written, and it is the second copy ADR 0023 names: the
 citation stays correct across this amendment and the re-derivation did not. It
 goes with #411.
+
+## Amendment: the blamed call moves with the argument
+
+#411 restated the native adapter's translation error's argument and left its
+`call` as dbplyr set it, so the error blamed
+`dplyr::summarize(dplyr::ungroup(.data), !!!dots)` — a call spelled with names
+the caller never wrote. #432 is the ticket, and the argument for the change is
+its.
+
+The two are one context and not two, which is what this amendment records: a
+Condition context is the argument, the grouping values, and the blamed call
+together, and CONTEXT.md's entry owes all three in the caller's terms. Nothing
+above ever decided that the native adapter keeps dbplyr's call — the section
+this amends reaches only the argument, because restating it was the whole of
+what #411 asked. So this extends the same amendment rather than reversing
+anything in it: the adapter takes the Margin verb from the executor and assigns
+it after `restate_condition_arguments()`, which returns the condition untouched
+when the map is empty and is therefore not where the second half can live.
+
+`with_branch_conditions()` is still not the vehicle, for the reason above: the
+adapter issues one `summarize()` and repeats nothing, so the deduplication and
+the grouping-value restatement have nothing to act on. What the two paths now
+share is the field assignment alone, which is why it is written at each of them
+rather than extracted.
+
+The grouping values are the third part, and they need nothing here. The native
+adapter groups by `pick(all_of(group_vars))` rather than by internal key
+columns, so dplyr already reports them under the names the caller wrote.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -483,6 +483,12 @@ isolated lazy-query node, and renders that node for confirmed native dialects.
 It receives the compiled plan and executor-prepared inputs; it does not
 prepare, validate, or finalize a Margin operation.
 
+It owes a Condition context too, over the one condition it can raise while the
+verb runs: an error dbplyr raises translating the caller's rewritten summary
+expressions. It restates that error's argument and its blamed call, and needs
+no third part, because it groups by the caller's own columns. See
+[ADR 0022](adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md).
+
 ### Portable adapter (`R/grouping-adapter-union.R`)
 
 Owns branch materialization and `UNION ALL` composition. The summary path
@@ -492,9 +498,10 @@ per grouping set; nesting builds on that expansion in its verb executor. Like
 the native adapter, it consumes derived inputs and does not own the lifecycle.
 
 Because it is the one path that summarizes the caller's own expressions once
-per grouping set, it is also the one that owes a Condition context: it wraps
-the branch summary alone in `with_branch_conditions()`, so that the checks and
-builders around it keep raising their Package conditions unchanged.
+per grouping set, it is the only one where a Repeated condition exists and the
+only one whose grouping values arrive under names the caller never wrote: it
+wraps the branch summary alone in `with_branch_conditions()`, so that the
+checks and builders around it keep raising their Package conditions unchanged.
 
 The same fact gives it a second responsibility, and ADR 0025 is where the
 decision behind it sits. An Absorbing backend answers an expression its own

--- a/investigation/which-native-summarize-raises-a-translation-error.md
+++ b/investigation/which-native-summarize-raises-a-translation-error.md
@@ -1,0 +1,44 @@
+# Which of the native adapter's two summarizes raises a translation error
+
+Investigated: 2026-09-04
+
+`summarize_margin_native()` hands dplyr the caller's rewritten expressions
+twice: once ungrouped through `native_summary_output_names()` to learn the
+output names, and once grouped to build the query. #411 caught the translation
+error around the first of them, and ADR 0022's amendment records that "which of
+the two dbplyr reaches first is not a contract". #432 asked whether the second
+can raise one of its own.
+
+## What was searched for
+
+Seventeen expression shapes, each handed to a `dplyr::summarize()` over
+`dplyr::ungroup(tb)` and to a `dplyr::summarize()` over
+`dplyr::group_by(tb, dplyr::pick(dplyr::all_of("a")))` — the two calls the
+adapter issues — on a duckdb connection holding
+`data.frame(a = c("x", "y"), b = c("p", "q"), v = c(1, 2))`:
+
+`sum(v)`, `lag(v)`, `cumsum(v)`, `first(v)`, `nth(v, 2)`, `v`, `max(a)`,
+`sum(v) / 0`, `switch(a, x = 1)`, `Recall(v)`, `seq_len(3)`, `list(v)`,
+`sapply(v, identity)`, `zzz_no_such(v)`, `sum(.data$nope)`,
+`mean(nonexistent)`, and `across(everything(), mean)`.
+
+## What was found
+
+No shape failed the grouped call while the ungrouped one succeeded. The two
+that failed — `mean(nonexistent)` and `across(everything(), mean)` — failed
+both, so the ungrouped call reaches them first in each case. The remainder
+translated under both.
+
+This is evidence and not a proof: it bounds the search rather than the
+behaviour, and dbplyr is free to translate the grouped call differently in a
+later release. Nothing was changed to rest on it. ADR 0022's amendment is
+authoritative for what does rest on it, which is nothing — the tests assert the
+restored context through the verb, so a dbplyr that moved the translation to
+the grouped call fails them rather than dropping the restatement silently.
+
+## What was not measured
+
+Whether a real PostgreSQL connection blames the same call as duckdb. No
+PostgreSQL driver is named in `optional_suggest_spec()`, so the suite has no
+connection to reach the native path with; `dbplyr::simulate_postgres()` covers
+the translation through the same adapter code, and is what the tests use.

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -755,6 +755,26 @@ test_that("a native translation error quotes the caller's own spelling", {
   expect_s3_class(error$parent, "condition")
 })
 
+# The other half of the Condition context on this path (#432). The adapter
+# catches dbplyr's error to restate its argument, and the call it arrived with
+# is the internal `summarize()` the adapter issued over `.data` and `dots` --
+# names the caller never wrote. Asserted on the rendered call rather than on
+# its name alone, because the name a bare `dplyr::summarize()` carries is not
+# what a caller reads: an error header prints the whole call.
+test_that("a native translation error blames the Margin verb", {
+  error <- expect_error(native_translation_failure())
+
+  expect_identical(
+    rlang::call_name(conditionCall(error)),
+    "summarize_with_margins"
+  )
+  expect_false(grepl(
+    "dots",
+    paste(deparse(conditionCall(error)), collapse = " "),
+    fixed = TRUE
+  ))
+})
+
 test_that("a native label two dots share is left as dplyr wrote it", {
   error <- expect_error(native_shared_label_failure())
 

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -758,21 +758,35 @@ test_that("a native translation error quotes the caller's own spelling", {
 # The other half of the Condition context on this path (#432). The adapter
 # catches dbplyr's error to restate its argument, and the call it arrived with
 # is the internal `summarize()` the adapter issued over `.data` and `dots` --
-# names the caller never wrote. Asserted on the rendered call rather than on
-# its name alone, because the name a bare `dplyr::summarize()` carries is not
-# what a caller reads: an error header prints the whole call.
+# names the caller never wrote. The whole call is asserted and not its name,
+# because an error header prints the whole call: a blamed
+# `dplyr::summarize(dplyr::ungroup(.data), !!!dots)` and the verb agree on
+# nothing but that they are calls. The expected calls are written out rather
+# than read back off the helpers, so that a helper edited without this test
+# fails it.
+#
+# Both reproductions are asserted, because the two halves of this context are
+# restated by separate statements: `native_shared_label_failure()` is the case
+# whose restatement map is empty, where `restate_condition_arguments()` returns
+# the condition untouched and the blamed call is owed anyway.
 test_that("a native translation error blames the Margin verb", {
-  error <- expect_error(native_translation_failure())
-
   expect_identical(
-    rlang::call_name(conditionCall(error)),
-    "summarize_with_margins"
+    conditionCall(expect_error(native_translation_failure())),
+    quote(summarize_with_margins(
+      native_grouping_sets_input(),
+      total = sum(value) + grouping_bit(a) + no_such_column,
+      .grouping = rollup(a)
+    ))
   )
-  expect_false(grepl(
-    "dots",
-    paste(deparse(conditionCall(error)), collapse = " "),
-    fixed = TRUE
-  ))
+  expect_identical(
+    conditionCall(expect_error(native_shared_label_failure())),
+    quote(summarize_with_margins(
+      native_grouping_sets_input(),
+      grouping_bit(a) + no_such_column,
+      grouping_bit(a) + value,
+      .grouping = rollup(a)
+    ))
+  )
 })
 
 test_that("a native label two dots share is left as dplyr wrote it", {


### PR DESCRIPTION
Closes #432.

A dbplyr translation error raised on the native `GROUPING SETS` path had its
arguments restated (#411, ADR 0022) but its `call` left as dbplyr set it, so
the error header named `dplyr::summarize(dplyr::ungroup(.data), !!!dots)` —
a call spelled with the internal names `.data` and `dots`. `CONTEXT.md`'s
*Condition context* requires the blamed call to be the Margin verb the caller
wrote, and ADR 0021 records that an error names it. The union adapter already
does this through `with_branch_conditions()`.

`summarize_margin_native()` now takes the operation's `call` and assigns it
alongside the existing `restate_condition_arguments()`, after the restatement
rather than inside it, since that function returns the condition untouched when
the map is empty. The argument is optional and defaults to `NULL`, as
`summarize_margin_union()`'s is, so a caller reaching the adapter directly
leaves the blamed call alone.

`with_branch_conditions()` is still not the vehicle, for the reason #411 gave.

## Verification

The issue's reproduction, before and after:

```
tbl_duckdb_connection -> dplyr::summarize(dplyr::ungroup(.data), !!!dots)
tbl_SQLiteConnection  -> summarize_with_margins(tb, ...)
```
```
tbl_duckdb_connection -> summarize_with_margins(tb, ...)
tbl_SQLiteConnection  -> summarize_with_margins(tb, ...)
```

`test-execution-conditions.R`'s new *a native translation error blames the
Margin verb* fails without the change. It runs on `simulate_postgres()`, so it
needs no optional backend.

`lintr::lint_package()` clean; full suite green under `NOT_CRAN=true`.

## What the issue left unmeasured

Both are recorded in
`investigation/which-native-summarize-raises-a-translation-error.md`, which
ADR 0022's amendment cites.

- **Can the second `summarize()` raise a translation error of its own?** Not
  found. Seventeen expression shapes were probed on duckdb against both the
  ungrouped call `native_summary_output_names()` issues and the grouped call
  below it, and no shape failed the grouped call while the ungrouped one
  succeeded. That is evidence and not a proof, which is what ADR 0022's
  amendment already says: "Which of the two dbplyr reaches first is not a
  contract", and the tests assert the restored context through the verb, so a
  dbplyr that moved the translation fails them rather than dropping this
  silently.
- **Does the PostgreSQL native path blame the same call?** Not run — no
  PostgreSQL driver is named in `optional_suggest_spec()`, so the suite has no
  connection to reach it with. `simulate_postgres()` covers the translation
  through the same adapter code and blames the verb.
