### PR TITLE
Force the input before emptying the sent-queries record

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -276,6 +276,10 @@
   forwarding where that argument is not bound. The check carries no call
   there now, and a share's conditions still name the call you wrote,
   forwarding and all (#357).
+* A Margin verb piped into another one now names itself when it refuses.
+  `f(x) |> g()` runs `f` while `g` reads its input, and `g` reported every
+  marginplyr error raised there against its own call, so a refusal you would
+  fix by rewriting `f` was blamed on `g` (#455).
 * A condition raised while your summary expression runs now reports its
   context in names you can act on. A margin operation summarizes that
   expression once per grouping set, so the grouping values it reported were
@@ -344,5 +348,8 @@
   collision or by an ineligible share source leaves readable every query it
   had already sent. A call one of these verbs refused before sending anything
   reads back as the empty record it is, rather than as the previous call's,
-  and is a call the session has recorded. The option is off by default
-  (#318, #400, #401, #409).
+  and is a call the session has recorded. Piping one Margin verb into another
+  leaves the outer call's record and not both calls': the input runs before
+  the outer call empties one, so `"result"` is in the record once and is the
+  query you were handed. The option is off by default
+  (#318, #400, #401, #409, #455).

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -92,6 +92,7 @@ expand_with_margins <- function(.data,
                                 .duplicates = c("error", "drop", "keep"),
                                 .id = NULL,
                                 .sort = c("none", "last", "first")) {
+  force(.data)
   reset_sent_queries()
   call <- rlang::current_call()
   with_margin_error_call(

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -136,6 +136,7 @@ inspect_grouping <- function(.data,
                              .grouping = NULL,
                              .duplicates = c("error", "drop", "keep"),
                              .format = c("text", "list")) {
+  force(.data)
   reset_sent_queries()
   call <- rlang::current_call()
   grouping_quo <- rlang::enquo(.grouping)

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -119,6 +119,7 @@ nest_by_with_margins <- function(.data,
                                  .sort = c("none", "last", "first"),
                                  .key = "data",
                                  .keep = FALSE) {
+  force(.data)
   reset_sent_queries()
   call <- rlang::current_call()
   grouping_quo <- rlang::enquo(.grouping)

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -165,6 +165,7 @@ nest_with_margins <- function(.data,
                               .sort = c("none", "last", "first"),
                               .key = "data",
                               .keep = FALSE) {
+  force(.data)
   reset_sent_queries()
   call <- rlang::current_call()
   if (is.null(.key)) {

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -9,10 +9,13 @@ sent_queries <- new.env(parent = emptyenv())
 # reading per call, kept with this call's record (ADR 0027). Anything but
 # `TRUE` is "not audited", and nothing here reports it.
 #
-# Called as the first statement of every entry point, ahead of the argument
-# validation each of them opens with (ADR 0027). The backend is not known yet,
-# so the SQL flag starts `FALSE` and `remember_sent_query_backend()` sets it
-# where the backend is computed.
+# Called by every entry point directly after it forces `.data` and ahead of
+# the argument validation each of them opens with (ADR 0027). Both halves of
+# that placement decide which call the record belongs to: an entry point whose
+# input is another Margin verb runs that verb while forcing the promise, so
+# emptying the record first would leave this call holding what the input
+# recorded. The backend is not known yet, so the SQL flag starts `FALSE` and
+# `remember_sent_query_backend()` sets it where the backend is computed.
 reset_sent_queries <- function() {
   sent_queries$recorded <- TRUE
   sent_queries$audited <- isTRUE(getOption("marginplyr.audit_sql"))
@@ -63,7 +66,9 @@ record_sent_query <- function(purpose, query) {
 #' [expand_with_margins()], [nest_with_margins()], [nest_by_with_margins()],
 #' or [inspect_grouping()] -- and this function reads it back. The record is
 #' emptied at the start of every call, so what it holds belongs to that call
-#' alone.
+#' alone. Piping one Margin verb into another is two calls, and the outer one
+#' is the most recent: its input runs first and its rows are then emptied,
+#' leaving the outer call's own.
 #'
 #' @return A tibble with two character columns. `purpose` says what the query
 #'   was sent for and `sql` holds the statement as it was rendered. Rows are in

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -10,11 +10,8 @@ sent_queries <- new.env(parent = emptyenv())
 # `TRUE` is "not audited", and nothing here reports it.
 #
 # Called by every entry point directly after it forces `.data` and ahead of
-# the argument validation each of them opens with (ADR 0027). Both halves of
-# that placement decide which call the record belongs to: an entry point whose
-# input is another Margin verb runs that verb while forcing the promise, so
-# emptying the record first would leave this call holding what the input
-# recorded. The backend is not known yet, so the SQL flag starts `FALSE` and
+# the argument validation each of them opens with (ADR 0027). The backend is
+# not known yet, so the SQL flag starts `FALSE` and
 # `remember_sent_query_backend()` sets it where the backend is computed.
 reset_sent_queries <- function() {
   sent_queries$recorded <- TRUE

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -845,6 +845,7 @@ summarize_with_margins <- function(.data,
                                    .duplicates = c("error", "drop", "keep"),
                                    .id = NULL,
                                    .sort = c("none", "last", "first")) {
+  force(.data)
   reset_sent_queries()
   call <- rlang::current_call()
   dots <- rlang::enquos(...)

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -187,6 +187,55 @@ is exactly the set of exported functions taking `.grouping`, and that each of
 them calls it first. An entry point added without a reset, and a validation
 moved above one, are each what it fires on.
 
+## Amendment: the input's promise is forced before the reset
+
+**"The record is emptied at the first statement"** of each entry point no
+longer holds, nor does the last sentence of the amendment above, which fixes
+the gate on that ordering. Each entry point opens with `force(.data)` and
+empties the record at its second statement instead (#455).
+
+The amendment above bounds the record by the body and stops there, and `.data`
+is a promise, so the body decides when the call that wrote `.data` runs. `|>`
+expands to `g(f(x))`: `g` emptied the record, then forced `.data` in the
+validation it opens with, which ran `f`. `f` emptied the record again and
+recorded its own rows, and `g` appended to them. The record then held both
+calls, with `"result"` — the one promised `purpose` — in it twice and nothing
+saying it spanned two calls. That is the `dbplyr::last_sql()` defect *Why a
+record rather than a signal* names, reproduced by the idiomatic way of writing
+the call.
+
+The reading is unchanged and sharpened: a promise the body forces belongs to
+the call that wrote it, not to the call reading it. Forcing `.data` first is
+what puts the input's whole execution before this call's record exists.
+
+The four answers hold as the amendment above states them, and two of them are
+reached for the first time under a pipe. An outer call refused inside its body
+takes *The call was audited and sent nothing*, the third, where before it was
+answered with the rows its input had recorded. And an input that refuses raises
+before the outer call's reset, so what stays readable is the input's own
+record, holding every query it had already sent — *A query is recorded before
+it is sent*, applied to the call that sent them.
+
+One thing outside this decision moves with the placement, and is recorded here
+because nothing else would hold it. Each entry point rewrites the call of every
+`marginplyr_error` raised inside the block its validation runs in. A `.data`
+forced inside that block therefore reported an input verb's refusal against the
+outer call, which is not the call the caller would rewrite to avoid it. Forcing
+ahead of the block is the same move, so the two are not separable and neither
+is traded for the other.
+
+The gate moves with the placement, in one half. The set of functions calling
+`reset_sent_queries()` is still exactly the set of exported functions taking
+`.grouping`. What each of them is held to is now two statements in order:
+`force(.data)`, then `reset_sent_queries()`. A swapped pair and a validation
+moved above either are each what it fires on.
+
+`.data` is the whole of it. Another formal holding a Margin verb — a
+`.margin_label` computed by one — is forced wherever the body reads it, and
+nothing here changes that or asserts anything about it. `.data` is the formal
+every entry point takes, the one a pipe writes to, and the only one whose
+promise is a call a reader would think of as the previous one.
+
 ## Corrections
 
 Four claims in the plan this decision settles were true of an earlier codebase

--- a/man/last_sent_queries.Rd
+++ b/man/last_sent_queries.Rd
@@ -21,7 +21,9 @@ the SQL of one call -- the most recent call to \code{\link[=summarize_with_margi
 \code{\link[=expand_with_margins]{expand_with_margins()}}, \code{\link[=nest_with_margins]{nest_with_margins()}}, \code{\link[=nest_by_with_margins]{nest_by_with_margins()}},
 or \code{\link[=inspect_grouping]{inspect_grouping()}} -- and this function reads it back. The record is
 emptied at the start of every call, so what it holds belongs to that call
-alone.
+alone. Piping one Margin verb into another is two calls, and the outer one
+is the most recent: its input runs first and its rows are then emptied,
+leaving the outer call's own.
 }
 \section{What the record promises}{
 

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -143,6 +143,27 @@ test_that("Grouping plan errors use the package condition seam", {
   )
 })
 
+test_that("a refused input keeps its own call when piped into a verb", {
+  data <- data.frame(a = c("x", "y"), value = 1:2)
+
+  # An entry point rewrites the call of every `marginplyr_error` raised inside
+  # the block its validation runs in. The input's promise is forced before
+  # that block, so an input that is itself a Margin verb reports the call the
+  # caller wrote it as rather than the one reading it (#455).
+  error <- expect_error(
+    summarize_with_margins(
+      data,
+      n = dplyr::n(),
+      .grouping = rollup(a),
+      .duplicates = "bogus"
+    ) |>
+      summarize_with_margins(total = sum(n), .grouping = rollup(a))
+  )
+
+  expect_s3_class(error, "marginplyr_error")
+  expect_identical(conditionCall(error)$.duplicates, "bogus")
+})
+
 test_that("Grouping tidyselect conditions retain their class and cause", {
   data <- data.frame(a = c("x", "y"), value = 1:2)
   selection <- rlang::quo(unknown)

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -297,7 +297,7 @@ test_that("a piped Margin verb records only the outer call's result", {
   remote <- sent_queries_table(con)
 
   with_audit_option(TRUE, {
-    remote |>
+    query <- remote |>
       summarize_with_margins(
         inner = sum(v, na.rm = TRUE),
         .grouping = rollup(g)
@@ -310,9 +310,33 @@ test_that("a piped Margin verb records only the outer call's result", {
   })
 
   # One row, not two: `"result"` is the one promised `purpose`, and a reader
-  # matching on it must find the query they were handed and no other.
+  # matching on it must find the query they were handed and no other. The
+  # outer query nests the input's, so its text holds the input's too, and what
+  # tells the two apart is which query the row is -- not a substring absent
+  # from one of them, as it is where the two calls read the same table.
   expect_identical(record$purpose, "result")
-  expect_match(record$sql, "outer", fixed = TRUE)
+  expect_identical(record$sql, as.character(dbplyr::sql_render(query)))
+})
+
+test_that("a piped expand_with_margins() records only its own result", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    query <- remote |>
+      summarize_with_margins(
+        inner = sum(v, na.rm = TRUE),
+        .grouping = rollup(g)
+      ) |>
+      expand_with_margins(.grouping = rollup(g))
+    record <- last_sent_queries()
+  })
+
+  expect_identical(record$purpose, "result")
+  expect_identical(record$sql, as.character(dbplyr::sql_render(query)))
 })
 
 test_that("a dplyr verb between two Margin verbs changes nothing", {
@@ -834,7 +858,7 @@ strip_coverage_wrapper <- function(expr) {
 nth_statement <- function(fn, n) {
   fn_body <- strip_coverage_wrapper(body(fn))
   if (!is.call(fn_body) || !identical(as.character(fn_body[[1]]), "{")) {
-    if (identical(n, 1L)) {
+    if (n == 1L) {
       return(fn_body)
     }
     return(NULL)
@@ -898,6 +922,11 @@ test_that("the reset scan tells an opening statement from a later one", {
     reset_sent_queries()
     force(.data)
   }
+  validates_between <- function() {
+    force(.data)
+    stop("unreachable")
+    reset_sent_queries()
+  }
   bare <- function() reset_sent_queries()
   reset <- quote(reset_sent_queries())
   forced <- quote(force(.data))
@@ -909,10 +938,15 @@ test_that("the reset scan tells an opening statement from a later one", {
   expect_identical(nth_statement(opens_correctly, 2L), reset)
   # Each way the two statements can be wrong is a distinct reading, and the
   # gate above is an `||` over both, so neither position may pass on its own:
-  # a body missing the forcing, and a body holding both in the other order.
+  # a body missing the forcing, a body holding both in the other order, and a
+  # body whose forcing is right with a statement pushed between the two. The
+  # last is the only one the second position alone rejects, and is what a
+  # validation moved above the reset would look like.
   expect_false(identical(nth_statement(resets_later, 1L), forced))
   expect_identical(nth_statement(swapped, 1L), reset)
   expect_false(identical(nth_statement(swapped, 2L), reset))
+  expect_identical(nth_statement(validates_between, 1L), forced)
+  expect_false(identical(nth_statement(validates_between, 2L), reset))
   # An unbraced body is the statement itself, which the gate above reads for no
   # entry point today and would read for one written that way. It has no second
   # statement, and an empty braced body has neither; both answer that rather

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -280,6 +280,146 @@ test_that("inspect_grouping() after a Margin verb holds only its own rows", {
   })
 })
 
+# --- a call whose input is another call --------------------------------------
+
+# `|>` expands to `g(f(x))`, so `f` runs while `g` forces `.data`, and which
+# call the record belongs to turns on whether `g` empties it before or after
+# that forcing. Emptying first leaves the record spanning both, which is the
+# `dbplyr::last_sql()` defect ADR 0027 exists to remove, reached by the
+# idiomatic way of writing the call (#455). RSQLite records no selection proxy,
+# so each of these reads a record whose whole content is result rows.
+
+test_that("a piped Margin verb records only the outer call's result", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    remote |>
+      summarize_with_margins(
+        inner = sum(v, na.rm = TRUE),
+        .grouping = rollup(g)
+      ) |>
+      summarize_with_margins(
+        outer = sum(inner, na.rm = TRUE),
+        .grouping = rollup(g)
+      )
+    record <- last_sent_queries()
+  })
+
+  # One row, not two: `"result"` is the one promised `purpose`, and a reader
+  # matching on it must find the query they were handed and no other.
+  expect_identical(record$purpose, "result")
+  expect_match(record$sql, "outer", fixed = TRUE)
+})
+
+test_that("a dplyr verb between two Margin verbs changes nothing", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    remote |>
+      summarize_with_margins(
+        inner = sum(v, na.rm = TRUE),
+        .grouping = rollup(g)
+      ) |>
+      dplyr::filter(inner > 0) |>
+      expand_with_margins(.grouping = rollup(g))
+    record <- last_sent_queries()
+  })
+
+  expect_identical(record$purpose, "result")
+})
+
+test_that("inspect_grouping() piped from a Margin verb sends nothing", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  # The zero-row answer is the third of the four, and reaching it here is what
+  # says the record belongs to the call that sent nothing rather than to the
+  # one that filled it.
+  with_audit_option(TRUE, {
+    remote |>
+      summarize_with_margins(
+        inner = sum(v, na.rm = TRUE),
+        .grouping = rollup(g)
+      ) |>
+      inspect_grouping(.grouping = rollup(g))
+    expect_sent_nothing()
+  })
+})
+
+test_that("an outer verb refused after its input ran reports its own record", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  # A refusal inside the body takes the third answer (ADR 0027), and an input
+  # that recorded rows of its own is where that is hardest to hold: those rows
+  # are in the record when the outer call begins.
+  with_audit_option(TRUE, {
+    condition <- rlang::catch_cnd(
+      remote |>
+        summarize_with_margins(
+          inner = sum(v, na.rm = TRUE),
+          .grouping = rollup(g)
+        ) |>
+        summarize_with_margins(
+          outer = sum(inner, na.rm = TRUE),
+          .grouping = rollup(g),
+          .duplicates = "bogus"
+        ),
+      classes = "marginplyr_error"
+    )
+    expect_s3_class(condition, "marginplyr_error")
+    expect_sent_nothing()
+  })
+})
+
+test_that("an input that refuses leaves its own record readable", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- sent_queries_table(con)
+  saved <- as.list(share_dialect_verdicts, all.names = TRUE)
+  on.exit(restore_share_dialect_verdicts(saved), add = TRUE)
+  empty_share_dialect_verdicts()
+
+  # The other direction of the same forcing: the input raises, so the outer
+  # call never reaches its own reset and the record left readable is the
+  # input's, holding every query it had already sent.
+  with_audit_option(TRUE, {
+    condition <- rlang::catch_cnd(
+      remote |>
+        summarize_with_margins(
+          total = sum(v, na.rm = TRUE),
+          share = share_of_parent(total),
+          .grouping = rollup(g, h)
+        ) |>
+        summarize_with_margins(
+          outer = sum(total, na.rm = TRUE),
+          .grouping = rollup(g)
+        ),
+      classes = "marginplyr_error"
+    )
+    record <- last_sent_queries()
+  })
+
+  expect_s3_class(condition, "marginplyr_error")
+  expect_identical(record$purpose, "share_dialect")
+})
+
 # --- a statement with no SQL form --------------------------------------------
 
 test_that("a translation refused at render is recorded as NA", {
@@ -687,21 +827,25 @@ strip_coverage_wrapper <- function(expr) {
   branch[[3]]
 }
 
-# The first expression of `fn`'s body, which is the body itself where it is not
-# a braced block. Both readings go through the unwrapping above, because covr
-# wraps an unbraced body whole and wraps each statement of a braced one.
-first_statement <- function(fn) {
+# The `n`th expression of `fn`'s body, or `NULL` where the body has fewer. An
+# unbraced body is one expression, so it answers `n == 1` and nothing else.
+# Both readings go through the unwrapping above, because covr wraps an unbraced
+# body whole and wraps each statement of a braced one.
+nth_statement <- function(fn, n) {
   fn_body <- strip_coverage_wrapper(body(fn))
   if (!is.call(fn_body) || !identical(as.character(fn_body[[1]]), "{")) {
-    return(fn_body)
-  }
-  if (length(fn_body) < 2L) {
+    if (identical(n, 1L)) {
+      return(fn_body)
+    }
     return(NULL)
   }
-  strip_coverage_wrapper(fn_body[[2]])
+  if (length(fn_body) < n + 1L) {
+    return(NULL)
+  }
+  strip_coverage_wrapper(fn_body[[n + 1L]])
 }
 
-test_that("every entry point empties the record before anything else", {
+test_that("every entry point forces its input and then empties the record", {
   ns <- asNamespace("marginplyr")
   # An entry point is an exported function that compiles a Grouping plan of
   # its own, and `.grouping` is how a specification reaches one. One taking a
@@ -719,22 +863,30 @@ test_that("every entry point empties the record before anything else", {
   # part-way through one truncates that call's own (ADR 0027).
   expect_setequal(emptying, entry_points)
 
-  late <- Filter(
+  # `force(.data)` first and the reset second, in that order. Emptying the
+  # record before the input's promise is forced attributes to this call
+  # whatever the call that wrote `.data` recorded, and forcing the promise
+  # after any other statement is a statement running under the previous call's
+  # record (#455).
+  misordered <- Filter(
     function(name) {
-      opening <- first_statement(get(name, envir = ns))
-      !identical(opening, quote(reset_sent_queries()))
+      fn <- get(name, envir = ns)
+      !identical(nth_statement(fn, 1L), quote(force(.data))) ||
+        !identical(nth_statement(fn, 2L), quote(reset_sent_queries()))
     },
     entry_points
   )
-  # Named rather than counted: a validation moved above the reset is what this
-  # fires on, and which entry point took it is not otherwise in the report.
-  expect_identical(late, character())
+  # Named rather than counted: a validation moved above either statement is
+  # what this fires on, and which entry point took it is not otherwise in the
+  # report.
+  expect_identical(misordered, character())
 })
 
-test_that("the reset scan tells a first statement from a later one", {
+test_that("the reset scan tells an opening statement from a later one", {
   # Both readings run over synthetic functions rather than over a member of the
   # namespace, since a member that failed either is what the gate above reports.
-  resets_first <- function() {
+  opens_correctly <- function() {
+    force(.data)
     reset_sent_queries()
     stop("unreachable")
   }
@@ -742,20 +894,32 @@ test_that("the reset scan tells a first statement from a later one", {
     stop("unreachable")
     reset_sent_queries()
   }
+  swapped <- function() {
+    reset_sent_queries()
+    force(.data)
+  }
   bare <- function() reset_sent_queries()
   reset <- quote(reset_sent_queries())
+  forced <- quote(force(.data))
 
-  expect_true(empties_the_record(resets_first))
+  expect_true(empties_the_record(opens_correctly))
   expect_true(empties_the_record(resets_later))
   expect_false(empties_the_record(function() NULL))
-  expect_identical(first_statement(resets_first), reset)
-  expect_false(identical(first_statement(resets_later), reset))
+  expect_identical(nth_statement(opens_correctly, 1L), forced)
+  expect_identical(nth_statement(opens_correctly, 2L), reset)
+  # Each way the two statements can be wrong is a distinct reading, and the
+  # gate above is an `||` over both, so neither position may pass on its own:
+  # a body missing the forcing, and a body holding both in the other order.
+  expect_false(identical(nth_statement(resets_later, 1L), forced))
+  expect_identical(nth_statement(swapped, 1L), reset)
+  expect_false(identical(nth_statement(swapped, 2L), reset))
   # An unbraced body is the statement itself, which the gate above reads for no
-  # entry point today and would read for one written that way. An empty braced
-  # one has no first statement to read, and answers that rather than raising a
-  # subscript error the gate would report as neither verdict.
-  expect_identical(first_statement(bare), reset)
-  expect_null(first_statement(function() {}))
+  # entry point today and would read for one written that way. It has no second
+  # statement, and an empty braced body has neither; both answer that rather
+  # than raising a subscript error the gate would report as neither verdict.
+  expect_identical(nth_statement(bare, 1L), reset)
+  expect_null(nth_statement(bare, 2L))
+  expect_null(nth_statement(function() {}, 1L))
 })
 
 test_that("the reset scan reads through covr's instrumentation", {
@@ -767,17 +931,18 @@ test_that("the reset scan reads through covr's instrumentation", {
   # Only the counter's head is substituted in, for the reason its own reader
   # gives; the wrapper around it is the literal covr writes.
   reset <- quote(reset_sent_queries())
+  forced <- quote(force(.data))
   counter <- coverage_counter()
 
   braced <- function() NULL
   body(braced) <- bquote({
     if (TRUE) {
       .(counter)("marginplyr/R/grouping-plan.R:1:1:1:1")
-      reset_sent_queries()
+      force(.data)
     }
     if (TRUE) {
       .(counter)("marginplyr/R/grouping-plan.R:2:1:2:1")
-      stop("unreachable")
+      reset_sent_queries()
     }
   })
 
@@ -787,8 +952,9 @@ test_that("the reset scan reads through covr's instrumentation", {
     reset_sent_queries()
   })
 
-  expect_identical(first_statement(braced), reset)
-  expect_identical(first_statement(unbraced), reset)
+  expect_identical(nth_statement(braced, 1L), forced)
+  expect_identical(nth_statement(braced, 2L), reset)
+  expect_identical(nth_statement(unbraced, 1L), reset)
   # The instrumented body still answers the other reading, which walks rather
   # than counts positions and is what the wrapper leaves alone.
   expect_true(empties_the_record(braced))
@@ -803,5 +969,5 @@ test_that("the reset scan reads through covr's instrumentation", {
       reset_sent_queries()
     }
   })
-  expect_false(identical(first_statement(authored), reset))
+  expect_false(identical(nth_statement(authored, 1L), reset))
 })

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -632,6 +632,26 @@ test_that("every entry point admits input the same way", {
   )
 })
 
+test_that("an omitted input is answered by R and not by the verb", {
+  # Every entry point opens by forcing `.data`, which is ahead of the block
+  # that rewrites a marginplyr error's call, so an omitted input raises where
+  # R raises it. It was never a marginplyr condition -- that block rewrites
+  # only those -- and the message naming the formal is what a caller acts on
+  # (#455).
+  for (verb in verbs_taking(".grouping")) {
+    error <- expect_error(
+      eval(rlang::call2(verb, .grouping = quote(rollup(g))))
+    )
+    expect_s3_class(error, "missingArgError")
+    expect_false(inherits(error, "marginplyr_error"))
+    expect_match(
+      conditionMessage(error),
+      "argument \".data\" is missing",
+      fixed = TRUE
+    )
+  }
+})
+
 test_that("admission does not widen what the nesting verbs accept", {
   skip_if_suggest_absent("arrow")
 

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -600,6 +600,9 @@ The record is a tibble of two character columns, `purpose` and `sql`, holding
 one row per query in the order it was sent. It belongs to that one call: the
 next call to a Margin verb — or to `inspect_grouping()`, which compiles a
 grouping plan and sends queries of its own — empties it and starts again.
+Piping one Margin verb into another is two such calls, and the record you read
+afterwards is the outer one's: the input runs first, and the outer call empties
+what it left.
 
 `"result"` is the only `purpose` marginplyr promises, and it is the query
 `audit_query` holds:


### PR DESCRIPTION
Closes #455.

Every entry point emptied the sent-queries record as its first statement, but
`.data` is a promise that the argument validation each of them opens with is
the first to force. `|>` expands to `g(f(x))`, so `g` reset, then forced
`.data`, which ran `f`; `f` reset again, recorded its own rows, and `g`
appended to them. The record held both calls, with `"result"` — the one
promised `purpose` — in it twice and nothing saying it spanned two. That is the
`dbplyr::last_sql()` defect ADR 0027 exists to remove, reached by the idiomatic
spelling.

Each entry point now opens with `force(.data)` and empties the record second,
which puts the input's whole execution before this call's record exists.

Forcing ahead of the validation block is the same move as forcing ahead of the
`tryCatch()` that block runs in, so an input verb's `marginplyr_error` keeps
its own call instead of being reported against the verb reading it. The two are
not separable.

The gate in `test-sent-queries.R` fixed the defective ordering; it now holds
each entry point to the two statements in order, and its reader takes a
statement by position rather than only the first. ADR 0027 gains an amendment
for the placement, and the Rd, the vignette, and NEWS say which call a piped
record belongs to.