### PR TITLE
Refuse a selection predicate with the context a verb owes

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -73,6 +73,50 @@ condition_chain <- function(cnd) {
   c(list(cnd), condition_chain(cnd$parent))
 }
 
+# Whether a failure is tidyselect refusing a predicate for want of column
+# types. The whole chain is read for the reason `condition_chain()` above
+# gives: a predicate written under a selection helper is refused one level in.
+#
+# The class is tidyselect's own and is the whole of the test. A backend whose
+# selection proxy carries types answers a predicate rather than refusing one,
+# so no reading of the backend is needed to tell the two cases apart, and a
+# tidyselect that stopped raising this class leaves the caller the untyped
+# diagnostic they had before this refusal existed.
+is_unsupported_predicate <- function(cnd) {
+  any(vapply(
+    condition_chain(cnd),
+    inherits,
+    logical(1),
+    what = "tidyselect_error_predicates_unsupported"
+  ))
+}
+
+# The refusal a selection predicate gets where the proxy has no types. `label`
+# is the argument as the caller spelled it, and `parent` is tidyselect's own
+# condition, kept so the caller reads why tidyselect refused.
+#
+# The blamed call is left to `with_margin_error_call()`, which every selection
+# site reaching this runs under: what it puts there is the Margin verb the
+# caller wrote, which is what CONTEXT.md's *Condition context* asks for and
+# what no frame here could name.
+#
+# Reading the types would mean a query the caller did not ask for, which
+# ADR 0020 refuses; that is why the proxy is typeless here rather than an
+# omission this could fix.
+abort_selection_predicate <- function(label, parent) {
+  abort_marginplyr(
+    c(
+      "Can't select with a predicate in {.code {label}}.",
+      i = paste0(
+        "This input's backend doesn't report column types without a query, ",
+        "and marginplyr sends none you didn't ask for."
+      ),
+      i = "Select the columns by name, or collect the input first."
+    ),
+    parent = parent
+  )
+}
+
 # What an External condition raised while one grouping-set branch runs is
 # reported with. `keys` maps each `..marginplyr_key_N` column the branch
 # grouped by to the column the caller named, and `call` is the Margin verb the

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -100,9 +100,8 @@ is_unsupported_predicate <- function(cnd) {
 # caller wrote, which is what CONTEXT.md's *Condition context* asks for and
 # what no frame here could name.
 #
-# Reading the types would mean a query the caller did not ask for, which
-# ADR 0020 refuses; that is why the proxy is typeless here rather than an
-# omission this could fix.
+# The refusal stands rather than reading the types, ADR 0020 being what the
+# read would cross.
 abort_selection_predicate <- function(label, parent) {
   abort_marginplyr(
     c(

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -134,10 +134,24 @@ resolve_fixed_keys <- function(by_quo, group_vars, data_vars) {
 # `get_col_names()`'s other callers read back names dplyr assigned on purpose,
 # so the check belongs on this resolution rather than in that helper.
 resolve_by_selection <- function(by_quo, data_proxy) {
-  resolve_column_selection(
-    by_quo,
-    data_proxy,
-    on_rename = abort_by_rename
+  # A predicate reaches here only from the resolution against the input's own
+  # proxy: the name-only reader withholds one from the names-only proxy, which
+  # answers no predicate whatever the backend is.
+  tryCatch(
+    resolve_column_selection(
+      by_quo,
+      data_proxy,
+      on_rename = abort_by_rename
+    ),
+    error = function(cnd) {
+      if (is_unsupported_predicate(cnd)) {
+        abort_selection_predicate(
+          rlang::as_label(rlang::quo_get_expr(by_quo)),
+          cnd
+        )
+      }
+      stop(cnd)
+    }
   )
 }
 
@@ -1212,6 +1226,12 @@ resolve_grouping_selection <- function(arg, data_proxy) {
       raised <- !is.null(predicate) &&
         any(vapply(condition_chain(cnd), identical, logical(1), predicate))
       if (!raised && !is_grouping_spec_subscript(cnd, label)) {
+        # Last, so that a specification tidyselect took for a predicate keeps
+        # the refusal written for it above: this reads the failure that speaks
+        # for no specification at all.
+        if (is_unsupported_predicate(cnd)) {
+          abort_selection_predicate(label, cnd)
+        }
         stop(cnd)
       }
       abort_nested_grouping_spec(label)

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -154,6 +154,14 @@
 #' collision checks. Use `.by` for columns that must always remain fixed, and
 #' use `.grouping` for dimensions that may become totals.
 #'
+#' Both are written as column selections, so a selection predicate —
+#' [tidyselect::where()] and anything written with it — needs the column types
+#' of the input. Some lazy backends do not report those without a query, and
+#' marginplyr sends none you did not ask for, so a predicate written against
+#' one of them is refused rather than answered. Select the columns by name, or
+#' collect the input first. Local data and the lazy backends whose types are
+#' available without a query answer a predicate as dplyr does.
+#'
 #' @section Grouped and row-wise inputs:
 #' When `.data` has been grouped with [dplyr::group_by()] and `.by` is `NULL`,
 #' its grouping columns become implicit fixed keys. For example,
@@ -381,13 +389,9 @@
 #' every branch: a dimension remains excluded even in a grouping set from
 #' which it is omitted.
 #'
-#' A selection predicate, [tidyselect::where()] and anything written with it,
-#' needs the column types of the input. Some lazy backends do not report those
-#' without a query, and marginplyr sends none you did not ask for, so a
-#' predicate written against one of them is refused rather than answered — in
-#' `...`, in `.grouping`, and in `.by` alike. Select the columns by name, or
-#' collect the input first. Local data and the lazy backends whose types are
-#' available without a query answer a predicate as [dplyr::summarize()] does.
+#' A selection predicate here is refused against the same inputs it is refused
+#' against in `.by` and `.grouping`, for the same reason and with the same
+#' remedy: see *Fixed columns and grouping dimensions*.
 #'
 #' Where an unnamed summary's value is a data frame, a local input expands its
 #' columns into the result, exactly as [dplyr::summarize()] does, and a name

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -381,6 +381,14 @@
 #' every branch: a dimension remains excluded even in a grouping set from
 #' which it is omitted.
 #'
+#' A selection predicate, [tidyselect::where()] and anything written with it,
+#' needs the column types of the input. Some lazy backends do not report those
+#' without a query, and marginplyr sends none you did not ask for, so a
+#' predicate written against one of them is refused rather than answered — in
+#' `...`, in `.grouping`, and in `.by` alike. Select the columns by name, or
+#' collect the input first. Local data and the lazy backends whose types are
+#' available without a query answer a predicate as [dplyr::summarize()] does.
+#'
 #' Where an unnamed summary's value is a data frame, a local input expands its
 #' columns into the result, exactly as [dplyr::summarize()] does, and a name
 #' marginplyr assigned such a summary does not appear. Writing a name of your

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -454,6 +454,7 @@ plan_summary_expressions <- function(dots,
     data_proxy = data_proxy,
     data_vars = data_vars,
     group_vars = group_vars,
+    caller_labels = caller_labels,
     normalize_across_names = FALSE,
     skip_shares = TRUE
   )
@@ -481,6 +482,7 @@ plan_summary_expressions <- function(dots,
     data_proxy = data_proxy,
     data_vars = data_vars,
     group_vars = group_vars,
+    caller_labels = caller_labels,
     normalize_across_names = identical(backend_kind, "dtplyr")
   )
   if (length(summary_plan$cardinality) > 0L) {
@@ -528,12 +530,18 @@ find_summary_context_helpers <- function(expr) {
   )
 }
 
+# `caller_labels` is what a refusal quotes the failing dot by, and is passed in
+# rather than read off `dots`: the second resolution runs over dots this one
+# rewrote, whose labels are marginplyr's spelling and not the caller's
+# (ADR 0022).
 resolve_summary_selections <- function(dots,
                                        data_proxy,
                                        data_vars,
                                        group_vars,
+                                       caller_labels,
                                        normalize_across_names = FALSE,
                                        skip_shares = FALSE) {
+  stopifnot(length(dots) == length(caller_labels))
   selectable_vars <- setdiff(data_vars, unique(group_vars))
   selection_proxy <- dplyr::select(
     data_proxy,
@@ -541,8 +549,9 @@ resolve_summary_selections <- function(dots,
   )
 
   lapply(
-    dots,
-    function(dot) {
+    seq_along(dots),
+    function(i) {
+      dot <- dots[[i]]
       expr <- rlang::quo_get_expr(dot)
       if (
         skip_shares &&
@@ -550,11 +559,19 @@ resolve_summary_selections <- function(dots,
       ) {
         return(dot)
       }
-      expr <- rewrite_summary_selections(
-        expr,
-        env = rlang::quo_get_env(dot),
-        data_proxy = selection_proxy,
-        normalize_across_names = normalize_across_names
+      expr <- tryCatch(
+        rewrite_summary_selections(
+          expr,
+          env = rlang::quo_get_env(dot),
+          data_proxy = selection_proxy,
+          normalize_across_names = normalize_across_names
+        ),
+        error = function(cnd) {
+          if (is_unsupported_predicate(cnd)) {
+            abort_selection_predicate(caller_labels[[i]], cnd)
+          }
+          stop(cnd)
+        }
       )
       rlang::new_quosure(expr, env = rlang::quo_get_env(dot))
     }

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -142,6 +142,14 @@ margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
+
+Both are written as column selections, so a selection predicate —
+\code{\link[tidyselect:where]{tidyselect::where()}} and anything written with it — needs the column types
+of the input. Some lazy backends do not report those without a query, and
+marginplyr sends none you did not ask for, so a predicate written against
+one of them is refused rather than answered. Select the columns by name, or
+collect the input first. Local data and the lazy backends whose types are
+available without a query answer a predicate as dplyr does.
 }
 
 \section{Grouped and row-wise inputs}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -141,6 +141,14 @@ margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
+
+Both are written as column selections, so a selection predicate —
+\code{\link[tidyselect:where]{tidyselect::where()}} and anything written with it — needs the column types
+of the input. Some lazy backends do not report those without a query, and
+marginplyr sends none you did not ask for, so a predicate written against
+one of them is refused rather than answered. Select the columns by name, or
+collect the input first. Local data and the lazy backends whose types are
+available without a query answer a predicate as dplyr does.
 }
 
 \section{Grouped and row-wise inputs}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -187,6 +187,14 @@ margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
+
+Both are written as column selections, so a selection predicate —
+\code{\link[tidyselect:where]{tidyselect::where()}} and anything written with it — needs the column types
+of the input. Some lazy backends do not report those without a query, and
+marginplyr sends none you did not ask for, so a predicate written against
+one of them is refused rather than answered. Select the columns by name, or
+collect the input first. Local data and the lazy backends whose types are
+available without a query answer a predicate as dplyr does.
 }
 
 \section{Grouped and row-wise inputs}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -436,6 +436,14 @@ complete grouping plan. This extends dplyr's grouping-column rule across
 every branch: a dimension remains excluded even in a grouping set from
 which it is omitted.
 
+A selection predicate, \code{\link[tidyselect:where]{tidyselect::where()}} and anything written with it,
+needs the column types of the input. Some lazy backends do not report those
+without a query, and marginplyr sends none you did not ask for, so a
+predicate written against one of them is refused rather than answered — in
+\code{...}, in \code{.grouping}, and in \code{.by} alike. Select the columns by name, or
+collect the input first. Local data and the lazy backends whose types are
+available without a query answer a predicate as \code{\link[dplyr:summarize]{dplyr::summarize()}} does.
+
 Where an unnamed summary's value is a data frame, a local input expands its
 columns into the result, exactly as \code{\link[dplyr:summarize]{dplyr::summarize()}} does, and a name
 marginplyr assigned such a summary does not appear. Writing a name of your

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -200,6 +200,14 @@ margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
+
+Both are written as column selections, so a selection predicate —
+\code{\link[tidyselect:where]{tidyselect::where()}} and anything written with it — needs the column types
+of the input. Some lazy backends do not report those without a query, and
+marginplyr sends none you did not ask for, so a predicate written against
+one of them is refused rather than answered. Select the columns by name, or
+collect the input first. Local data and the lazy backends whose types are
+available without a query answer a predicate as dplyr does.
 }
 
 \section{Grouped and row-wise inputs}{
@@ -436,13 +444,9 @@ complete grouping plan. This extends dplyr's grouping-column rule across
 every branch: a dimension remains excluded even in a grouping set from
 which it is omitted.
 
-A selection predicate, \code{\link[tidyselect:where]{tidyselect::where()}} and anything written with it,
-needs the column types of the input. Some lazy backends do not report those
-without a query, and marginplyr sends none you did not ask for, so a
-predicate written against one of them is refused rather than answered — in
-\code{...}, in \code{.grouping}, and in \code{.by} alike. Select the columns by name, or
-collect the input first. Local data and the lazy backends whose types are
-available without a query answer a predicate as \code{\link[dplyr:summarize]{dplyr::summarize()}} does.
+A selection predicate here is refused against the same inputs it is refused
+against in \code{.by} and \code{.grouping}, for the same reason and with the same
+remedy: see \emph{Fixed columns and grouping dimensions}.
 
 Where an unnamed summary's value is a data frame, a local input expands its
 columns into the result, exactly as \code{\link[dplyr:summarize]{dplyr::summarize()}} does, and a name

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2919,3 +2919,64 @@ test_that("a name on an empty argument is refused by position", {
     )
   )
 })
+
+# The same refusal a summary selection gets, at the two selections a Margin
+# verb resolves against the input's own proxy. A backend that reports no column
+# types leaves tidyselect nothing to test a predicate against, and reading them
+# would be a query nobody asked for (ADR 0020), so what is owed the caller is
+# the argument and the verb rather than an answer (#453).
+test_that("a grouping predicate is refused with the argument and the verb", {
+  data <- data.frame(region = c("a", "b"), grade = c("x", "y"), value = 1:2)
+  remote <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_dbi())
+  refusal <- paste0(
+    "i This input's backend doesn't report column types without a query, ",
+    "and marginplyr sends none you didn't ask for.\n",
+    "i Select the columns by name, or collect the input first."
+  )
+
+  dimension <- expect_error(summarize_with_margins(
+    remote,
+    n = dplyr::n(),
+    .grouping = rollup(dplyr::where(is.character))
+  ))
+  expect_s3_class(dimension, "marginplyr_error")
+  expect_match(
+    conditionMessage(dimension),
+    paste0(
+      "Can't select with a predicate in `dplyr::where(is.character)`.\n",
+      refusal
+    ),
+    fixed = TRUE
+  )
+  expect_identical(
+    rlang::call_name(conditionCall(dimension)),
+    "summarize_with_margins"
+  )
+  expect_s3_class(dimension$parent, "tidyselect_error_predicates_unsupported")
+
+  # A fixed key is selected against the same proxy and is refused the same way.
+  fixed <- expect_error(summarize_with_margins(
+    remote,
+    n = dplyr::n(),
+    .by = dplyr::where(is.character),
+    .grouping = rollup(region)
+  ))
+  expect_s3_class(fixed, "marginplyr_error")
+  expect_match(
+    conditionMessage(fixed),
+    paste0(
+      "Can't select with a predicate in `dplyr::where(is.character)`.\n",
+      refusal
+    ),
+    fixed = TRUE
+  )
+
+  # A proxy that carries types answers both predicates, as it did before.
+  answered <- summarize_with_margins(
+    data,
+    n = dplyr::n(),
+    .by = dplyr::where(is.numeric),
+    .grouping = rollup(dplyr::where(is.character))
+  )
+  expect_named(answered, c("value", "region", "grade", "n"))
+})

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2920,11 +2920,9 @@ test_that("a name on an empty argument is refused by position", {
   )
 })
 
-# The same refusal a summary selection gets, at the two selections a Margin
-# verb resolves against the input's own proxy. A backend that reports no column
-# types leaves tidyselect nothing to test a predicate against, and reading them
-# would be a query nobody asked for (ADR 0020), so what is owed the caller is
-# the argument and the verb rather than an answer (#453).
+# The refusal `test-summarize-operation.R` states the reasons for, at the two
+# selections a Margin verb resolves against the input's own proxy rather than
+# against the summary's (#453).
 test_that("a grouping predicate is refused with the argument and the verb", {
   data <- data.frame(region = c("a", "b"), grade = c("x", "y"), value = 1:2)
   remote <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_dbi())

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -323,3 +323,50 @@ test_that("summary tidyselect conditions retain their class and cause", {
   expect_false(inherits(error, "marginplyr_error"))
   expect_match(conditionMessage(error), "Column `unknown` doesn't exist")
 })
+
+# A backend whose selection proxy is the lazy table itself carries no column
+# types, so tidyselect refuses a predicate rather than answering it. The
+# refusal stands -- reading the types would be a query nobody asked for
+# (ADR 0020) -- but the caller is owed the argument they wrote and the verb
+# they wrote it in (#453).
+test_that("a summary predicate is refused with the argument and the verb", {
+  data <- data.frame(group = c("x", "y"), value = 1:2)
+  remote <- dbplyr::tbl_lazy(data, con = dbplyr::simulate_dbi())
+
+  error <- expect_error(summarize_with_margins(
+    remote,
+    dplyr::across(dplyr::where(is.numeric), sum),
+    .grouping = rollup(group)
+  ))
+  expect_s3_class(error, "marginplyr_error")
+  # Matched rather than compared whole, because the rendered message ends with
+  # the cause, whose line names the internal frame tidyselect refused in.
+  expect_match(
+    conditionMessage(error),
+    paste0(
+      "Can't select with a predicate in ",
+      "`dplyr::across(dplyr::where(is.numeric), sum)`.\n",
+      "i This input's backend doesn't report column types without a query, ",
+      "and marginplyr sends none you didn't ask for.\n",
+      "i Select the columns by name, or collect the input first."
+    ),
+    fixed = TRUE
+  )
+  # The verb the caller wrote is what the refusal blames, and tidyselect's own
+  # diagnostic is still reachable as the cause.
+  expect_identical(
+    rlang::call_name(conditionCall(error)),
+    "summarize_with_margins"
+  )
+  expect_s3_class(error$parent, "tidyselect_error_predicates_unsupported")
+
+  # A proxy that carries types answers the predicate, as it did before.
+  expect_named(
+    summarize_with_margins(
+      data,
+      dplyr::across(dplyr::where(is.numeric), sum),
+      .grouping = rollup(group)
+    ),
+    c("group", "value")
+  )
+})


### PR DESCRIPTION
Closes #453.

A backend whose selection proxy is the lazy table itself reports no column types, so tidyselect refuses a `where()` predicate with its own diagnostic and nothing else. The refusal stands — reading the types would be a query nobody asked for (ADR 0020) — but it named neither the argument the caller wrote nor the verb they wrote it in, which is the Condition context `CONTEXT.md` says a Margin verb owes.

`abort_selection_predicate()` re-raises it as a Package condition, carrying tidyselect's own condition as its cause, at the three selections resolved against the input's proxy: a summary selection, a grouping dimension, and a fixed `.by` key. `.by` is the one the ticket did not name; it reaches `resolve_column_selection()` by the same route and was refused the same way.

The class `tidyselect_error_predicates_unsupported` is the whole of the test, and nothing reads the backend: a proxy carrying types answers a predicate rather than refusing one.

*This PR body was generated by AI.*