### PR TITLE
Cast a dictionary column inside the Margin order key

### DIFF
--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -103,10 +103,9 @@ backend_capabilities <- function(kind) {
       "can_read_schema",
       # Arrow holds a factor as a dictionary column, and its sort refuses one
       # -- `dplyr::arrange()` on a dictionary fails the same way with no
-      # marginplyr in the pipeline, so the Margin order casts such a column
-      # inside its key (#452). No other kind is granted this: each of the
-      # others sorts its own factor representation, and casting would order a
-      # restored factor by its character values instead of its levels.
+      # marginplyr in the pipeline (#452). ADR 0018's *Factor dimensions sort
+      # by level* is authoritative for what the Margin order does about it and
+      # for why no other kind is granted this.
       "refuses_dictionary_sort"
     ),
     duckdb = c(

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -65,7 +65,8 @@ backend_capabilities <- function(kind) {
     "native_duplicate_sets",
     "records_window_order",
     "invents_row_on_column_add",
-    "drops_na_factor_level_on_union"
+    "drops_na_factor_level_on_union",
+    "refuses_dictionary_sort"
   )
   enabled <- list(
     local = c(
@@ -98,7 +99,16 @@ backend_capabilities <- function(kind) {
       # branch exists, which is outside what marginplyr promises (ADR 0016).
       "drops_na_factor_level_on_union"
     ),
-    arrow = "can_read_schema",
+    arrow = c(
+      "can_read_schema",
+      # Arrow holds a factor as a dictionary column, and its sort refuses one
+      # -- `dplyr::arrange()` on a dictionary fails the same way with no
+      # marginplyr in the pipeline, so the Margin order casts such a column
+      # inside its key (#452). No other kind is granted this: each of the
+      # others sorts its own factor representation, and casting would order a
+      # restored factor by its character values instead of its levels.
+      "refuses_dictionary_sort"
+    ),
     duckdb = c(
       "collect_selection_proxy",
       "can_read_schema",

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -406,7 +406,8 @@ order_margin_result <- function(operation, result, execution) {
   terms <- margin_order_terms(
     plan = operation$plan,
     sort = operation$sort,
-    sort_id = key_id
+    sort_id = key_id,
+    as_character = margin_dictionary_sort_columns(result, operation$backend)
   )
   if (length(terms) > 0L) {
     result <- dplyr::arrange(result, !!!terms)
@@ -422,6 +423,36 @@ order_margin_result <- function(operation, result, execution) {
 # the result's own column and is never dropped.
 margin_staged_sort_identifier <- function(operation, sort_id) {
   if (identical(sort_id, operation$set_id_name)) NULL else sort_id
+}
+
+# The result columns the key has to cast rather than name, because the backend
+# will not sort them as they stand. Empty for every backend but Arrow, whose
+# dictionary columns its sort refuses.
+#
+# `arrow::schema()` answers from the query's own type metadata, so this adds no
+# query (ADR 0020); it is the read `grouping_selection_proxy()` performs for
+# the same reason. The result is read rather than the input, because what the
+# key names is the result's columns: a labelled dimension crossed the union as
+# character and is not a dictionary by now, whatever the input held.
+#
+# The field's own type is asked rather than `as.data.frame()`'s factor, which
+# would answer the same question through R's conversion. That spelling is what
+# `grouping_selection_proxy()` needs, having to hand the proxy back as a data
+# frame; here nothing needs the conversion, and writing `as.data.frame()`
+# without needing it would put this function in `test-query-policy.R`'s
+# reaching set -- the static scan matches that entry point by name, its subject
+# test being available only to the tracer.
+margin_dictionary_sort_columns <- function(result, backend) {
+  if (!backend$refuses_dictionary_sort) {
+    return(character())
+  }
+  fields <- arrow::schema(result)$fields
+  is_dictionary <- vapply(
+    fields,
+    function(field) inherits(field$type, "DictionaryType"),
+    logical(1)
+  )
+  vapply(fields[is_dictionary], function(field) field$name, character(1))
 }
 
 # Where a backend records a window ordering, `arrange()` has written the key
@@ -452,10 +483,21 @@ forget_margin_window_order <- function(result, backend) {
 #
 # `"first"` reverses the Grouping bits alone. Missingness and values stay
 # ascending, because first and last position margins and not missing values.
-margin_order_terms <- function(plan, sort, sort_id) {
+#
+# `as_character` names the columns whose value term is cast rather than named.
+# Only the value term takes it: the missingness term is a comparison over the
+# column and every backend accepts that. The cast reaches the key alone, so the
+# result's own column keeps whatever the executor left in it.
+margin_order_terms <- function(plan,
+                               sort,
+                               sort_id,
+                               as_character = character()) {
   terms <- unlist(
     lapply(plan$by, function(key) {
-      list(margin_missing_last_expr(key), margin_column_pronoun(key))
+      list(
+        margin_missing_last_expr(key),
+        margin_sort_value_expr(key, as_character)
+      )
     }),
     recursive = FALSE
   )
@@ -475,7 +517,7 @@ margin_order_terms <- function(plan, sort, sort_id) {
       terms,
       list(
         margin_missing_last_expr(dimension),
-        margin_column_pronoun(dimension)
+        margin_sort_value_expr(dimension, as_character)
       )
     )
   }
@@ -484,6 +526,18 @@ margin_order_terms <- function(plan, sort, sort_id) {
     terms <- c(terms, list(margin_column_pronoun(sort_id)))
   }
   terms
+}
+
+# One column's value term, cast where the backend will not sort the column as
+# it stands. The cast is `as.character()` and not a wider coercion because the
+# only such column is a dictionary one, whose values are already strings: a
+# numeric cast to character would order lexicographically and put 10 before 9.
+margin_sort_value_expr <- function(column, as_character) {
+  pronoun <- margin_column_pronoun(column)
+  if (!(column %in% as_character)) {
+    return(pronoun)
+  }
+  rlang::expr(as.character(!!pronoun))
 }
 
 # One column's missingness term. Written as a comparison rather than as the

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -425,9 +425,9 @@ margin_staged_sort_identifier <- function(operation, sort_id) {
   if (identical(sort_id, operation$set_id_name)) NULL else sort_id
 }
 
-# The result columns the key has to cast rather than name, because the backend
-# will not sort them as they stand. Empty for every backend but Arrow, whose
-# dictionary columns its sort refuses.
+# The result columns the key has to cast rather than name. Empty unless the
+# backend holds `refuses_dictionary_sort`, which is where why it does is
+# recorded.
 #
 # `arrow::schema()` answers from the query's own type metadata, so this adds no
 # query (ADR 0020); it is the read `grouping_selection_proxy()` performs for

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -74,6 +74,16 @@ A caller who declared `small < medium < large` asked for that order, and
 `can_restore_factors` is true only for local, dtplyr, and DuckDB, so no
 backend is asked for an order it cannot express.
 
+Arrow is the one backend that expresses neither. It holds a factor as a
+dictionary column and its sort refuses one, so the key casts such a column to
+its values — `refuses_dictionary_sort` is what grants that, and Arrow alone
+holds it. The declared levels are therefore not honoured there, and the cost is
+real: a caller who declared `small < medium < large` gets value order. The
+alternative is not level order but no order at all, the call failing at
+`collect()` with Arrow's own error (#452), which is what it did. The cast
+reaches the key alone, so the result's column is what Arrow returns and this
+takes nothing else away.
+
 ### Missing values come last, and that is promised
 
 Dialects disagree by default: with `arrange(g)` DuckDB returns `NA` last and

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -1330,12 +1330,11 @@ test_that("Arrow executes a Margin order end to end", {
   expect_identical(result$size, c("large", "medium", "small", "Total"))
 })
 
-# Arrow holds a factor as a dictionary column and refuses to sort one, so a
-# Margin order over a factor reaches Arrow's own error unless something
-# converted the column first. A Margin label does that, which is why the block
-# above says nothing about it; these say what happens where nothing does --
-# a typed-missing label, which inserts none, and a fixed key, which holds none
-# (#452).
+# A Margin label converts its dimension to character, which is why the block
+# above reaches no dictionary column and says nothing about one. These cover
+# what a label leaves behind: a typed-missing label, which inserts none, and a
+# fixed key, which holds none (#452). `refuses_dictionary_sort` in
+# `R/grouping-backend.R` is why the distinction matters on this backend alone.
 
 test_that("Arrow orders a factor dimension whose label inserts nothing", {
   skip_if_suggest_absent("arrow")
@@ -1366,7 +1365,18 @@ test_that("Arrow orders a factor dimension whose label inserts nothing", {
     # The result column is untouched: a typed-missing label converts nothing,
     # so the dimension comes back as Arrow returns it and the margin row's
     # value is missing rather than a label.
-    expect_true(is.factor(result$size))
+    # The dimension is an ordered factor, and the class is what the same call
+    # returns without a Margin order: the cast reaches the key alone.
+    expect_identical(
+      class(result$size),
+      class(dplyr::collect(summarize_with_margins(
+        input,
+        units = sum(units),
+        .grouping = rollup(size),
+        .margin_label = label
+      ))$size)
+    )
+    expect_true(is.ordered(result$size))
     expect_identical(
       as.character(result$size),
       replace(labelled$size, labelled$size == "Total", NA_character_)
@@ -1391,25 +1401,32 @@ test_that("Arrow orders a factor fixed key, which holds no Margin label", {
 
   data <- margin_order_data()
   data$region <- factor(data$region, levels = c("West", "East"))
-  result <- dplyr::collect(summarize_with_margins(
-    arrow::as_arrow_table(data),
-    units = sum(units),
-    .by = region,
-    .grouping = rollup(store),
-    .sort = "last"
-  ))
+  input <- arrow::as_arrow_table(data)
 
-  # A fixed key is never converted, so it stays a dictionary column and orders
-  # by its values -- Arrow restores no levels, so "East" precedes "West".
-  expect_true(is.factor(result$region))
-  expect_identical(
-    as.character(result$region),
-    c("East", "East", "East", "West", "West", "West")
-  )
-  expect_identical(
-    result$store,
-    c("s1", "s2", "Total", "s3", "s4", "Total")
-  )
+  for (label in list("Total", NULL)) {
+    result <- dplyr::collect(summarize_with_margins(
+      input,
+      units = sum(units),
+      .by = region,
+      .grouping = rollup(store),
+      .margin_label = label,
+      .sort = "last"
+    ))
+
+    # A fixed key is never converted whatever the label is, so it stays a
+    # dictionary column and orders by its values rather than by the declared
+    # levels, which put "West" first.
+    expect_true(is.factor(result$region))
+    expect_identical(
+      as.character(result$region),
+      c("East", "East", "East", "West", "West", "West")
+    )
+    margin <- label %||% NA_character_
+    expect_identical(
+      as.character(result$store),
+      c("s1", "s2", margin, "s3", "s4", margin)
+    )
+  }
 })
 
 test_that("Arrow orders a composite factor dimension under expansion", {
@@ -1426,8 +1443,7 @@ test_that("Arrow orders a composite factor dimension under expansion", {
   ))
 
   # A composite dimension's columns share one Grouping bit, so the margin rows
-  # come last as a block. The order is the local backend's, which the
-  # alphabetical levels here make comparable across the two.
+  # come last as a block rather than one per column.
   expect_true(is.factor(result$region))
   expect_identical(
     as.character(result$region),

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -1329,3 +1329,112 @@ test_that("Arrow executes a Margin order end to end", {
   ))
   expect_identical(result$size, c("large", "medium", "small", "Total"))
 })
+
+# Arrow holds a factor as a dictionary column and refuses to sort one, so a
+# Margin order over a factor reaches Arrow's own error unless something
+# converted the column first. A Margin label does that, which is why the block
+# above says nothing about it; these say what happens where nothing does --
+# a typed-missing label, which inserts none, and a fixed key, which holds none
+# (#452).
+
+test_that("Arrow orders a factor dimension whose label inserts nothing", {
+  skip_if_suggest_absent("arrow")
+
+  input <- arrow::as_arrow_table(margin_order_factor_data())
+
+  # The order a Margin label already produced on this backend, which the block
+  # above asserts: Arrow restores no levels, so the dimension orders by its
+  # character values and the margin row goes last. A typed-missing label owes
+  # the same order, with a missing value where the label would have been.
+  labelled <- dplyr::collect(summarize_with_margins(
+    input,
+    units = sum(units),
+    .grouping = rollup(size),
+    .margin_label = "Total",
+    .sort = "last"
+  ))
+  expect_identical(labelled$size, c("large", "medium", "small", "Total"))
+
+  for (label in list(NULL, NA_character_)) {
+    result <- dplyr::collect(summarize_with_margins(
+      input,
+      units = sum(units),
+      .grouping = rollup(size),
+      .margin_label = label,
+      .sort = "last"
+    ))
+    # The result column is untouched: a typed-missing label converts nothing,
+    # so the dimension comes back as Arrow returns it and the margin row's
+    # value is missing rather than a label.
+    expect_true(is.factor(result$size))
+    expect_identical(
+      as.character(result$size),
+      replace(labelled$size, labelled$size == "Total", NA_character_)
+    )
+  }
+
+  first <- dplyr::collect(summarize_with_margins(
+    input,
+    units = sum(units),
+    .grouping = rollup(size),
+    .margin_label = NULL,
+    .sort = "first"
+  ))
+  expect_identical(
+    as.character(first$size),
+    c(NA, "large", "medium", "small")
+  )
+})
+
+test_that("Arrow orders a factor fixed key, which holds no Margin label", {
+  skip_if_suggest_absent("arrow")
+
+  data <- margin_order_data()
+  data$region <- factor(data$region, levels = c("West", "East"))
+  result <- dplyr::collect(summarize_with_margins(
+    arrow::as_arrow_table(data),
+    units = sum(units),
+    .by = region,
+    .grouping = rollup(store),
+    .sort = "last"
+  ))
+
+  # A fixed key is never converted, so it stays a dictionary column and orders
+  # by its values -- Arrow restores no levels, so "East" precedes "West".
+  expect_true(is.factor(result$region))
+  expect_identical(
+    as.character(result$region),
+    c("East", "East", "East", "West", "West", "West")
+  )
+  expect_identical(
+    result$store,
+    c("s1", "s2", "Total", "s3", "s4", "Total")
+  )
+})
+
+test_that("Arrow orders a composite factor dimension under expansion", {
+  skip_if_suggest_absent("arrow")
+
+  data <- margin_order_data()
+  data$region <- factor(data$region)
+  data$store <- factor(data$store)
+  result <- dplyr::collect(expand_with_margins(
+    arrow::as_arrow_table(data),
+    .grouping = rollup(c(region, store)),
+    .margin_label = NULL,
+    .sort = "last"
+  ))
+
+  # A composite dimension's columns share one Grouping bit, so the margin rows
+  # come last as a block. The order is the local backend's, which the
+  # alphabetical levels here make comparable across the two.
+  expect_true(is.factor(result$region))
+  expect_identical(
+    as.character(result$region),
+    c(rep("East", 4L), rep("West", 4L), rep(NA_character_, 4L))
+  )
+  expect_identical(
+    as.character(result$store),
+    c("s1", "s2", NA, NA, "s3", "s4", NA, NA, rep(NA_character_, 4L))
+  )
+})


### PR DESCRIPTION
Closes #452.

Arrow holds a factor as a dictionary column and its sort refuses one, so a Margin order over a factor dimension whose Margin label inserts nothing, or over a factor fixed key, failed at `collect()` with Arrow's own error. A label converts the dimension to character, which is why only the typed-missing case and the fixed key — which never holds a label — reached it. `dplyr::arrange()` on a dictionary fails the same way with no marginplyr in the pipeline.

Two documented promises were false while that stood: that a Margin order composes with no diagnostic, and that a typed-missing label converts nothing on Arrow. The cast reaches the sort key alone, so the second stays literally true of the result — the dimension still comes back as Arrow returns it.

`refuses_dictionary_sort` is granted to Arrow alone. ADR 0018's *Factor dimensions sort by level* now records what that costs there: a caller who declared `small < medium < large` gets value order, the alternative being no order at all.

The dictionary columns are read from the result's Arrow schema, which sends no query (ADR 0020). The field's own type is asked rather than `as.data.frame()`'s factor, so `test-query-policy.R`'s reaching set is unchanged — its static scan matches that entry point by name, the subject test being the tracer's alone.

## Review record

One round, `mattpocock-skills:code-review`, against `main`...`17161a9`. Answered in `ce1915c`.

**Standards** — two findings.

| finding | disposition |
|---|---|
| ADR 0018's *Factor dimensions sort by level* is silent on a backend that expresses neither level order nor value order without a cast, and the diff amends nothing (hard violation) | fixed in prose: the section now records Arrow's case and its cost |
| the same argument for the cast is written in three files that can drift (judgement call, Duplicated Code) | fixed in prose: the capability grant and ADR 0018 own it, and the helper header and the test comment cite them |

Checked and compliant: `arrow::schema()` sits behind a backend-kind guard, the case *Dependency metadata* names for `R/backend-metadata.R`; ADR 0020 is not reached; each new test requires Arrow alone through `skip_if_suggest_absent()`.

**Spec** — no scope creep and nothing implemented wrongly; three coverage gaps, each over behaviour that already worked.

| finding | disposition |
|---|---|
| the result column's class is asserted in the absolute rather than against the same call without a Margin order | fixed in code |
| no test constructs an ordered factor — raised in error, the fixture already is one, but the assertion read `is.factor()` | fixed in code: the assertion is now `is.ordered()` |
| the factor fixed key is exercised under one label only | fixed in code: both a named and a typed-missing label |
| the composite test's comment claims a comparison against the local backend that it never runs | fixed in prose: the claim is deleted |

Local: full suite green with `NOT_CRAN` set, `lintr::lint_package()` clean, `verify-context-budget.R` within baseline. No roxygen changed, so nothing under `man/` regenerates.