### PR TITLE
Refuse a dtplyr step a backend would write to

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -372,6 +372,12 @@ markers <- list(
     "DuckDB covers native SQL end to end",
     "dozen-plus fallback dialects",
     "Arrow and dtplyr are tested for the lazy",
+    # The unconditional half of the mutable-step refusal (ADR 0029). Its
+    # `must_error` chunk is behind `has_dtplyr`, so the prose introducing it is
+    # what a marker can reach, and this run of it holds no apostrophe and no
+    # double hyphen — pandoc's `smart` extension rewrites both in prose, where
+    # only a code span keeps them literal.
+    "builds one branch per grouping set from the step it is given",
     # The unconditional half of the absorbed-summary section. Its `must_error`
     # chunk is behind `has_arrow` like the two share refusals below it, so the
     # prose introducing it is what a marker can reach. Chosen from a run of

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,6 +161,22 @@ absorbing reads every column of the input while a caller who is told can read
 fewer.
 _Avoid_: Pulling backend, fallback backend, collecting backend
 
+**Mutable step**:
+A dtplyr step whose root was built with `dtplyr::lazy_dt(immutable = FALSE)`,
+which is the caller giving data.table permission to write to their own table.
+It is a property of how the input was constructed rather than of its class,
+and it is therefore finer-grained than a backend kind, one kind holding both,
+which is why it is established by walking the step's parents to its root
+rather than looked up. Nothing below the root separates the derivations that
+destroy the caller's table from the ones that survive: a `filter()` and a
+`select()` over the same mutable root produce the same step class carrying the
+same field value and fall on opposite sides. A Margin verb refuses one before
+any branch is built, because it builds one branch per grouping set from the
+same step and data.table writes each of them to the caller's table by
+reference — leaving a result in which every row carries the margin label, and
+a table whose columns were dropped or whose names were permuted.
+_Avoid_: Mutable input, in-place backend
+
 **Sent query**:
 One SQL statement marginplyr gives to a backend while compiling a Grouping
 plan or while executing the Margin operation built on one, recorded with the

--- a/NEWS.md
+++ b/NEWS.md
@@ -206,6 +206,18 @@
   returned the right answer, having read the whole input to get it — so on
   those versions this is a breaking change, and the rewrites the refusal names
   reproduce the old result while letting you choose what is read.
+* A dtplyr input built with `dtplyr::lazy_dt(immutable = FALSE)` is now
+  refused, before any branch is built. A margin verb builds one branch per
+  grouping set from the step you gave it, and a mutable step lets data.table
+  write every one of those branches back to your own table by reference: the
+  call returned a result whose every row carried the margin label, and left
+  your table with a column dropped or its names permuted while its data stayed
+  put. The refusal names the one rewrite, `dtplyr::lazy_dt(immutable = TRUE)`,
+  which is what `lazy_dt()` does by default. It is deliberately wider than the
+  damage — a mutable step you only filtered comes back correct today and is
+  refused with the rest — because which derivations survive is decided by the
+  query dtplyr generates rather than by anything marginplyr can promise. A
+  `data.table` passed directly is unaffected, and so is every other backend.
 * A `.grouping` or `.by` selection whose failure the column names already
   settle is now refused without querying your input. This reaches the
   set-difference operator `/` that tidyselect reads, the arithmetic and

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -61,9 +61,9 @@ grouping_backend <- function(.data) {
 # the copy.
 #
 # The root is what is read, and every derived step carries the field too. Its
-# value there answers a different question: `filter()` and `select()` both
-# produce a `dtplyr_step_subset` carrying `TRUE`, and only one of them destroys
-# the caller's table, so no step below the root separates the destructive
+# value there answers a different question: a `filter()` and a `select()` over
+# one mutable root both carry `TRUE`, and only one of them destroys the
+# caller's table, so no step below the root separates the destructive
 # derivations from the safe ones (#451). Walking to the root asks the question
 # that does separate them -- whether dtplyr was given permission to write to
 # the caller's table at all.
@@ -73,29 +73,27 @@ grouping_backend <- function(.data) {
 # `data.table` it was built from, so a class test would be a second reading of
 # the same boundary.
 #
-# A missing field answers `FALSE`. Both names are non-exported dtplyr
-# internals, so a dtplyr that renamed either would otherwise make this refuse
-# on a field that no longer means what it did; `test-grouping-backends.R` pins
-# both, which is what reports that change.
+# Both fields are read with `[[`, whose character index is exact, and not with
+# `$`, which matches a prefix on a list -- so a dtplyr that renamed
+# `implicit_copy` to something starting with it would otherwise be read rather
+# than let through. A field neither name finds answers `FALSE`, both being
+# non-exported dtplyr internals; `test-grouping-backends.R` pins them, which is
+# what reports such a release.
 mutable_dtplyr_step <- function(.data) {
   if (!inherits(.data, "dtplyr_step")) {
     return(FALSE)
   }
   root <- .data
-  while (inherits(root$parent, "dtplyr_step")) {
-    root <- root$parent
+  while (inherits(root[["parent"]], "dtplyr_step")) {
+    root <- root[["parent"]]
   }
-  isTRUE(root$implicit_copy)
+  isTRUE(root[["implicit_copy"]])
 }
 
 # The refusal a Mutable step earns, raised before any branch is built and so
-# before the caller's table can be written to (ADR 0029).
-#
-# The refusal is deliberately wider than the damage: a step derived from a
-# mutable root with `filter()` alone comes back correct today, and is refused
-# anyway, because which derivations survive is a property of the query dtplyr
-# generated rather than anything this package can promise. ADR 0029 records
-# that line and what it costs.
+# before the caller's table can be written to. ADR 0029 records why the input
+# is refused rather than copied, and how much wider than the damage the line is
+# drawn.
 abort_mutable_dtplyr_step <- function() {
   abort_marginplyr(c(
     "{.arg .data} comes from {.code dtplyr::lazy_dt(immutable = FALSE)}.",

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -55,6 +55,58 @@ grouping_backend <- function(.data) {
   )
 }
 
+# Whether this input is a Mutable step: a dtplyr step whose root was built with
+# `immutable = FALSE`. `lazy_dt()` records that argument as `implicit_copy` on
+# the `dtplyr_step_first` it returns, inverted -- `TRUE` is the caller waiving
+# the copy.
+#
+# The root is what is read, and every derived step carries the field too. Its
+# value there answers a different question: `filter()` and `select()` both
+# produce a `dtplyr_step_subset` carrying `TRUE`, and only one of them destroys
+# the caller's table, so no step below the root separates the destructive
+# derivations from the safe ones (#451). Walking to the root asks the question
+# that does separate them -- whether dtplyr was given permission to write to
+# the caller's table at all.
+#
+# The walk stops where the parent stops being a step, rather than at
+# `dtplyr_step_first` by class: the root's own `parent` holds the
+# `data.table` it was built from, so a class test would be a second reading of
+# the same boundary.
+#
+# A missing field answers `FALSE`. Both names are non-exported dtplyr
+# internals, so a dtplyr that renamed either would otherwise make this refuse
+# on a field that no longer means what it did; `test-grouping-backends.R` pins
+# both, which is what reports that change.
+mutable_dtplyr_step <- function(.data) {
+  if (!inherits(.data, "dtplyr_step")) {
+    return(FALSE)
+  }
+  root <- .data
+  while (inherits(root$parent, "dtplyr_step")) {
+    root <- root$parent
+  }
+  isTRUE(root$implicit_copy)
+}
+
+# The refusal a Mutable step earns, raised before any branch is built and so
+# before the caller's table can be written to (ADR 0029).
+#
+# The refusal is deliberately wider than the damage: a step derived from a
+# mutable root with `filter()` alone comes back correct today, and is refused
+# anyway, because which derivations survive is a property of the query dtplyr
+# generated rather than anything this package can promise. ADR 0029 records
+# that line and what it costs.
+abort_mutable_dtplyr_step <- function() {
+  abort_marginplyr(c(
+    "{.arg .data} comes from {.code dtplyr::lazy_dt(immutable = FALSE)}.",
+    i = paste0(
+      "A margin verb builds one branch per grouping set from the same step, ",
+      "and data.table writes each branch to your table by reference."
+    ),
+    i = "Rebuild the input with {.code dtplyr::lazy_dt(immutable = TRUE)}."
+  ))
+}
+
 backend_capabilities <- function(kind) {
   capability_names <- c(
     "collect_selection_proxy",

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -183,13 +183,10 @@ prepare_grouping_plan <- function(.data,
       input <- normalize_grouping_input(.data, by_quo)
       data <- input$data
       backend <- grouping_backend(data)
-      # Here rather than in `grouping_backend()`, which several callers ask for
-      # a kind without building anything, and after it rather than before:
-      # `check_backend_version()` runs inside it, so a dtplyr below the floor
-      # is answered by the floor rather than by a field that version may spell
-      # differently. Nothing above this point has read a row (ADR 0005), and a
-      # `.grouping` grammar error keeps the precedence it already had, its
-      # passes sitting further up.
+      # After `grouping_backend()` rather than before, because
+      # `check_backend_version()` runs inside it: a dtplyr below the floor is
+      # then answered by the floor rather than by a field that version may
+      # spell differently. ADR 0029 is authoritative for the placement.
       if (mutable_dtplyr_step(data)) {
         abort_mutable_dtplyr_step()
       }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -183,6 +183,16 @@ prepare_grouping_plan <- function(.data,
       input <- normalize_grouping_input(.data, by_quo)
       data <- input$data
       backend <- grouping_backend(data)
+      # Here rather than in `grouping_backend()`, which several callers ask for
+      # a kind without building anything, and after it rather than before:
+      # `check_backend_version()` runs inside it, so a dtplyr below the floor
+      # is answered by the floor rather than by a field that version may spell
+      # differently. Nothing above this point has read a row (ADR 0005), and a
+      # `.grouping` grammar error keeps the precedence it already had, its
+      # passes sitting further up.
+      if (mutable_dtplyr_step(data)) {
+        abort_mutable_dtplyr_step()
+      }
       remember_sent_query_backend(backend)
       data_vars <- get_col_names(data, dplyr::everything())
       by <- resolve_fixed_keys(by_quo, input$groups, data_vars)

--- a/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
+++ b/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
@@ -53,9 +53,9 @@ FALSE) |> filter(...)` returns a correct result today and leaves the table
 intact, and it is refused. This is accepted rather than worked around, because
 what makes it safe is a property of the query dtplyr generated for that
 derivation and not anything this package can promise across dtplyr versions —
-and, measured in #451, `filter()` and `select()` produce the same step class
-carrying the same `implicit_copy` value and fall on opposite sides. No step
-below the root separates them.
+and, measured in #451, a `filter()` and a `select()` over one mutable root
+carry the same `implicit_copy` value and fall on opposite sides. No step below
+the root separates them.
 
 Nor does the verb separate them. `summarize_with_margins()` returned a correct
 result over the same input while `expand_with_margins()` did not, and
@@ -119,9 +119,11 @@ against the input. ADR 0005 puts a local refusal in front of both.
 
 The database-backends vignette shows the refusal in a `must_error:
 marginplyr_error` chunk beside the other dtplyr sections, and
-`.github/scripts/verify-site.R` gains the matching marker. The marker is chosen
-from the refusal's own uninterpolated prose, per ADR 0023's condition 3; the
-refusal interpolates nothing, so any of its three lines would serve.
+`.github/scripts/verify-site.R` gains the matching marker. That chunk is behind
+`has_dtplyr` and renders nothing where dtplyr is absent, so the marker is
+quoted from the unconditional prose introducing it rather than from the
+diagnostic — the placement `verify-site.R`'s own comment on the entry states,
+and the one the Arrow refusal beside it already takes.
 
 `?marginplyr` is unchanged: what a caller catches is the `marginplyr_error`
 that page already promises.
@@ -129,17 +131,28 @@ that page already promises.
 ## Test strategy
 
 The tests sit where the backend-kind contracts do and are guarded by
-`skip_if_suggest_absent("dtplyr")`. They require dtplyr alone, so the
-one-backend-per-test rule `AGENTS.md` states holds.
+`skip_if_suggest_absent("dtplyr")`. They call `data.table::` — `lazy_dt()`
+refuses `immutable = FALSE` for anything that is not already a data table, so
+the input cannot be built without it — and take no guard on data.table, which
+is the one-backend-per-test rule holding rather than being bent. dtplyr
+declares `Imports: data.table`, so data.table is never the reason one of these
+tests could fail, and a guard on it would instead skip the whole set in the
+dtplyr coverage configuration, where `verify-suite-coverage.R` hides every
+other member of `optional_backends()`. The test states this where it calls it.
 
-Four assertions, and the last of them is the one that is not about behaviour:
+The last assertion below is the one that is not about behaviour:
 
-- Every verb `verbs_taking(".grouping")` returns refuses a mutable root, with
-  the wording pinned once by snapshot. The set is derived rather than listed,
-  so a seventh verb fails here instead of arriving unrefused.
+- Every verb `verbs_taking(".grouping")` returns refuses a mutable root, each
+  pinned by snapshot. The set is derived rather than listed, so a seventh verb
+  fails here instead of arriving unrefused, and one snapshot per verb is what
+  pins the part that differs between them — the call the refusal blames.
 - The caller's table is unchanged after a refusal, in names, columns, and rows.
   That is what the refusal is for, and a refusal raised after the damage would
   otherwise pass every other assertion.
+- A grouped mutable step reaches this refusal rather than the fixed-key
+  rejection its groups used to earn, the refusal sitting above key resolution.
+  That is a consequence of the placement above and is pinned rather than left
+  to be rediscovered.
 - The pair that proves the predicate reads the root: a `filter()` over a
   mutable root is refused, a `mutate()` over an immutable one is accepted. Both
   steps sit one level from their root, so a predicate reading the step it was

--- a/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
+++ b/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
@@ -1,0 +1,161 @@
+# Refuse a step a backend would write to
+
+A Margin verb refuses a Mutable step — a dtplyr step whose root was built with
+`dtplyr::lazy_dt(immutable = FALSE)` — and refuses it before any branch is
+built. The refusal is a Package condition naming where the input came from, why
+a Margin verb cannot use it, and the one rewrite that fixes it:
+`dtplyr::lazy_dt(immutable = TRUE)`.
+
+`CONTEXT.md` defines *Mutable step*. What the refusal answers is measured in
+#451: over such an input `expand_with_margins()` returned a result in which
+every row carried the margin label, and left the caller holding a table whose
+column *names* had been permuted while its column *data* had not — so
+`dtx$region` afterwards held the integers that had been `dtx$year`. A
+`select()` in the input's own pipeline lost the caller a column outright.
+
+## Why this is marginplyr's to refuse
+
+The hazard is dtplyr's. `union_all(mutate(l, region = "T"), l)` over a mutable
+step returns the same wrong answer with no marginplyr involved, so a
+multi-branch query over a step data.table may write to is broken wherever it is
+written. That report is filed separately and this refusal does not wait on it.
+
+What marginplyr adds is the part a caller cannot see. A Margin verb builds one
+branch per grouping set from the one step it was handed, so a caller who wrote
+no union at all gets one; the branches then write to the same table by
+reference and the second overwrites the first before the union runs. The caller
+asked for a rollup and received a corrupted table, and the only thing marginplyr
+said about it was a `data.table` shallow-copy warning it passed along.
+
+## Why the input is refused rather than copied or documented
+
+[ADR 0025](0025-refuse-a-summary-a-backend-would-absorb.md) is the precedent,
+and this differs from it in what is at stake rather than in the disposition.
+0025 refuses because a backend would **read more than the caller needs** — the
+result is right and the cost is unasked-for. This refuses because a backend
+would **destroy what the caller holds**. So 0025 had to argue that the caller
+loses nothing by being asked; here there is no comparison to make, because the
+alternative is a wrong answer over a damaged input.
+
+The rest follows from ADR 0020's rule that when the caller's data is touched is
+the caller's to decide, read at its strongest: a verb that writes to the
+caller's table has not merely read early, it has changed what the caller can
+read at all.
+
+## The line is drawn at the root, and it over-refuses
+
+The refusal is decided by walking `$parent` to the root and asking whether that
+`dtplyr_step_first` carries `implicit_copy = TRUE`, which is `lazy_dt()`'s
+`immutable = FALSE` recorded under the opposite name.
+
+That question is deliberately coarser than the damage. `lazy_dt(d, immutable =
+FALSE) |> filter(...)` returns a correct result today and leaves the table
+intact, and it is refused. This is accepted rather than worked around, because
+what makes it safe is a property of the query dtplyr generated for that
+derivation and not anything this package can promise across dtplyr versions —
+and, measured in #451, `filter()` and `select()` produce the same step class
+carrying the same `implicit_copy` value and fall on opposite sides. No step
+below the root separates them.
+
+Nor does the verb separate them. `summarize_with_margins()` returned a correct
+result over the same input while `expand_with_margins()` did not, and
+`nest_with_margins()` corrupted the caller's table while returning a correct
+result — three verbs, three different consequences, one preparation path. So
+"the verbs that build more than one branch", which is how #451 first framed the
+scope, is not a boundary either: every verb reaches the same place, and whether
+the reference write is destructive is decided by the query.
+
+**A field that cannot be found lets the input through.** A future dtplyr that
+renames or removes `implicit_copy` would otherwise make this refuse on a field
+that no longer means what it did, and a Package condition raised on a
+misreading is worse than the hazard, because the rewrite it names would not
+help. The tests are what report such a release: they pin both fields in both
+directions and on a derived step, so the change fails CI rather than silently
+switching the refusal off.
+
+## Where it is raised
+
+On the one preparation path every verb taking `.grouping` shares —
+`prepare_grouping_plan()`, which `prepare_margin_operation()` and
+`inspect_grouping()` both reach — immediately after `grouping_backend()` has
+resolved the kind.
+
+After rather than before, because `grouping_backend()` checks the dtplyr
+version floor: a dtplyr below it is answered by the floor rather than by a
+field that version may spell differently. Nothing above that point has read a
+row, which is what ADR 0005 requires, and no `.grouping` grammar error loses
+its precedence — those passes sit further up the same function and are not
+hoisted.
+
+## Considered options
+
+**Warn and copy the input.** Rejected. It is the option that looks like a
+service and is not one: `data.table::copy()` on a caller's table is a
+materialization of exactly the size they asked not to pay for, chosen by a verb
+they did not ask to choose it — the shape ADR 0020 exists to forbid, arriving
+under a warning most callers will not act on. It also answers the wrong
+question, since the caller's `immutable = FALSE` was a deliberate statement
+about their memory budget and copying overrides it silently.
+
+**A per-step predicate, refusing only the derivations that destroy.** Rejected
+on the measurement above: `filter()` and `select()` are indistinguishable by
+step class and by field value. Building one would mean reading dtplyr's
+generated expression to decide, which is a second implementation of dtplyr's
+translation whose failure mode is the silent corruption this refuses.
+
+**Document the hazard and leave the input accepted.** Rejected, and it is worth
+naming because it is what the package did. Nothing in `R/`, `man/`, or
+`vignettes/` mentioned `immutable` before this decision, so "leave it
+documented" was never the status quo it sounds like — and a documented hazard
+whose symptom is a silently permuted table is one a reader has to have already
+hit to recognise.
+
+**Refuse in the union adapter, where the branches are built.** Rejected. It is
+where the damage happens and not where it can be prevented: by then metadata
+has been acquired and, for the verbs that read one, the plan has been compiled
+against the input. ADR 0005 puts a local refusal in front of both.
+
+## Documentation consequences
+
+The database-backends vignette shows the refusal in a `must_error:
+marginplyr_error` chunk beside the other dtplyr sections, and
+`.github/scripts/verify-site.R` gains the matching marker. The marker is chosen
+from the refusal's own uninterpolated prose, per ADR 0023's condition 3; the
+refusal interpolates nothing, so any of its three lines would serve.
+
+`?marginplyr` is unchanged: what a caller catches is the `marginplyr_error`
+that page already promises.
+
+## Test strategy
+
+The tests sit where the backend-kind contracts do and are guarded by
+`skip_if_suggest_absent("dtplyr")`. They require dtplyr alone, so the
+one-backend-per-test rule `AGENTS.md` states holds.
+
+Four assertions, and the last of them is the one that is not about behaviour:
+
+- Every verb `verbs_taking(".grouping")` returns refuses a mutable root, with
+  the wording pinned once by snapshot. The set is derived rather than listed,
+  so a seventh verb fails here instead of arriving unrefused.
+- The caller's table is unchanged after a refusal, in names, columns, and rows.
+  That is what the refusal is for, and a refusal raised after the damage would
+  otherwise pass every other assertion.
+- The pair that proves the predicate reads the root: a `filter()` over a
+  mutable root is refused, a `mutate()` over an immutable one is accepted. Both
+  steps sit one level from their root, so a predicate reading the step it was
+  handed passes neither.
+- Both dtplyr fields, pinned in both directions and on a derived step. A dtplyr
+  that renames either makes the refusal stop firing, and a refusal that stopped
+  firing reads exactly like an input nothing is wrong with — which is the
+  silence this decision exists to remove.
+
+## Related decisions
+
+ADR 0025 is the precedent and the contrast above. ADR 0020 is the rule this
+serves. ADR 0005 is what places the refusal before any backend read. ADR 0015
+is the boundary it is placed against — a caller reaching it has a one-line
+rewrite, which is what makes it a Package condition. ADR 0023 is the idiom it
+is authored in and ADR 0024 the rule it spells `.data` by.
+
+Evidence: #451, whose triage comment holds the table of eight inputs the root
+predicate was chosen from.

--- a/tests/testthat/_snaps/grouping-backends.md
+++ b/tests/testthat/_snaps/grouping-backends.md
@@ -1,0 +1,11 @@
+# every margin verb refuses a mutable dtplyr step
+
+    Code
+      expand_with_margins(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE),
+      .grouping = rollup(region))
+    Condition
+      Error in `expand_with_margins()`:
+      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
+      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
+

--- a/tests/testthat/_snaps/grouping-backends.md
+++ b/tests/testthat/_snaps/grouping-backends.md
@@ -1,10 +1,65 @@
-# every margin verb refuses a mutable dtplyr step
+# the refusal reads as it is written, for every verb
 
     Code
-      expand_with_margins(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE),
-      .grouping = rollup(region))
+      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
+        region))
+    Condition
+      Error in `summarize_with_margins()`:
+      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
+      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
+
+---
+
+    Code
+      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
+        region))
+    Condition
+      Error in `summarise_with_margins()`:
+      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
+      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
+
+---
+
+    Code
+      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
+        region))
     Condition
       Error in `expand_with_margins()`:
+      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
+      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
+
+---
+
+    Code
+      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
+        region))
+    Condition
+      Error in `nest_with_margins()`:
+      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
+      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
+
+---
+
+    Code
+      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
+        region))
+    Condition
+      Error in `nest_by_with_margins()`:
+      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
+      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
+
+---
+
+    Code
+      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
+        region))
+    Condition
+      Error in `inspect_grouping()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
       i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.

--- a/tests/testthat/helper-margin-verbs.R
+++ b/tests/testthat/helper-margin-verbs.R
@@ -22,3 +22,45 @@ verbs_taking <- function(arg) {
     getNamespaceExports("marginplyr")
   )
 }
+
+# One wrapper per verb, forwarding both arguments with `{{ }}`, so that a test
+# putting one expression through every verb writes it once. Each supplies
+# whatever else its own signature requires and nothing more, which is why the
+# two summary verbs carry a `total` and the other four take the data alone.
+#
+# Here rather than in the file that wanted it first, by the argument this
+# file's header already makes: `test-grouping-plan.R` puts empty arguments
+# through it and `test-grouping-backends.R` a refused input, and a per-file
+# copy is what could disagree with `verbs_taking()` above while the other still
+# matched it. Every caller holds the two to each other, so a seventh verb fails
+# where it is used rather than arriving uncovered.
+forwarded_verbs <- list(
+  summarize_with_margins = function(data, by, grouping) {
+    summarize_with_margins(
+      data,
+      total = sum(value),
+      .by = {{ by }},
+      .grouping = {{ grouping }}
+    )
+  },
+  summarise_with_margins = function(data, by, grouping) {
+    summarise_with_margins(
+      data,
+      total = sum(value),
+      .by = {{ by }},
+      .grouping = {{ grouping }}
+    )
+  },
+  expand_with_margins = function(data, by, grouping) {
+    expand_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+  },
+  nest_with_margins = function(data, by, grouping) {
+    nest_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+  },
+  nest_by_with_margins = function(data, by, grouping) {
+    nest_by_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
+  },
+  inspect_grouping = function(data, by, grouping) {
+    inspect_grouping(data, .by = {{ by }}, .grouping = {{ grouping }})
+  }
+)

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -2171,3 +2171,146 @@ test_that("DuckDB safely quotes factor identifiers and labels", {
   expect_true(is.factor(result[["odd name"]]))
   expect_true("O'Total" %in% levels(result[["odd name"]]))
 })
+
+# A Mutable step is a dtplyr step whose root was built with
+# `immutable = FALSE`, and every verb taking `.grouping` refuses one (#451,
+# ADR 0029). The tests below require dtplyr alone, so the one-backend-per-test
+# rule holds.
+mutable_step_data <- function() {
+  data.table::data.table(
+    year = c(2023L, 2023L, 2024L),
+    region = c("East", "West", "West"),
+    value = c(1, 2, 3)
+  )
+}
+
+# One call per verb, each supplying only what its signature requires. The names
+# are held to `verbs_taking(".grouping")` below rather than being trusted, so a
+# seventh verb fails here instead of arriving unrefused.
+mutable_step_verbs <- list(
+  summarize_with_margins = function(data) {
+    summarize_with_margins(data, total = sum(value), .grouping = rollup(region))
+  },
+  summarise_with_margins = function(data) {
+    summarise_with_margins(data, total = sum(value), .grouping = rollup(region))
+  },
+  expand_with_margins = function(data) {
+    expand_with_margins(data, .grouping = rollup(region))
+  },
+  nest_with_margins = function(data) {
+    nest_with_margins(data, .grouping = rollup(region))
+  },
+  nest_by_with_margins = function(data) {
+    nest_by_with_margins(data, .grouping = rollup(region))
+  },
+  inspect_grouping = function(data) {
+    inspect_grouping(data, .grouping = rollup(region))
+  }
+)
+
+test_that("every margin verb refuses a mutable dtplyr step", {
+  skip_if_suggest_absent("dtplyr")
+  expect_setequal(names(mutable_step_verbs), verbs_taking(".grouping"))
+
+  for (name in names(mutable_step_verbs)) {
+    data <- mutable_step_data()
+    before <- data.table::copy(data)
+    step <- dtplyr::lazy_dt(data, immutable = FALSE)
+
+    error <- expect_error(mutable_step_verbs[[name]](step))
+    expect_s3_class(error, "marginplyr_error")
+    # The whole point of refusing: the table the caller still holds is the one
+    # they handed over, in its names, its columns, and its rows.
+    expect_identical(as.data.frame(data), as.data.frame(before), info = name)
+  }
+
+  # The wording, pinned once. Every verb raises the same three lines, and the
+  # blamed call is the only part that differs between them.
+  expect_snapshot(
+    error = TRUE,
+    expand_with_margins(
+      dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE),
+      .grouping = rollup(region)
+    )
+  )
+})
+
+test_that("the refusal reads the root step and not the step it was given", {
+  skip_if_suggest_absent("dtplyr")
+
+  # The pair that separates the two readings. A `filter()` over a mutable root
+  # returns a correct result today and is refused anyway, because which
+  # derivations survive is a property of the query dtplyr generated
+  # (ADR 0029); a `mutate()` over an immutable root carries no permission to
+  # write and is accepted, though the step it produces sits one level from its
+  # root exactly as the refused one does.
+  derived_mutable <- dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE) |>
+    dplyr::filter(value > 0)
+  expect_error(
+    expand_with_margins(derived_mutable, .grouping = rollup(region)),
+    class = "marginplyr_error"
+  )
+
+  derived_immutable <- dtplyr::lazy_dt(
+    mutable_step_data(),
+    immutable = TRUE
+  ) |>
+    dplyr::mutate(doubled = value * 2)
+  accepted <- dplyr::collect(
+    expand_with_margins(derived_immutable, .grouping = rollup(region))
+  )
+  expect_setequal(accepted$region, c("East", "West", "Total"))
+  expect_identical(accepted$doubled, c(2, 4, 6, 2, 4, 6))
+})
+
+test_that("an immutable dtplyr step and a bare data.table are accepted", {
+  skip_if_suggest_absent("dtplyr")
+  data <- mutable_step_data()
+
+  step_result <- dplyr::collect(summarize_with_margins(
+    dtplyr::lazy_dt(data, immutable = TRUE),
+    total = sum(value),
+    .grouping = rollup(region)
+  ))
+  expect_setequal(step_result$total, c(1, 5, 6))
+
+  # A bare `data.table` resolves to the `local` kind, where dplyr's copy
+  # semantics apply, so nothing here refuses it.
+  local_result <- summarize_with_margins(
+    data,
+    total = sum(value),
+    .grouping = rollup(region)
+  )
+  expect_setequal(local_result$total, c(1, 5, 6))
+})
+
+test_that("the dtplyr fields the refusal reads still mean what it reads", {
+  skip_if_suggest_absent("dtplyr")
+  data <- mutable_step_data()
+
+  mutable_root <- dtplyr::lazy_dt(data, immutable = FALSE)
+  immutable_root <- dtplyr::lazy_dt(data, immutable = TRUE)
+  expect_s3_class(mutable_root, "dtplyr_step_first")
+  expect_true(mutable_root$implicit_copy)
+  expect_false(immutable_root$implicit_copy)
+
+  # The root's own `parent` is the table rather than another step, which is
+  # where the walk stops.
+  expect_false(inherits(mutable_root$parent, "dtplyr_step"))
+
+  # A derived step reaches its root through `$parent`, and carries a value of
+  # its own that answers a different question: this one is `TRUE` while the
+  # derivation is harmless, which is why the walk exists.
+  derived <- dplyr::filter(immutable_root, value > 0)
+  expect_true(derived$implicit_copy)
+  expect_identical(derived$parent, immutable_root)
+
+  expect_true(mutable_dtplyr_step(mutable_root))
+  expect_false(mutable_dtplyr_step(derived))
+  # A step whose fields dtplyr renamed is let through rather than refused: the
+  # three expectations above are what report such a release.
+  expect_false(mutable_dtplyr_step(structure(
+    list(),
+    class = c("dtplyr_step_first", "dtplyr_step")
+  )))
+})

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -2174,8 +2174,16 @@ test_that("DuckDB safely quotes factor identifiers and labels", {
 
 # A Mutable step is a dtplyr step whose root was built with
 # `immutable = FALSE`, and every verb taking `.grouping` refuses one (#451,
-# ADR 0029). The tests below require dtplyr alone, so the one-backend-per-test
-# rule holds.
+# ADR 0029).
+#
+# `data.table::` is called here under a dtplyr guard and takes none of its own,
+# which is the one-backend-per-test rule holding rather than being bent.
+# `lazy_dt()` refuses `immutable = FALSE` for anything that is not already a
+# data table, so the input cannot be built without it; dtplyr declares
+# `Imports: data.table`, so it is never the reason one of these could fail; and
+# a guard on it would skip this whole section in the one configuration that
+# executes it, `verify-suite-coverage.R` hiding every backend but the selected
+# one.
 mutable_step_data <- function() {
   data.table::data.table(
     year = c(2023L, 2023L, 2024L),
@@ -2184,55 +2192,42 @@ mutable_step_data <- function() {
   )
 }
 
-# One call per verb, each supplying only what its signature requires. The names
-# are held to `verbs_taking(".grouping")` below rather than being trusted, so a
-# seventh verb fails here instead of arriving unrefused.
-mutable_step_verbs <- list(
-  summarize_with_margins = function(data) {
-    summarize_with_margins(data, total = sum(value), .grouping = rollup(region))
-  },
-  summarise_with_margins = function(data) {
-    summarise_with_margins(data, total = sum(value), .grouping = rollup(region))
-  },
-  expand_with_margins = function(data) {
-    expand_with_margins(data, .grouping = rollup(region))
-  },
-  nest_with_margins = function(data) {
-    nest_with_margins(data, .grouping = rollup(region))
-  },
-  nest_by_with_margins = function(data) {
-    nest_by_with_margins(data, .grouping = rollup(region))
-  },
-  inspect_grouping = function(data) {
-    inspect_grouping(data, .grouping = rollup(region))
-  }
-)
-
 test_that("every margin verb refuses a mutable dtplyr step", {
   skip_if_suggest_absent("dtplyr")
-  expect_setequal(names(mutable_step_verbs), verbs_taking(".grouping"))
+  expect_setequal(names(forwarded_verbs), verbs_taking(".grouping"))
 
-  for (name in names(mutable_step_verbs)) {
+  for (name in names(forwarded_verbs)) {
     data <- mutable_step_data()
     before <- data.table::copy(data)
     step <- dtplyr::lazy_dt(data, immutable = FALSE)
 
-    error <- expect_error(mutable_step_verbs[[name]](step))
+    error <- expect_error(forwarded_verbs[[name]](step, NULL, rollup(region)))
     expect_s3_class(error, "marginplyr_error")
     # The whole point of refusing: the table the caller still holds is the one
     # they handed over, in its names, its columns, and its rows.
     expect_identical(as.data.frame(data), as.data.frame(before), info = name)
   }
+})
 
-  # The wording, pinned once. Every verb raises the same three lines, and the
-  # blamed call is the only part that differs between them.
-  expect_snapshot(
-    error = TRUE,
-    expand_with_margins(
-      dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE),
-      .grouping = rollup(region)
+test_that("the refusal reads as it is written, for every verb", {
+  skip_if_suggest_absent("dtplyr")
+
+  # One snapshot per verb rather than one for the set: the three lines are the
+  # same everywhere and the header is not, so the call each verb blames is the
+  # part only a per-verb pin covers. The wrapper deparses identically in every
+  # one of them, which is why the header is what tells them apart -- it is also
+  # the only thing they differ by, and the reason they are all here.
+  for (name in names(forwarded_verbs)) {
+    verb <- forwarded_verbs[[name]]
+    expect_snapshot(
+      error = TRUE,
+      verb(
+        dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE),
+        NULL,
+        rollup(region)
+      )
     )
-  )
+  }
 })
 
 test_that("the refusal reads the root step and not the step it was given", {
@@ -2263,25 +2258,53 @@ test_that("the refusal reads the root step and not the step it was given", {
   expect_identical(accepted$doubled, c(2, 4, 6, 2, 4, 6))
 })
 
-test_that("an immutable dtplyr step and a bare data.table are accepted", {
+test_that("an immutable dtplyr step answers as the local input does", {
   skip_if_suggest_absent("dtplyr")
   data <- mutable_step_data()
 
+  # The baseline is the same call over a local frame rather than a written-out
+  # expectation, which is what "returns the same result it does today" means:
+  # a refusal that reached an immutable step would fail this, and so would one
+  # that changed what an accepted step returns.
+  local_result <- summarize_with_margins(
+    as.data.frame(data),
+    total = sum(value),
+    .grouping = rollup(region)
+  )
   step_result <- dplyr::collect(summarize_with_margins(
     dtplyr::lazy_dt(data, immutable = TRUE),
     total = sum(value),
     .grouping = rollup(region)
   ))
-  expect_setequal(step_result$total, c(1, 5, 6))
+  expect_equal(as.data.frame(step_result), as.data.frame(local_result))
 
   # A bare `data.table` resolves to the `local` kind, where dplyr's copy
-  # semantics apply, so nothing here refuses it.
-  local_result <- summarize_with_margins(
+  # semantics apply, so nothing here refuses it either.
+  table_result <- summarize_with_margins(
     data,
     total = sum(value),
     .grouping = rollup(region)
   )
-  expect_setequal(local_result$total, c(1, 5, 6))
+  expect_equal(as.data.frame(table_result), as.data.frame(local_result))
+})
+
+test_that("a grouped mutable step is refused before its groups are read", {
+  skip_if_suggest_absent("dtplyr")
+  data <- mutable_step_data()
+  grouped <- dplyr::group_by(
+    dtplyr::lazy_dt(data, immutable = FALSE),
+    region
+  )
+
+  # The refusal sits above key resolution, so it displaces the fixed-key
+  # rejection these groups used to earn -- `region` arriving as both a fixed
+  # key and a dimension. Pinned because the displacement is a consequence of
+  # where ADR 0029 puts the refusal rather than something it asked for.
+  error <- expect_error(
+    expand_with_margins(grouped, .grouping = rollup(region))
+  )
+  expect_s3_class(error, "marginplyr_error")
+  expect_match(conditionMessage(error), "immutable = FALSE", fixed = TRUE)
 })
 
 test_that("the dtplyr fields the refusal reads still mean what it reads", {
@@ -2307,10 +2330,12 @@ test_that("the dtplyr fields the refusal reads still mean what it reads", {
 
   expect_true(mutable_dtplyr_step(mutable_root))
   expect_false(mutable_dtplyr_step(derived))
-  # A step whose fields dtplyr renamed is let through rather than refused: the
-  # three expectations above are what report such a release.
+  # A step whose fields dtplyr renamed is let through rather than refused. The
+  # name is spelled out in full because `[[` is exact where `$` is not: a
+  # rename keeping the old name as a prefix would be read by `$` and is let
+  # through here, which is the direction this has to fail in.
   expect_false(mutable_dtplyr_step(structure(
-    list(),
+    list(implicit_copy_renamed = TRUE),
     class = c("dtplyr_step_first", "dtplyr_step")
   )))
 })

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -833,41 +833,6 @@ test_that("the empty spellings that already had a reading keep it", {
   )
 })
 
-# One wrapper per verb, forwarding both arguments with `{{ }}`. File level
-# because two tests below put different expressions through the same six
-# verbs; a second copy could disagree with the derivation above while this
-# one still matched it.
-forwarded_verbs <- list(
-  summarize_with_margins = function(data, by, grouping) {
-    summarize_with_margins(
-      data,
-      total = sum(value),
-      .by = {{ by }},
-      .grouping = {{ grouping }}
-    )
-  },
-  summarise_with_margins = function(data, by, grouping) {
-    summarise_with_margins(
-      data,
-      total = sum(value),
-      .by = {{ by }},
-      .grouping = {{ grouping }}
-    )
-  },
-  expand_with_margins = function(data, by, grouping) {
-    expand_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
-  },
-  nest_with_margins = function(data, by, grouping) {
-    nest_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
-  },
-  nest_by_with_margins = function(data, by, grouping) {
-    nest_by_with_margins(data, .by = {{ by }}, .grouping = {{ grouping }})
-  },
-  inspect_grouping = function(data, by, grouping) {
-    inspect_grouping(data, .by = {{ by }}, .grouping = {{ grouping }})
-  }
-)
-
 # The two verb arguments injection can leave empty, and neither is the `.by = `
 # above: R matches a named formal's empty argument to that formal's default,
 # while `{{ }}` splices R's missing marker into the quosure. Only the second

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -469,6 +469,24 @@ show_query(dt_query)
 collect(dt_query)
 ```
 
+The step has to be built with `immutable = TRUE`, which is what `lazy_dt()`
+does by default. A margin verb builds one branch per grouping set from the
+step it is given, and when the step was built with `immutable = FALSE`
+data.table writes every one of those branches back to your own table by
+reference. That returns a result in which each row carries the margin label,
+and leaves you holding a table that has lost a column or had its names
+permuted. Such an input is refused before any branch is built:
+
+```{r}
+#| label: mutable-dtplyr-step
+#| eval: !expr has_dtplyr
+#| must_error: marginplyr_error
+
+data.table::as.data.table(january_sales) |>
+  dtplyr::lazy_dt(immutable = FALSE) |>
+  expand_with_margins(.grouping = rollup(region, store))
+```
+
 `nest_with_margins()` also supports dtplyr and remains lazy until collection.
 SQL database and Arrow tables cannot use the nesting verbs because their
 result contains a list column:


### PR DESCRIPTION
Fixes #451.

A dtplyr step whose root was built with `dtplyr::lazy_dt(immutable = FALSE)` — a *Mutable step* — is refused by every verb taking `.grouping`, before any branch is built.

A margin verb builds one branch per grouping set from the one step it was handed, and data.table writes each branch to the caller's own table by reference. Over such an input `expand_with_margins()` returned a result in which every row carried the margin label, and left the caller holding a table whose column *names* had been permuted while its column *data* had not; a `select()` in the input's own pipeline lost the caller a column outright.

```
Error in `expand_with_margins()`:
! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
```

## What is here

- The refusal, on `prepare_grouping_plan()` immediately after `grouping_backend()` resolves the kind — the one preparation path every verb taking `.grouping` reaches, and a point that has read no rows (ADR 0005). The predicate walks `$parent` to the root and reads `implicit_copy` there.
- **Mutable step** in `CONTEXT.md`, the analogue of *Absorbing backend*.
- ADR 0029, recording why the input is refused rather than silently copied or merely documented, with ADR 0025 as the precedent and what differs: 0025 refuses because a backend would read more than the caller needs, this refuses because a backend would destroy what the caller holds.
- A `must_error: marginplyr_error` chunk in the database-backends vignette, with the matching marker in `verify-site.R`.
- Tests in `test-grouping-backends.R`, guarded by `skip_if_suggest_absent("dtplyr")` and requiring dtplyr alone.
- A `NEWS.md` entry.

## The line, and what it costs

The predicate reads the root and nothing below it. `lazy_dt(d, immutable = FALSE) |> filter(...)` returns a correct result today and is refused anyway: `filter()` and `select()` produce the same step class carrying the same `implicit_copy` value and fall on opposite sides, so nothing below the root separates the destructive derivations from the safe ones. ADR 0029 records that over-refusal and the alternatives discarded for it.

A field the walk cannot find lets the input through rather than refusing on a name that no longer means what it did. Both fields are pinned in both directions and on a derived step, so a dtplyr that renames either fails CI instead of silently switching the refusal off.

A bare `data.table` is unaffected (it resolves to the `local` kind), as is every other backend.

## Verification

- `lintr::lint_package()` — no lints
- full test suite under `NOT_CRAN=true` — 0 failures, 0 skips
- `verify-must-error.R`, `verify-context-budget.R`, `verify-doc-references.R`, `verify-verifier-invocation.R` — pass
- the vignette rendered standalone against the installed working tree: the `must_error` chunk raises, and the new site marker matches the rendered page