### PR TITLE
Blame the shared-label call as the caller spelled it

### DIFF
--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -786,8 +786,8 @@ test_that("a native translation error blames the Margin verb", {
     conditionCall(expect_error(native_shared_label_failure())),
     quote(summarize_with_margins(
       native_grouping_sets_input(),
-      grouping_bit(a) + no_such_column,
-      grouping_bit(a) + value,
+      x = grouping_bit(a) + no_such_column,
+      x = grouping_bit(a) + value,
       .grouping = rollup(a)
     ))
   )


### PR DESCRIPTION
`main` has been red since ed3ae00, and this restores it. Test-only; nothing in
`R/` changes.

## What fails

```
── Failure ('test-execution-conditions.R:785:3'): a native translation error blames the Margin verb ──
- `summarize_with_margins(native_grouping_sets_input(), x = grouping_bit(a) + `
+ `summarize_with_margins(native_grouping_sets_input(), grouping_bit(a) + `
```

`native_shared_label_failure()` writes `x = grouping_bit(a) + no_such_column`
and `x = grouping_bit(a) + value`. The blamed call carries those names; the
expectation omitted them. So the assertion required marginplyr to drop a name
its caller had spelled, and `CONTEXT.md`'s *Condition context* is the other way
round — the blamed call is the Margin verb the caller wrote. The first
reproduction in the same test already asserts its `total =` name, which is the
shape this one now matches.

## Why nothing caught it

A semantic merge conflict. Neither branch was wrong on its own:

| commit | | test |
|---|---|---|
| `1c126b2` | before #438 | passes (test absent) |
| #438 branch head `aecd58b` | | **passes** |
| `ed3ae00` | merge of #438 | **fails** |
| `535e3c0` | merge of #437 | fails |

#438 branched from `a1cfe56`, where the reconstruction dropped the names.
`main` meanwhile gained `52584d9`, which moved where a summary is named to
before the Condition context reads the caller's labels, so the names survive
into the blamed call. The merge is where the two meet, and a merge runs no
branch's CI.

## Verification

Full suite, `NOT_CRAN=true` and `MARGINPLYR_REQUIRED_SUGGESTS=""`, every
optional package installed so nothing skipped:

```
FAIL: 0  ERROR: 0  SKIP: 0  PASS: 6753
```

`lintr::lint_package()` after `pkgload::load_all(".")`: no lints.

Found while investigating why #441's CI was red — it is not, its base was.