### PR TITLE
Expand a data-frame summary marginplyr named

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -196,6 +196,19 @@ runs when it is. A diagnostic refusing one tells the caller their spelling is
 glossary, and not a second term.
 _Avoid_: Contextual function, masked helper, reserved argument
 
+**Assigned summary name**:
+The column name marginplyr writes for an unnamed summary it rewrites, read from
+the caller's own expression rather than from the rewrite. It is never a name
+the caller wrote, and it exists only while the query is built: where a local
+result holds a data-frame column under one, that column's own columns take its
+place and the assigned name does not appear, so an unnamed summary expands as
+`dplyr::summarize()` expands it. A name the caller wrote is not one of these
+and packs, as it does under dplyr. Which unnamed summaries take one is decided
+by spelling, and whether one expands is decided from the value after the
+summary runs; ADR 0028 is authoritative for why the two are settled in
+different places.
+_Avoid_: Generated name, internal summary name, rewritten name
+
 **Option argument**:
 An argument whose value is one of a fixed set of strings, spelled in full. An
 abbreviation is not shorthand for the value it begins, and a `NULL` is not

--- a/NEWS.md
+++ b/NEWS.md
@@ -161,13 +161,17 @@
   after the caller's own expression, identically on every backend. A summary no
   rewrite reaches is named by dplyr exactly as before, and so is a summary
   written as `across()` or `pick()` itself, so both go on expanding a
-  data-frame value's columns into the result. A data-frame-valued summary a
-  rewrite *does* reach is now named, and dplyr packs a named one:
-  `range_frame(pick(x))` returned `lo` and `hi` and now returns one
-  data-frame column named after the call. Telling that summary from
-  `nrow(pick(v, w))` is a question about the value's type rather than about how
-  it is spelled, so give either one a name of your own where you want the
-  columns expanded or packed regardless (#430, #435).
+  data-frame value's columns into the result. So does a summary the naming
+  *does* reach whose value is a data frame, which dplyr would pack under any
+  name: on a local input marginplyr expands that column again after the
+  summary runs, so `range_frame(pick(x))` returns `lo` and `hi` as it did
+  before, and the name marginplyr assigned does not appear. Write a name of
+  your own to pack those columns into one column under it. Which summaries
+  those are is a question about the value's type — `nrow(pick(v, w))` is one
+  call away and has to be named — so it is answered from the value rather than
+  from the spelling, and only for an input already in memory: Arrow packed such
+  a summary before this change too, and no SQL backend expanded one
+  (#430, #435).
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
   Lazy margin-label checks use portable numeric `CASE` aggregates across

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -477,6 +477,18 @@ summarize_margin_union <- function(.data,
         result <- dplyr::rename(result, !!!rename_pairs)
       }
 
+      # After the rename and before the labelling: the grouping columns are
+      # under their own names by here, and the label and identifier columns
+      # the checks below would have to be told to ignore are not there yet.
+      # ADR 0028 is what expands.
+      result <- expand_assigned_data_frames(
+        result,
+        assigned_names = summaries$assigned_names,
+        group_vars = group_vars,
+        set_id_name = set_id_name,
+        set_id_is_internal = set_id_is_internal
+      )
+
       result <- label_margin_branch(
         result,
         plan = plan,

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -381,6 +381,16 @@
 #' every branch: a dimension remains excluded even in a grouping set from
 #' which it is omitted.
 #'
+#' An unnamed summary takes its column name from the expression you wrote
+#' rather than from what marginplyr rewrote it into, so
+#' `sum(v) + grouping_bit(a)` names the same column on every backend. Where
+#' such a summary's value is a data frame, a local input expands its columns
+#' into the result and the name marginplyr assigned does not appear, exactly as
+#' [dplyr::summarize()] expands an unnamed one. Writing a name of your own
+#' packs those columns into a single column under it, again as dplyr does. A
+#' lazy input follows its own backend: Arrow packs them whether or not the
+#' summary is named, and a SQL backend has no expanded form to give.
+#'
 #' Summary results may not overwrite a fixed key or grouping dimension,
 #' including through a data-frame-valued summary. The local dplyr backend can
 #' overwrite an existing variable and reuse a newly created summary in a

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1067,6 +1067,19 @@ stage_margin_summaries <- function(operation,
       stop(cnd)
     }
   )
+  # The adapters check against the identifier they were handed, which is the
+  # allocated one wherever the two branches above replaced the caller's. Every
+  # name they can see was checked against the caller's `.id` before execution
+  # -- except the ones an expansion puts there (ADR 0028), which no static
+  # reading could predict. Left unasked, the caller's `.id` overwrites such a
+  # column when it is renamed back onto the result.
+  if (set_id_is_internal) {
+    check_margin_id_collision(
+      operation$set_id_name,
+      get_col_names(result, dplyr::everything()),
+      "a summary output"
+    )
+  }
   new_margin_summary_stage(result, set_id_name, sort_id = sort_id)
 }
 

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -381,15 +381,11 @@
 #' every branch: a dimension remains excluded even in a grouping set from
 #' which it is omitted.
 #'
-#' An unnamed summary takes its column name from the expression you wrote
-#' rather than from what marginplyr rewrote it into, so
-#' `sum(v) + grouping_bit(a)` names the same column on every backend. Where
-#' such a summary's value is a data frame, a local input expands its columns
-#' into the result and the name marginplyr assigned does not appear, exactly as
-#' [dplyr::summarize()] expands an unnamed one. Writing a name of your own
-#' packs those columns into a single column under it, again as dplyr does. A
-#' lazy input follows its own backend: Arrow packs them whether or not the
-#' summary is named, and a SQL backend has no expanded form to give.
+#' Where an unnamed summary's value is a data frame, a local input expands its
+#' columns into the result, exactly as [dplyr::summarize()] does, and a name
+#' marginplyr assigned such a summary does not appear. Writing a name of your
+#' own packs those columns into a single column under it, again as dplyr does.
+#' A lazy input gives whatever shape its own backend gives.
 #'
 #' Summary results may not overwrite a fixed key or grouping dimension,
 #' including through a data-frame-valued summary. The local dplyr backend can

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1068,11 +1068,8 @@ stage_margin_summaries <- function(operation,
     }
   )
   # The adapters check against the identifier they were handed, which is the
-  # allocated one wherever the two branches above replaced the caller's. Every
-  # name they can see was checked against the caller's `.id` before execution
-  # -- except the ones an expansion puts there (ADR 0028), which no static
-  # reading could predict. Left unasked, the caller's `.id` overwrites such a
-  # column when it is renamed back onto the result.
+  # allocated one wherever the two branches above replaced the caller's, so
+  # this is the frame that can still ask the caller's own (ADR 0028).
   if (set_id_is_internal) {
     check_margin_id_collision(
       operation$set_id_name,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -252,6 +252,68 @@ check_summary_output_names <- function(output_names,
   check_margin_id_collision(set_id_name, output_names, "a summary output")
 }
 
+# The columns of a data-frame-valued summary that took an Assigned summary
+# name, put back where dplyr would have put them had the summary stayed
+# unnamed (ADR 0028). A name the caller wrote is not among the assigned ones,
+# so it packs as it does under `dplyr::summarize()`.
+#
+# `is.data.frame()` is the whole of the scope. No other backend expanded such a
+# summary before the name was assigned, so expanding one there would be a new
+# behavior rather than a repair.
+#
+# Reached from `summarize_margin_union()` only, that being the adapter a local
+# result is built by: `summarize_margin_native()` opens by reading its input's
+# remote connection, so nothing it returns is a data frame.
+#
+# The two checks that can now have a subject are asked again, of the names that
+# replaced the assigned one -- the pre-execution pass and the adapter's own
+# could only ask them of a name standing for the whole frame.
+# `check_summary_output_names()` is not asked, because the internal columns its
+# third question is about are renamed or dropped by the point this runs.
+expand_assigned_data_frames <- function(result,
+                                        assigned_names,
+                                        group_vars,
+                                        set_id_name,
+                                        set_id_is_internal = FALSE) {
+  if (!is.data.frame(result)) {
+    return(result)
+  }
+  packed <- intersect(assigned_names[!is.na(assigned_names)], names(result))
+  packed <- Filter(function(name) is.data.frame(result[[name]]), packed)
+  if (length(packed) == 0L) {
+    return(result)
+  }
+
+  inner_names <- unlist(
+    lapply(packed, function(name) names(result[[name]])),
+    use.names = FALSE
+  )
+  check_summary_group_overwrite(inner_names, group_vars = group_vars)
+  # A Grouping set identifier the package allocated for itself is not the
+  # caller's `.id`, and reporting a collision with it as one names an argument
+  # the caller never wrote, exactly as in `check_summary_output_names()`.
+  if (!set_id_is_internal) {
+    check_margin_id_collision(set_id_name, inner_names, "a summary output")
+  }
+
+  for (name in packed) {
+    result <- expand_packed_summary_column(result, name)
+  }
+  result
+}
+
+# `dplyr::mutate()` writes the columns, which is what makes two inner columns
+# of one name resolve the way dplyr's own expansion resolves them, and what
+# keeps the result's class dplyr's (ADR 0016). `.after` is what puts them where
+# the packed column stood.
+expand_packed_summary_column <- function(result, name) {
+  columns <- as.list(result[[name]])
+  result <- dplyr::mutate(result, !!!columns, .after = dplyr::all_of(name))
+  # An inner column of the assigned name has already taken the packed column's
+  # place above, and there is then nothing left under that name to drop.
+  dplyr::select(result, -dplyr::all_of(setdiff(name, names(columns))))
+}
+
 check_internal_summary_names <- function(output_names, internal_names) {
   conflicting_names <- intersect(output_names, internal_names)
   if (length(conflicting_names) == 0L) {
@@ -273,29 +335,41 @@ check_internal_summary_names <- function(output_names, internal_names) {
 }
 
 # What execution carries for the caller's summary arguments: the dots to hand
-# dplyr, beside the caller's own label for each. Constructed at the one point
-# both halves are final -- after every rewrite -- so a pair that stops agreeing
-# in length cannot be built at all, which is an invariant rather than a Package
-# condition (ADR 0015): no call produces it, and a map built from a misaligned
-# pair would quote one argument's expression under another.
+# dplyr, beside the caller's own label for each and the Assigned summary name
+# for each. Constructed at the one point all three are final -- after every
+# rewrite -- so vectors that stop agreeing in length cannot be built at all,
+# which is an invariant rather than a Package condition (ADR 0015): no call
+# produces it, and a map built from a misaligned pair would quote one
+# argument's expression under another.
 #
 # The labels default to the dots' own, which is the truth for a caller reaching
 # an adapter directly: what it passed is what it wrote. Nothing is restated
 # there, because `branch_argument_map()` drops a label a rewrite left alone --
 # so "no spelling to restore" needs no representation of its own, and a length
-# is checked once rather than only when a second value says to.
+# is checked once rather than only when a second value says to. The assigned
+# names default to none for the same reason: such a caller wrote every name its
+# dots carry, and ADR 0028 expands only a name marginplyr wrote.
 new_summary_arguments <- function(dots,
-                                  labels = summary_argument_labels(dots)) {
+                                  labels = summary_argument_labels(dots),
+                                  assigned_names = rep(
+                                    NA_character_,
+                                    length(dots)
+                                  )) {
   stopifnot(
     is.list(dots),
     is.character(labels),
-    length(labels) == length(dots)
+    length(labels) == length(dots),
+    is.character(assigned_names),
+    length(assigned_names) == length(dots)
   )
-  list(dots = dots, labels = labels)
+  list(dots = dots, labels = labels, assigned_names = assigned_names)
 }
 
 # The name dplyr would have given each unnamed summary marginplyr rewrites,
-# read from what the caller wrote rather than from the rewrite.
+# read from what the caller wrote rather than from the rewrite. The named dots
+# arrive beside the Assigned summary name each one took, `NA` where none was
+# assigned: ADR 0028 decides after execution, and a result column carrying a
+# name marginplyr wrote is the only thing it acts on.
 #
 # dplyr names an unnamed summary by deparsing the expression it receives, and
 # what a rewritten one hands it is marginplyr's spelling: a branch-local `0L`
@@ -320,7 +394,7 @@ new_summary_arguments <- function(dots,
 # data-frame-valued expression the static reading does not recognize, and no
 # reading separates it from a scalar one: `nrow(pick(v, w))` has to be named
 # and `range_frame(pick(v))` has to not be, which is a question about the
-# value's type. #435 holds what that costs and what answering it would take.
+# value's type. ADR 0028 is where that one is answered.
 #
 # `rlang::as_label()` is `rlang::quos_auto_name()`'s own labeller, so the name
 # is dplyr's up to the width at which rlang abbreviates a long expression:
@@ -330,6 +404,7 @@ new_summary_arguments <- function(dots,
 name_rewritten_summary_dots <- function(original, resolved) {
   stopifnot(length(original) == length(resolved))
   arg_names <- rlang::names2(resolved)
+  assigned_names <- rep(NA_character_, length(resolved))
   for (i in which(!nzchar(arg_names))) {
     expr <- rlang::quo_get_expr(original[[i]])
     rewritten <- !identical(expr, rlang::quo_get_expr(resolved[[i]])) ||
@@ -338,8 +413,12 @@ name_rewritten_summary_dots <- function(original, resolved) {
       next
     }
     arg_names[[i]] <- rlang::as_label(expr)
+    assigned_names[[i]] <- arg_names[[i]]
   }
-  stats::setNames(resolved, arg_names)
+  list(
+    dots = stats::setNames(resolved, arg_names),
+    assigned_names = assigned_names
+  )
 }
 
 plan_summary_expressions <- function(dots,
@@ -376,7 +455,8 @@ plan_summary_expressions <- function(dots,
   # below this either answers a named dot or is one of those moves. The labels
   # above are read first because they are the caller's spelling for a Condition
   # context, which a name assigned here would spell `sum(v) = sum(v)`.
-  dots <- name_rewritten_summary_dots(original_dots, dots)
+  named <- name_rewritten_summary_dots(original_dots, dots)
+  dots <- named$dots
   summary_plan <- plan_share_expressions(
     dots,
     selection_proxy = selection_proxy,
@@ -385,9 +465,10 @@ plan_summary_expressions <- function(dots,
     validate_cardinality = wraps_share_sources_in_summary(backend_kind)
   )
   # Share planning is the one step that moves a dot, so it reports where each
-  # dot it produced came from and the labels are subscripted by that. Every
-  # other rewrite here answers one dot with one dot in place.
+  # dot it produced came from and both per-dot vectors are subscripted by that.
+  # Every other rewrite here answers one dot with one dot in place.
   caller_labels <- caller_labels[summary_plan$origin_positions]
+  assigned_names <- named$assigned_names[summary_plan$origin_positions]
   summary_plan$dots <- resolve_summary_selections(
     summary_plan$dots,
     data_proxy = data_proxy,
@@ -404,7 +485,11 @@ plan_summary_expressions <- function(dots,
     )
   }
   list(
-    summaries = new_summary_arguments(summary_plan$dots, caller_labels),
+    summaries = new_summary_arguments(
+      summary_plan$dots,
+      caller_labels,
+      assigned_names
+    ),
     requests = summary_plan$requests
   )
 }

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -252,68 +252,6 @@ check_summary_output_names <- function(output_names,
   check_margin_id_collision(set_id_name, output_names, "a summary output")
 }
 
-# The columns of a data-frame-valued summary that took an Assigned summary
-# name, put back where dplyr would have put them had the summary stayed
-# unnamed (ADR 0028). A name the caller wrote is not among the assigned ones,
-# so it packs as it does under `dplyr::summarize()`.
-#
-# `is.data.frame()` is the whole of the scope. No other backend expanded such a
-# summary before the name was assigned, so expanding one there would be a new
-# behavior rather than a repair.
-#
-# Reached from `summarize_margin_union()` only, that being the adapter a local
-# result is built by: `summarize_margin_native()` opens by reading its input's
-# remote connection, so nothing it returns is a data frame.
-#
-# The two checks that can now have a subject are asked again, of the names that
-# replaced the assigned one -- the pre-execution pass and the adapter's own
-# could only ask them of a name standing for the whole frame.
-# `check_summary_output_names()` is not asked, because the internal columns its
-# third question is about are renamed or dropped by the point this runs.
-expand_assigned_data_frames <- function(result,
-                                        assigned_names,
-                                        group_vars,
-                                        set_id_name,
-                                        set_id_is_internal = FALSE) {
-  if (!is.data.frame(result)) {
-    return(result)
-  }
-  packed <- intersect(assigned_names[!is.na(assigned_names)], names(result))
-  packed <- Filter(function(name) is.data.frame(result[[name]]), packed)
-  if (length(packed) == 0L) {
-    return(result)
-  }
-
-  inner_names <- unlist(
-    lapply(packed, function(name) names(result[[name]])),
-    use.names = FALSE
-  )
-  check_summary_group_overwrite(inner_names, group_vars = group_vars)
-  # A Grouping set identifier the package allocated for itself is not the
-  # caller's `.id`, and reporting a collision with it as one names an argument
-  # the caller never wrote, exactly as in `check_summary_output_names()`.
-  if (!set_id_is_internal) {
-    check_margin_id_collision(set_id_name, inner_names, "a summary output")
-  }
-
-  for (name in packed) {
-    result <- expand_packed_summary_column(result, name)
-  }
-  result
-}
-
-# `dplyr::mutate()` writes the columns, which is what makes two inner columns
-# of one name resolve the way dplyr's own expansion resolves them, and what
-# keeps the result's class dplyr's (ADR 0016). `.after` is what puts them where
-# the packed column stood.
-expand_packed_summary_column <- function(result, name) {
-  columns <- as.list(result[[name]])
-  result <- dplyr::mutate(result, !!!columns, .after = dplyr::all_of(name))
-  # An inner column of the assigned name has already taken the packed column's
-  # place above, and there is then nothing left under that name to drop.
-  dplyr::select(result, -dplyr::all_of(setdiff(name, names(columns))))
-}
-
 check_internal_summary_names <- function(output_names, internal_names) {
   conflicting_names <- intersect(output_names, internal_names)
   if (length(conflicting_names) == 0L) {
@@ -332,6 +270,64 @@ check_internal_summary_names <- function(output_names, internal_names) {
     i = "{.var {conflicting_names}}.",
     i = "Use different summary output names."
   ))
+}
+
+# The columns of a data-frame-valued summary that took an Assigned summary
+# name, put back where dplyr would have put them had the summary stayed
+# unnamed (ADR 0028).
+#
+# Reached from `summarize_margin_union()` only. `use_native` in
+# `stage_margin_summaries()` gates the other adapter on `native_grouping_sets`,
+# which `backend_capabilities()` grants to the two SQL kinds alone, so no local
+# result is built there.
+#
+# The composite check is asked again, of the names that replaced the assigned
+# one. Its internal names are empty here: the branch's `..marginplyr_key_`
+# columns are renamed or gone by this point, and the one internal column still
+# to be added -- the Grouping set identifier -- arrives through
+# `set_id_is_internal` instead.
+expand_assigned_data_frames <- function(result,
+                                        assigned_names,
+                                        group_vars,
+                                        set_id_name,
+                                        set_id_is_internal = FALSE) {
+  if (!is.data.frame(result)) {
+    return(result)
+  }
+  packed <- intersect(assigned_names[!is.na(assigned_names)], names(result))
+  packed <- Filter(function(name) is.data.frame(result[[name]]), packed)
+  if (length(packed) == 0L) {
+    return(result)
+  }
+
+  check_summary_output_names(
+    unlist(
+      lapply(packed, function(name) names(result[[name]])),
+      use.names = FALSE
+    ),
+    group_vars = group_vars,
+    internal_names = character(),
+    set_id_name = set_id_name,
+    set_id_is_internal = set_id_is_internal
+  )
+
+  for (name in packed) {
+    result <- expand_packed_summary_column(result, name)
+  }
+  result
+}
+
+# `dplyr::mutate()` writes the columns, so `.after` is what puts them where the
+# packed column stood.
+expand_packed_summary_column <- function(result, name) {
+  columns <- as.list(result[[name]])
+  result <- dplyr::mutate(result, !!!columns, .after = dplyr::all_of(name))
+  # An inner column of the assigned name has taken the packed column's place
+  # above, leaving nothing under that name to drop.
+  if (name %in% names(columns)) {
+    return(result)
+  }
+  dplyr::select(result, -dplyr::all_of(name))
 }
 
 # What execution carries for the caller's summary arguments: the dots to hand

--- a/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
+++ b/design/adr/0016-delegate-result-class-and-attributes-to-dplyr.md
@@ -36,6 +36,8 @@ marginplyr passes through, and therefore describes but does not promise:
 
 Nothing else in the package needs a reconstruction rule, because every Margin
 verb ends in a dplyr verb applied to a data frame that dplyr itself produced.
+[ADR 0028](0028-expand-a-data-frame-summary-marginplyr-named.md) is the
+exception, and states its own scope.
 
 ### Measured behavior
 

--- a/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
+++ b/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
@@ -79,9 +79,11 @@ margin labelling. That is the point the grouping columns are under their own
 names and the label and identifier columns are not there yet, so the checks
 below need to be told to ignore nothing.
 
-`summarize_margin_native()` is not a second site. It opens by reading its
-input's remote connection, so nothing it returns is a data frame and the guard
-above could never pass there.
+`summarize_margin_native()` is not a second site. `stage_margin_summaries()`
+chooses it only where `supports_grouping_sets()` holds, which needs the
+`native_grouping_sets` capability, which `backend_capabilities()` grants to the
+`duckdb` and `postgres` kinds alone — both lazy. So no local result is built
+there and the guard above could never pass.
 
 The carrier is `new_summary_arguments()`, which gains a third vector parallel to
 the dots and the caller labels: the Assigned summary name for each dot, `NA`
@@ -92,18 +94,22 @@ subscripted by the same origin positions the caller labels already are.
 
 ## What is checked again
 
-`check_summary_group_overwrite()` and `check_margin_id_collision()` are asked a
-second time, of the names that replaced the assigned one. Neither could have
-been asked of them before: the summary stood for one column under a name of
-marginplyr's, and no pre-execution reading knew what it held. An inner name
-equal to a grouping dimension is refused, and one equal to the caller's `.id`
-is refused, in the wording those two already use.
+`check_summary_output_names()` is asked a second time, of the names that
+replaced the assigned one. None of its three questions could have been asked of
+them before: the summary stood for one column under a name of marginplyr's, and
+no pre-execution reading knew what it held. An inner name equal to a grouping
+dimension is refused, and one equal to the caller's `.id` is refused, in the
+wording those two already use.
 
-`check_summary_output_names()` is not asked. Its third question is about the
-internal columns the adapter put beside the summary outputs, and those are
-renamed or gone by this point, so asking it with an empty set would add a case
-to a composition whose contract is that both execution paths ask the same three
-questions in the same order.
+The composite is asked rather than its parts, so this becomes a third path
+under the contract that every path asks the same three questions in the same
+order. Its `internal_names` is empty at this point, the branch's
+`..marginplyr_key_` columns having been renamed or dropped, but the internal
+question still has a subject: where the Grouping set identifier is one the
+package allocated for itself, `add_grouping_set_id()` has yet to write it, and
+`set_id_is_internal` is what puts it back among the internal names. Asking only
+the other two would leave an inner name equal to that column silently
+overwritten.
 
 ## Consequences
 

--- a/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
+++ b/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
@@ -111,6 +111,13 @@ package allocated for itself, `add_grouping_set_id()` has yet to write it, and
 the other two would leave an inner name equal to that column silently
 overwritten.
 
+Where the package allocated that identifier it replaced the caller's `.id` with
+it, so the adapter holds no name to ask the `.id` question with, and
+`stage_margin_summaries()` asks it once over the staged result instead. Every
+other name the result carries was asked before execution; only an expanded one
+was not, and the caller's `.id` is renamed onto the result at the end, so an
+unasked collision loses the summary rather than refusing it.
+
 ## Consequences
 
 `dplyr::mutate()` is what writes the expanded columns, so the result's class

--- a/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
+++ b/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
@@ -1,0 +1,125 @@
+# Expand a data-frame summary marginplyr named
+
+An **Assigned summary name** is the column name marginplyr wrote for an unnamed
+summary it rewrote, read from the caller's own expression
+([ADR 0007](0007-capture-user-expressions-at-public-verbs.md) captured that
+expression, and #430 decided that the name comes from it). It is never a name
+the caller wrote, it exists only while the query is built, and it is the
+subject of this decision.
+
+Where a local result holds a data-frame column under an Assigned summary name,
+that column's own columns take its place and the assigned name does not appear.
+A name the caller wrote stays packed, exactly as `dplyr::summarize()` packs it.
+Every other summary is unaffected.
+
+## Why the decision cannot be made from the spelling
+
+[ADR 0019](0019-resolve-contextual-helper-names-by-static-spelling.md) resolves
+a Contextual helper by how it is spelled, and every rewrite marginplyr performs
+is decided that way. This question is not one a spelling can answer.
+
+dplyr expands a data-frame-valued summary's columns into the result while the
+summary is unnamed, and packs them into one column under any name. So naming a
+summary changes its result shape whenever its value is a data frame, and
+`name_rewritten_summary_dots()` must not name one whose value is. Which
+summaries those are is a question about the value's type, and two expressions
+one call apart fall on opposite sides of it:
+
+- `nrow(pick(v, w))` is scalar-valued and has to be named, or the rewritten
+  `all_of()` literal names the column (#430's second reproduction).
+- `range_frame(pick(x))` is data-frame-valued and has to not be, or its `lo`
+  and `hi` come back packed under `range_frame(dplyr::pick(x))` (#435).
+
+`name_rewritten_summary_dots()` excludes the data-frame-valued shapes a static
+reading does reach — a summary written as `across()` or `pick()` itself, and
+the `tibble()`/`data.frame()` family — because each names its own outputs and a
+reading can say so. What is left is a data-frame-valued expression built from a
+function of the caller's own, which no reading separates from a scalar one:
+`range_frame` is an ordinary closure and its return type is not in the call.
+
+So the summary is named, and the decision is made after the summarize, from
+the value: a result column holding a data frame under an Assigned summary name
+is one that was going to expand.
+
+`rlang::quos_auto_name()` applied before any rewriting was #430's own stated fix
+direction, and it is rejected here for the reason #435 gives: it packs strictly
+more than the shapes at issue, `across()` and `range_frame(x)` included, which
+is a behavior change for summaries this decision leaves alone.
+
+## Scope: a local input
+
+The expansion is guarded by `is.data.frame()` and by nothing else. No backend
+capability is declared, because there is no difference between backends to
+declare — only a local case to repair.
+
+Measured against arrow 25.0.1, duckdb 1.5.5, dtplyr 1.3.3, RSQLite 3.53.3,
+dplyr 1.2.1, and dbplyr 2.6.0:
+
+| Input | Before an Assigned summary name existed | Today |
+|---|---|---|
+| `data.frame`, `data.table` | expanded | packed, and expanded again here |
+| Arrow | packed, named or not | packed |
+| dtplyr | data.table's own error at `collect()` | unchanged |
+| SQL | aliased, never expanded | unchanged |
+
+Only the first row changed when #430 named the summary, so only the first row
+is repaired. Expanding on any other backend would be a new behavior rather than
+a repair, and the packed/expanded distinction is not dplyr's to make on a SQL
+backend at all: DuckDB reaches a data-frame column by `struct_pack()`, which
+no summary marginplyr names goes through.
+
+[ADR 0020](0020-ask-before-reading-a-lazy-input.md) is not engaged. The
+expansion inspects a result already in memory and sends no query; the guard is
+what keeps it away from every input that could be asked one.
+
+## Where the expansion runs
+
+`summarize_margin_union()`, per branch, between the branch's key rename and its
+margin labelling. That is the point the grouping columns are under their own
+names and the label and identifier columns are not there yet, so the checks
+below need to be told to ignore nothing.
+
+`summarize_margin_native()` is not a second site. It opens by reading its
+input's remote connection, so nothing it returns is a data frame and the guard
+above could never pass there.
+
+The carrier is `new_summary_arguments()`, which gains a third vector parallel to
+the dots and the caller labels: the Assigned summary name for each dot, `NA`
+where marginplyr assigned none, under the same length invariant
+([ADR 0015](0015-separate-package-conditions-from-internal-invariants.md)).
+Share planning is the one step that moves a dot, so the new vector is
+subscripted by the same origin positions the caller labels already are.
+
+## What is checked again
+
+`check_summary_group_overwrite()` and `check_margin_id_collision()` are asked a
+second time, of the names that replaced the assigned one. Neither could have
+been asked of them before: the summary stood for one column under a name of
+marginplyr's, and no pre-execution reading knew what it held. An inner name
+equal to a grouping dimension is refused, and one equal to the caller's `.id`
+is refused, in the wording those two already use.
+
+`check_summary_output_names()` is not asked. Its third question is about the
+internal columns the adapter put beside the summary outputs, and those are
+renamed or gone by this point, so asking it with an empty set would add a case
+to a composition whose contract is that both execution paths ask the same three
+questions in the same order.
+
+## Consequences
+
+`dplyr::mutate()` is what writes the expanded columns, so the result's class
+stays dplyr's and two inner columns sharing a name resolve the way dplyr's own
+expansion resolves them.
+[ADR 0016](0016-delegate-result-class-and-attributes-to-dplyr.md) records this
+decision as the exception to its sentence about ending in a dplyr verb applied
+to a data frame dplyr produced.
+
+The reference states the rule a caller needs and not this argument: an unnamed
+summary expands, a name you write packs, and a name marginplyr assigns does not
+appear.
+
+Two things stay outside this decision, both following from #430 rather than
+from it, and both are #439: `rlang::as_label()`'s abbreviation producing a
+column name the caller cannot read back, and an assigned name differing between
+`pick(x)` and `dplyr::pick(x)`. Each applies equally to a scalar summary, which
+this decision does not touch.

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -436,6 +436,16 @@ complete grouping plan. This extends dplyr's grouping-column rule across
 every branch: a dimension remains excluded even in a grouping set from
 which it is omitted.
 
+An unnamed summary takes its column name from the expression you wrote
+rather than from what marginplyr rewrote it into, so
+\code{sum(v) + grouping_bit(a)} names the same column on every backend. Where
+such a summary's value is a data frame, a local input expands its columns
+into the result and the name marginplyr assigned does not appear, exactly as
+\code{\link[dplyr:summarize]{dplyr::summarize()}} expands an unnamed one. Writing a name of your own
+packs those columns into a single column under it, again as dplyr does. A
+lazy input follows its own backend: Arrow packs them whether or not the
+summary is named, and a SQL backend has no expanded form to give.
+
 Summary results may not overwrite a fixed key or grouping dimension,
 including through a data-frame-valued summary. The local dplyr backend can
 overwrite an existing variable and reuse a newly created summary in a

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -436,15 +436,11 @@ complete grouping plan. This extends dplyr's grouping-column rule across
 every branch: a dimension remains excluded even in a grouping set from
 which it is omitted.
 
-An unnamed summary takes its column name from the expression you wrote
-rather than from what marginplyr rewrote it into, so
-\code{sum(v) + grouping_bit(a)} names the same column on every backend. Where
-such a summary's value is a data frame, a local input expands its columns
-into the result and the name marginplyr assigned does not appear, exactly as
-\code{\link[dplyr:summarize]{dplyr::summarize()}} expands an unnamed one. Writing a name of your own
-packs those columns into a single column under it, again as dplyr does. A
-lazy input follows its own backend: Arrow packs them whether or not the
-summary is named, and a SQL backend has no expanded form to give.
+Where an unnamed summary's value is a data frame, a local input expands its
+columns into the result, exactly as \code{\link[dplyr:summarize]{dplyr::summarize()}} does, and a name
+marginplyr assigned such a summary does not appear. Writing a name of your
+own packs those columns into a single column under it, again as dplyr does.
+A lazy input gives whatever shape its own backend gives.
 
 Summary results may not overwrite a fixed key or grouping dimension,
 including through a data-frame-valued summary. The local dplyr backend can

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -1514,6 +1514,44 @@ test_that("Arrow preserves margin values without implicit ordering", {
   expect_setequal(result$group, unordered_margin_expected())
 })
 
+# ADR 0028 scopes the expansion by `is.data.frame()`, and these are the two
+# input classes on either side of that carrying one summary between them. A
+# `data.table` is a data frame, so what it holds is expanded; an Arrow table is
+# not, and Arrow packed such a summary before an Assigned summary name existed
+# to pack it under, so there is nothing there to restore.
+expanded_summary_data <- function() {
+  data.frame(group = c("a", "a", "b"), x = c(1, 3, 5))
+}
+
+expanded_summary_totals <- function(value, bit) {
+  data.frame(sum = sum(value), margin = bit)
+}
+
+test_that("a data.table input expands a rewritten data-frame summary", {
+  skip_if_suggest_absent("data.table")
+  result <- summarize_with_margins(
+    data.table::as.data.table(expanded_summary_data()),
+    expanded_summary_totals(x, grouping_bit(group)),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(result), c("group", "sum", "margin"))
+  expect_equal(result$sum, c(4, 5, 9))
+  expect_equal(result$margin, c(0L, 0L, 1L))
+})
+
+test_that("Arrow packs a rewritten data-frame summary", {
+  skip_if_suggest_absent("arrow")
+  result <- summarize_with_margins(
+    arrow::Table$create(expanded_summary_data()),
+    expanded_summary_totals(x, grouping_bit(group)),
+    .grouping = rollup(group)
+  ) |>
+    dplyr::collect()
+  packed <- "expanded_summary_totals(x, grouping_bit(group))"
+  expect_equal(names(result), c("group", packed))
+  expect_s3_class(result[[packed]], "data.frame")
+})
+
 test_that("dtplyr nesting retains original keys and empty rowwise behavior", {
   skip_if_suggest_absent("dtplyr")
   data <- data.frame(

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1376,10 +1376,9 @@ test_that("an expanded inner name is checked against an internal identifier", {
   )
 })
 
-# The same share, against the other identifier: `.id` is the caller's own here,
-# and the adapter was handed the allocated one in its place, so the adapter
-# cannot ask this. Unasked, the caller's `.id` is renamed onto the expanded
-# column and the summary is lost rather than refused.
+# The same share, against the other identifier: the adapter was handed the
+# allocated one in the caller's `.id`'s place, so `stage_margin_summaries()`
+# is what asks this one.
 test_that("an expanded inner name is checked against a replaced `.id`", {
   data <- data.frame(
     g1 = c("a", "a", "b"),

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1376,6 +1376,33 @@ test_that("an expanded inner name is checked against an internal identifier", {
   )
 })
 
+# The same share, against the other identifier: `.id` is the caller's own here,
+# and the adapter was handed the allocated one in its place, so the adapter
+# cannot ask this. Unasked, the caller's `.id` is renamed onto the expanded
+# column and the summary is lost rather than refused.
+test_that("an expanded inner name is checked against a replaced `.id`", {
+  data <- data.frame(
+    g1 = c("a", "a", "b"),
+    g2 = c("p", "q", "p"),
+    x = c(1, 3, 5)
+  )
+  shadows_id <- function(value) {
+    stats::setNames(data.frame(sum(value)), "sid")
+  }
+
+  expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(x),
+      parent = share_of_parent(total),
+      shadows_id(dplyr::pick(x)[[1L]]),
+      .grouping = rollup(g1, g2),
+      .id = "sid"
+    ),
+    "`.id`.*`sid`.*conflicts with a summary output"
+  )
+})
+
 test_that("data-frame summaries cannot overwrite grouping columns", {
   data <- data.frame(group = c("a", "a", "b"), value = 1:3)
 

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1253,15 +1253,16 @@ test_that("an unnamed summary no rewrite reaches keeps dplyr's own naming", {
   )
 })
 
-# What that bound costs, pinned here rather than left to be found: a
-# data-frame-valued summary a rewrite *does* reach is named, and dplyr packs a
-# named one into a single column. Both shapes below expanded before #430.
+# A data-frame-valued summary a rewrite reaches takes an Assigned summary name,
+# which dplyr would pack under; ADR 0028 expands it again on a local input, so
+# both shapes below hold the columns they held before #430. Telling them from
+# `nrow(pick(x, y))` above is a question about the value's type, which is why
+# the decision is made here rather than from the spelling (ADR 0019).
 #
-# Telling them from `nrow(pick(x, y))` above, which #430 requires be named, is a
-# question about the value's type, and ADR 0019 reads spellings. So this is the
-# assertion that says the two recognized shapes are excluded by name because a
-# static reading reaches them and not because the exclusion is complete (#435).
-test_that("a rewritten data-frame-valued summary is named and packed", {
+# The caller-named call is asserted beside them because it is what says the
+# expansion is keyed on who wrote the name: `out` is a name dplyr packs under
+# and marginplyr assigned none, so it packs.
+test_that("a rewritten data-frame-valued summary is named and expanded", {
   data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
   range_frame <- function(columns) {
     data.frame(lo = min(columns[[1L]]), hi = max(columns[[1L]]))
@@ -1275,15 +1276,83 @@ test_that("a rewritten data-frame-valued summary is named and packed", {
     range_frame(dplyr::pick(x)),
     .grouping = rollup(group)
   )
-  expect_equal(names(selected), c("group", "range_frame(dplyr::pick(x))"))
-  expect_s3_class(selected[["range_frame(dplyr::pick(x))"]], "data.frame")
+  expect_equal(names(selected), c("group", "lo", "hi"))
+  expect_equal(selected[["lo"]], c(1, 5, 1))
+  expect_equal(selected[["hi"]], c(3, 5, 5))
 
   helped <- summarize_with_margins(
     data,
     totals(x, grouping_bit(group)),
     .grouping = rollup(group)
   )
-  expect_equal(names(helped), c("group", "totals(x, grouping_bit(group))"))
+  expect_equal(names(helped), c("group", "sum", "margin"))
+  expect_equal(helped[["sum"]], c(4, 5, 9))
+  expect_equal(helped[["margin"]], c(0L, 0L, 1L))
+
+  named <- summarize_with_margins(
+    data,
+    out = range_frame(dplyr::pick(x)),
+    .grouping = rollup(group)
+  )
+  expect_equal(names(named), c("group", "out"))
+  expect_s3_class(named[["out"]], "data.frame")
+})
+
+# The expansion runs once per branch, so a plan with more than one grouping set
+# is what says the branches still agree on their columns -- `bind_rows()` fills
+# a column a branch is missing rather than refusing the pair, so a disagreement
+# would arrive as an `NA` and not as an error.
+test_that("an expanded data-frame summary crosses a multi-set union", {
+  data <- data.frame(
+    region = c("east", "east", "west"),
+    channel = c("web", "shop", "web"),
+    x = c(1, 3, 5)
+  )
+  totals <- function(value, bit) {
+    data.frame(sum = sum(value), margin = bit)
+  }
+
+  result <- summarize_with_margins(
+    data,
+    totals(x, grouping_bit(region)),
+    .grouping = cube(region, channel)
+  )
+  expect_equal(names(result), c("region", "channel", "sum", "margin"))
+  expect_false(anyNA(result[["sum"]]))
+  # The rows of the two sets that omit `region`: `channel` alone and the Grand
+  # total. Every other row came from a branch where the bit is `0L`.
+  expect_equal(sum(result[["margin"]] == 1L), 3L)
+})
+
+# The columns an expansion puts in the result are names no pre-execution check
+# could read, since the summary stood for one column there under a name of
+# marginplyr's. Both questions that still have a subject are asked again.
+test_that("an expanded inner name is checked against the result's names", {
+  data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5))
+  shadows_group <- function(value) {
+    data.frame(group = sum(value))
+  }
+  totals <- function(value, bit) {
+    data.frame(sum = sum(value), margin = bit)
+  }
+
+  expect_error(
+    summarize_with_margins(
+      data,
+      shadows_group(dplyr::pick(x)[[1L]]),
+      .grouping = rollup(group)
+    ),
+    "cannot overwrite grouping column.*`group`"
+  )
+  expect_error(
+    summarize_with_margins(
+      data,
+      totals(x, grouping_bit(group)),
+      .grouping = rollup(group),
+      .id = "sum"
+    ),
+    "`.id`.*`sum`.*conflicts with a summary output"
+  )
 })
 
 test_that("data-frame summaries cannot overwrite grouping columns", {

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1253,15 +1253,9 @@ test_that("an unnamed summary no rewrite reaches keeps dplyr's own naming", {
   )
 })
 
-# A data-frame-valued summary a rewrite reaches takes an Assigned summary name,
-# which dplyr would pack under; ADR 0028 expands it again on a local input, so
-# both shapes below hold the columns they held before #430. Telling them from
-# `nrow(pick(x, y))` above is a question about the value's type, which is why
-# the decision is made here rather than from the spelling (ADR 0019).
-#
-# The caller-named call is asserted beside them because it is what says the
-# expansion is keyed on who wrote the name: `out` is a name dplyr packs under
-# and marginplyr assigned none, so it packs.
+# ADR 0028, over the two shapes #435 reported. The caller-named call is
+# asserted beside them because it is what says the expansion is keyed on who
+# wrote the name: `out` is a name marginplyr assigned none of, so it packs.
 test_that("a rewritten data-frame-valued summary is named and expanded", {
   data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
   range_frame <- function(columns) {
@@ -1352,6 +1346,33 @@ test_that("an expanded inner name is checked against the result's names", {
       .id = "sum"
     ),
     "`.id`.*`sum`.*conflicts with a summary output"
+  )
+})
+
+# The third question, which the expansion is asked with no internal names of
+# its own: a share keeps set identity under a Grouping set identifier the
+# package allocated, and `add_grouping_set_id()` has yet to write it when the
+# expansion runs. Reachable only through an expansion -- packed, the inner name
+# is inside a column and collides with nothing.
+test_that("an expanded inner name is checked against an internal identifier", {
+  data <- data.frame(
+    g1 = c("a", "a", "b"),
+    g2 = c("p", "q", "p"),
+    x = c(1, 3, 5)
+  )
+  shadows_identifier <- function(value) {
+    stats::setNames(data.frame(sum(value)), "..marginplyr_set_id_1")
+  }
+
+  expect_error(
+    summarize_with_margins(
+      data,
+      total = sum(x),
+      parent = share_of_parent(total),
+      shadows_identifier(dplyr::pick(x)[[1L]]),
+      .grouping = rollup(g1, g2)
+    ),
+    "summary output names conflict with internal grouping columns"
   )
 })
 


### PR DESCRIPTION
Closes #435.

## What changed

An unnamed summary a rewrite reaches takes an **Assigned summary name** — the column name marginplyr writes for it, read from the caller's own expression (#430). dplyr expands a data-frame-valued summary's columns into the result only while the summary is unnamed, so such a summary came back packed under that name where it used to expand.

Which summaries are data-frame-valued is a question about the value's type, and `nrow(pick(v, w))` — which #430 requires be named — is one call from `range_frame(pick(x))`, so no static reading separates them (ADR 0019). The decision is made after the summarize instead:

- `new_summary_arguments()` carries the assigned name for each dot beside the caller labels it already carried, under the same length invariant, subscripted by the same origin positions share planning reports.
- `summarize_margin_union()` expands a local branch's data-frame column sitting under an assigned name, between the branch's key rename and its margin labelling.
- `check_summary_output_names()` is asked a second time, of the names that replaced the assigned one. Where the package allocated a Grouping set identifier over the caller's `.id`, the adapter holds no name to ask the `.id` question with, so `stage_margin_summaries()` asks that one over the staged result.

`is.data.frame()` is the whole of the scope: Arrow packed such a summary before #430 too, dtplyr cannot hold a packed column, and SQL never expanded one, so nothing there is being restored. ADR 0020 is not engaged — the expansion reads a result already in memory, and `get_col_names()` is not an execution entry point.

## Documents

- New ADR 0028, *Expand a data-frame summary marginplyr named*.
- ADR 0016 gains one line naming it as the exception.
- `CONTEXT.md` gains **Assigned summary name**.
- `?summarize_with_margins`, under *Relationship to dplyr summaries*, states the rule a caller needs.
- The `NEWS.md` paragraph covering #430 is amended in place.

## Two deviations from the agent brief

1. The brief's *Key interfaces* says the shared helper is called from "Both grouping adapters (native and union)". It is called from the union adapter only. `stage_margin_summaries()` chooses the native adapter only where `supports_grouping_sets()` holds, which needs `native_grouping_sets`, which `backend_capabilities()` grants to the `duckdb` and `postgres` kinds alone — both lazy. So the helper's `is.data.frame()` guard could never pass there, and a branch nothing executes is one nothing asserts.
2. The brief says the expansion asks `check_summary_group_overwrite()` and `check_margin_id_collision()` but "Not `check_summary_output_names()`: its internal-name question has no subject at that point". That premise is false — `add_grouping_set_id()` writes the internal Grouping set identifier *after* the expansion runs, so an inner column of that name would be silently overwritten. The composite is asked instead, with no internal names of its own; `set_id_is_internal` is what puts the identifier back among them.

Both are argued in ADR 0028's *Where the expansion runs* and *What is checked again*.

## Checks

`lintr::lint_package()` after `pkgload::load_all()`, `roxygen2::roxygenise()`, `spelling::spell_check_package()`, the full test suite under `NOT_CRAN=true` (768 tests), `verify-context-budget.R`, `verify-verifier-invocation.R`, `verify-must-error.R`, `verify-suite-coverage.R`, and `verify-site.R` over a local render are all clean.