### PR TITLE
Bind the share source where the plan builds no ratio

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2672,7 +2672,18 @@ apply_joined_shares <- function(result,
       source <- pair$source
       denominator <- denominator_names[[source]]
       if (length(joined_ids) == 0L) {
-        return(rlang::expr(1.0))
+        # This branch builds no ratio, so this expression is the only thing
+        # binding the source's type, which is what a refusing dialect rejects a
+        # character source by (#446). Both arms are `1.0` and `is.na()` answers
+        # every value, so the constant this branch has always produced is
+        # unchanged for an eligible source.
+        return(rlang::expr(
+          dplyr::if_else(
+            is.na((!!margin_column_pronoun(source)) * 1L),
+            1.0,
+            1.0
+          )
+        ))
       }
       rlang::expr(
         dplyr::if_else(

--- a/R/share.R
+++ b/R/share.R
@@ -2674,10 +2674,9 @@ apply_joined_shares <- function(result,
       if (length(joined_ids) == 0L) {
         # No denominator was joined, so nothing else in the staged query names
         # the source: this is what binds it there, for the reason the ratio's
-        # own `* 1L` below gives (#446). Both arms are the constant this branch
-        # has always produced, and the condition is an `IS NULL`, which SQL
-        # never answers with `NULL`, so no third value leaks from the `CASE`
-        # dbplyr renders without an `ELSE`.
+        # own `* 1L` below gives (#446). Both arms are `1.0`, and the condition
+        # is an `IS NULL`, which SQL never answers with `NULL`, so no third
+        # value leaks from the `CASE` dbplyr renders without an `ELSE`.
         return(rlang::expr(
           dplyr::if_else(
             is.na((!!margin_column_pronoun(source)) * 1L),

--- a/R/share.R
+++ b/R/share.R
@@ -2672,11 +2672,12 @@ apply_joined_shares <- function(result,
       source <- pair$source
       denominator <- denominator_names[[source]]
       if (length(joined_ids) == 0L) {
-        # This branch builds no ratio, so this expression is the only thing
-        # binding the source's type, which is what a refusing dialect rejects a
-        # character source by (#446). Both arms are `1.0` and `is.na()` answers
-        # every value, so the constant this branch has always produced is
-        # unchanged for an eligible source.
+        # No denominator was joined, so nothing else in the staged query names
+        # the source: this is what binds it there, for the reason the ratio's
+        # own `* 1L` below gives (#446). Both arms are the constant this branch
+        # has always produced, and the condition is an `IS NULL`, which SQL
+        # never answers with `NULL`, so no third value leaks from the `CASE`
+        # dbplyr renders without an `ELSE`.
         return(rlang::expr(
           dplyr::if_else(
             is.na((!!margin_column_pronoun(source)) * 1L),

--- a/investigation/README.md
+++ b/investigation/README.md
@@ -101,10 +101,13 @@ overturned.
 1. Add one line to the header block:
 
    ```text
-   Revised: <YYYY-MM-DD> — investigation/<successor>.md
+   Revised: <YYYY-MM-DD> — <what established the correction>
    ```
 
-   one per revision, in date order after `Investigated:`.
+   one per revision, in date order after `Investigated:`. What follows the dash
+   is what step 2 names — usually `investigation/<successor>.md`, and the
+   artifact where the correction was established in code or configuration
+   rather than in another note.
 
 2. Add a section headed `## Revisions (<YYYY-MM-DD>)`, placed after the
    findings it amends, stating what changed and why. Name the note or artifact

--- a/investigation/README.md
+++ b/investigation/README.md
@@ -111,11 +111,13 @@ overturned.
    that established the correction.
 
    A second revision on a date the note already carries writes the issue
-   number into both — `Revised: <YYYY-MM-DD> (#<issue>) — <target>` and
-   `## Revisions (<YYYY-MM-DD>, #<issue>)` — so that a header line names one
-   section. Without it a reader has two entries and two sections and no way to
-   pair them, which is what `refusing-a-character-share-source-in-the-staged-query.md`
-   reached the day it was written: two investigations, one date, one target.
+   number into both — `(#<issue>)` after the date in step 1's line, and
+   `## Revisions (<YYYY-MM-DD>, #<issue>)` here — so that a header line names
+   one section. Without it a reader has two entries and two sections and no way
+   to pair them, which is what
+   `refusing-a-character-share-source-in-the-staged-query.md` reached the day
+   it was written: two investigations, one date, and the same thing named
+   after the dash.
 
 3. Leave the original findings in place, unedited. The point of the note is
    what was believed on its date; deleting the superseded text destroys the

--- a/investigation/README.md
+++ b/investigation/README.md
@@ -110,6 +110,13 @@ overturned.
    findings it amends, stating what changed and why. Name the note or artifact
    that established the correction.
 
+   A second revision on a date the note already carries writes the issue
+   number into both — `Revised: <YYYY-MM-DD> (#<issue>) — <target>` and
+   `## Revisions (<YYYY-MM-DD>, #<issue>)` — so that a header line names one
+   section. Without it a reader has two entries and two sections and no way to
+   pair them, which is what `refusing-a-character-share-source-in-the-staged-query.md`
+   reached the day it was written: two investigations, one date, one target.
+
 3. Leave the original findings in place, unedited. The point of the note is
    what was believed on its date; deleting the superseded text destroys the
    only record of that.

--- a/investigation/refusing-a-character-share-source-in-the-staged-query.md
+++ b/investigation/refusing-a-character-share-source-in-the-staged-query.md
@@ -2,6 +2,7 @@
 
 Investigated: 2026-09-05
 Revised: 2026-09-05 — `R/share.R`
+Revised: 2026-09-05 (#446) — `R/share.R`
 
 `investigation/share-source-eligibility-on-coercing-dialects.md` (2026-08-16)
 established that a dialect can be asked whether it converts a non-numeric value
@@ -248,3 +249,62 @@ Nothing above is overturned. Which operations each dialect refused for a
 character column stands, and every form measured made DuckDB and PostgreSQL
 refuse a character source value-independently; what these measurements settled
 is which of them is safe for the numeric sources that must keep working.
+
+## Revisions (2026-09-05, #446)
+
+Everything above measures the *ratio*. #446 found the path that builds no
+ratio: when a Grouping plan gives every occurrence its own denominator, share
+construction returns before any denominator is mapped or joined, and nothing in
+the staged query then referenced the source at all. A refusing dialect was
+never asked to bind it, so DuckDB answered `1` for a character source that the
+local path refuses. This section measures that path and the expression now
+placed in it; nothing above is overturned, because no measurement above reaches
+a share with no denominator.
+
+Measured on 2026-09-05 against R 4.6.1, dplyr 1.2.1, dbplyr 2.6.0, duckdb
+1.5.5, RSQLite 3.53.3, dtplyr 1.3.3, and data.table 1.18.6.1, with marginplyr
+loaded from the working tree via `pkgload::load_all()`.
+
+**Which plans reach it.** A Total share reaches the branch whenever every
+occurrence's variable part is empty. All six combinations of `.grouping` absent,
+`grouping_sets(grouping_set())`, and two empty sets under
+`.duplicates = "keep"`, each with and without `.by`, reached it. A **Parent
+share cannot**: `share_of_parent()` requires `.grouping` to be one pure
+`rollup()`, every rollup has at least one dimension, and every such plan gives
+some occurrence a parent. Both empty-set spellings were refused by that
+grouping check before any share was built.
+
+**Which backends had the gap.** The local path and dtplyr both refused a
+character source with the eligible-type diagnostic, from the result and before
+any share expression. RSQLite refused the call whatever the source held —
+including an eligible one — because the dialect verdict is what refuses it
+there. The gap was general dbplyr on a refusing dialect alone.
+
+**What binds the source without changing the value.** Three forms were run on
+DuckDB over a `VARCHAR` holding `'1','2','3'` and one holding `'1','2','n'`:
+
+| SQL | numeric-looking | non-numeric |
+|---|---|---|
+| `CASE WHEN (c*1) IS NULL THEN 1.0 ELSE 1.0 END` | Binder Error | Binder Error |
+| `1.0 + 0 * (c*1)` | Binder Error | Binder Error |
+| `MAX(c*1) IS NULL` | Binder Error | Binder Error |
+
+Each refused at binding, value-independently, reporting
+`'*(VARCHAR, INTEGER_LITERAL)'` — the same operand pair *A substitution, not an
+addition* recorded, so this rests on the same 20-of-24 result and adds no
+dialect behaviour to it. The first is what `dplyr::if_else()` renders, and it is
+the form taken: the condition is an `IS NULL`, which SQL never answers with
+`NULL`, so neither arm can be skipped and the value stays exactly `1.0`. dbplyr
+rendered it without an `ELSE`, as
+`CASE WHEN ((total * 1) IS NULL) THEN 1.0 WHEN NOT ((total * 1) IS NULL) THEN 1.0 END`,
+which is why that property is what the branch rests on rather than a
+convenience.
+
+Over eligible sources on DuckDB — a double, a zero, an all-`NA` double, and an
+integer — every share was `1` of type double.
+
+**`.check_share_source = FALSE` does not relax it.** With the flag set, the
+local path still refused a character source (its type check does not read the
+argument) and DuckDB still failed at collection. The flag suppresses the
+converting-dialect verdict refusal only, which is what it already did for the
+ratio.

--- a/investigation/refusing-a-character-share-source-in-the-staged-query.md
+++ b/investigation/refusing-a-character-share-source-in-the-staged-query.md
@@ -257,9 +257,10 @@ ratio: when a Grouping plan gives every occurrence its own denominator, share
 construction returns before any denominator is mapped or joined, and nothing in
 the staged query then referenced the source at all. A refusing dialect was
 never asked to bind it, so DuckDB answered `1` for a character source that the
-local path refuses. This section measures that path and the expression now
-placed in it; nothing above is overturned, because no measurement above reaches
-a share with no denominator.
+local path refused. This section measures that path and the expression put in
+it on this date; nothing above is overturned, because no measurement above
+reaches a share with no denominator. `R/share.R` is authoritative for what the
+package sends.
 
 Measured on 2026-09-05 against R 4.6.1, dplyr 1.2.1, dbplyr 2.6.0, duckdb
 1.5.5, RSQLite 3.53.3, dtplyr 1.3.3, and data.table 1.18.6.1, with marginplyr
@@ -292,19 +293,18 @@ DuckDB over a `VARCHAR` holding `'1','2','3'` and one holding `'1','2','n'`:
 Each refused at binding, value-independently, reporting
 `'*(VARCHAR, INTEGER_LITERAL)'` — the same operand pair *A substitution, not an
 addition* recorded, so this rests on the same 20-of-24 result and adds no
-dialect behaviour to it. The first is what `dplyr::if_else()` renders, and it is
-the form taken: the condition is an `IS NULL`, which SQL never answers with
-`NULL`, so neither arm can be skipped and the value stays exactly `1.0`. dbplyr
-rendered it without an `ELSE`, as
-`CASE WHEN ((total * 1) IS NULL) THEN 1.0 WHEN NOT ((total * 1) IS NULL) THEN 1.0 END`,
-which is why that property is what the branch rests on rather than a
-convenience.
+dialect behaviour to it. The first is what `dplyr::if_else()` rendered, and
+dbplyr rendered it without an `ELSE`, as
+`CASE WHEN ((total * 1) IS NULL) THEN 1.0 WHEN NOT ((total * 1) IS NULL) THEN 1.0 END`.
+So what kept the value at exactly `1.0` was that the condition is an `IS NULL`,
+which SQL never answers with `NULL`: neither arm could be skipped, and no third
+value could come from the missing `ELSE`.
 
 Over eligible sources on DuckDB — a double, a zero, an all-`NA` double, and an
 integer — every share was `1` of type double.
 
-**`.check_share_source = FALSE` does not relax it.** With the flag set, the
-local path still refused a character source (its type check does not read the
-argument) and DuckDB still failed at collection. The flag suppresses the
-converting-dialect verdict refusal only, which is what it already did for the
+**`.check_share_source = FALSE` relaxed nothing here.** With the flag set, the
+local path still refused a character source — its type check did not read the
+argument — and DuckDB still failed at collection. The flag suppressed the
+converting-dialect verdict refusal alone, which is what it already did for the
 ratio.

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1630,6 +1630,76 @@ test_that("DuckDB refuses a character share source whatever it holds", {
   }
 })
 
+# #446. The plan below gives every occurrence its own denominator, so no
+# denominator is joined and the share is built as a constant. The refusal here
+# is therefore of the expression that branch emits for the sole purpose of
+# binding the source, and not of the ratio `DuckDB refuses a character share
+# source whatever it holds` covers. Only a Total share reaches it: a Parent
+# share requires a rollup, and every rollup gives some occurrence a parent.
+test_that("DuckDB refuses a character source for a share that needs no join", {
+  skip_if_suggest_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    numeric_looking = c("1", "2", "3"),
+    non_numeric = c("n", "m", "o"),
+    revenue = c(1, 2, 4),
+    zero = c(0, 0, 0),
+    missing = rep(NA_real_, 3L)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_whole_character_duckdb_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  # `.grouping` is left absent so that the shape under test is the default one
+  # a Total share takes, rather than a spelling of it.
+  summarize <- function(source, column, ...) {
+    summarize_with_margins(
+      source,
+      total = max(!!rlang::sym(column)),
+      whole = share_of_total(total),
+      .by = region,
+      ...
+    )
+  }
+
+  # Runs first for the reason the joined refusal's does: the errors below are
+  # read for their class alone, so without an eligible collection a dropped
+  # table would satisfy them.
+  for (column in c("revenue", "zero", "missing")) {
+    eligible <- dplyr::collect(summarize(remote, column))
+    expect_type(eligible$whole, "double")
+    expect_identical(eligible$whole, rep(1, nrow(eligible)), info = column)
+  }
+
+  for (column in c("numeric_looking", "non_numeric")) {
+    expect_error(
+      summarize(data, column),
+      "plain integer or double scalar",
+      info = column
+    )
+    query <- summarize(remote, column)
+    expect_s3_class(query, "tbl_lazy")
+    error <- expect_error(dplyr::collect(query), info = column)
+    expect_false(inherits(error, "marginplyr_error"), info = column)
+
+    # `.check_share_source = FALSE` governs the dialect-verdict refusal only,
+    # so it does not relax the eligible-type rule on either path.
+    expect_error(
+      summarize(data, column, .check_share_source = FALSE),
+      "plain integer or double scalar",
+      info = column
+    )
+    relaxed <- summarize(remote, column, .check_share_source = FALSE)
+    expect_s3_class(relaxed, "tbl_lazy")
+    expect_error(dplyr::collect(relaxed), info = column)
+  }
+})
+
 test_that("DuckDB Parent shares agree across native, portable, local paths", {
   skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -204,10 +204,10 @@ test_that("dtplyr integer and double Parent shares match local results", {
   expect_type(result$double_share, "double")
 })
 
-# #446 put an expression in the branch that builds no ratio, on every backend
-# rather than on the SQL kinds alone, so data.table is asked to translate it
-# too. What is at risk here is the value: the refusal below is the local
-# eligible-type check, which dtplyr reaches before any share is built.
+# The branch that builds no ratio is not conditioned on backend kind, so
+# data.table translates the same expression the SQL kinds send (#446). What is
+# at risk here is the value: the refusal below is the local eligible-type
+# check, which dtplyr reaches before any share is built.
 test_that("dtplyr Total shares needing no join match local results", {
   skip_if_suggest_absent("dtplyr")
   data <- data.frame(

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1716,9 +1716,9 @@ test_that("DuckDB refuses a character source for a share that needs no join", {
     )
   }
 
-  # Runs first for the reason the joined refusal's does: the errors below are
-  # read for their class alone, so without an eligible collection a dropped
-  # table would satisfy them.
+  # Runs first for the reason the joined refusal's does: the errors a
+  # collection raises below are read for their class alone, so without this a
+  # dropped table would satisfy them.
   for (column in c("revenue", "zero", "missing")) {
     eligible <- dplyr::collect(summarize(remote, column))
     expect_type(eligible$whole, "double")

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -204,6 +204,55 @@ test_that("dtplyr integer and double Parent shares match local results", {
   expect_type(result$double_share, "double")
 })
 
+# #446 put an expression in the branch that builds no ratio, on every backend
+# rather than on the SQL kinds alone, so data.table is asked to translate it
+# too. What is at risk here is the value: the refusal below is the local
+# eligible-type check, which dtplyr reaches before any share is built.
+test_that("dtplyr Total shares needing no join match local results", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.frame(
+    group = c("x", "x", "y"),
+    integer_value = 1:3,
+    double_value = c(0.5, 1.5, 4),
+    missing_value = rep(NA_real_, 3L),
+    zero_value = c(0, 0, 0),
+    character_value = c("1", "2", "3")
+  )
+  # No `.grouping`, so the only occurrence is the Grand total set and every
+  # share is its own denominator.
+  summarize <- function(source) {
+    summarize_with_margins(
+      source,
+      integer_total = sum(integer_value),
+      double_total = sum(double_value),
+      missing_total = sum(missing_value),
+      zero_total = sum(zero_value),
+      integer_share = share_of_total(integer_total),
+      double_share = share_of_total(double_total),
+      missing_share = share_of_total(missing_total),
+      zero_share = share_of_total(zero_total)
+    )
+  }
+
+  expected <- summarize(data)
+  query <- summarize(dtplyr::lazy_dt(data))
+  expect_s3_class(query, "dtplyr_step")
+  result <- dplyr::collect(query)
+  expect_equal(as.data.frame(result), as.data.frame(expected))
+  for (share in c("integer", "double", "missing", "zero")) {
+    expect_identical(result[[paste0(share, "_share")]], 1, info = share)
+  }
+
+  expect_error(
+    dplyr::collect(summarize_with_margins(
+      dtplyr::lazy_dt(data),
+      total = max(character_value),
+      whole = share_of_total(total)
+    )),
+    "plain integer or double scalar"
+  )
+})
+
 test_that("dtplyr validates each referenced source expanded by across", {
   skip_if_suggest_absent("dtplyr")
   data <- data.frame(


### PR DESCRIPTION
Closes #446.

## What was wrong

When every occurrence in a Grouping plan is its own denominator,
`apply_joined_shares()` returned the constant `1.0` before mapping any
denominator or building any ratio. Nothing in the staged query then referenced
the source summary, so a refusing dialect was never asked to bind it: DuckDB
answered `1` for a character source that the local and dtplyr paths refuse.

This is the default shape of a Total share — no `.grouping` and no `.by` reach
it — and it is pre-existing on `main`, not a residual of #429. #429 made the
*ratio* refuse an ineligible source, and this is the path with no ratio.

## The fix

Triage settled that the eligible-type rule is a rule about the source, not
about the ratio, so the code is what is wrong. The constant branch now emits

```r
dplyr::if_else(is.na(<source> * 1L), 1.0, 1.0)
```

which applies to the source the same integer multiplication the ratio applies
— what a refusing dialect rejects for a character column whatever it holds —
while both arms give the constant the branch has always produced. The
condition is an `IS NULL`, which SQL never answers with `NULL`, so no third
value can leak from the `CASE` dbplyr renders without an `ELSE`.

Emitted on every backend, as the ratio's `* 1L` already is, and not
conditional on `.check_share_source`, which governs the dialect-verdict
refusal alone. The denominator mapping and the join stay skipped, so no term
is added to a share that has a denominator and the joined path's SQL is
unchanged.

## Verification

- New test `DuckDB refuses a character source for a share that needs no join`,
  beside the joined refusal's, guarded on `duckdb` and `DBI` alone. It covers
  a numeric-looking and a non-numeric character column, asserts a `tbl_lazy`
  from the verb and a non-`marginplyr_error` at `collect()`, asserts eligible
  double, zero, and all-`NA` sources still collect `1` as a double, and
  asserts `.check_share_source = FALSE` relaxes nothing.
- `Total shares need no join when every occurrence is the whole` keeps every
  assertion and gains no optional-backend requirement.
- `investigation/refusing-a-character-share-source-in-the-staged-query.md`
  gains a dated revisions section with the reachability, backend, SQL-form,
  and flag measurements.
- Full suite: `FAIL 0 | WARN 0 | SKIP 0 | PASS 6835` with `NOT_CRAN=true`.
  `lintr::lint_package()` clean after `load_all()`.

No change to `?share_of_parent`, ADR 0010, any vignette, or `NEWS.md` — the
rule they state is the one being restored.