### PR TITLE
Render the package page, and hold it in the derived set

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -27,9 +27,10 @@ read_page <- function(path) {
 }
 
 # `\keyword{internal}` is the rule altdoc applies when deciding that a topic
-# documents internals and gets no page of its own. Stating the rule rather than
-# naming the topic it currently excludes keeps a second internal topic from
-# demanding a page that will never be rendered.
+# documents internals and gets no page of its own. No topic has carried it
+# since #456, so this filter drops nothing today; it stays written as the rule
+# so that a topic given the keyword later leaves the set rather than demanding
+# a page that will never be rendered.
 documents_internals <- function(path) {
   any(grepl(
     "\\keyword{internal}",
@@ -419,12 +420,10 @@ markers <- list(
     "cannot select any column named in the complete grouping plan",
     "cur_group_id"
   ),
-  # Naming this page here is what holds it in the derived set. `@keywords
-  # internal` on the topic takes it out of `reference_sources` above, which
-  # requires no page and so fails nothing -- how the three sections below left
-  # the site for as long as they did (#456). A `markers` key naming a page the
-  # site does not produce is an error, so restoring that keyword now stops this
-  # script rather than silently dropping the page again.
+  # `@keywords internal` on the `"_PACKAGE"` topic takes it out of
+  # `reference_sources` above, which requires no page and so fails nothing --
+  # how the three sections below left the site for as long as they did (#456).
+  # Naming the page here is what fails the run if the keyword returns.
   "docs/man/marginplyr-package.html" = c(
     # One marker per section that has no other page. The condition class and
     # the audit option are each quoted by the sentence stating what it
@@ -434,10 +433,13 @@ markers <- list(
     "is the only class marginplyr promises",
     "Recording the SQL marginplyr sends",
     "switches the record on",
-    # The Guides list, by the one entry whose wording is this list's own. The
-    # other four name their vignette closely enough that the navbar or a
-    # cross-reference could supply the same run.
-    "Complete absent keys before margins"
+    # The Guides list, by its heading and by one entry's href. No entry's text
+    # can serve: all five are vignette titles, and the sidebar renders every
+    # one of them on all 21 pages, so a marker quoting one passes on a page
+    # whose Guides section was deleted. The href is the list's own because the
+    # sidebar links the same vignette relatively.
+    "Guides",
+    "https://sayuks.github.io/marginplyr/vignettes/completing_keys.html"
   ),
   "docs/man/inspect_grouping.html" = c(
     "Formats and ordinary tibble behavior",

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -419,6 +419,26 @@ markers <- list(
     "cannot select any column named in the complete grouping plan",
     "cur_group_id"
   ),
+  # Naming this page here is what holds it in the derived set. `@keywords
+  # internal` on the topic takes it out of `reference_sources` above, which
+  # requires no page and so fails nothing -- how the three sections below left
+  # the site for as long as they did (#456). A `markers` key naming a page the
+  # site does not produce is an error, so restoring that keyword now stops this
+  # script rather than silently dropping the page again.
+  "docs/man/marginplyr-package.html" = c(
+    # One marker per section that has no other page. The condition class and
+    # the audit option are each quoted by the sentence stating what it
+    # promises, not by the name alone: a name survives a section reduced to a
+    # cross-reference.
+    "Errors and warnings",
+    "is the only class marginplyr promises",
+    "Recording the SQL marginplyr sends",
+    "switches the record on",
+    # The Guides list, by the one entry whose wording is this list's own. The
+    # other four name their vignette closely enough that the navbar or a
+    # cross-reference could supply the same run.
+    "Complete absent keys before margins"
+  ),
   "docs/man/inspect_grouping.html" = c(
     "Formats and ordinary tibble behavior",
     "Positron",

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -160,7 +160,6 @@
 #' [g4]: https://sayuks.github.io/marginplyr/vignettes/completing_keys.html
 #' [g5]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
 #'
-#' @keywords internal
 #' @examples
 #' summarize_with_margins(
 #'   .data = retail_sales,

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -197,4 +197,3 @@ Authors:
 }
 
 }
-\keyword{internal}


### PR DESCRIPTION
Closes #456.

`@keywords internal` on the `"_PACKAGE"` topic kept altdoc from rendering any page for it — `.render_one_man()` skips an `.Rd` matching `\keyword{internal}` — and `verify-site.R` derives its required pages from the non-internal `man/*.Rd`, so nothing asked for one. That topic is the only place documenting the `"marginplyr_error"` class contract, the `marginplyr.audit_sql` option and `last_sent_queries()`, and the five guides as one list; the README names none of them. The site had no path to any of it.

Dropping the keyword is the whole of the fix in the positive direction. altdoc names the page after the `.Rd`, which is what `page_for()` already derives, so `docs/man/marginplyr-package.html` joins the derived set with no edit to the script.

It is not the whole of the fix in the other direction. Restoring the keyword would take the page back out of `reference_sources`, requiring no page and failing nothing — which is how the three sections left the site for as long as they did. Naming the page in `markers` closes that: a `markers` key naming a page the site does not produce stops the script. Verified by re-adding the keyword to the generated `.Rd`, which now fails with `` `markers` names pages the site does not produce ``.

## Verified

- `Rscript .github/scripts/verify-site.R` — passes; 21 pages from 5 vignettes and **11** help topics, up from 10, with `docs/man/marginplyr-package.html` carrying markers.
- The rendered page carries all three sections, and `docs/index.html` links it from the Reference sidebar.
- `lintr::lint_package()` — no lints. Full suite under `NOT_CRAN=true` — all pass.
- `verify-context-budget.R`, `verify-verifier-invocation.R` — pass.