### PR TITLE
State that the eligible-type rule reads each backend's own summary

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -386,12 +386,12 @@
 #' from a source it has shown to be ineligible. None of it reads a row of your
 #' data.
 #'
-#' That rule reads the type the backend itself computed, not the type the same
-#' expression would produce in R, so an aggregate whose result type differs
-#' across backends is eligible on some and refused on others. `max()` over a
-#' logical column is one: R coerces it to an integer, which the rule accepts,
-#' while a database whose `MAX` returns a boolean has produced an ineligible
-#' summary and refuses the share as its own error at [dplyr::collect()].
+#' The summary that rule judges is the one the backend computed, not the one
+#' the same expression would produce in R, so an aggregate whose result type
+#' differs across backends is eligible on some and refused on others. `max()`
+#' over a logical column is one: R coerces it to an integer, which the rule
+#' accepts, while a database whose `MAX` returns a boolean has produced an
+#' ineligible summary and refuses the share.
 #'
 #' What differs is what establishes the rule, and whether the
 #' exactly-one-value cardinality rule is established with it:

--- a/R/share.R
+++ b/R/share.R
@@ -384,7 +384,16 @@
 #' reported locally, before execution, on every backend. The eligible-type
 #' rule is also enforced on every backend, and no backend calculates a share
 #' from a source it has shown to be ineligible. None of it reads a row of your
-#' data. What differs is what establishes the rule, and whether the
+#' data.
+#'
+#' That rule reads the type the backend itself computed, not the type the same
+#' expression would produce in R, so an aggregate whose result type differs
+#' across backends is eligible on some and refused on others. `max()` over a
+#' logical column is one: R coerces it to an integer, which the rule accepts,
+#' while a database whose `MAX` returns a boolean has produced an ineligible
+#' summary and refuses the share as its own error at [dplyr::collect()].
+#'
+#' What differs is what establishes the rule, and whether the
 #' exactly-one-value cardinality rule is established with it:
 #'
 #' | Backend | What establishes the source rules |

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -404,12 +404,12 @@ rule is also enforced on every backend, and no backend calculates a share
 from a source it has shown to be ineligible. None of it reads a row of your
 data.
 
-That rule reads the type the backend itself computed, not the type the same
-expression would produce in R, so an aggregate whose result type differs
-across backends is eligible on some and refused on others. \code{max()} over a
-logical column is one: R coerces it to an integer, which the rule accepts,
-while a database whose \code{MAX} returns a boolean has produced an ineligible
-summary and refuses the share as its own error at \code{\link[dplyr:collect]{dplyr::collect()}}.
+The summary that rule judges is the one the backend computed, not the one
+the same expression would produce in R, so an aggregate whose result type
+differs across backends is eligible on some and refused on others. \code{max()}
+over a logical column is one: R coerces it to an integer, which the rule
+accepts, while a database whose \code{MAX} returns a boolean has produced an
+ineligible summary and refuses the share.
 
 What differs is what establishes the rule, and whether the
 exactly-one-value cardinality rule is established with it:\tabular{ll}{

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -402,7 +402,16 @@ Syntax, source-name, written-order, and \code{across()} errors are always
 reported locally, before execution, on every backend. The eligible-type
 rule is also enforced on every backend, and no backend calculates a share
 from a source it has shown to be ineligible. None of it reads a row of your
-data. What differs is what establishes the rule, and whether the
+data.
+
+That rule reads the type the backend itself computed, not the type the same
+expression would produce in R, so an aggregate whose result type differs
+across backends is eligible on some and refused on others. \code{max()} over a
+logical column is one: R coerces it to an integer, which the rule accepts,
+while a database whose \code{MAX} returns a boolean has produced an ineligible
+summary and refuses the share as its own error at \code{\link[dplyr:collect]{dplyr::collect()}}.
+
+What differs is what establishes the rule, and whether the
 exactly-one-value cardinality rule is established with it:\tabular{ll}{
    Backend \tab What establishes the source rules \cr
    Local data frame \tab Both, from the result, before any share \cr

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1749,6 +1749,53 @@ test_that("DuckDB refuses a character source for a share that needs no join", {
   }
 })
 
+# #449. The eligible-type rule reads the summary its own backend computed, so
+# an aggregate whose result type differs across backends divides them: R's
+# `max()` coerces a logical to an integer the rule accepts, while DuckDB's
+# `MAX` returns a `BOOLEAN` the staged share's multiplication refuses. Neither
+# backend departed from the rule (ADR 0010), and `?share_of_parent` states the
+# split this pins.
+test_that("a logical source is eligible locally and refused on DuckDB", {
+  skip_if_suggest_absent("duckdb", "DBI")
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  data <- data.frame(
+    region = c("E", "E", "W"),
+    flag = c(TRUE, TRUE, FALSE),
+    revenue = c(1, 2, 4)
+  )
+  remote <- dplyr::copy_to(
+    con,
+    data,
+    "share_source_logical_duckdb_data",
+    overwrite = TRUE,
+    temporary = TRUE
+  )
+  summarize <- function(source, column) {
+    summarize_with_margins(
+      source,
+      total = max(!!rlang::sym(column)),
+      whole = share_of_total(total),
+      .by = region
+    )
+  }
+
+  # Runs first for the reason the character refusals' does: the error collected
+  # below is read for its class alone, since DuckDB's wording is its version's,
+  # so without this a dropped table would satisfy it.
+  eligible <- dplyr::collect(summarize(remote, "revenue"))
+  expect_identical(eligible$whole, rep(1, nrow(eligible)))
+
+  local <- summarize(data, "flag")
+  expect_type(local$total, "integer")
+  expect_identical(local$whole, rep(1, nrow(local)))
+
+  query <- summarize(remote, "flag")
+  expect_s3_class(query, "tbl_lazy")
+  error <- expect_error(dplyr::collect(query))
+  expect_false(inherits(error, "marginplyr_error"))
+})
+
 test_that("DuckDB Parent shares agree across native, portable, local paths", {
   skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1749,12 +1749,11 @@ test_that("DuckDB refuses a character source for a share that needs no join", {
   }
 })
 
-# #449. The eligible-type rule reads the summary its own backend computed, so
-# an aggregate whose result type differs across backends divides them: R's
-# `max()` coerces a logical to an integer the rule accepts, while DuckDB's
-# `MAX` returns a `BOOLEAN` the staged share's multiplication refuses. Neither
-# backend departed from the rule (ADR 0010), and `?share_of_parent` states the
-# split this pins.
+# #449. The eligible-type rule is applied to the summary each backend
+# computed, so an aggregate whose result type differs across backends divides
+# them: DuckDB's `MAX` returns a `BOOLEAN`, which the staged share's
+# multiplication refuses. Neither backend departed from the rule (ADR 0010),
+# and `?share_of_parent` states the split this pins.
 test_that("a logical source is eligible locally and refused on DuckDB", {
   skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
@@ -1780,11 +1779,15 @@ test_that("a logical source is eligible locally and refused on DuckDB", {
     )
   }
 
-  # Runs first for the reason the character refusals' does: the error collected
-  # below is read for its class alone, since DuckDB's wording is its version's,
-  # so without this a dropped table would satisfy it.
+  # Runs first for the reason the character refusals' probe does.
   eligible <- dplyr::collect(summarize(remote, "revenue"))
   expect_identical(eligible$whole, rep(1, nrow(eligible)))
+
+  # What divides the backends is that DuckDB computes the summary and refuses
+  # only the share on it. A `max(flag)` DuckDB could not compute would be the
+  # `mean(<logical>)` case, which plain dbplyr fails identically and which is
+  # therefore not this one.
+  expect_true(dplyr::collect(dplyr::summarise(remote, m = max(flag)))$m)
 
   local <- summarize(data, "flag")
   expect_type(local$total, "integer")


### PR DESCRIPTION
Closes #449.

`max()` over a logical column is an eligible share source locally and refused
on DuckDB: R's `max()` coerces the logical to an integer the eligible-type rule
accepts, while DuckDB's `MAX` returns a `BOOLEAN` that the staged share's
`* 1L` refuses at binding. Both backends applied the rule ADR 0010 states; what
differed is the summary each applied it to. No behavioral change is made — the
reference is what was missing.

## What changed

- `?share_of_parent`'s *Lazy execution boundaries* section now states that the
  eligible-type rule reads the type the backend itself computed, not the type
  the same expression would produce in R, with `max()` over a logical column as
  the aggregate whose result type differs. The backend table's four rows are
  unchanged: the addition is about the input to the rule.
- A DuckDB test pins the split so a change on either side is visible. The local
  call succeeds with an integer summary and a share of `1`; the same call on
  DuckDB builds a `tbl_lazy` that fails at `collect()` with an error that is not
  a `marginplyr_error`. It collects an eligible source first, as the
  neighbouring character-source tests do, so a dropped table cannot satisfy an
  assertion that reads the error for its class alone.

The database-backends vignette was left alone. Its staged-query section already
carries the dialect-verdict argument, and stating the split there too would be a
second copy of what the reference topic now owns.

## Checks

- `testthat::test_local()` with `NOT_CRAN` and every optional Suggest required:
  0 failures, 0 skips.
- `lintr::lint_package()` after `pkgload::load_all(".")`: no lints.
- `roxygen2::roxygenise()`: `man/share_of_parent.Rd` is regenerated and
  committed.
- `spelling::spell_check_package()`: clean.
- The site was not rendered locally. No page, section heading, or
  `verify-site.R` marker is touched by this diff; `altdoc.yaml` covers it.