### PR TITLE
Correct what four guides claim about themselves

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,12 @@ consistently to local and remote data.
 
 ## Language
 
+**Grain**:
+What one row of a summary stands for: the dimensions it is grouped by. An
+ordinary grouped summary has one grain; a Grouping plan produces several in
+one result.
+_Avoid_: Granularity, aggregation level
+
 **Grouping specification**:
 A user-declared description of the grouping sets, rollups, cubes, or products
 to be applied.

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -132,8 +132,12 @@ record_sent_query <- function(purpose, query) {
 #' ```
 #'
 #' @seealso *[When marginplyr queries your data][summarize_with_margins]* for
-#'   the queries a Margin verb sends without being asked, and
-#'   [dplyr::show_query()] for the result query alone.
+#'   the queries a Margin verb sends without being asked,
+#'   [dplyr::show_query()] for the result query alone, and *Record the SQL
+#'   marginplyr sends* in the [database-backends guide][guide] for the record
+#'   read against a live connection.
+#'
+#' [guide]: https://sayuks.github.io/marginplyr/vignettes/database_backends.html
 #' @export
 #' @examples
 #' # The record is kept only while the option is set, so the example restores

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -633,6 +633,9 @@
 #' [summarize_with_margins()]'s `.check_share_source` reads nothing on any
 #' backend, so it defaults to `TRUE` there.
 #'
+#' [last_sent_queries()] reports what a call actually sent, which is how this
+#' rule is checked against a connection rather than read here.
+#'
 #' @family summarize and expand data with margins
 #' @export
 #' @examples

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -633,8 +633,9 @@
 #' [summarize_with_margins()]'s `.check_share_source` reads nothing on any
 #' backend, so it defaults to `TRUE` there.
 #'
-#' [last_sent_queries()] reports what a call actually sent, which is how this
-#' rule is checked against a connection rather than read here.
+#' [last_sent_queries()] reports what a call actually sent, which is how the
+#' two unasked queries above are counted against a connection rather than
+#' taken from this page.
 #'
 #' @family summarize and expand data with margins
 #' @export

--- a/README.Rmd
+++ b/README.Rmd
@@ -58,7 +58,7 @@ Row order is unspecified: the same call on the same data in a different order
 can arrange the result differently. `.sort` asks for a Margin order, which puts
 each subtotal with the rows it summarizes, and `arrange()` gives any other
 presentation order. [Put each subtotal with the rows it
-summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html) shows
+summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html#put-each-subtotal-with-the-rows-it-summarizes) shows
 `.sort` at work and what it does not promise.
 
 - Works with local data frames and lazy `dbplyr` tables.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ order can arrange the result differently. `.sort` asks for a Margin
 order, which puts each subtotal with the rows it summarizes, and
 `arrange()` gives any other presentation order. [Put each subtotal with
 the rows it
-summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html)
+summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html#put-each-subtotal-with-the-rows-it-summarizes)
 shows `.sort` at work and what it does not promise.
 
 - Works with local data frames and lazy `dbplyr` tables.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -494,8 +494,9 @@ Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
 
-\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
-rule is checked against a connection rather than read here.
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
+two unasked queries above are counted against a connection rather than
+taken from this page.
 }
 
 \section{Backend extension design}{

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -493,6 +493,9 @@ not is not. \code{.check_margin_label} scans the grouping columns, so every
 Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
+
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
+rule is checked against a connection rather than read here.
 }
 
 \section{Backend extension design}{

--- a/man/last_sent_queries.Rd
+++ b/man/last_sent_queries.Rd
@@ -126,6 +126,8 @@ if (
 }
 \seealso{
 \emph{\link[=summarize_with_margins]{When marginplyr queries your data}} for
-the queries a Margin verb sends without being asked, and
-\code{\link[dplyr:show_query]{dplyr::show_query()}} for the result query alone.
+the queries a Margin verb sends without being asked,
+\code{\link[dplyr:show_query]{dplyr::show_query()}} for the result query alone, and \emph{Record the SQL
+marginplyr sends} in the \href{https://sayuks.github.io/marginplyr/vignettes/database_backends.html}{database-backends guide} for the record
+read against a live connection.
 }

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -464,6 +464,9 @@ not is not. \code{.check_margin_label} scans the grouping columns, so every
 Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
+
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
+rule is checked against a connection rather than read here.
 }
 
 \section{Backend extension design}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -465,8 +465,9 @@ Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
 
-\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
-rule is checked against a connection rather than read here.
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
+two unasked queries above are counted against a connection rather than
+taken from this page.
 }
 
 \section{Backend extension design}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -511,8 +511,9 @@ Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
 
-\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
-rule is checked against a connection rather than read here.
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
+two unasked queries above are counted against a connection rather than
+taken from this page.
 }
 
 \section{Backend extension design}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -510,6 +510,9 @@ not is not. \code{.check_margin_label} scans the grouping columns, so every
 Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
+
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
+rule is checked against a connection rather than read here.
 }
 
 \section{Backend extension design}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -699,8 +699,9 @@ Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
 
-\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
-rule is checked against a connection rather than read here.
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
+two unasked queries above are counted against a connection rather than
+taken from this page.
 }
 
 \examples{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -698,6 +698,9 @@ not is not. \code{.check_margin_label} scans the grouping columns, so every
 Margin verb defaults it to \code{is.data.frame(.data)}.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}'s \code{.check_share_source} reads nothing on any
 backend, so it defaults to \code{TRUE} there.
+
+\code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how this
+rule is checked against a connection rather than read here.
 }
 
 \examples{

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -136,8 +136,8 @@ substantive modeling choice.
 
 If the intended change is only presentational, summarize the observed facts
 first and replace the finished display value afterwards. A completed key with
-no observed fact averages an empty selection, so the mean it reports is
-missing:
+no observed fact averages an empty selection, so the mean it reports is `NaN`,
+which `coalesce()` replaces as it does any missing value:
 
 ```{r}
 #| eval: !expr has_tidyr

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -19,6 +19,11 @@ before a Margin operation when synthetic facts should participate in detail,
 subtotal, and grand-total summaries. Replace values after a summary when the
 change is only for display.
 
+If grouping sets are new to you, read [Get
+started](https://sayuks.github.io/marginplyr/vignettes/get_started.html)
+first. It introduces the Grouping specifications, Margin labels, and Margin
+operations this guide assumes.
+
 ```{r setup}
 #| message: false
 
@@ -26,10 +31,10 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. The tidyr and SQLite sections below need
-optional packages, so their chunks evaluate only when those packages are
-installed at the versions marginplyr asks for. Where a package is missing or
-too old the code is still shown, but its output is absent.
+Nothing beyond marginplyr's own dependencies is required. The tidyr and SQLite
+sections below need optional packages, so their chunks evaluate only when those
+packages are installed at the versions marginplyr asks for. Where a package is
+missing or too old the code is still shown, but its output is absent.
 
 ```{r}
 #| include: false
@@ -130,12 +135,16 @@ The two means show that filling synthetic facts before a summary is a
 substantive modeling choice.
 
 If the intended change is only presentational, summarize the observed facts
-first and replace the finished display value afterwards:
+first and replace the finished display value afterwards. A completed key with
+no observed fact averages an empty selection, so the mean it reports is
+missing:
 
 ```{r}
-observed_summary <- facts |>
+#| eval: !expr has_tidyr
+
+observed_summary <- completed_facts |>
   summarize_with_margins(
-    mean_revenue = mean(revenue),
+    mean_revenue = mean(revenue[is_fact]),
     .grouping = rollup(region, store, product)
   )
 
@@ -143,7 +152,9 @@ observed_summary |>
   mutate(display_mean = dplyr::coalesce(mean_revenue, 0))
 ```
 
-That `mutate()` does not add fact rows or alter any existing aggregate.
+Three detail rows change; every subtotal and the grand total keep the value
+they were summarized to, because that `mutate()` adds no fact rows and alters
+no existing aggregate.
 
 ## Union an explicit scaffold with observed keys
 
@@ -238,8 +249,8 @@ The union, join, completion expressions, and Margin summary remain lazy.
 ## Move local keys only when you ask to
 
 For a small local key table, `dbplyr::copy_inline()` embeds the rows in the
-lazy SQL with `VALUES`. This avoids creating a persistent table but makes the
-query text grow with the number of keys:
+lazy SQL as a `VALUES` subquery. This avoids creating a persistent table but
+makes the query text grow with the number of keys:
 
 ```{r}
 #| message: false
@@ -281,9 +292,20 @@ show_query(reusable_query)
 DBI::dbDisconnect(con)
 ```
 
+Read the two renderings side by side. The inline query carries the key rows
+themselves — on SQLite, a zero-row `SELECT` unioned with a `VALUES` list,
+wrapped in the casts that give the columns their types — while the `copy_to()`
+query names `requested_keys`, a table that now exists on the connection.
+
 Use explicit `dplyr::copy_to()` for a larger or reusable local key relation.
 It performs data movement at the line where the caller requested it.
 
 marginplyr never copies, collects, uploads, downloads, or otherwise moves
 completion data implicitly. Connection choice, data movement, and execution
 remain ordinary dplyr and dbplyr operations owned by the caller.
+
+Execution, not completion, is where a backend's own rules start to matter.
+[Database
+backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
+takes the lazy pipeline from here through query shape, `collect()`, and what
+each backend is verified to do.

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -293,9 +293,10 @@ DBI::dbDisconnect(con)
 ```
 
 Read the two renderings side by side. The inline query carries the key rows
-themselves — on SQLite, a zero-row `SELECT` unioned with a `VALUES` list,
-wrapped in the casts that give the columns their types — while the `copy_to()`
-query names `requested_keys`, a table that now exists on the connection.
+themselves — on SQLite, a zero-row `SELECT` joined by `UNION ALL` to a
+`VALUES` list, wrapped in the casts that give the columns their types — while
+the `copy_to()` query names `requested_keys`, a table that now exists on the
+connection.
 
 Use explicit `dplyr::copy_to()` for a larger or reusable local key relation.
 It performs data movement at the line where the caller requested it.
@@ -304,8 +305,8 @@ marginplyr never copies, collects, uploads, downloads, or otherwise moves
 completion data implicitly. Connection choice, data movement, and execution
 remain ordinary dplyr and dbplyr operations owned by the caller.
 
-Execution, not completion, is where a backend's own rules start to matter.
-[Database
+Execution, not completion, is where each backend starts to impose rules of its
+own. [Database
 backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
 takes the lazy pipeline from here through query shape, `collect()`, and what
 each backend is verified to do.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -42,10 +42,11 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. The DuckDB, SQLite, dtplyr, and Arrow
-sections below need optional packages, so their chunks evaluate only when those
-packages are installed at the versions marginplyr asks for. Where a package is
-missing or too old the code is still shown, but its output is absent.
+Nothing beyond marginplyr's own dependencies is required. The DuckDB, SQLite,
+dtplyr, and Arrow sections below need optional packages, so their chunks
+evaluate only when those packages are installed at the versions marginplyr asks
+for. Where a package is missing or too old the code is still shown, but its
+output is absent.
 
 ```{r}
 #| include: false

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -507,7 +507,7 @@ declared factor level is rejected on every backend either way. Result row
 order is unspecified for both local and lazy inputs unless
 `.sort` asks for a Margin order; use `arrange()` for any other presentation
 order. [Put each subtotal with the rows it
-summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html)
+summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html#put-each-subtotal-with-the-rows-it-summarizes)
 shows `.sort` at work and what it does not promise. A label is only a
 display value; retain `grouping_bit()` or `grouping_id()` whenever source
 values can equal the label.
@@ -786,7 +786,7 @@ documents both helpers.
 
 Which rows the denominator covers is decided by the fixed `.by` keys. [Compare
 each row with the right
-total](https://sayuks.github.io/marginplyr/vignettes/recipes.html) works
+total](https://sayuks.github.io/marginplyr/vignettes/recipes.html#compare-each-row-with-the-right-total) works
 through that choice.
 
 ## Complete absent keys before summarizing
@@ -871,7 +871,7 @@ dbplyr::tbl_lazy(
 Expanded rows are also the way to compute something one aggregation pass
 cannot express, which is a real limit on a database rather than a local one.
 [Compute what the summary pass cannot
-express](https://sayuks.github.io/marginplyr/vignettes/recipes.html) works
+express](https://sayuks.github.io/marginplyr/vignettes/recipes.html#compute-what-the-summary-pass-cannot-express) works
 through that case.
 
 ### Nest locally or with dtplyr

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -40,10 +40,10 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. A few sections below illustrate optional
-tooling, so their chunks evaluate only when that tooling is installed at the
-version marginplyr asks for. Where a package is missing or too old the code is
-still shown, but its output is absent.
+Nothing beyond marginplyr's own dependencies is required. A few sections below
+illustrate optional tooling, so their chunks evaluate only when that tooling is
+installed at the version marginplyr asks for. Where a package is missing or too
+old the code is still shown, but its output is absent.
 
 ```{r}
 #| include: false

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -13,6 +13,7 @@ format:
 date: last-modified
 ---
 
+A grain is what one row of a summary stands for — one row per store, say.
 Reports often need several grains at once: detail rows, subtotals, and a grand
 total. `marginplyr` creates those levels with one dplyr-style summary. SQL
 calls this idea `GROUPING SETS`; you do not need to know that syntax to begin.
@@ -491,46 +492,13 @@ retail_sales |>
 ```
 
 `.margin_label = NULL` and `NA_character_` are the same request: typed missing
-output, and no observed collision check on that dimension. They part on one
-point — an existing factor NA level is always a structural conflict for
+output, and no observed collision check on that dimension. They part on
+factors, where an existing NA level is always a structural conflict for
 `NA_character_`, whatever `.check_margin_label` says, while `NULL` preserves
-it. A named list chooses either one per dimension, which a named character
-vector cannot do for `NULL`, because `c()` drops a `NULL` element.
-
-A factor NA level and a missing factor code are different even though both
-can print as `<NA>`. Here the second value uses the NA level and the third is
-actually missing:
-
-```{r}
-factor_status <- structure(
-  c(1L, 2L, NA_integer_),
-  levels = c("kept", NA_character_),
-  class = "factor"
-)
-is.na(factor_status)
-levels(factor_status)
-
-factor_margins <- data.frame(
-  status = factor_status,
-  value = 1:3
-) |>
-  summarize_with_margins(
-    n = dplyr::n(),
-    status_is_margin = grouping_bit(status),
-    .grouping = rollup(status),
-    .margin_label = NULL
-  )
-
-levels(factor_margins$status)
-is.na(factor_margins$status)
-factor_margins
-```
-
-`NULL` preserves the NA level and uses a missing factor code for the Margin
-row. Retain `grouping_bit()` or `grouping_id()` because source missing values
-and generated Margin values are otherwise indistinguishable. With
-`NA_character_`, an existing factor NA level is a structural conflict even
-when `.check_margin_label = FALSE`.
+it. [Three kinds of apparent
+missingness](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html#three-kinds-of-apparent-missingness)
+works one factor through an NA level, a source missing value, and a
+typed-missing Margin value, which can all print as `<NA>`.
 
 For local data, `.check_margin_label = TRUE` prevents an existing value such
 as `"Total"` from becoming visually ambiguous. Lazy inputs default to
@@ -647,19 +615,12 @@ retail_sales |>
   )
 ```
 
-That refusal is by spelling, as every recognized name here is. A few names mean
-what marginplyr rewrites them into rather than what they are bound to:
-`grouping_bit()`, `grouping_id()`, `share_of_parent()`, `share_of_total()`,
-`across()`, `if_any()`, `if_all()`, `pick()`, `where()`, and the
-`cur_group*()` family are recognized bare or qualified with the package that
-owns them, and a binding of the same name in your own environment never
-changes what a Margin verb does with one. Redundant parentheses are
-transparent to that, so `(pick)(units)` and `(pick(units))` ask for what
-`pick(units)` asks for. For `cur_group_id()` that is stricter than
-`dplyr::summarize()`, which resolves it by ordinary lookup;
-here it stays refused, because reading the binding would mean resolving a call
-head against the calling environment. Every other name, `n()` included,
-follows ordinary lookup.
+That refusal is by spelling, as every recognized name here is. The helpers a
+Margin verb rewrites — `grouping_bit()`, `pick()`, the `cur_group*()` family
+and the rest — are read from how they are written, so a binding of the same
+name in your own environment never changes what one does. `cur_group_id()`
+stays refused for that reason, where `dplyr::summarize()` would resolve it by
+ordinary lookup. Every other name, `n()` included, follows ordinary lookup.
 
 Two familiar conveniences also behave differently. Row order is unspecified
 for local and lazy results alike unless `.sort` asks for a Margin order, which
@@ -1072,12 +1033,6 @@ The list column is a regular list of data frames; a
 `nest_by_with_margins()` follows `dplyr::nest_by()` and returns one row
 containing the empty data frame when there are no keys.
 
-`dplyr::nest_by()` is currently not a stable upstream API and may eventually
-be deprecated in favor of `tidyr::nest(.by = )`. marginplyr nevertheless
-keeps its row-wise wrapper because per-margin modeling and reporting are
-useful, and implements it through the same nesting core rather than a separate
-semantic path.
-
 ## Optional Quarto tabsets with quartabs
 
 [`quartabs`](https://sayuks.github.io/quartabs/) can turn the nested report
@@ -1123,6 +1078,6 @@ tabbed_report |>
   )
 ```
 
-The `"Total"` tab is created by the grouping plan. The ordered factor makes it
-the first tab; `quartabs` only handles presentation, while marginplyr defines
-which source rows belong to that total.
+The `"Total"` tab is created by the grouping plan. The factor's level order
+makes it the first tab; `quartabs` only handles presentation, while marginplyr
+defines which source rows belong to that total.

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -45,11 +45,12 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. Four recipes execute against DuckDB, so
-their chunks evaluate only when DuckDB is installed at the version marginplyr
-asks for. Where a package is missing or too old the code is still shown, but
-its output is absent. Everything else runs either locally or against
-`dbplyr::simulate_postgres()`, which needs no database and no optional package.
+Nothing beyond marginplyr's own dependencies is required. Four recipes execute
+against DuckDB, so their chunks evaluate only when DuckDB is installed at the
+version marginplyr asks for. Where a package is missing or too old the code is
+still shown, but its output is absent. Everything else runs either locally or
+against `dbplyr::simulate_postgres()`, which needs no database and no optional
+package.
 
 ```{r}
 #| include: false

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -45,7 +45,7 @@ library(marginplyr)
 library(dplyr)
 ```
 
-Only dplyr and dbplyr are required. Three recipes execute against DuckDB, so
+Only dplyr and dbplyr are required. Four recipes execute against DuckDB, so
 their chunks evaluate only when DuckDB is installed at the version marginplyr
 asks for. Where a package is missing or too old the code is still shown, but
 its output is absent. Everything else runs either locally or against
@@ -119,7 +119,7 @@ questions.
 
 A Margin order leaves every dimension's values ascending, so a report that
 wants the newest year at the top asks for the same key with one term changed.
-`grouping_bit()` puts the Grouping bits the key reads into the result, and the
+`grouping_bit()` exposes the same Grouping bits the key uses, and the
 `arrange()` is then the key above with `desc()` on the term you are reversing:
 
 ```{r}
@@ -561,9 +561,13 @@ retail_sales |>
 ```
 
 For a single dimension, `grouping_bit()` avoids the bit arithmetic altogether:
-retain one flag column per dimension and filter on the flags. [Grouping
-identity](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
-compares all four identity values and states their duplicate-occurrence rules.
+retain one flag column per dimension and filter on the flags. The
+[`grouping_bit()`
+reference](https://sayuks.github.io/marginplyr/man/grouping_bit.html) compares
+all four identity values and states their duplicate-occurrence rules, and the
+[Grouping identity
+guide](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html)
+works through what that comparison means in practice.
 
 ## Name the grouping set on every row
 
@@ -614,7 +618,8 @@ retail_sales |>
 `inspect_grouping()` is local even when `.data` is not: it reads captured
 column metadata and the Grouping plan, never the source rows
 ([ADR 0013][adr13]). A lazy result and a local tibble have no common source,
-so dbplyr refuses the join outright:
+so dbplyr refuses the join outright, and its message names the two `copy`
+routes out of the refusal:
 
 [adr13]: https://github.com/sayuks/marginplyr/blob/main/design/adr/0013-inspect-grouping-plans-as-ordinary-tibbles.md
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -292,8 +292,8 @@ For a denominator one rollup level up rather than at the top, use
 `share_of_parent()`. The
 [`share_of_parent()`
 reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
-documents both helpers, and [Get
-started](https://sayuks.github.io/marginplyr/vignettes/get_started.html)
+documents both helpers, and [Compare a summary with the
+whole](https://sayuks.github.io/marginplyr/vignettes/get_started.html#compare-a-summary-with-the-whole)
 compares them side by side. For a level between the two, [Compare a row with
 an ancestor level](#compare-a-row-with-an-ancestor-level) runs the same `.by`
 lever the other way.


### PR DESCRIPTION
Four documentation issues from the 2026-09-06 review, taken in one pass
because three of them are the same kind of defect: a guide stating something
the code does not do.

**#458** -- the DuckDB chunk count, the claim that `grouping_bit()` puts the
bits the Margin order key reads into the result, and a pointer crediting the
Grouping identity guide with a comparison it defers to the `grouping_bit()`
reference. The issue's fourth item was verified wrong and is not implemented
as written: the lazy-join refusal is dbplyr's, raised by
`dbplyr:::dbplyr_auto_copy()`, so the sentence keeps its subject and gains
only what the reader needs from the diagnostic.

**#459** -- the post-summary example replaced nothing, because `facts$revenue`
has no missing value. It now summarizes the observed facts out of
`completed_facts`, where a completed key with no observed fact averages an
empty selection. `copy_inline()` renders a `VALUES` subquery, not bare
`VALUES`. The guide gains an entry pointer to Get started and an exit pointer
to Database backends, closing a link the database guide already made the other
way.

**#460** -- the `NA_character_`/`NULL` factor block and the call-head
resolution block both belong to a reader who already uses the package, and
both have an owner: *Three kinds of apparent missingness* in the Grouping
identity guide, and *Relationship to dplyr summaries* in the reference. Get
started keeps a sentence and a link for each. "Grain" is defined at first use;
an ordered factor that is a plain `factor()` is named correctly; a note on
`dplyr::nest_by()`'s upstream stability is dropped.

**#464 / #465, in part** -- four links that named a heading and landed at a
page top now carry its fragment, and `last_sent_queries()` is connected to its
only guide coverage in both directions. The rest of both issues is left open.

"Only dplyr and dbplyr are required" answered a question about `library()`
calls with a claim about the dependency closure; all four guides now say
nothing beyond marginplyr's own dependencies is required.

Closes #458
Closes #459
Closes #460
Refs #464, #465
