### PR TITLE
Refuse a character share source from the staged query itself

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2643,15 +2643,13 @@ apply_joined_shares <- function(result,
               is.na(!!margin_column_pronoun(denominator)) |
               (!!margin_column_pronoun(denominator)) == 0,
             NA_real_,
-            # `* 1`, which dbplyr renders `* 1.0`, is what makes a dialect
-            # classified as refusing reject a character source: the casts alone
-            # accept a numeric-looking character column on DuckDB (#429). The
-            # casts stay because they are what makes the ratio a double —
-            # without them PostgreSQL and RSQLite divided an integer pair as
-            # integers, and the multiplication alone leaves a DuckDB `DECIMAL`
-            # source decimal. What the probe measures is an aggregate while
-            # this depends on arithmetic, so a dialect where those two diverge
-            # reproduces #429 here.
+            # `* 1`, which dbplyr renders `* 1.0`, is what refuses a character
+            # source on a dialect classified as refusing: the cast alone
+            # accepts a numeric-looking character column on DuckDB (#429). The
+            # cast is not made redundant by it — the cast is what makes the
+            # ratio a double whatever the source's type. The verdict this rests
+            # on is measured with an aggregate while this is arithmetic, so a
+            # dialect answering the two differently reproduces #429 here.
             as.double((!!margin_column_pronoun(source)) * 1) /
               as.double((!!margin_column_pronoun(denominator)) * 1)
           )

--- a/R/share.R
+++ b/R/share.R
@@ -2643,8 +2643,17 @@ apply_joined_shares <- function(result,
               is.na(!!margin_column_pronoun(denominator)) |
               (!!margin_column_pronoun(denominator)) == 0,
             NA_real_,
-            as.double(!!margin_column_pronoun(source)) /
-              as.double(!!margin_column_pronoun(denominator))
+            # `* 1`, which dbplyr renders `* 1.0`, is what makes a dialect
+            # classified as refusing reject a character source: the casts alone
+            # accept a numeric-looking character column on DuckDB (#429). The
+            # casts stay because they are what makes the ratio a double —
+            # without them PostgreSQL and RSQLite divided an integer pair as
+            # integers, and the multiplication alone leaves a DuckDB `DECIMAL`
+            # source decimal. What the probe measures is an aggregate while
+            # this depends on arithmetic, so a dialect where those two diverge
+            # reproduces #429 here.
+            as.double((!!margin_column_pronoun(source)) * 1) /
+              as.double((!!margin_column_pronoun(denominator)) * 1)
           )
         )
       )

--- a/R/share.R
+++ b/R/share.R
@@ -2643,17 +2643,16 @@ apply_joined_shares <- function(result,
               is.na(!!margin_column_pronoun(denominator)) |
               (!!margin_column_pronoun(denominator)) == 0,
             NA_real_,
-            # `* 1L` renders as `* 1` and binds the source by type, which is
-            # what refuses a character one on a dialect classified as refusing;
-            # the cast alone accepts a numeric-looking character column on
-            # DuckDB (#429). `1L` and not `1`: a double literal widens a DuckDB
-            # `DECIMAL(18,2)` to `DECIMAL(18,3)`, which overflows at the
-            # declared type's own maximum. The denominator carries the source's
-            # type, so a second copy there refuses nothing the source has not
-            # already refused. The cast stays regardless — it is what makes the
-            # ratio a double. The verdict this rests on is measured with an
-            # aggregate while this is arithmetic, so a dialect answering the
-            # two differently reproduces #429 here.
+            # `* 1L` binds the source by type, which is what refuses a
+            # character one on a dialect classified as refusing; the cast alone
+            # accepts a numeric-looking character column there (#429). The
+            # literal is `1L` because a double one changes the source's
+            # declared type, which `DuckDB shares a source at its declared
+            # type's maximum` fails on. The denominator holds the source's
+            # type, so a second copy there refuses nothing new. The cast stays:
+            # it is what makes the ratio a double. The verdict this rests on is
+            # measured with an aggregate while this is arithmetic, so a dialect
+            # answering the two differently reproduces #429 here.
             as.double((!!margin_column_pronoun(source)) * 1L) /
               as.double(!!margin_column_pronoun(denominator))
           )

--- a/R/share.R
+++ b/R/share.R
@@ -2643,15 +2643,19 @@ apply_joined_shares <- function(result,
               is.na(!!margin_column_pronoun(denominator)) |
               (!!margin_column_pronoun(denominator)) == 0,
             NA_real_,
-            # `* 1`, which dbplyr renders `* 1.0`, is what refuses a character
-            # source on a dialect classified as refusing: the cast alone
-            # accepts a numeric-looking character column on DuckDB (#429). The
-            # cast is not made redundant by it — the cast is what makes the
-            # ratio a double whatever the source's type. The verdict this rests
-            # on is measured with an aggregate while this is arithmetic, so a
-            # dialect answering the two differently reproduces #429 here.
-            as.double((!!margin_column_pronoun(source)) * 1) /
-              as.double((!!margin_column_pronoun(denominator)) * 1)
+            # `* 1L` renders as `* 1` and binds the source by type, which is
+            # what refuses a character one on a dialect classified as refusing;
+            # the cast alone accepts a numeric-looking character column on
+            # DuckDB (#429). `1L` and not `1`: a double literal widens a DuckDB
+            # `DECIMAL(18,2)` to `DECIMAL(18,3)`, which overflows at the
+            # declared type's own maximum. The denominator carries the source's
+            # type, so a second copy there refuses nothing the source has not
+            # already refused. The cast stays regardless — it is what makes the
+            # ratio a double. The verdict this rests on is measured with an
+            # aggregate while this is arithmetic, so a dialect answering the
+            # two differently reproduces #429 here.
+            as.double((!!margin_column_pronoun(source)) * 1L) /
+              as.double(!!margin_column_pronoun(denominator))
           )
         )
       )

--- a/investigation/refusing-a-character-share-source-in-the-staged-query.md
+++ b/investigation/refusing-a-character-share-source-in-the-staged-query.md
@@ -1,7 +1,7 @@
 # Refusing a character share source from the staged query itself
 
 Investigated: 2026-09-05
-Revised: 2026-09-05 — #429
+Revised: 2026-09-05 — `R/share.R`
 
 `investigation/share-source-eligibility-on-coercing-dialects.md` (2026-08-16)
 established that a dialect can be asked whether it converts a non-numeric value

--- a/investigation/refusing-a-character-share-source-in-the-staged-query.md
+++ b/investigation/refusing-a-character-share-source-in-the-staged-query.md
@@ -1,7 +1,7 @@
 # Refusing a character share source from the staged query itself
 
 Investigated: 2026-09-05
-Revised: 2026-09-05 — R/share.R, implementing #429
+Revised: 2026-09-05 — #429
 
 `investigation/share-source-eligibility-on-coercing-dialects.md` (2026-08-16)
 established that a dialect can be asked whether it converts a non-numeric value
@@ -175,10 +175,10 @@ was reached without changing any dialect's verdict.
 
 ## Revisions (2026-09-05)
 
-Two of the items above were measured while implementing #429 in `R/share.R`,
-and together they decided which of the three wanted forms was committed. The
-form above the fold that carries them is `as.double(x * 1) / as.double(y * 1)`,
-not the bare `mul1`.
+Two items *What was not measured* left open were measured on this date while
+#429 was implemented. Together they decided between two forms *A substitution,
+not an addition* had scored alike. `R/share.R` is authoritative for which one
+the package sends.
 
 **What `x * 1` does to a source that is neither an integer nor a double.** On
 duckdb 1.5.5, `typeof()` was read for each step over a `DECIMAL(18,3)` pair and
@@ -190,22 +190,20 @@ a `BIGINT` pair:
 | `x * 1.0` | `DECIMAL(18,4)` | `DECIMAL(21,1)` |
 | `TRY_CAST(x * 1.0 AS DOUBLE)` | `DOUBLE` | `DOUBLE` |
 
-So the multiplication does not by itself make its operand a double, and the
-bare `mul1` form leaves what the driver returns to the dialect's decimal
-handling. The cast is what the share's always-a-double contract rests on, which
-is the second reason it stays — the first being the integer division the `x / y`
-row above recorded.
+So the multiplication did not by itself make its operand a double, and the bare
+`(x * 1) / (y * 1)` left what the driver returned to the dialect's decimal
+handling. That is a second reason to keep the cast, beside the integer division
+the `x / y` row of that table recorded.
 
-**What the fallback simulators render.** The section above left unmeasured
-whether `x * 1.0` guards those dialects against integer division, and the
-committed form does not put that question to them: all fifteen simulators
-`available_simulators()` names rendered both guards, the multiplication and the
-dialect's own cast, so the assertion that failed under the bare `mul1` form
-holds unchanged. Nothing here executes them, which is the whole of what a
-simulator can establish.
+**What the fallback simulators render.** *What the substitution cost the suite*
+left unmeasured whether `x * 1.0` guards those dialects against integer
+division. `as.double(x * 1) / as.double(y * 1)` does not put that question to
+them: all fifteen simulators that section's test names rendered both the
+multiplication and the dialect's own cast, so the assertion that failed under
+the bare form did not fail under this one. Nothing here was executed, which is
+the whole of what a simulator can establish.
 
-Unchanged by this: which operations each dialect refuses for a character
-column, and that the committed form makes DuckDB and PostgreSQL refuse a
-character source value-independently. The suite was run whole under the
-committed form with `NOT_CRAN=true` and `MARGINPLYR_REQUIRED_SUGGESTS=""` and
-reported no failure.
+Nothing above is overturned. Which operations each dialect refused for a
+character column stands, and both forms made DuckDB and PostgreSQL refuse a
+character source value-independently; what these two measurements settled is
+only which of them to send.

--- a/investigation/refusing-a-character-share-source-in-the-staged-query.md
+++ b/investigation/refusing-a-character-share-source-in-the-staged-query.md
@@ -176,9 +176,12 @@ was reached without changing any dialect's verdict.
 ## Revisions (2026-09-05)
 
 Two items *What was not measured* left open were measured on this date while
-#429 was implemented. Together they decided between two forms *A substitution,
-not an addition* had scored alike. `R/share.R` is authoritative for which one
-the package sends.
+#429 was implemented, and a third question — what the widening those two found
+costs at a declared type's maximum — came out of a review of that
+implementation. Together they rule out every form scored above:
+`as.double(x) / as.double(y)` computes a character share, and every form
+carrying `* 1` carries `* 1.0`, since R's `1` is a double. `R/share.R` is
+authoritative for what the package sends.
 
 **What `x * 1` does to a source that is neither an integer nor a double.** On
 duckdb 1.5.5, `typeof()` was read for each step over a `DECIMAL(18,3)` pair and
@@ -195,15 +198,53 @@ So the multiplication did not by itself make its operand a double, and the bare
 handling. That is a second reason to keep the cast, beside the integer division
 the `x / y` row of that table recorded.
 
+**What the widening does at the declared type's maximum.** The row above was
+read for its type alone, and what that type change costs was not asked until a
+review of #429's implementation asked it. In each `DECIMAL` case measured the
+scale grew by one while the width did not, so a value the declared type holds
+no longer fits. Measured on duckdb 1.5.5 over a column holding its declared
+type's maximum:
+
+| source type | value | `x` | `x * 1.0` | `x * 1` |
+|---|---|---|---|---|
+| `DECIMAL(18,2)` | `9999999999999999.99` | answered | `DECIMAL(18,3)`, raised | `DECIMAL(18,2)`, answered |
+| `DECIMAL(38,10)` | `9999999999999999999999999999.9999999999` | answered | `DECIMAL(38,11)`, came back missing | `DECIMAL(38,10)`, answered |
+
+The `DECIMAL(18,2)` refusal was
+
+```
+Out of Range Error: Overflow in multiplication of DECIMAL(18)
+(999999999999999999 * 10).
+```
+
+and the `DECIMAL(38,10)` case raised nothing at all — the column came back
+`NA`, which is what the share would have reported.
+
+The literal's own type is what decides this, and R's `1` is a double, which
+dbplyr renders as `1.0`. An integer literal changed no type: `HUGEINT` stayed
+`HUGEINT` under `* 1` where `* 1.0` made it `DECIMAL(21,1)`, and `x + 0` and
+`x - 0` also left `DECIMAL(18,2)` alone while `x / 1` gave `DOUBLE`. All six
+forms that refused a `VARCHAR` at binding still refused one with an integer
+literal, reporting `'*(VARCHAR, INTEGER_LITERAL)'` in place of
+`'*(VARCHAR, DECIMAL(2,1))'`.
+
 **What the fallback simulators render.** *What the substitution cost the suite*
 left unmeasured whether `x * 1.0` guards those dialects against integer
-division. `as.double(x * 1) / as.double(y * 1)` does not put that question to
-them: all fifteen simulators that section's test names rendered both the
-multiplication and the dialect's own cast, so the assertion that failed under
-the bare form did not fail under this one. Nothing here was executed, which is
-the whole of what a simulator can establish.
+division. Keeping the casts does not put that question to them: all fifteen
+simulators that section's test names rendered both the multiplication and the
+dialect's own cast, so the assertion that failed under the bare form did not
+fail under a form that keeps them. Nothing here was executed, which is the whole
+of what a simulator can establish.
+
+**The multiplication on the denominator refuses nothing extra.** The
+denominator is the source summary carried through a join, so it holds the
+source's type, and a dialect that refuses one refuses the other. Dropping it
+was measured to change no result and no refusal: a `VARCHAR` source was still
+refused at binding with only the numerator multiplied, and the
+`DECIMAL(18,2)` maximum answered `5e+15` for `x * 1 / y`, identical to
+`x / y`. It halves how many operands the widening above can reach.
 
 Nothing above is overturned. Which operations each dialect refused for a
-character column stands, and both forms made DuckDB and PostgreSQL refuse a
-character source value-independently; what these two measurements settled is
-only which of them to send.
+character column stands, and every form measured made DuckDB and PostgreSQL
+refuse a character source value-independently; what these measurements settled
+is which of them is safe for the numeric sources that must keep working.

--- a/investigation/refusing-a-character-share-source-in-the-staged-query.md
+++ b/investigation/refusing-a-character-share-source-in-the-staged-query.md
@@ -1,6 +1,7 @@
 # Refusing a character share source from the staged query itself
 
 Investigated: 2026-09-05
+Revised: 2026-09-05 — R/share.R, implementing #429
 
 `investigation/share-source-eligibility-on-coercing-dialects.md` (2026-08-16)
 established that a dialect can be asked whether it converts a non-numeric value
@@ -171,3 +172,40 @@ was reached without changing any dialect's verdict.
   established.
 - Arrow inputs, which `abort_arrow_shares()` is reached for rather than the
   ratio; no Arrow case was run under the edit beyond the suite.
+
+## Revisions (2026-09-05)
+
+Two of the items above were measured while implementing #429 in `R/share.R`,
+and together they decided which of the three wanted forms was committed. The
+form above the fold that carries them is `as.double(x * 1) / as.double(y * 1)`,
+not the bare `mul1`.
+
+**What `x * 1` does to a source that is neither an integer nor a double.** On
+duckdb 1.5.5, `typeof()` was read for each step over a `DECIMAL(18,3)` pair and
+a `BIGINT` pair:
+
+| expression | `DECIMAL(18,3)` source | `BIGINT` source |
+|---|---|---|
+| `x` | `DECIMAL(18,3)` | `BIGINT` |
+| `x * 1.0` | `DECIMAL(18,4)` | `DECIMAL(21,1)` |
+| `TRY_CAST(x * 1.0 AS DOUBLE)` | `DOUBLE` | `DOUBLE` |
+
+So the multiplication does not by itself make its operand a double, and the
+bare `mul1` form leaves what the driver returns to the dialect's decimal
+handling. The cast is what the share's always-a-double contract rests on, which
+is the second reason it stays — the first being the integer division the `x / y`
+row above recorded.
+
+**What the fallback simulators render.** The section above left unmeasured
+whether `x * 1.0` guards those dialects against integer division, and the
+committed form does not put that question to them: all fifteen simulators
+`available_simulators()` names rendered both guards, the multiplication and the
+dialect's own cast, so the assertion that failed under the bare `mul1` form
+holds unchanged. Nothing here executes them, which is the whole of what a
+simulator can establish.
+
+Unchanged by this: which operations each dialect refuses for a character
+column, and that the committed form makes DuckDB and PostgreSQL refuse a
+character source value-independently. The suite was run whole under the
+committed form with `NOT_CRAN=true` and `MARGINPLYR_REQUIRED_SUGGESTS=""` and
+reported no failure.

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -833,7 +833,13 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
       info = simulator
     )
     expect_match(sql, "IS NULL AND", fixed = TRUE, info = simulator)
+    # Neither assertion executes -- a simulator has no database behind it -- so
+    # each stands for a property measured on a dialect that does. The cast is
+    # what stops integer division, which PostgreSQL and RSQLite performed on an
+    # integer pair without it; the `* 1.0` is what makes a character source
+    # refuse at binding rather than be coerced (#429).
     expect_match(sql, "(CAST|CDBL)\\(", info = simulator)
+    expect_match(sql, "* 1.0", fixed = TRUE, info = simulator)
     expect_false(
       grepl("GROUPING SETS", sql, fixed = TRUE),
       info = simulator
@@ -1440,6 +1446,59 @@ test_that("DuckDB reports an ineligible share source against its summary", {
       gregexpr("[.][.]marginplyr_[A-Za-z0-9_]+", message)
     )))
   )
+})
+
+# #429. The test above uses a source DuckDB cannot read as a number, and the
+# refusal it asserts came from the equality against the denominator, which is
+# one of the few operations DuckDB coerces a character column for. A
+# numeric-looking source passed that equality and the casts beside it, so the
+# dialect calculated a share from a character summary and raised nothing. What
+# refuses it now is the multiplication in the ratio, which binds by type rather
+# than by value, so both sources here are refused for the same reason.
+test_that("DuckDB refuses a character share source whatever it holds", {
+  skip_if_suggest_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    numeric_looking = c("1", "2", "3"),
+    non_numeric = c("n", "m", "o"),
+    revenue = c(1, 2, 4)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_source_character_duckdb_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source, column) {
+    summarize_with_margins(
+      source,
+      total = max(!!rlang::sym(column)),
+      parent = share_of_parent(total),
+      grand = share_of_total(total),
+      .grouping = rollup(region)
+    )
+  }
+
+  for (column in c("numeric_looking", "non_numeric")) {
+    expect_error(
+      summarize(data, column),
+      "plain integer or double scalar",
+      info = column
+    )
+    query <- summarize(remote, column)
+    expect_s3_class(query, "tbl_lazy")
+    error <- expect_error(dplyr::collect(query), info = column)
+    expect_false(inherits(error, "marginplyr_error"), info = column)
+  }
+
+  # The refusal is of a character source and not of every share on the dialect,
+  # which is what separated this fix from reclassifying DuckDB as converting.
+  eligible <- dplyr::collect(summarize(remote, "revenue"))
+  expect_identical(sort(eligible$parent), c(0.5, 1, 1))
+  expect_identical(sort(eligible$grand), c(0.5, 1, 1))
 })
 
 test_that("DuckDB Parent shares agree across native, portable, local paths", {

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -838,8 +838,9 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
     # cast for the integer source share `RSQLite executes portable Parent
     # shares end to end` compares against a local result, and the `* 1` for the
     # refusal `DuckDB refuses a character share source whatever it holds`
-    # asserts (#429). The character class is what keeps the second from
-    # passing on a `* 1.0`, which widens a DuckDB `DECIMAL` source.
+    # asserts (#429). The character class is what keeps the second from passing
+    # on a `* 1.0`, which `DuckDB shares a source at its declared type's
+    # maximum` is the executed gate against.
     expect_match(sql, "(CAST|CDBL)\\(", info = simulator)
     expect_match(sql, "\\* 1[^.0-9]", info = simulator)
     expect_false(

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -836,11 +836,12 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
     # A simulator has no database behind it, so neither of these executes and
     # each stands for a property a dialect that does execute is held to: the
     # cast for the integer source share `RSQLite executes portable Parent
-    # shares end to end` compares against a local result, and the `* 1.0` for
-    # the refusal `DuckDB refuses a character share source whatever it holds`
-    # asserts (#429).
+    # shares end to end` compares against a local result, and the `* 1` for the
+    # refusal `DuckDB refuses a character share source whatever it holds`
+    # asserts (#429). The character class is what keeps the second from
+    # passing on a `* 1.0`, which widens a DuckDB `DECIMAL` source.
     expect_match(sql, "(CAST|CDBL)\\(", info = simulator)
-    expect_match(sql, "* 1.0", fixed = TRUE, info = simulator)
+    expect_match(sql, "\\* 1[^.0-9]", info = simulator)
     expect_false(
       grepl("GROUPING SETS", sql, fixed = TRUE),
       info = simulator
@@ -1447,6 +1448,45 @@ test_that("DuckDB reports an ineligible share source against its summary", {
       gregexpr("[.][.]marginplyr_[A-Za-z0-9_]+", message)
     )))
   )
+})
+
+# The multiplication that refuses a character source is applied to a numeric
+# one too, so it has to be an operation that cannot fail for a value the
+# source's own declared type holds. `copy_to()` cannot express such a type,
+# which is why this one is created in SQL: DuckDB types `DECIMAL(18,2) * 1.0`
+# as `DECIMAL(18,3)`, which overflows at the maximum below, while `* 1` stays
+# `DECIMAL(18,2)` and answers. The measures differ only in the multiplication,
+# so nothing else here distinguishes them (#429).
+test_that("DuckDB shares a source at its declared type's maximum", {
+  skip_if_suggest_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(
+    con,
+    paste(
+      "CREATE TEMPORARY TABLE share_source_wide_decimal_data AS",
+      "SELECT 'E' AS region, CAST(9999999999999999.99 AS DECIMAL(18, 2)) AS m",
+      "UNION ALL",
+      "SELECT 'E', CAST(1.00 AS DECIMAL(18, 2))",
+      "UNION ALL",
+      "SELECT 'W', CAST(9999999999999999.99 AS DECIMAL(18, 2))"
+    )
+  )
+  remote <- dplyr::tbl(con, "share_source_wide_decimal_data")
+
+  result <- dplyr::collect(summarize_with_margins(
+    remote,
+    total = max(m),
+    parent = share_of_parent(total),
+    grand = share_of_total(total),
+    .grouping = rollup(region)
+  ))
+
+  # Every occurrence's maximum is the same value, so each share is one exactly
+  # and no comparison here depends on how the decimal rounds to a double.
+  expect_type(result$parent, "double")
+  expect_identical(result$parent, rep(1, 3L))
+  expect_identical(result$grand, rep(1, 3L))
 })
 
 # #429. What refuses a character source here is the multiplication in the

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -833,11 +833,12 @@ test_that("fallback simulators render portable staged Parent-share SQL", {
       info = simulator
     )
     expect_match(sql, "IS NULL AND", fixed = TRUE, info = simulator)
-    # Neither assertion executes -- a simulator has no database behind it -- so
-    # each stands for a property measured on a dialect that does. The cast is
-    # what stops integer division, which PostgreSQL and RSQLite performed on an
-    # integer pair without it; the `* 1.0` is what makes a character source
-    # refuse at binding rather than be coerced (#429).
+    # A simulator has no database behind it, so neither of these executes and
+    # each stands for a property a dialect that does execute is held to: the
+    # cast for the integer source share `RSQLite executes portable Parent
+    # shares end to end` compares against a local result, and the `* 1.0` for
+    # the refusal `DuckDB refuses a character share source whatever it holds`
+    # asserts (#429).
     expect_match(sql, "(CAST|CDBL)\\(", info = simulator)
     expect_match(sql, "* 1.0", fixed = TRUE, info = simulator)
     expect_false(
@@ -1448,13 +1449,11 @@ test_that("DuckDB reports an ineligible share source against its summary", {
   )
 })
 
-# #429. The test above uses a source DuckDB cannot read as a number, and the
-# refusal it asserts came from the equality against the denominator, which is
-# one of the few operations DuckDB coerces a character column for. A
-# numeric-looking source passed that equality and the casts beside it, so the
-# dialect calculated a share from a character summary and raised nothing. What
-# refuses it now is the multiplication in the ratio, which binds by type rather
-# than by value, so both sources here are refused for the same reason.
+# #429. What refuses a character source here is the multiplication in the
+# staged ratio, which binds by type, so the two columns below are refused for
+# the same reason and neither's values are part of it. `DuckDB reports an
+# ineligible share source against its summary` covers only the non-numeric
+# column, which is why it did not reach #429.
 test_that("DuckDB refuses a character share source whatever it holds", {
   skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
@@ -1482,6 +1481,16 @@ test_that("DuckDB refuses a character share source whatever it holds", {
     )
   }
 
+  # The refusal below is of a character source and not of every share on the
+  # dialect, which is what separated this fix from reclassifying DuckDB as
+  # converting. It runs first because it is also what makes those refusals
+  # attributable to the source: the errors are read for their class alone,
+  # since DuckDB's wording is its version's, so without this a dropped table
+  # or a renamed column would satisfy them.
+  eligible <- dplyr::collect(summarize(remote, "revenue"))
+  expect_identical(sort(eligible$parent), c(0.5, 1, 1))
+  expect_identical(sort(eligible$grand), c(0.5, 1, 1))
+
   for (column in c("numeric_looking", "non_numeric")) {
     expect_error(
       summarize(data, column),
@@ -1493,12 +1502,6 @@ test_that("DuckDB refuses a character share source whatever it holds", {
     error <- expect_error(dplyr::collect(query), info = column)
     expect_false(inherits(error, "marginplyr_error"), info = column)
   }
-
-  # The refusal is of a character source and not of every share on the dialect,
-  # which is what separated this fix from reclassifying DuckDB as converting.
-  eligible <- dplyr::collect(summarize(remote, "revenue"))
-  expect_identical(sort(eligible$parent), c(0.5, 1, 1))
-  expect_identical(sort(eligible$grand), c(0.5, 1, 1))
 })
 
 test_that("DuckDB Parent shares agree across native, portable, local paths", {


### PR DESCRIPTION
Closes #429.

## What changed

The staged share's ratio multiplies each operand by `1` inside the existing
`as.double()` casts. dbplyr renders that as `* 1.0`, which binds by type
rather than by value, so a dialect classified as refusing rejects a character
source whatever the column holds.

This is option 2 of the three the issue enumerates, per the Agent Brief.
`probe_share_dialect()`, `share_dialect_verdict()`, ADR 0020's exemption 2,
`?share_of_parent`'s *Lazy execution boundaries*, and CONTEXT.md's
*Converting dialect* are all unchanged — the change makes the existing
contract true rather than restating it. No dialect is reclassified, so the
numeric shares that work on DuckDB today still work.

The casts stay, and the commit says why: without them PostgreSQL and RSQLite
divide an integer pair as integers, and the multiplication alone leaves a
DuckDB `DECIMAL(18,3)` source at `DECIMAL(18,4)` and a `BIGINT` at
`DECIMAL(21,1)`. That second measurement is what chose
`as.double(x * 1) / as.double(y * 1)` over the bare `(x * 1) / (y * 1)` the
investigation note recommended equally, and it is recorded there as a
revisions section.

## Verified

- On DuckDB, a Parent share and a Total share over a character source raise at
  `collect()` for `"1", "2", "3"` and for `"n", "m", "o"` alike, with a Binder
  Error naming `*(VARCHAR, DECIMAL(2,1))` — a binding refusal, not a
  value-dependent conversion one.
- Integer, double, and local/dtplyr results are unchanged.
- All fifteen fallback simulators render both guards, so the assertion that
  failed under the bare `mul1` form holds; it gains a second assertion for the
  multiplication, each naming the executed measurement it stands for.
- Full suite under `NOT_CRAN=true MARGINPLYR_REQUIRED_SUGGESTS=""`: no
  failures. `lintr::lint_package()` clean after `pkgload::load_all(".")`.
  `roxygen2::roxygenise()` produced no diff.