### PR TITLE
Give the dialect probe's control its own reading of a result

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2409,10 +2409,9 @@ probe_share_dialect <- function(con) {
 # `purpose` is the name this query is recorded under (ADR 0027). `control` says
 # which of the two questions this is, which is what decides the reading below.
 probe_share_dialect_answer <- function(con, expr, purpose, control = FALSE) {
-  # Bound outside the wrap below for the reason `probe_share_dialect_holds()`
-  # binds its number outside its own: what these wraps read as a connection
-  # that could not be asked is an error, and marginplyr's own frames raise
-  # errors that are defects.
+  # Bound outside the wraps below for the reason `probe_share_dialect_holds()`
+  # binds its number outside its own: what each of them reads as something the
+  # connection did is an error.
   scaffold <- share_probe_scaffold()$sql
   query <- tryCatch(
     dplyr::summarize(dplyr::tbl(con, scaffold, vars = "z"), p = !!expr),

--- a/R/share.R
+++ b/R/share.R
@@ -2409,11 +2409,13 @@ probe_share_dialect <- function(con) {
 # `purpose` is the name this query is recorded under (ADR 0027). `control` says
 # which of the two questions this is, which is what decides the reading below.
 probe_share_dialect_answer <- function(con, expr, purpose, control = FALSE) {
+  # Bound outside the wrap below for the reason `probe_share_dialect_holds()`
+  # binds its number outside its own: what these wraps read as a connection
+  # that could not be asked is an error, and marginplyr's own frames raise
+  # errors that are defects.
+  scaffold <- share_probe_scaffold()$sql
   query <- tryCatch(
-    dplyr::summarize(
-      dplyr::tbl(con, share_probe_scaffold()$sql, vars = "z"),
-      p = !!expr
-    ),
+    dplyr::summarize(dplyr::tbl(con, scaffold, vars = "z"), p = !!expr),
     error = function(cnd) NULL
   )
   if (is.null(query)) {

--- a/R/share.R
+++ b/R/share.R
@@ -2428,23 +2428,33 @@ probe_share_dialect_answer <- function(con, expr, purpose, expected = NULL) {
     return("raised")
   }
   value <- answer$value
-  if (
-    !is.data.frame(value) ||
-      nrow(value) != 1L ||
-      ncol(value) != 1L ||
-      !is.numeric(value[[1L]])
-  ) {
+  if (!is.data.frame(value) || nrow(value) != 1L || ncol(value) != 1L) {
     return("unanswerable")
   }
-  # Not `is_share_source_type()`, which is the eligible-type rule about a
-  # caller's summary and rejects a classed value. What class the driver mapped
-  # the database's type to is a fact about the driver: PostgreSQL's
-  # `SUM(integer)` is `bigint`, which RPostgres maps to `bit64::integer64`, a
-  # classed double that `is.numeric()` holds of (#440).
-  if (!is.null(expected) && !isTRUE(value[[1L]] == expected)) {
+  if (!probe_share_dialect_holds(value[[1L]], expected)) {
     return("unanswerable")
   }
   "answered"
+}
+
+# Whether the one value a query came back with is the answer its caller asked
+# for. Not `is_share_source_type()`: that is the eligible-type rule about a
+# caller's summary, and it rejects a classed value, so it also rejects what a
+# driver mapped a database type to. RPostgres alone offers four mappings for
+# the `bigint` PostgreSQL sums an integer to -- `bit64::integer64`, `integer`,
+# `numeric`, and `character`, the first a classed double and the last not a
+# number at all -- and the caller chooses between them when they connect
+# (#440).
+#
+# So the probe asks only that a number came back, which is the conversion. The
+# control names the number the scaffolding selected and asks for that, in
+# whatever type the mapping produced: `==` compares across those four, where a
+# type test admits three of them.
+probe_share_dialect_holds <- function(value, expected) {
+  if (is.null(expected)) {
+    return(is.numeric(value))
+  }
+  isTRUE(value == expected)
 }
 
 # The table-free scaffolding both questions are asked against, and the number

--- a/R/share.R
+++ b/R/share.R
@@ -2378,7 +2378,8 @@ probe_share_dialect <- function(con) {
     control <- probe_share_dialect_answer(
       con,
       quote(sum(z, na.rm = TRUE)),
-      purpose = "share_dialect_control"
+      purpose = "share_dialect_control",
+      expected = share_probe_scaffold()$number
     )
     if (identical(control, "answered")) {
       return("refuses")
@@ -2405,11 +2406,12 @@ probe_share_dialect <- function(con) {
 # the share. An unrecognised status therefore fails closed by construction,
 # and that is the property worth writing down rather than asserting.
 #
-# `purpose` is the name this query is recorded under (ADR 0027).
-probe_share_dialect_answer <- function(con, expr, purpose) {
+# `purpose` is the name this query is recorded under (ADR 0027). `expected` is
+# the number the answer must hold, which only the control names.
+probe_share_dialect_answer <- function(con, expr, purpose, expected = NULL) {
   query <- tryCatch(
     dplyr::summarize(
-      dplyr::tbl(con, dbplyr::sql("SELECT 1 AS z"), vars = "z"),
+      dplyr::tbl(con, share_probe_scaffold()$sql, vars = "z"),
       p = !!expr
     ),
     error = function(cnd) NULL
@@ -2430,11 +2432,27 @@ probe_share_dialect_answer <- function(con, expr, purpose) {
     !is.data.frame(value) ||
       nrow(value) != 1L ||
       ncol(value) != 1L ||
-      !is_share_source_type(value[[1L]])
+      !is.numeric(value[[1L]])
   ) {
     return("unanswerable")
   }
+  # Not `is_share_source_type()`, which is the eligible-type rule about a
+  # caller's summary and rejects a classed value. What class the driver mapped
+  # the database's type to is a fact about the driver: PostgreSQL's
+  # `SUM(integer)` is `bigint`, which RPostgres maps to `bit64::integer64`, a
+  # classed double that `is.numeric()` holds of (#440).
+  if (!is.null(expected) && !isTRUE(value[[1L]] == expected)) {
+    return("unanswerable")
+  }
   "answered"
+}
+
+# The table-free scaffolding both questions are asked against, and the number
+# it selects. One definition because the control's reading is that its result
+# is that number, so a scaffolding edited on its own would read every control
+# as unanswerable.
+share_probe_scaffold <- function() {
+  list(sql = dbplyr::sql("SELECT 1 AS z"), number = 1)
 }
 
 # The refusal names whichever helpers the caller wrote, as the Arrow one does

--- a/R/share.R
+++ b/R/share.R
@@ -2448,18 +2448,23 @@ probe_share_dialect_answer <- function(con, expr, purpose, control = FALSE) {
 #
 # The probe asks only that a number came back, which is the conversion. The
 # control asks for the number the scaffolding selected, in whatever type the
-# mapping produced, which is why it tests both. `==` alone would be the weaker
-# question of what R coerces equal to that number: a logical, a factor, a Date,
-# a raw, and a length-1 list all compare equal to `1`, and a `blob` column
-# raises inside `==` where nothing catches it. Each of those would read as the
-# control answering, and `"refuses"` is the verdict that proceeds -- the rule
-# switched off and that cached against the dialect.
+# mapping produced, and tests the type as well as the value: `==` alone is the
+# weaker question of what R coerces equal to that number, which several base
+# types answer without being it.
+#
+# The comparison is wrapped because a class that passes the type test can raise
+# inside `==` rather than return `FALSE` -- `haven::labelled` and `units` both
+# do -- and nothing between here and the caller catches it, where every other
+# way this function can fail already falls to "unanswerable".
 probe_share_dialect_holds <- function(value, control) {
   if (!control) {
     return(is.numeric(value))
   }
   (is.numeric(value) || is.character(value)) &&
-    isTRUE(value == share_probe_scaffold()$number)
+    isTRUE(tryCatch(
+      value == share_probe_scaffold()$number,
+      error = function(cnd) FALSE
+    ))
 }
 
 # The table-free scaffolding both questions are asked against, and the number

--- a/R/share.R
+++ b/R/share.R
@@ -2453,18 +2453,19 @@ probe_share_dialect_answer <- function(con, expr, purpose, control = FALSE) {
 # types answer without being it.
 #
 # The comparison is wrapped because a class that passes the type test can raise
-# inside `==` rather than return `FALSE` -- `haven::labelled` and `units` both
+# inside `==` rather than return `FALSE` -- `units` and `vctrs::new_vctr` both
 # do -- and nothing between here and the caller catches it, where every other
-# way this function can fail already falls to "unanswerable".
+# way this function can fail already falls to "unanswerable". The number is
+# bound first so that only the comparison is inside the wrap: an error raised
+# by marginplyr's own frame is a defect, and reading it as a dialect that could
+# not answer would hide it behind a refused share.
 probe_share_dialect_holds <- function(value, control) {
   if (!control) {
     return(is.numeric(value))
   }
+  number <- share_probe_scaffold()$number
   (is.numeric(value) || is.character(value)) &&
-    isTRUE(tryCatch(
-      value == share_probe_scaffold()$number,
-      error = function(cnd) FALSE
-    ))
+    isTRUE(tryCatch(value == number, error = function(cnd) FALSE))
 }
 
 # The table-free scaffolding both questions are asked against, and the number

--- a/R/share.R
+++ b/R/share.R
@@ -2379,7 +2379,7 @@ probe_share_dialect <- function(con) {
       con,
       quote(sum(z, na.rm = TRUE)),
       purpose = "share_dialect_control",
-      expected = share_probe_scaffold()$number
+      control = TRUE
     )
     if (identical(control, "answered")) {
       return("refuses")
@@ -2406,9 +2406,9 @@ probe_share_dialect <- function(con) {
 # the share. An unrecognised status therefore fails closed by construction,
 # and that is the property worth writing down rather than asserting.
 #
-# `purpose` is the name this query is recorded under (ADR 0027). `expected` is
-# the number the answer must hold, which only the control names.
-probe_share_dialect_answer <- function(con, expr, purpose, expected = NULL) {
+# `purpose` is the name this query is recorded under (ADR 0027). `control` says
+# which of the two questions this is, which is what decides the reading below.
+probe_share_dialect_answer <- function(con, expr, purpose, control = FALSE) {
   query <- tryCatch(
     dplyr::summarize(
       dplyr::tbl(con, share_probe_scaffold()$sql, vars = "z"),
@@ -2431,7 +2431,7 @@ probe_share_dialect_answer <- function(con, expr, purpose, expected = NULL) {
   if (!is.data.frame(value) || nrow(value) != 1L || ncol(value) != 1L) {
     return("unanswerable")
   }
-  if (!probe_share_dialect_holds(value[[1L]], expected)) {
+  if (!probe_share_dialect_holds(value[[1L]], control = control)) {
     return("unanswerable")
   }
   "answered"
@@ -2446,15 +2446,20 @@ probe_share_dialect_answer <- function(con, expr, purpose, expected = NULL) {
 # number at all -- and the caller chooses between them when they connect
 # (#440).
 #
-# So the probe asks only that a number came back, which is the conversion. The
-# control names the number the scaffolding selected and asks for that, in
-# whatever type the mapping produced: `==` compares across those four, where a
-# type test admits three of them.
-probe_share_dialect_holds <- function(value, expected) {
-  if (is.null(expected)) {
+# The probe asks only that a number came back, which is the conversion. The
+# control asks for the number the scaffolding selected, in whatever type the
+# mapping produced, which is why it tests both. `==` alone would be the weaker
+# question of what R coerces equal to that number: a logical, a factor, a Date,
+# a raw, and a length-1 list all compare equal to `1`, and a `blob` column
+# raises inside `==` where nothing catches it. Each of those would read as the
+# control answering, and `"refuses"` is the verdict that proceeds -- the rule
+# switched off and that cached against the dialect.
+probe_share_dialect_holds <- function(value, control) {
+  if (!control) {
     return(is.numeric(value))
   }
-  isTRUE(value == expected)
+  (is.numeric(value) || is.character(value)) &&
+    isTRUE(value == share_probe_scaffold()$number)
 }
 
 # The table-free scaffolding both questions are asked against, and the number

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1376,10 +1376,10 @@ test_that("the control takes the scaffolding's number in any driver type", {
   )
 })
 
-# Every wrap on these two paths reads an error as something the connection did,
-# so a marginplyr frame inside one would have its own defect reported as the
-# dialect. `share_probe_scaffold()` is the frame both readings reach, and it is
-# read outside all of them.
+# Every wrap whose value decides the verdict reads an error as something the
+# connection did, so a marginplyr frame inside one would have its own defect
+# reported as the dialect. `share_probe_scaffold()` is the frame both readings
+# reach, and it is read outside all of them.
 test_that("a defect in marginplyr's own frame is not read as a dialect", {
   local_mocked_bindings(
     share_probe_scaffold = function() stop("scaffold defect")

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1304,70 +1304,54 @@ test_that("an answer of an unexpected shape is not read as a verdict", {
   }
 
   expect_identical(verdict_for_answer(data.frame(p = 0)), "converts")
+  # A number the driver mapped to a class of its own is still the conversion.
+  expect_identical(
+    verdict_for_answer(data.frame(p = structure(0, class = "driver_mapped"))),
+    "converts"
+  )
   expect_identical(verdict_for_answer(data.frame(a = 1, b = 2)), "unknown")
   expect_identical(verdict_for_answer(data.frame(p = numeric(0))), "unknown")
   expect_identical(verdict_for_answer(data.frame(p = "x")), "unknown")
   expect_identical(verdict_for_answer(list(p = 1)), "unknown")
 })
 
-# What class the driver mapped the database's type to is a fact about the
-# driver, and the control asks about the connection: did this query come back
-# with the number the scaffolding selected? PostgreSQL's `SUM(integer)` is
-# `bigint`, which RPostgres maps to `bit64::integer64` -- a classed double.
-# Reading the control through the eligible-type rule, which rejects a classed
-# value because the rule is about a caller's summary, therefore refused every
-# share on the dialect including the numeric ones (#440).
-#
-# The class here stands in for `bit64::integer64`, and is deliberately not
-# named after it. bit64 is no dependency of this package, so the class would
-# carry methods here or not depending on whether an earlier test happened to
-# load it, and a double built by hand does not hold an `integer64`'s bit
-# pattern: with bit64 loaded, `structure(1, class = "integer64") == 1` is
-# `FALSE` where `bit64::as.integer64(1) == 1` is `TRUE`. What the reading turns
-# on is that the value is classed, not which class it carries. `is.numeric()`
-# and `== 1` were both measured to hold of a real `bit64::integer64` under
-# bit64 4.8.6.
-test_that("a classed number answers the control", {
-  bigint <- structure(1, class = "driver_mapped_bigint")
-  expect_false(is_share_source_type(bigint))
-
-  local_mocked_bindings(
-    collect = local({
-      calls <- 0L
-      function(x, ...) {
-        calls <<- calls + 1L
-        if (calls == 1L) {
-          stop("function sum(unknown) does not exist")
+# The four answering cases are RPostgres's four `bigint` mappings, each
+# measured `"refuses"` against a live PostgreSQL 17.11. The classed one carries
+# a name no package defines methods for, deliberately: a double built by hand
+# does not hold a `bit64::integer64` bit pattern, so with bit64 loaded
+# `structure(1, class = "integer64") == 1` is `FALSE` where
+# `bit64::as.integer64(1) == 1` is `TRUE`, and borrowing the name would assert
+# the driver's arithmetic rather than this reading.
+test_that("the control takes the scaffolding's number in any driver type", {
+  verdict_when_control_returns <- function(value) {
+    local_mocked_bindings(
+      collect = local({
+        calls <- 0L
+        function(x, ...) {
+          calls <<- calls + 1L
+          if (calls == 1L) {
+            stop("function sum(unknown) does not exist")
+          }
+          data.frame(p = value)
         }
-        data.frame(p = bigint)
-      }
-    }),
-    .package = "dplyr"
-  )
+      }),
+      .package = "dplyr"
+    )
+    probe_share_dialect(dbplyr::simulate_postgres())
+  }
+  classed <- structure(1, class = "driver_mapped_bigint")
+  expect_false(is_share_source_type(classed))
 
-  expect_identical(probe_share_dialect(dbplyr::simulate_postgres()), "refuses")
-})
+  expect_identical(verdict_when_control_returns(classed), "refuses")
+  expect_identical(verdict_when_control_returns(1L), "refuses")
+  expect_identical(verdict_when_control_returns(1), "refuses")
+  expect_identical(verdict_when_control_returns("1"), "refuses")
 
-# The control asks the one thing no dialect can refuse -- summing the number
-# the scaffolding already selects -- so a result that is some other number says
-# the query that answered is not the query the scaffolding built, and the
-# refusal the probe's raise looked like cannot be read from it.
-test_that("a control returning another number answers nothing", {
-  local_mocked_bindings(
-    collect = local({
-      calls <- 0L
-      function(x, ...) {
-        calls <<- calls + 1L
-        if (calls == 1L) {
-          stop("function sum(unknown) does not exist")
-        }
-        data.frame(p = 7)
-      }
-    }),
-    .package = "dplyr"
-  )
-
-  expect_identical(probe_share_dialect(dbplyr::simulate_postgres()), "unknown")
+  # The refusal is read from a query that raised where the same scaffolding
+  # demonstrably works, so a result that is some other number leaves the raise
+  # unexplained.
+  expect_identical(verdict_when_control_returns(7), "unknown")
+  expect_identical(verdict_when_control_returns("x"), "unknown")
 })
 
 # Reading any raised query as the dialect's refusal is how the protection came

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1376,12 +1376,10 @@ test_that("the control takes the scaffolding's number in any driver type", {
   )
 })
 
-# Three wraps read an error as a connection that could not be asked: the two
-# building and executing the query, and the one around the control's
-# comparison. A marginplyr frame inside any of them would report its own defect
-# as a dialect that cannot answer, and every share on that dialect would be
-# refused with nothing said about why. `share_probe_scaffold()` is the frame
-# both readings reach, and it is read outside all three.
+# Every wrap on these two paths reads an error as something the connection did,
+# so a marginplyr frame inside one would have its own defect reported as the
+# dialect. `share_probe_scaffold()` is the frame both readings reach, and it is
+# read outside all of them.
 test_that("a defect in marginplyr's own frame is not read as a dialect", {
   local_mocked_bindings(
     share_probe_scaffold = function() stop("scaffold defect")

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1310,6 +1310,66 @@ test_that("an answer of an unexpected shape is not read as a verdict", {
   expect_identical(verdict_for_answer(list(p = 1)), "unknown")
 })
 
+# What class the driver mapped the database's type to is a fact about the
+# driver, and the control asks about the connection: did this query come back
+# with the number the scaffolding selected? PostgreSQL's `SUM(integer)` is
+# `bigint`, which RPostgres maps to `bit64::integer64` -- a classed double.
+# Reading the control through the eligible-type rule, which rejects a classed
+# value because the rule is about a caller's summary, therefore refused every
+# share on the dialect including the numeric ones (#440).
+#
+# The class here stands in for `bit64::integer64`, and is deliberately not
+# named after it. bit64 is no dependency of this package, so the class would
+# carry methods here or not depending on whether an earlier test happened to
+# load it, and a double built by hand does not hold an `integer64`'s bit
+# pattern: with bit64 loaded, `structure(1, class = "integer64") == 1` is
+# `FALSE` where `bit64::as.integer64(1) == 1` is `TRUE`. What the reading turns
+# on is that the value is classed, not which class it carries. `is.numeric()`
+# and `== 1` were both measured to hold of a real `bit64::integer64` under
+# bit64 4.8.6.
+test_that("a classed number answers the control", {
+  bigint <- structure(1, class = "driver_mapped_bigint")
+  expect_false(is_share_source_type(bigint))
+
+  local_mocked_bindings(
+    collect = local({
+      calls <- 0L
+      function(x, ...) {
+        calls <<- calls + 1L
+        if (calls == 1L) {
+          stop("function sum(unknown) does not exist")
+        }
+        data.frame(p = bigint)
+      }
+    }),
+    .package = "dplyr"
+  )
+
+  expect_identical(probe_share_dialect(dbplyr::simulate_postgres()), "refuses")
+})
+
+# The control asks the one thing no dialect can refuse -- summing the number
+# the scaffolding already selects -- so a result that is some other number says
+# the query that answered is not the query the scaffolding built, and the
+# refusal the probe's raise looked like cannot be read from it.
+test_that("a control returning another number answers nothing", {
+  local_mocked_bindings(
+    collect = local({
+      calls <- 0L
+      function(x, ...) {
+        calls <<- calls + 1L
+        if (calls == 1L) {
+          stop("function sum(unknown) does not exist")
+        }
+        data.frame(p = 7)
+      }
+    }),
+    .package = "dplyr"
+  )
+
+  expect_identical(probe_share_dialect(dbplyr::simulate_postgres()), "unknown")
+})
+
 # Reading any raised query as the dialect's refusal is how the protection came
 # to be off exactly where it was needed: `"refuses"` is the verdict that
 # proceeds, so every unrelated reason a query can raise switched the rule off

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1376,6 +1376,27 @@ test_that("the control takes the scaffolding's number in any driver type", {
   )
 })
 
+# Three wraps read an error as a connection that could not be asked: the two
+# building and executing the query, and the one around the control's
+# comparison. A marginplyr frame inside any of them would report its own defect
+# as a dialect that cannot answer, and every share on that dialect would be
+# refused with nothing said about why. `share_probe_scaffold()` is the frame
+# both readings reach, and it is read outside all three.
+test_that("a defect in marginplyr's own frame is not read as a dialect", {
+  local_mocked_bindings(
+    share_probe_scaffold = function() stop("scaffold defect")
+  )
+
+  expect_error(
+    probe_share_dialect(dbplyr::simulate_postgres()),
+    "scaffold defect"
+  )
+  expect_error(
+    probe_share_dialect_holds(1, control = TRUE),
+    "scaffold defect"
+  )
+})
+
 # Reading any raised query as the dialect's refusal is how the protection came
 # to be off exactly where it was needed: `"refuses"` is the verdict that
 # proceeds, so every unrelated reason a query can raise switched the rule off

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1361,12 +1361,9 @@ test_that("the control takes the scaffolding's number in any driver type", {
   expect_identical(verdict_when_control_returns(I(list(1))), "unknown")
   expect_identical(verdict_when_control_returns(as.raw(1)), "unknown")
 
-  # A class that passes the type test and raises inside `==`, which
-  # `haven::labelled` and `units` both do. Nothing between the comparison and
-  # the caller catches it, so without the wrap this escapes as a bare R error
-  # rather than as the verdict that refuses the share. Registered in the global
-  # environment because that is where dispatch for an internal generic reaches
-  # from marginplyr's namespace.
+  # A class that passes the type test and raises inside `==`. The method is
+  # registered in the global environment because one defined in this frame is
+  # not dispatched from marginplyr's namespace, where the comparison runs.
   assign(
     "==.raises_on_comparison",
     function(e1, e2) stop("cannot compare"),

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1347,11 +1347,21 @@ test_that("the control takes the scaffolding's number in any driver type", {
   expect_identical(verdict_when_control_returns(1), "refuses")
   expect_identical(verdict_when_control_returns("1"), "refuses")
 
-  # The refusal is read from a query that raised where the same scaffolding
-  # demonstrably works, so a result that is some other number leaves the raise
-  # unexplained.
   expect_identical(verdict_when_control_returns(7), "unknown")
   expect_identical(verdict_when_control_returns("x"), "unknown")
+  expect_identical(verdict_when_control_returns(NA), "unknown")
+
+  # Every one of these compares equal to `1` under R's coercion rules, and the
+  # last raises inside `==`. Reading any as the control answering would record
+  # `"refuses"`, which proceeds, against the dialect.
+  expect_identical(verdict_when_control_returns(TRUE), "unknown")
+  expect_identical(verdict_when_control_returns(factor("1")), "unknown")
+  expect_identical(
+    verdict_when_control_returns(as.Date("1970-01-02")),
+    "unknown"
+  )
+  expect_identical(verdict_when_control_returns(I(list(1))), "unknown")
+  expect_identical(verdict_when_control_returns(as.raw(1)), "unknown")
 })
 
 # Reading any raised query as the dialect's refusal is how the protection came

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1351,9 +1351,7 @@ test_that("the control takes the scaffolding's number in any driver type", {
   expect_identical(verdict_when_control_returns("x"), "unknown")
   expect_identical(verdict_when_control_returns(NA), "unknown")
 
-  # Every one of these compares equal to `1` under R's coercion rules, and the
-  # last raises inside `==`. Reading any as the control answering would record
-  # `"refuses"`, which proceeds, against the dialect.
+  # Every one of these compares equal to `1` under R's coercion rules.
   expect_identical(verdict_when_control_returns(TRUE), "unknown")
   expect_identical(verdict_when_control_returns(factor("1")), "unknown")
   expect_identical(
@@ -1362,6 +1360,23 @@ test_that("the control takes the scaffolding's number in any driver type", {
   )
   expect_identical(verdict_when_control_returns(I(list(1))), "unknown")
   expect_identical(verdict_when_control_returns(as.raw(1)), "unknown")
+
+  # A class that passes the type test and raises inside `==`, which
+  # `haven::labelled` and `units` both do. Nothing between the comparison and
+  # the caller catches it, so without the wrap this escapes as a bare R error
+  # rather than as the verdict that refuses the share. Registered in the global
+  # environment because that is where dispatch for an internal generic reaches
+  # from marginplyr's namespace.
+  assign(
+    "==.raises_on_comparison",
+    function(e1, e2) stop("cannot compare"),
+    envir = globalenv()
+  )
+  on.exit(rm("==.raises_on_comparison", envir = globalenv()), add = TRUE)
+  expect_identical(
+    verdict_when_control_returns(structure(1, class = "raises_on_comparison")),
+    "unknown"
+  )
 })
 
 # Reading any raised query as the dialect's refusal is how the protection came


### PR DESCRIPTION
Closes #440.

## What was wrong

`probe_share_dialect_answer()` accepted a collected result only when
`is_share_source_type()` held of it. That predicate is the *eligible-type rule*
for a share source, and it requires `!is.object(value)`. PostgreSQL's
`SUM(integer)` is `bigint`, which RPostgres maps to `bit64::integer64` — a
classed double. The control therefore read as "the question could not be put
here", `probe_share_dialect()` returned `"unknown"`, and every share on
PostgreSQL was refused whatever the source's type. Nothing was cached, so both
queries were re-sent on every share request on the dialect.

Two questions had been conflated. The eligible-type rule is about a caller's
data. The control asks about the connection: did this query come back with the
number the scaffolding selected?

## What changed

`probe_share_dialect_holds()` is where each of the two questions is now
written. The probe asks that a number came back, which is the conversion. The
control asks for the number the scaffolding selected, in whatever type the
driver mapped the database's type to, and tests the type as well as the value —
`==` alone is the weaker question of what R coerces equal to that number. The
comparison is wrapped, because a class that passes the type test can raise
inside `==` and nothing between there and the caller catches it.

`share_probe_scaffold()` holds the scaffolding and the number it selects
together, and is read outside every wrap whose value decides the verdict: an
error from a marginplyr frame is a defect, and reading it as a dialect that
could not answer would hide it behind a refused share.

`is_share_source_type()` is unchanged, and its header's "two raising sites" is
true again. So are `probe_share_dialect()`'s structure, the verdict vocabulary,
the cache policy, ADR 0020's exemption 2, and ADR 0027's two purposes.

## Measured

Against PostgreSQL 17.11 (Homebrew) through RPostgres, dbplyr 2.6.0, dplyr
1.2.1, across all four `bigint` mappings the driver offers — `bit64::integer64`,
`integer`, `numeric`, and `character`:

- `probe_share_dialect(con)` returns `"refuses"` and is recorded, so a second
  share request sends only its result query.
- Parent and Total shares over a double source calculate, as does a Parent
  share over `n()`, whose `bigint` result is the value that used to refuse.
- A character source raises with PostgreSQL's own
  `function sum(text) does not exist`, for a numeric-looking source
  (`c("1","2","3")`) and a non-numeric one alike — earlier than the `= 0.0`
  comparison #429 is about.

DuckDB's `"refuses"` and SQLite's `"converts"` are unchanged. Full suite green
under `NOT_CRAN=true`; `lintr::lint_package()` clean.

## Tests

All in `test-share-backends.R`, none requiring a live server or any member of
`optional_backends()`:

- the control reads a classed number, an `integer`, a `double` and a character
  `"1"` as the scaffolding's number, and reads `7`, `"x"`, `NA`, and five values
  R coerces equal to `1` — a logical, a factor, a Date, a length-1 list, a raw —
  as no answer, along with a class whose `==` raises;
- the probe reads a driver-classed number as the conversion;
- a defect raised by `share_probe_scaffold()` reaches the caller instead of
  being reported as a dialect that cannot answer.

The classed value carries a name no package defines methods for, deliberately: a
double built by hand does not hold a `bit64::integer64` bit pattern, so with
bit64 loaded `structure(1, class = "integer64") == 1` is `FALSE` where
`bit64::as.integer64(1) == 1` is `TRUE`, and borrowing the name would assert the
driver's arithmetic rather than this reading.

Eight review rounds ran; the record is in a comment below.