### PR TITLE
Name a rewritten summary the way dplyr names it

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -346,8 +346,9 @@ report_branch_warnings <- function(conditions) {
 # The label dplyr quotes an argument by, reproduced so that the expression
 # marginplyr handed it can be recognised in a context it rendered. Plain
 # `rlang::as_label()` under dplyr's `name = ` convention is what this uses,
-# rather than dplyr's `expr_as_label()`; ADR 0022 is authoritative for where
-# the two diverge and for why neither divergence is observable.
+# rather than dplyr's `expr_as_label()`. What this site writes is a condition
+# label, and that is what ADR 0022 decides; a name a caller reads back falls
+# the other way, under the same ADR's amendment for #439.
 summary_argument_labels <- function(dots) {
   arg_names <- names(dots)
   if (is.null(arg_names)) {

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -361,6 +361,18 @@ new_summary_arguments <- function(dots,
   list(dots = dots, labels = labels, assigned_names = assigned_names)
 }
 
+# The name `dplyr::summarize()` gives an unnamed argument, for an argument
+# marginplyr names in dplyr's place. dplyr's `expr_as_label()` is
+# `rlang::as_label()` with rlang's infix labelling suppressed through an
+# undocumented option, and the two spellings differ once an expression is long
+# enough to abbreviate. Setting that option is the whole of the reproduction:
+# the other branch of `expr_as_label()` deparses a bare data pronoun, which no
+# expression reaching the one caller here can be (ADR 0022, amended).
+dplyr_auto_name <- function(expr) {
+  rlang::local_options(`rlang:::use_as_label_infix` = FALSE)
+  rlang::as_label(expr)
+}
+
 # The name dplyr would have given each unnamed summary marginplyr rewrites,
 # read from what the caller wrote rather than from the rewrite. The named dots
 # arrive beside the Assigned summary name each one took, `NA` where none was
@@ -392,11 +404,10 @@ new_summary_arguments <- function(dots,
 # and `range_frame(pick(v))` has to not be, which is a question about the
 # value's type. ADR 0028 is where that one is answered.
 #
-# `rlang::as_label()` is `rlang::quos_auto_name()`'s own labeller, so the name
-# is dplyr's up to the width at which rlang abbreviates a long expression:
-# dplyr asks rlang for a variant spelling of that abbreviation through an
-# internal option, and neither spelling stands for an expression the caller
-# could read back.
+# The label is `dplyr_auto_name()` and not `rlang::as_label()`, because what is
+# written here is a column name rather than a condition label: ADR 0022's
+# rejection of reproducing dplyr's spelling reaches the label alone, and its
+# amendment for #439 says so.
 name_rewritten_summary_dots <- function(original, resolved) {
   stopifnot(length(original) == length(resolved))
   arg_names <- rlang::names2(resolved)
@@ -408,7 +419,7 @@ name_rewritten_summary_dots <- function(original, resolved) {
     if (!rewritten || !is.null(data_frame_valued_summary_kind(expr))) {
       next
     }
-    arg_names[[i]] <- rlang::as_label(expr)
+    arg_names[[i]] <- dplyr_auto_name(expr)
     assigned_names[[i]] <- arg_names[[i]]
   }
   list(

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -162,7 +162,8 @@ measurement: share planning drops a dot to `NULL` and expands a placeholder
 into one dot per output before flattening, so position is not preserved.
 
 **Reproduce `expr_as_label()` faithfully, undocumented option included.**
-Rejected above: what it covers is unobservable.
+Rejected above: what it covers is unobservable. That reaches a condition label
+and nothing else, which the amendment for #439 records.
 
 **Extend the restatement to the native grouping-sets adapter.** Rejected as
 covering nothing today, since both backends holding the capability are lazy.
@@ -313,3 +314,36 @@ rather than extracted.
 The grouping values are the third part, and they need nothing here. The native
 adapter groups by `pick(all_of(group_vars))` rather than by internal key
 columns, so dplyr already reports them under the names the caller wrote.
+
+## Amendment: an Assigned summary name reproduces the option
+
+*dplyr's rendering is reproduced only as far as it is observable* rests on a
+label dplyr truncated rendering the same whichever expression it came from, and
+*Considered Options* rejects reproducing `expr_as_label()` on that ground. The
+subject of both is a **condition label**, and there the argument holds
+unchanged. It does not reach an Assigned summary name, which #430 introduced
+after this decision was taken: that name is a column of the result, so
+`... + 5` where dplyr writes `+...` is a column the caller subscripts by, and
+`?summarize_with_margins` fixes dplyr's naming as the contract for `...`. #439
+is the ticket.
+
+`name_rewritten_summary_dots()` therefore labels through `dplyr_auto_name()`,
+which is `rlang::as_label()` under the option dplyr sets. Reproducing the option
+is the whole of it. `expr_as_label()`'s other branch deparses a bare data
+pronoun instead of labelling it, and no expression reaching that call site is
+one: a summary spelled `.data$x` is rewritten by nothing, so it is never
+assigned a name, and a pronoun inside a larger expression is not the expression
+the labeller reads.
+
+Nothing else moves. `summary_argument_labels()` goes on labelling with plain
+`rlang::as_label()`, for the reason the amended section gives, so the two
+callers now spell one expression two ways where it abbreviates — which is what
+the sections above already describe as the label matching nothing and the
+quotation standing.
+
+What the option's disappearance would cost is a silent return to the old
+spelling, and the test is written against that rather than against a string:
+it computes both the assigned name and `dplyr::summarize()`'s own name for the
+same expression, and asserts separately that the expression is still one the
+two labellers disagree about. An rlang that dropped the option fails the first;
+one that stopped abbreviating at that width fails the second.

--- a/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
+++ b/design/adr/0022-quote-the-callers-own-spelling-in-a-condition-context.md
@@ -341,9 +341,8 @@ callers now spell one expression two ways where it abbreviates — which is what
 the sections above already describe as the label matching nothing and the
 quotation standing.
 
-What the option's disappearance would cost is a silent return to the old
-spelling, and the test is written against that rather than against a string:
-it computes both the assigned name and `dplyr::summarize()`'s own name for the
-same expression, and asserts separately that the expression is still one the
-two labellers disagree about. An rlang that dropped the option fails the first;
-one that stopped abbreviating at that width fails the second.
+Depending on an undocumented option in another package is the cost, and it is
+paid rather than avoided: the alternative is a name that is dplyr's only until
+an expression grows long, which is the defect itself. An rlang that dropped the
+option would put that name back, and the tests are written against dplyr's own
+naming rather than against a spelling, so it would not go unreported.

--- a/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
+++ b/design/adr/0028-expand-a-data-frame-summary-marginplyr-named.md
@@ -131,8 +131,11 @@ The reference states the rule a caller needs and not this argument: an unnamed
 summary expands, a name you write packs, and a name marginplyr assigns does not
 appear.
 
-Two things stay outside this decision, both following from #430 rather than
-from it, and both are #439: `rlang::as_label()`'s abbreviation producing a
-column name the caller cannot read back, and an assigned name differing between
-`pick(x)` and `dplyr::pick(x)`. Each applies equally to a scalar summary, which
-this decision does not touch.
+One thing stayed outside this decision, following from #430 rather than from
+it, and it was #439: an assigned name abbreviating a long expression the way
+`rlang::as_label()` does rather than the way `dplyr::summarize()` does. It
+applied equally to a scalar summary, which this decision does not touch, and
+ADR 0022's amendment for #439 is where it is now settled. The second thing
+named here was that `pick(x)` and `dplyr::pick(x)` take different assigned
+names; #439 measured that `dplyr::summarize()` names those two differently as
+well, so it was never marginplyr's to answer.

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1205,6 +1205,64 @@ test_that("an unnamed summary is named from the caller's own expression", {
   expect_true("sum(v) + grouping_bit(a)" %in% colnames(native))
 })
 
+# #439. The name is dplyr's or it is nothing, and an expression long enough for
+# rlang to abbreviate is where the two labellers part: dplyr suppresses rlang's
+# infix labelling, so `+...` where plain `rlang::as_label()` writes `... + 5`.
+# Both sides are computed here rather than written out, so what the assertion
+# holds is the equality and not a spelling.
+#
+# `expect_false` beside each is what keeps the case from going vacuous. Every
+# other assigned name in this file is short enough that both labellers agree, so
+# an expression that stopped abbreviating would pass the equality while
+# asserting nothing about the divergence it was written for.
+test_that("an assigned name abbreviates the way dplyr's does", {
+  data <- data.frame(g = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
+  # `dplyr::summarize()` evaluates what it names, so the Grouping helper is
+  # shadowed by a binding its data mask reaches before the export. marginplyr
+  # reads the spelling rather than the binding (ADR 0019), so the shadow leaves
+  # its own rewrite untouched.
+  grouping_bit <- function(...) 0L
+
+  selected <- rlang::expr(
+    sum(dplyr::pick(x)[[1]]) + 1 + sum(y) + 2 + mean(x) + 3 + mean(y) + 4 +
+      stats::median(x) + 5
+  )
+  helped <- rlang::expr(
+    sum(x) + 1 + sum(y) + 2 + mean(x) + 3 + mean(y) + 4 + max(x) +
+      grouping_bit(g)
+  )
+  dplyr_name <- function(expr) {
+    setdiff(names(dplyr::summarize(data, !!expr, .by = g)), "g")
+  }
+
+  expect_false(dplyr_name(selected) == rlang::as_label(selected))
+  expect_equal(
+    setdiff(
+      names(summarize_with_margins(data, !!selected, .grouping = rollup(g))),
+      "g"
+    ),
+    dplyr_name(selected)
+  )
+
+  expect_false(dplyr_name(helped) == rlang::as_label(helped))
+  expect_equal(
+    setdiff(
+      names(summarize_with_margins(data, !!helped, .grouping = rollup(g))),
+      "g"
+    ),
+    dplyr_name(helped)
+  )
+
+  # The native adapter receives the named dots too, over a simulated connection
+  # so that the case runs wherever the suite does.
+  native <- summarize_with_margins(
+    dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres()),
+    !!helped,
+    .grouping = rollup(g)
+  )
+  expect_true(dplyr_name(helped) %in% colnames(native))
+})
+
 test_that("an unnamed summary is named before a selection is resolved", {
   data <- data.frame(group = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
 

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1205,16 +1205,13 @@ test_that("an unnamed summary is named from the caller's own expression", {
   expect_true("sum(v) + grouping_bit(a)" %in% colnames(native))
 })
 
-# #439. The name is dplyr's or it is nothing, and an expression long enough for
-# rlang to abbreviate is where the two labellers part: dplyr suppresses rlang's
-# infix labelling, so `+...` where plain `rlang::as_label()` writes `... + 5`.
-# Both sides are computed here rather than written out, so what the assertion
-# holds is the equality and not a spelling.
+# #439. Both names are computed here rather than written out, so what the
+# assertion holds is the equality with dplyr's own and not a spelling.
 #
-# `expect_false` beside each is what keeps the case from going vacuous. Every
-# other assigned name in this file is short enough that both labellers agree, so
-# an expression that stopped abbreviating would pass the equality while
-# asserting nothing about the divergence it was written for.
+# `expect_false` is what keeps the case from going vacuous. Every other assigned
+# name in this file is short enough that the two labellers agree, so an
+# expression that stopped abbreviating would pass the equality while asserting
+# nothing about the divergence it was written for.
 test_that("an assigned name abbreviates the way dplyr's does", {
   data <- data.frame(g = c("a", "a", "b"), x = c(1, 3, 5), y = c(2, 4, 6))
   # `dplyr::summarize()` evaluates what it names, so the Grouping helper is
@@ -1223,44 +1220,34 @@ test_that("an assigned name abbreviates the way dplyr's does", {
   # its own rewrite untouched.
   grouping_bit <- function(...) 0L
 
-  selected <- rlang::expr(
-    sum(dplyr::pick(x)[[1]]) + 1 + sum(y) + 2 + mean(x) + 3 + mean(y) + 4 +
-      stats::median(x) + 5
-  )
-  helped <- rlang::expr(
-    sum(x) + 1 + sum(y) + 2 + mean(x) + 3 + mean(y) + 4 + max(x) +
-      grouping_bit(g)
-  )
-  dplyr_name <- function(expr) {
-    setdiff(names(dplyr::summarize(data, !!expr, .by = g)), "g")
+  # Both adapters, the native one over a simulated connection so that the case
+  # runs wherever the suite does.
+  expect_dplyr_name <- function(expr) {
+    dplyr_name <- setdiff(names(dplyr::summarize(data, !!expr, .by = g)), "g")
+    expect_false(dplyr_name == rlang::as_label(expr))
+    expect_equal(
+      setdiff(
+        names(summarize_with_margins(data, !!expr, .grouping = rollup(g))),
+        "g"
+      ),
+      dplyr_name
+    )
+    native <- summarize_with_margins(
+      dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres()),
+      !!expr,
+      .grouping = rollup(g)
+    )
+    expect_equal(setdiff(colnames(native), "g"), dplyr_name)
   }
 
-  expect_false(dplyr_name(selected) == rlang::as_label(selected))
-  expect_equal(
-    setdiff(
-      names(summarize_with_margins(data, !!selected, .grouping = rollup(g))),
-      "g"
-    ),
-    dplyr_name(selected)
-  )
-
-  expect_false(dplyr_name(helped) == rlang::as_label(helped))
-  expect_equal(
-    setdiff(
-      names(summarize_with_margins(data, !!helped, .grouping = rollup(g))),
-      "g"
-    ),
-    dplyr_name(helped)
-  )
-
-  # The native adapter receives the named dots too, over a simulated connection
-  # so that the case runs wherever the suite does.
-  native <- summarize_with_margins(
-    dbplyr::tbl_lazy(data, con = dbplyr::simulate_postgres()),
-    !!helped,
-    .grouping = rollup(g)
-  )
-  expect_true(dplyr_name(helped) %in% colnames(native))
+  expect_dplyr_name(rlang::expr(
+    sum(dplyr::pick(x)[[1]]) + 1 + sum(y) + 2 + mean(x) + 3 + mean(y) + 4 +
+      stats::median(x) + 5
+  ))
+  expect_dplyr_name(rlang::expr(
+    sum(x) + 1 + sum(y) + 2 + mean(x) + 3 + mean(y) + 4 + max(x) +
+      grouping_bit(g)
+  ))
 })
 
 test_that("an unnamed summary is named before a selection is resolved", {


### PR DESCRIPTION
Closes #439.

An unnamed summary marginplyr rewrites was named through `rlang::as_label()`,
while `dplyr::summarize()` names one through `expr_as_label()` — `as_label()`
with rlang's infix labelling suppressed through an undocumented option. The two
agree until an expression is long enough for rlang to abbreviate it, where
dplyr writes `+...` and `as_label()` writes `... + 5`. `?summarize_with_margins`
documents `...` as dplyr's name-value pairs, so the divergence reached the
caller as a column name.

`dplyr_auto_name()` sets the option dplyr sets, and
`name_rewritten_summary_dots()` labels through it. Nothing else about who gets
named changes.

The test computes both names rather than writing either out — the assigned name
and `dplyr::summarize()`'s own name for the same expression — and asserts
separately that the expression is still one the two labellers disagree about,
so an rlang that dropped the option fails the first and one that stopped
abbreviating at that width fails the second. Both rewrite routes are covered,
and the grouping-helper one is asserted on the native adapter over
`dbplyr::simulate_postgres()`.

ADR 0022 rejected reproducing `expr_as_label()` for a **condition label**, on
the ground that the divergence there is unobservable; that ground does not
reach a column name, and its amendment records the split. ADR 0028's closing
paragraph named two things it left to #439 — one turned out to be dplyr's own
behaviour and is dropped, the other is this.