### PR TITLE
Give the live-SQLite verification scope one owner

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -368,10 +368,12 @@ markers <- list(
     # renders: every chunk in it is behind `has_duckdb`, so on a machine
     # without DuckDB the section produces no output for a marker to quote.
     "Record the SQL marginplyr sends",
-    "Only DuckDB and SQLite are exercised as live SQL databases",
-    "DuckDB covers native SQL end to end",
-    "dozen-plus fallback dialects",
-    "Arrow and dtplyr are tested for the lazy",
+    # The verification section, which states no scope of its own: the
+    # `summarize_with_margins()` reference owns that, so a marker naming a
+    # backend here would be the restatement the section was reduced to remove.
+    "SQL simulation is useful evidence about rendering",
+    "treat a simulator-only backend as SQL-generation support",
+    "Which claim rests on which is stated in one place",
     # The unconditional half of the mutable-step refusal (ADR 0029). Its
     # `must_error` chunk is behind `has_dtplyr`, so the prose introducing it is
     # what a marker can reach, and this run of it holds no apostrophe and no

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -370,7 +370,7 @@ markers <- list(
     "Record the SQL marginplyr sends",
     # The verification section, which states no scope of its own: the
     # `summarize_with_margins()` reference owns that, so a marker naming a
-    # backend here would be the restatement the section was reduced to remove.
+    # backend here would pin a restatement this section does not carry.
     "SQL simulation is useful evidence about rendering",
     "treat a simulator-only backend as SQL-generation support",
     "Which claim rests on which is stated in one place",

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -556,14 +556,15 @@
 #' tests execute DuckDB queries against a live in-memory database and verify
 #' PostgreSQL SQL with dbplyr's simulator.
 #'
-#' SQLite is the other live database, and it runs the portable `UNION ALL`
-#' path end to end: Parent shares under `.check_share_source = FALSE`, the
-#' refusal the default raises there -- SQLite converts a value of another type
-#' to a number rather than refusing it -- a Margin order through both
+#' SQLite is the other live database. It runs the portable `UNION ALL` path
+#' end to end: Parent shares under `summarize_with_margins()`'s
+#' `.check_share_source = FALSE`, a Margin order through both
 #' [dplyr::collect()] and [dplyr::compute()], including the missing-value
 #' placement its own ordering would not produce, the observed half of the
 #' Margin label collision check, and the queries [last_sent_queries()]
-#' records. Tests that compare rendered SQL run against that database too;
+#' records. The refusal that argument's default raises on the dialect is
+#' covered there too, and outside that list: it lands before a portable query
+#' is built. Tests that compare rendered SQL also run against that database;
 #' what those establish is what was rendered, which is what a simulator
 #' establishes.
 #'

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -556,12 +556,22 @@
 #' tests execute DuckDB queries against a live in-memory database and verify
 #' PostgreSQL SQL with dbplyr's simulator.
 #'
-#' The portable `UNION ALL` SQL path is executed end to end for contextual
-#' shares against a live in-memory SQLite database. It is also verified with
-#' dbplyr simulators for Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL
-#' Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, and
-#' Teradata, plus generic DBI and ODBC connections. Simulator coverage verifies
-#' SQL generation, not execution against every database server.
+#' SQLite is the other live database, and it runs the portable `UNION ALL`
+#' path end to end: Parent shares under `.check_share_source = FALSE`, the
+#' refusal the default raises there -- SQLite converts a value of another type
+#' to a number rather than refusing it -- a Margin order through both
+#' [dplyr::collect()] and [dplyr::compute()], including the missing-value
+#' placement its own ordering would not produce, the observed half of the
+#' Margin label collision check, and the queries [last_sent_queries()]
+#' records. Tests that compare rendered SQL run against that database too;
+#' what those establish is what was rendered, which is what a simulator
+#' establishes.
+#'
+#' The portable path is also verified with dbplyr simulators for Access, SAP
+#' HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon
+#' Redshift, Snowflake, Spark SQL, SQLite, and Teradata, plus generic DBI and
+#' ODBC connections. Simulator coverage verifies SQL generation, not execution
+#' against every database server.
 #'
 #' Arrow and dtplyr are also tested lazy backends, but they are not SQL
 #' database connections.

--- a/README.Rmd
+++ b/README.Rmd
@@ -282,9 +282,6 @@ Simulation verifies generated SQL but does not claim live execution against
 every database server. The [database
 guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
 shows native SQL, fallback SQL, live DuckDB execution, and `collect()`.
-*Database backend coverage* in the [`summarize_with_margins()`
-reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
-states what is verified on each backend.
 
 ## Keep the rows behind each total
 
@@ -335,11 +332,8 @@ dplyr code may be easier.
 
 ## Backend verification
 
-Support is not one status. Some backends are exercised against a live
-database; the rest are verified through dbplyr's SQL simulators, which
-establish what SQL is rendered and nothing about a running server. Which
-claim covers which backend is stated in one place, *Database backend
-coverage* in the [`summarize_with_margins()`
+What is verified on each backend, and how, is stated in one place: *Database
+backend coverage* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
 
 The function reference contains executable examples for composite dimensions,

--- a/README.Rmd
+++ b/README.Rmd
@@ -281,8 +281,10 @@ native support use a `UNION ALL` translation with the same grouping plan.
 Simulation verifies generated SQL but does not claim live execution against
 every database server. The [database
 guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
-shows native SQL, fallback SQL, live DuckDB execution, `collect()`, and the
-verification status of each backend.
+shows native SQL, fallback SQL, live DuckDB execution, and `collect()`.
+*Database backend coverage* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+states what is verified on each backend.
 
 ## Keep the rows behind each total
 
@@ -333,13 +335,12 @@ dplyr code may be easier.
 
 ## Backend verification
 
-| Verification status | Backends |
-|---|---|
-| Live native execution tested | DuckDB |
-| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses the share on these dialects | SQLite |
-| Native SQL generation tested | PostgreSQL |
-| Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections |
-| Non-SQL lazy backend tested | Arrow, dtplyr |
+Support is not one status. Some backends are exercised against a live
+database; the rest are verified through dbplyr's SQL simulators, which
+establish what SQL is rendered and nothing about a running server. Which
+claim covers which backend is stated in one place, *Database backend
+coverage* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
 
 The function reference contains executable examples for composite dimensions,
 tidy-select expressions, duplicate grouping sets, Cartesian products,

--- a/README.md
+++ b/README.md
@@ -388,9 +388,6 @@ grouping plan. Simulation verifies generated SQL but does not claim live
 execution against every database server. The [database
 guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
 shows native SQL, fallback SQL, live DuckDB execution, and `collect()`.
-*Database backend coverage* in the [`summarize_with_margins()`
-reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
-states what is verified on each backend.
 
 ## Keep the rows behind each total
 
@@ -456,11 +453,8 @@ subtotal, explicit dplyr code may be easier.
 
 ## Backend verification
 
-Support is not one status. Some backends are exercised against a live
-database; the rest are verified through dbplyr’s SQL simulators, which
-establish what SQL is rendered and nothing about a running server. Which
-claim covers which backend is stated in one place, *Database backend
-coverage* in the [`summarize_with_margins()`
+What is verified on each backend, and how, is stated in one place:
+*Database backend coverage* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
 
 The function reference contains executable examples for composite

--- a/README.md
+++ b/README.md
@@ -387,8 +387,10 @@ confirmed native support use a `UNION ALL` translation with the same
 grouping plan. Simulation verifies generated SQL but does not claim live
 execution against every database server. The [database
 guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
-shows native SQL, fallback SQL, live DuckDB execution, `collect()`, and
-the verification status of each backend.
+shows native SQL, fallback SQL, live DuckDB execution, and `collect()`.
+*Database backend coverage* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+states what is verified on each backend.
 
 ## Keep the rows behind each total
 
@@ -454,13 +456,12 @@ subtotal, explicit dplyr code may be easier.
 
 ## Backend verification
 
-| Verification status | Backends |
-|----|----|
-| Live native execution tested | DuckDB |
-| Live portable Parent-share execution tested, with `.check_share_source = FALSE`; the default refuses the share on these dialects | SQLite |
-| Native SQL generation tested | PostgreSQL |
-| Fallback SQL generation tested | Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, Teradata, and generic DBI/ODBC connections |
-| Non-SQL lazy backend tested | Arrow, dtplyr |
+Support is not one status. Some backends are exercised against a live
+database; the rest are verified through dbplyr’s SQL simulators, which
+establish what SQL is rendered and nothing about a running server. Which
+claim covers which backend is stated in one place, *Database backend
+coverage* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
 
 The function reference contains executable examples for composite
 dimensions, tidy-select expressions, duplicate grouping sets, Cartesian

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -414,14 +414,15 @@ DuckDB and PostgreSQL use native \verb{GROUP BY GROUPING SETS} SQL. Automated
 tests execute DuckDB queries against a live in-memory database and verify
 PostgreSQL SQL with dbplyr's simulator.
 
-SQLite is the other live database, and it runs the portable \verb{UNION ALL}
-path end to end: Parent shares under \code{.check_share_source = FALSE}, the
-refusal the default raises there -- SQLite converts a value of another type
-to a number rather than refusing it -- a Margin order through both
+SQLite is the other live database. It runs the portable \verb{UNION ALL} path
+end to end: Parent shares under \code{summarize_with_margins()}'s
+\code{.check_share_source = FALSE}, a Margin order through both
 \code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}}, including the missing-value
 placement its own ordering would not produce, the observed half of the
 Margin label collision check, and the queries \code{\link[=last_sent_queries]{last_sent_queries()}}
-records. Tests that compare rendered SQL run against that database too;
+records. The refusal that argument's default raises on the dialect is
+covered there too, and outside that list: it lands before a portable query
+is built. Tests that compare rendered SQL also run against that database;
 what those establish is what was rendered, which is what a simulator
 establishes.
 

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -414,12 +414,22 @@ DuckDB and PostgreSQL use native \verb{GROUP BY GROUPING SETS} SQL. Automated
 tests execute DuckDB queries against a live in-memory database and verify
 PostgreSQL SQL with dbplyr's simulator.
 
-The portable \verb{UNION ALL} SQL path is executed end to end for contextual
-shares against a live in-memory SQLite database. It is also verified with
-dbplyr simulators for Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL
-Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, and
-Teradata, plus generic DBI and ODBC connections. Simulator coverage verifies
-SQL generation, not execution against every database server.
+SQLite is the other live database, and it runs the portable \verb{UNION ALL}
+path end to end: Parent shares under \code{.check_share_source = FALSE}, the
+refusal the default raises there -- SQLite converts a value of another type
+to a number rather than refusing it -- a Margin order through both
+\code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}}, including the missing-value
+placement its own ordering would not produce, the observed half of the
+Margin label collision check, and the queries \code{\link[=last_sent_queries]{last_sent_queries()}}
+records. Tests that compare rendered SQL run against that database too;
+what those establish is what was rendered, which is what a simulator
+establishes.
+
+The portable path is also verified with dbplyr simulators for Access, SAP
+HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon
+Redshift, Snowflake, Spark SQL, SQLite, and Teradata, plus generic DBI and
+ODBC connections. Simulator coverage verifies SQL generation, not execution
+against every database server.
 
 Arrow and dtplyr are also tested lazy backends, but they are not SQL
 database connections.

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -619,14 +619,15 @@ DuckDB and PostgreSQL use native \verb{GROUP BY GROUPING SETS} SQL. Automated
 tests execute DuckDB queries against a live in-memory database and verify
 PostgreSQL SQL with dbplyr's simulator.
 
-SQLite is the other live database, and it runs the portable \verb{UNION ALL}
-path end to end: Parent shares under \code{.check_share_source = FALSE}, the
-refusal the default raises there -- SQLite converts a value of another type
-to a number rather than refusing it -- a Margin order through both
+SQLite is the other live database. It runs the portable \verb{UNION ALL} path
+end to end: Parent shares under \code{summarize_with_margins()}'s
+\code{.check_share_source = FALSE}, a Margin order through both
 \code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}}, including the missing-value
 placement its own ordering would not produce, the observed half of the
 Margin label collision check, and the queries \code{\link[=last_sent_queries]{last_sent_queries()}}
-records. Tests that compare rendered SQL run against that database too;
+records. The refusal that argument's default raises on the dialect is
+covered there too, and outside that list: it lands before a portable query
+is built. Tests that compare rendered SQL also run against that database;
 what those establish is what was rendered, which is what a simulator
 establishes.
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -619,12 +619,22 @@ DuckDB and PostgreSQL use native \verb{GROUP BY GROUPING SETS} SQL. Automated
 tests execute DuckDB queries against a live in-memory database and verify
 PostgreSQL SQL with dbplyr's simulator.
 
-The portable \verb{UNION ALL} SQL path is executed end to end for contextual
-shares against a live in-memory SQLite database. It is also verified with
-dbplyr simulators for Access, SAP HANA, Hive, Impala, MariaDB, Microsoft SQL
-Server, MySQL, Oracle, Amazon Redshift, Snowflake, Spark SQL, SQLite, and
-Teradata, plus generic DBI and ODBC connections. Simulator coverage verifies
-SQL generation, not execution against every database server.
+SQLite is the other live database, and it runs the portable \verb{UNION ALL}
+path end to end: Parent shares under \code{.check_share_source = FALSE}, the
+refusal the default raises there -- SQLite converts a value of another type
+to a number rather than refusing it -- a Margin order through both
+\code{\link[dplyr:collect]{dplyr::collect()}} and \code{\link[dplyr:compute]{dplyr::compute()}}, including the missing-value
+placement its own ordering would not produce, the observed half of the
+Margin label collision check, and the queries \code{\link[=last_sent_queries]{last_sent_queries()}}
+records. Tests that compare rendered SQL run against that database too;
+what those establish is what was rendered, which is what a simulator
+establishes.
+
+The portable path is also verified with dbplyr simulators for Access, SAP
+HANA, Hive, Impala, MariaDB, Microsoft SQL Server, MySQL, Oracle, Amazon
+Redshift, Snowflake, Spark SQL, SQLite, and Teradata, plus generic DBI and
+ODBC connections. Simulator coverage verifies SQL generation, not execution
+against every database server.
 
 Arrow and dtplyr are also tested lazy backends, but they are not SQL
 database connections.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -682,23 +682,13 @@ options(old)
 ## Backend verification levels
 
 Support is not one status. SQL simulation is useful evidence about rendering,
-but it is not the same as running a query on a live server, so it is worth
-knowing which claim rests on which.
+but it is not the same as running a query on a live server, so treat a
+simulator-only backend as SQL-generation support, and report server-specific
+behavior with a minimal query and the backend version.
 
-Only DuckDB and SQLite are exercised as live SQL databases. DuckDB covers
-native SQL end to end — generation, execution, result values, labels, and
-grouping identity — while SQLite's live claim is narrower: portable
-`UNION ALL` execution for Parent shares, including missing-safe matching and
-Grouping set identifiers. PostgreSQL and the dozen-plus fallback dialects are
-verified through dbplyr simulators, which prove what SQL is rendered and
-nothing about a running server. Arrow and dtplyr are tested for the lazy
-behavior each supports.
-
-Treat a simulator-only backend as SQL-generation support, and report
-server-specific behavior with a minimal query and the backend version.
-*Database backend coverage* in the [`summarize_with_margins()`
-reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
-names every verified backend.
+Which claim rests on which is stated in one place: *Database backend coverage*
+in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
 
 ## Practical rules for remote analysis
 


### PR DESCRIPTION
Closes #457.

Three documents stated what is verified against a live SQLite database and no two agreed:

- the README's *Backend verification* table — Parent-share execution, qualified with `.check_share_source = FALSE`;
- the database-backends vignette's *Backend verification levels* — Parent-share `UNION ALL` execution, unqualified, beside its own rule saying the share is refused by default there;
- *Database backend coverage* on `summarize_with_margins()` — contextual shares, end to end.

All three understated the suite. Live RSQLite connections are opened in five test files, covering Parent shares under `.check_share_source = FALSE`, the refusal the default raises on that dialect, portable Margin orders through `collect()` and `compute()` including missing-value placement SQLite's own ordering would not produce, the observed half of the Margin label collision check, and the queries `last_sent_queries()` records.

## What this does

The reference section is now the single owner of the scope. It also separates what is executed against a live SQLite connection from what is only rendered there — several tests `copy_to()` that database and then assert on `sql_render()` alone, so a statement conflating the two would have been the fourth wrong scope.

The vignette keeps the argument a vignette owes — simulator coverage is evidence about rendering and not about a running server — and links to the reference instead of restating a scope. The README carries a pointer in place of its table, and the earlier README cross-reference now names the owner rather than the guide that forwards to it.

`verify-site.R` pinned four sentences of the rewritten vignette section; its markers follow the new prose and name no backend, since a marker naming one would reintroduce what the section was reduced to remove.

## Checks

- `lintr::lint_package()` after `pkgload::load_all()` — no lints
- `spelling::spell_check_package()` — clean
- full `testthat::test_local()` with every optional Suggest present — passing
- `roxygen2::roxygenise()` and `rmarkdown::render("README.Rmd")` re-run and committed (local pandoc 3.10.1 matches the `document.yaml` pin)
- `altdoc::render_docs(parallel = FALSE, freeze = FALSE)` then `verify-site.R` — passing
- `verify-must-error.R`, `verify-context-budget.R`, `verify-verifier-invocation.R` — passing