### PR TITLE
Answer three documentation issues against one guide

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -414,6 +414,13 @@ markers <- list(
     "summarise_with_margins",
     "Relationship to dplyr summaries",
     "Display labels and grouping identity",
+    # The same section again, as the anchor rather than as its heading text.
+    # `grouping_identity.qmd` is the one vignette that links a man page with a
+    # fragment, and a heading whose words survive a change to how quarto
+    # derives its `id` would leave that link landing at the top of this page
+    # with nothing failing. The heading marker above cannot stand for it: it
+    # matches the words wherever they are written.
+    "id=\"display-labels-and-grouping-identity\"",
     "Contextual shares",
     "Backend extension design",
     "Database backend coverage",

--- a/R/share.R
+++ b/R/share.R
@@ -371,7 +371,11 @@
 #' | Without fixed `.by` keys | One row of the Grand total set | `1.0`, double |
 #' | With fixed `.by` keys | Zero rows | Empty double vector |
 #'
-#' Missing detail or subtotal combinations are not completed.
+#' Missing detail or subtotal combinations are not completed. The [completing
+#' keys guide][keys] shows how to complete the input facts before the summary,
+#' where synthetic facts are meant to reach every level.
+#'
+#' [keys]: https://sayuks.github.io/marginplyr/vignettes/completing_keys.html
 #'
 #' @section Lazy execution boundaries:
 #' Share execution supports local data frames and lazy dbplyr and dtplyr

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -6,7 +6,11 @@
 #'
 #' Use it when one report needs several levels of detail—for example, stores,
 #' region subtotals, and a company total—or when that report should use the
-#' same code locally and through [dbplyr::tbl_lazy()].
+#' same code locally and through [dbplyr::tbl_lazy()]. The [Get started
+#' guide][started] builds that report from a hand-written version, and is the
+#' page to read before this one.
+#'
+#' [started]: https://sayuks.github.io/marginplyr/vignettes/get_started.html
 #'
 #' @param .data A data frame or lazy table.
 #' @param ... Name-value pairs as used in [dplyr::summarize()]. Contextual

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -387,7 +387,8 @@ column keeps its type either way:\tabular{lrl}{
 }
 
 
-Missing detail or subtotal combinations are not completed.
+Missing detail or subtotal combinations are not completed. The \href{https://sayuks.github.io/marginplyr/vignettes/completing_keys.html}{completing keys guide} shows how to complete the input facts before the summary,
+where synthetic facts are meant to reach every level.
 }
 
 \section{Lazy execution boundaries}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -138,7 +138,8 @@ data frames and lazy tables.
 \details{
 Use it when one report needs several levels of detail—for example, stores,
 region subtotals, and a company total—or when that report should use the
-same code locally and through \code{\link[dbplyr:tbl_lazy]{dbplyr::tbl_lazy()}}.
+same code locally and through \code{\link[dbplyr:tbl_lazy]{dbplyr::tbl_lazy()}}. The \href{https://sayuks.github.io/marginplyr/vignettes/get_started.html}{Get started guide} builds that report from a hand-written version, and is the
+page to read before this one.
 
 \code{\link[=grouping_sets]{grouping_sets()}} forms a union of grouping families. \code{\link[=grouping_spec]{grouping_spec()}}
 combines its arguments by Cartesian product, matching comma-separated SQL

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -52,7 +52,11 @@ has_sqlite <- marginplyr_suggest_available("DBI") &&
 ## Why completion is a separate operation
 
 marginplyr does not provide `.complete`, `.fill`, or `.empty` arguments, and it
-does not provide `complete_with_margins()`.
+does not provide `complete_with_margins()`. A contextual share holds the same
+line: *Value rules* in the [`share_of_parent()`
+reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html) states
+that neither helper ever synthesizes or completes keys, so a denominator with
+no row behind it gives `NA_real_` rather than a number.
 
 Input completion and result completion answer different questions:
 

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -366,32 +366,21 @@ postgres_sales |>
 ```
 
 Syntax, source-name, written-order, and `across()` errors are validated before
-execution. A share source must still be a plain integer or double, and that
-rule holds here too — but marginplyr reads no row of your data to establish
-it. A database evaluates the source summary itself, so where the dialect
-refuses an ineligible summary that refusal is the answer, and it reaches you
-as the database's own diagnostic when you execute the query. The staged
-queries above are still not executed, and `show_query()` runs nothing.
+execution, and the staged queries above are still not executed: `show_query()`
+runs nothing. A share source must still be a plain integer or double, and that
+rule holds here too — but marginplyr reads no row of your data to establish it.
+A database evaluates the source summary itself, so marginplyr asks the dialect
+instead, with at most two queries referencing none of your tables, whether it
+refuses an ineligible summary or converts one to a number; where it refuses,
+that refusal is the answer and reaches you as the database's own diagnostic
+when you execute the query.
 
-Where the dialect converts a value of another type to a number instead of
-refusing it — SQLite answers `sum()` of a text column with `0` rather than an
-error — nothing applies the rule at all, and marginplyr refuses the share
-rather than calculating one from values nothing has checked. Which of the two
-a dialect does is asked with at most two queries referencing none of your
-tables: a probe, and — only when the probe is rejected — a control, which is
-what tells a dialect that genuinely refuses apart from one that could not
-answer at all. An answer is a property of the dialect, so a dialect that
-answers is asked once and every later connection carrying it reuses that
-answer. Where the question could not be answered, nothing is remembered and
-the next share request asks again, so a dropped connection or a warehouse that
-was resuming does not refuse your shares for the rest of the session. A
-connection that executes nothing, such as the simulators used above, cannot be
-asked and is refused for the same reason; `.check_share_source = FALSE`
-calculates the share from sources you have established yourself. What is
-remembered is the dialect's answer and not yours: `.check_share_source` is
-scoped to the call it is written in, so a dialect that converts needs it on
-every share request, and there is no session or connection default that
-records it once.
+Where the dialect converts instead — SQLite answers `sum()` of a text column
+with `0` rather than an error — nothing applies the rule at all, and the share
+is refused rather than calculated from values nothing has checked. A connection
+that executes nothing, such as the simulators used above, cannot be asked and
+is refused the same way; `.check_share_source = FALSE` calculates the share
+from sources you have established yourself, on the one call it is written in.
 
 A refusing dialect is therefore shown against a live DuckDB table rather than
 the simulator used above. The diagnostic is DuckDB's own, and the column it
@@ -442,7 +431,9 @@ denominators. Backend-specific non-finite representations are outside that
 contract. See the
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 for both helpers' supported sources, denominator rules, `across()` forms,
-empty inputs, and post-summary `mutate()` guidance.
+empty inputs, and post-summary `mutate()` guidance, and its *Lazy execution
+boundaries* for what each backend establishes, which later connections reuse a
+dialect's answer, and what an unanswered question leaves unremembered.
 
 ## Completion stays in the lazy input pipeline
 
@@ -722,16 +713,11 @@ reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
   one. Ask for a Margin order with `.sort`, or call `arrange()` for any other
   presentation order.
 
-- Lazy inputs default to `.check_margin_label = FALSE`, which skips only the
-  *observed* half of the collision check; a label equal to a *declared*
-  factor level is rejected either way. See *`.check_margin_label` on lazy
-  inputs* above.
+- Lazy inputs default to `.check_margin_label = FALSE`; see
+  *`.check_margin_label` on lazy inputs* above.
 
-- A contextual share needs `.check_share_source = FALSE` on every call against
-  a backend that cannot establish that its source is eligible: a connection
-  that executes nothing, such as a `simulate_*()` one, and a dialect that
-  converts an ineligible source rather than refusing it, such as SQLite. See
-  *Parent shares use a staged lazy query* above.
+- A contextual share may need `.check_share_source = FALSE`; see *Parent
+  shares use a staged lazy query* above.
 
 - A fallback query may repeat the source relation once per grouping set.
   Inspect the generated SQL and the database query plan for large workloads;

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -46,7 +46,9 @@ Nothing beyond marginplyr's own dependencies is required. The DuckDB, SQLite,
 dtplyr, and Arrow sections below need optional packages, so their chunks
 evaluate only when those packages are installed at the versions marginplyr asks
 for. Where a package is missing or too old the code is still shown, but its
-output is absent.
+output is absent. One dtplyr chunk calls `data.table::as.data.table()` and the
+list above does not name data.table, because dtplyr imports it: installing
+dtplyr installs it.
 
 ```{r}
 #| include: false
@@ -58,12 +60,11 @@ source(system.file("suggests", "guard.R", package = "marginplyr"))
 
 has_duckdb <- marginplyr_suggest_available("DBI") &&
   marginplyr_suggest_available("duckdb")
-# dtplyr imports data.table, so this guard answers for both: the refused-step
-# chunk below calls `data.table::as.data.table()` and needs none of its own.
-# That is also why the install list above names dtplyr and not data.table.
 # dbplyr's SQLite simulator opens no connection, but rendering its SQL reads
 # the installed driver version through RSQLite.
 has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
+# The one dtplyr chunk that calls `data.table::as.data.table()` is behind this
+# guard and needs none of its own, dtplyr importing data.table.
 has_dtplyr <- marginplyr_suggest_available("dtplyr")
 has_arrow <- marginplyr_suggest_available("arrow")
 
@@ -206,11 +207,13 @@ duckdb_result <- collect(duckdb_query)
 duckdb_result
 ```
 
-The `arrange()` above is one way to order that result. `.sort` is the other,
-and it is an argument of the verb, so it reaches the backend inside the same
-query rather than as a step over it. It puts each subtotal with the rows it
-summarizes, wherever the Margin label would otherwise fall among a dimension's
-values:
+The `arrange()` above orders by the labels, so `"Total"` falls wherever that
+string does among a dimension's values. `.sort` orders by the structure of the
+Grouping plan instead, so each subtotal lands with the rows it summarizes. It
+is an argument of the verb rather than a step after it; *Margin order* in the
+[`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
+states the key it builds and what a later verb can do to it:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -236,7 +239,7 @@ duckdb_stage <- compute(duckdb_query)
 class(duckdb_stage)
 
 duckdb_stage |>
-  filter(store == "Total") |>
+  filter(level == 1L) |>
   collect()
 ```
 
@@ -361,8 +364,9 @@ sqlite_sales |>
 
 `share_of_parent()` needs a denominator from another Grouping-set row, so it
 cannot be translated as one ordinary aggregate expression. marginplyr first
-forms the ordinary Margin summaries, then builds one Parent mapping shared by
-every requested measure. `.check_share_source = FALSE` appears here because
+computes the ordinary summaries for every grouping set, then builds one
+denominator lookup — the parent row for each result row — shared by every
+requested measure. `.check_share_source = FALSE` appears here because
 the simulated connection executes nothing and therefore cannot be asked what
 its dialect does with an ineligible source; the rule it opts out of is
 described below.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -58,6 +58,9 @@ source(system.file("suggests", "guard.R", package = "marginplyr"))
 
 has_duckdb <- marginplyr_suggest_available("DBI") &&
   marginplyr_suggest_available("duckdb")
+# dtplyr imports data.table, so this guard answers for both: the refused-step
+# chunk below calls `data.table::as.data.table()` and needs none of its own.
+# That is also why the install list above names dtplyr and not data.table.
 # dbplyr's SQLite simulator opens no connection, but rendering its SQL reads
 # the installed driver version through RSQLite.
 has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
@@ -200,13 +203,48 @@ the grouping sets and transfers only the summarized result:
 #| eval: !expr has_duckdb
 
 duckdb_result <- collect(duckdb_query)
-DBI::dbDisconnect(con)
-
 duckdb_result
 ```
 
-Use `compute()` instead when the next stage should remain in the database as a
-materialized or temporary remote table.
+The `arrange()` above is one way to order that result. `.sort` is the other,
+and it is an argument of the verb, so it reaches the backend inside the same
+query rather than as a step over it. It puts each subtotal with the rows it
+summarizes, wherever the Margin label would otherwise fall among a dimension's
+values:
+
+```{r}
+#| eval: !expr has_duckdb
+
+sales_db |>
+  filter(year == 2026L, month == "Jan") |>
+  summarize_with_margins(
+    revenue = sum(revenue, na.rm = TRUE),
+    .grouping = rollup(region, store),
+    .sort = "last"
+  ) |>
+  collect()
+```
+
+Use `compute()` instead of `collect()` when the next stage should remain in the
+database. It executes the query and stores the result there as a remote table,
+so what reads it afterwards is still a lazy query against the connection:
+
+```{r}
+#| eval: !expr has_duckdb
+
+duckdb_stage <- compute(duckdb_query)
+class(duckdb_stage)
+
+duckdb_stage |>
+  filter(store == "Total") |>
+  collect()
+```
+
+```{r}
+#| eval: !expr has_duckdb
+
+DBI::dbDisconnect(con)
+```
 
 DuckDB also preserves factor grouping columns represented as enums. When a
 factor dimension uses `.margin_label = NA_character_` or `NULL`, marginplyr
@@ -368,12 +406,12 @@ postgres_sales |>
 Syntax, source-name, written-order, and `across()` errors are validated before
 execution, and the staged queries above are still not executed: `show_query()`
 runs nothing. A share source must still be a plain integer or double, and that
-rule holds here too — but marginplyr reads no row of your data to establish it.
-A database evaluates the source summary itself, so marginplyr asks the dialect
-instead, with at most two queries referencing none of your tables, whether it
-refuses an ineligible summary or converts one to a number; where it refuses,
-that refusal is the answer and reaches you as the database's own diagnostic
-when you execute the query.
+rule holds here too — but marginplyr reads no row of your data to establish
+it. A database evaluates the source summary itself, so marginplyr asks the
+dialect instead, with at most two queries referencing none of your tables,
+whether it refuses an ineligible summary or converts one to a number; where it
+refuses, that refusal is the answer and reaches you as the database's own
+diagnostic when you execute the query.
 
 Where the dialect converts instead — SQLite answers `sum()` of a text column
 with `0` rather than an error — nothing applies the rule at all, and the share
@@ -494,6 +532,23 @@ postgres_sales |>
   nest_with_margins(
     .grouping = rollup(region, store)
   )
+```
+
+`nest_by_with_margins()` is the row-wise counterpart, and it is the one Margin
+verb that collects a lazy input without being asked: a row-wise data frame is a
+local object, so it has nothing lazy to return. *When marginplyr queries your
+data* names it as its one exemption. Its detail tables are the ones dtplyr
+built, so each cell is a `data.table`:
+
+```{r}
+#| eval: !expr has_dtplyr
+
+january_sales |>
+  dtplyr::lazy_dt() |>
+  nest_by_with_margins(
+    .grouping = rollup(region, store)
+  ) |>
+  mutate(revenue = sum(data$revenue))
 ```
 
 dtplyr also enforces the contextual-share source rules, for `share_of_parent()`

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -130,10 +130,12 @@ contains one `GROUP BY GROUPING SETS` operation. The requested rollup:
 ()
 ```
 
-becomes the equivalent SQL grouping-set list. Hidden `GROUPING()` flags allow
-the outer query to label only dimensions removed by aggregation. A source
-`NULL` therefore stays different from a generated subtotal even though SQL
-would otherwise display both as missing.
+becomes the equivalent SQL grouping-set list. In SQL, `GROUPING(x)` returns `1`
+when `x` was removed from the grouping set that produced a row and `0` when it
+remained part of the group. marginplyr adds one such flag per dimension and
+keeps it out of the result, so the outer query labels only the dimensions
+aggregation removed. A source `NULL` therefore stays different from a generated
+subtotal even though SQL would otherwise display both as missing.
 
 More complex grouping specifications use the same translation. The two
 rollups below are combined by Cartesian product, matching comma-separated SQL
@@ -269,7 +271,7 @@ DBI::dbDisconnect(con)
 
 Keeping `grouping_bit()` or `grouping_id()` in the result is the other free
 protection: either identifies every margin row structurally, so a source row
-and a margin row that print alike still stay distinguishable by position,
+and a margin row that print alike still differ in a column you can read,
 whatever `.check_margin_label` finds or misses.
 
 Opt into `.check_margin_label = TRUE` when the extra scan for an observed
@@ -343,7 +345,9 @@ This is still one lazy query. `show_query()` renders it without execution;
 only an explicit operation such as `collect()` or `compute()` asks the backend
 to run it. Native and portable grouping adapters both feed the same staged
 Parent-share contract. Parent matching uses internal Grouping identity and
-missing-safe keys rather than displayed Margin labels.
+missing-safe keys rather than displayed Margin labels; [Parent lookup is
+structural](https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html#parent-lookup-is-structural)
+works that through, and defines the Grand total set the next section reads.
 
 `share_of_total()` stages the same way and asks less of the query. Its
 denominator depends on the fixed `.by` keys and nothing else, so its mapping
@@ -391,10 +395,9 @@ records it once.
 
 A refusing dialect is therefore shown against a live DuckDB table rather than
 the simulator used above. The diagnostic is DuckDB's own, and the column it
-names carries the name of the summary to rewrite. It reaches you as a plain
-`rlang_error` with no marginplyr class in its `parent` chain — nothing here
-reads the row that used to make it a `marginplyr_error` — so the chunk below
-accepts any error rather than naming one:
+names carries the name of the summary to rewrite. The error is the database's
+and not marginplyr's, so the chunk below accepts any error rather than naming
+one:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -502,10 +505,10 @@ postgres_sales |>
   )
 ```
 
-dtplyr also enforces the contextual-share source rules, for both denominators.
-A valid request stays a native lazy query, and an ineligible source type or a
-non-scalar summary raises a Package condition at explicit execution, before an
-invalid grouping row is emitted:
+dtplyr also enforces the contextual-share source rules, for `share_of_parent()`
+and `share_of_total()` alike. A valid request stays a native lazy query, and an
+ineligible source type or a non-scalar summary raises a marginplyr error at
+explicit execution, before an invalid grouping row is emitted:
 
 ```{r}
 #| label: dtplyr-ineligible-share-source
@@ -617,8 +620,10 @@ sent$purpose
 
 The record is a tibble of two character columns, `purpose` and `sql`, holding
 one row per query in the order it was sent. It belongs to that one call: the
-next call to a Margin verb — or to `inspect_grouping()`, which compiles a
-grouping plan and sends queries of its own — empties it and starts again.
+next call to a Margin verb — or to
+[`inspect_grouping()`](https://sayuks.github.io/marginplyr/man/inspect_grouping.html),
+which compiles a grouping plan and sends queries of its own — empties it and
+starts again.
 Piping one Margin verb into another is two such calls, and the record you read
 afterwards is the outer one's: the input runs first, and the outer call empties
 what it left.
@@ -650,16 +655,23 @@ is what enumerates those queries and says which backends receive them. Names
 other than `"result"` are marginplyr's own and are not fixed, so match on
 `"result"` and read the rest as context.
 
-`last_sent_queries()` gives four answers, and it tells apart the three that
-could look like an empty record. It refuses with a marginplyr error when
-nothing has been recorded in this session — neither a Margin verb nor
-`inspect_grouping()` has run. It refuses again, naming `marginplyr.audit_sql`,
-when the last call was not audited: the option is read once as a call begins,
-so setting it afterwards cannot audit a call already made. An audited call that sent nothing returns a zero-row tibble, the only
-answer with zero rows — a data frame, a dtplyr table, and an Arrow table send
-no SQL, so an audited call on one records nothing and that is correct rather
-than a hole. And a statement dbplyr refuses to translate for the backend keeps
-its row with `NA` in `sql`, leaving the call itself unaffected.
+`last_sent_queries()` gives four answers, and three of them could otherwise
+look alike:
+
+- **Nothing has been recorded in this session**, neither a Margin verb nor
+  `inspect_grouping()` having run: refused with a marginplyr error.
+
+- **The last call was not audited**: refused with a marginplyr error naming
+  `marginplyr.audit_sql`. The option is read once as a call begins, so setting
+  it afterwards cannot audit a call already made.
+
+- **An audited call sent nothing**: a zero-row tibble, the only answer with
+  zero rows. A data frame, a dtplyr table, and an Arrow table send no SQL, so
+  an audited call on one records nothing, and that is correct rather than a
+  hole.
+
+- **A statement dbplyr refuses to translate for the backend**: its row is kept
+  with `NA` in `sql`, and the call itself is unaffected.
 
 Each row is written before its query is sent, so a call that fails leaves
 readable every query it had already sent.

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -295,13 +295,21 @@ retail_sales |>
       rollup(year, month),
       rollup(region, store)
     ),
-    .duplicates = "keep"
+    .duplicates = "keep",
+    .id = "occurrence",
+    .sort = "last"
   ) |>
   filter(
     year == "Total",
     region == "Total"
   )
 ```
+
+The two rows are the `()` set of each rollup, and only `occurrence` tells them
+apart: their Grouping identifiers are equal because the same dimensions are
+absent from both. `.sort` is what keeps them adjacent — `.id` is the Margin
+order's final tiebreak rather than its key, so a kept duplicate sits beside the
+occurrence it repeats and not somewhere else in the result.
 
 SQL combines comma-separated grouping items by Cartesian product.
 `grouping_spec()` provides that operation:

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -298,18 +298,15 @@ retail_sales |>
     .duplicates = "keep",
     .id = "occurrence",
     .sort = "last"
-  ) |>
-  filter(
-    year == "Total",
-    region == "Total"
   )
 ```
 
-The two rows are the `()` set of each rollup, and only `occurrence` tells them
-apart: their Grouping identifiers are equal because the same dimensions are
-absent from both. `.sort` is what keeps them adjacent — `.id` is the Margin
-order's final tiebreak rather than its key, so a kept duplicate sits beside the
-occurrence it repeats and not somewhere else in the result.
+The last two rows are the `()` set of each rollup, and only `occurrence` tells
+them apart: their Grouping identifiers are equal, because the same dimensions
+are absent from both. They are the last two rows, and next to each other,
+because `.sort` was asked for: `.id` is the Margin order's final tiebreak
+rather than its key, so a kept duplicate sits beside the occurrence it
+repeats.
 
 SQL combines comma-separated grouping items by Cartesian product.
 `grouping_spec()` provides that operation:
@@ -609,7 +606,7 @@ complete grouping plan, not only the ones active in one branch. The
 `cur_group*()` family is rejected outright: a branch-local identifier, row
 position, or column set has no global meaning once several grouping sets are
 combined, so use `grouping_bit()` or `grouping_id()` to identify levels
-instead. The refusal is a Package condition naming the replacement, not a
+instead. The refusal is a marginplyr error naming the replacement, not a
 silently different answer:
 
 ```{r}

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -15,8 +15,10 @@ date: last-modified
 
 A Margin result combines rows from several Grouping sets. Visible values such
 as `"Total"` are useful for display, but they do not identify which Grouping
-set produced a row. marginplyr provides Grouping set identifiers and
-structural Grouping identifiers for that purpose.
+set produced a row. marginplyr provides two kinds of identifier for that
+purpose, and they answer different questions: a *Grouping set identifier* says
+where in the Grouping plan an occurrence sits, and a *Grouping identifier*
+says which dimensions are absent from a row.
 
 Read [Get
 started](https://sayuks.github.io/marginplyr/vignettes/get_started.html) first
@@ -32,12 +34,11 @@ library(dplyr)
 
 ## Four related values
 
-Four interfaces answer two different questions. `.id` and
-`inspect_grouping()$set_id` describe *where an occurrence appears in one
-ordered Grouping plan*; `grouping_bit()` and `grouping_id()` describe *which
-dimensions are absent from a row*. A Grouping set identifier can therefore
-distinguish repeated identical sets, and a Grouping identifier deliberately
-cannot.
+Four interfaces answer those two questions. `.id` and
+`inspect_grouping()$set_id` are Grouping set identifiers; `grouping_bit()` and
+`grouping_id()` are Grouping identifiers. A Grouping set identifier can
+therefore distinguish repeated identical sets, and a Grouping identifier
+deliberately cannot.
 
 The [`grouping_bit()`
 reference](https://sayuks.github.io/marginplyr/man/grouping_bit.html)
@@ -301,10 +302,9 @@ The included source `NA` store and the subtotal's omitted `store` may display
 the same value, but their Grouping identities differ and Parent lookup remains
 unambiguous.
 
-`share_of_total()` is identified the same way and asks a smaller question of
-the plan: its denominator is the Grand total set, the grouping set in which
-every dimension is omitted, so it is defined for any plan containing one
-rather than for a rollup alone. See the
+`share_of_total()` is identified the same way. Its denominator is the Grand
+total set, the grouping set in which every dimension is omitted, so it is
+defined for any plan containing one rather than for a rollup alone. See the
 [`share_of_parent()` reference](https://sayuks.github.io/marginplyr/man/share_of_parent.html)
 for both helpers' value, source-summary, ordering, and `across()` rules, and
 [Compare a row with an ancestor

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -186,19 +186,10 @@ wide_plan |>
 
 This is a backend-independent Grouping plan, not a database execution plan.
 Use `show_query()` for generated SQL and database-native tooling for optimizer
-plans:
-
-```{r}
-dbplyr::tbl_lazy(
-  retail_sales,
-  con = dbplyr::simulate_postgres()
-) |>
-  summarize_with_margins(
-    revenue = sum(revenue),
-    .grouping = rollup(region, store)
-  ) |>
-  show_query()
-```
+plans. [Database and lazy
+backends](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
+renders the SQL one of these plans becomes, on a dialect with native grouping
+sets and on one without.
 
 ## Margin labels are display values
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -547,10 +547,11 @@ retail_sales |>
   filter(absence == 1L)
 ```
 
-Written with no columns at all, `grouping_id()` reads every `.grouping` column
-in plan order. That is the order `inspect_grouping()` reported above, so the
-identifier is the same one and there is no second list of dimensions to keep in
-step with the specification:
+`grouping_id()` can also be written with no columns at all, which the
+[`grouping_bit()`
+reference](https://sayuks.github.io/marginplyr/man/grouping_bit.html) defines
+against the resolved plan. It is the same identifier here, and there is no
+second list of dimensions to keep in step with the specification:
 
 ```{r}
 retail_sales |>
@@ -848,7 +849,7 @@ takes `.sort` itself, which orders the expansion rather than what follows it:
 
 ```{r}
 retail_sales |>
-  filter(year == 2026L, month == "Jan", region == "East") |>
+  filter(year == 2026L, month == "Jan") |>
   expand_with_margins(
     .grouping = rollup(region, store),
     .id = "set",
@@ -856,6 +857,11 @@ retail_sales |>
   ) |>
   select(set, region, store, units)
 ```
+
+Each region's detail copies now sit above its margin copies, and the
+all-regions copies come last. Without `.sort` the same call returns rows
+contiguous by grouping set instead, which is the order the expansion builds its
+branches in.
 
 The cost is in the row count: expansion produces one copy of the input per
 grouping set, so a plan with many sets multiplies the rows the database has to

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -547,6 +547,22 @@ retail_sales |>
   filter(absence == 1L)
 ```
 
+Written with no columns at all, `grouping_id()` reads every `.grouping` column
+in plan order. That is the order `inspect_grouping()` reported above, so the
+identifier is the same one and there is no second list of dimensions to keep in
+step with the specification:
+
+```{r}
+retail_sales |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    absence = grouping_id(),
+    .grouping = cube(region, channel),
+    .sort = "last"
+  ) |>
+  filter(absence == 1L)
+```
+
 Two steps are required because `grouping_id()` and `grouping_bit()` are
 contextual summary helpers. They read the Grouping set that produced a row,
 which only the summary knows, so calling one inside `filter()` is rejected:
@@ -827,10 +843,23 @@ DBI::dbDisconnect(con, shutdown = TRUE)
 Every value matches the local calculation above. The two tables are not laid
 out alike — this one carries the `set` column and is in no Margin order,
 because the pipeline ends in an ordinary `summarize()` rather than in a Margin
-verb — so compare them by key rather than row by row. The cost is in the row
-count:
-expansion produces one copy of the input per grouping set, so a plan with many
-sets multiplies the rows the database has to scan. Reach for this when the
+verb — so compare them by key rather than row by row. `expand_with_margins()`
+takes `.sort` itself, which orders the expansion rather than what follows it:
+
+```{r}
+retail_sales |>
+  filter(year == 2026L, month == "Jan", region == "East") |>
+  expand_with_margins(
+    .grouping = rollup(region, store),
+    .id = "set",
+    .sort = "last"
+  ) |>
+  select(set, region, store, units)
+```
+
+The cost is in the row count: expansion produces one copy of the input per
+grouping set, so a plan with many sets multiplies the rows the database has to
+scan. Reach for this when the
 aggregation pass genuinely cannot express the calculation, not to avoid
 writing a summary.
 

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -83,8 +83,9 @@ retail_sales |>
 ```
 
 `.sort = "last"` asks for a Margin order instead. Within each fixed `.by` key
-every dimension contributes its Grouping bit before its own value, so each
-subtotal sits directly beneath the rows it summarizes:
+every dimension contributes its Grouping bit — the `0`/`1` flag
+`grouping_bit()` returns for it, `1` where aggregation removed it — before its
+own value, so each subtotal sits directly beneath the rows it summarizes:
 
 ```{r}
 retail_sales |>
@@ -333,8 +334,9 @@ levels above it — read the ancestor level out of the result and join it back.
 
 The example below adds `product`, so that the level being measured against is
 genuinely intermediate: in `rollup(region, store, product, channel)` the
-parent of a channel row is its product, and `region`/`store` is two levels
-further up. Select that level and keep the revenue under a name of its own:
+parent of a channel row is its product, and the store level `(region, store)`
+is two levels further up. Select that level and keep the revenue under a name
+of its own:
 
 ```{r}
 store_totals <- retail_sales |>
@@ -430,10 +432,10 @@ sets out the three kinds of apparent missingness this confuses, and why
 
 **`na_matches = "na"` is written explicitly because the default differs by
 backend.** `dplyr::left_join()` matches `NA` to `NA`, so a local pipeline is
-right without the argument; dbplyr's method does not, so the same pipeline
-drops the unnamed store's share against a database and says nothing. Both
-halves are below — the join as written, then the same join with the argument
-dropped:
+right without the argument. dbplyr's method does not. The same pipeline
+therefore drops the unnamed store's share against a database, and nothing
+reports that it did. Both halves are below — the join as written, then the
+same join with the argument dropped:
 
 ```{r}
 #| eval: !expr has_duckdb


### PR DESCRIPTION
Three issues from the 2026-09-06 documentation review, taken in one branch
because all three concentrate on `database_backends.qmd` and would otherwise
conflict. One commit each.

**#463** -- thirteen sites where a term, a metaphor, or an abbreviation
arrives before the page introduces it, and with no link to the page that
does. `GROUPING()` gains its definition. "Raises a Package condition" and
"for both denominators" are written in the vocabulary a vignette reader has.
`last_sent_queries()`'s four answers become four bullets, the shape
`R/sent-queries.R` already reads in, which also removes a 128-character line.
The Grouping identity guide's opening no longer uses two terms `CONTEXT.md`
lists as each other's *Avoid* term and gloss them twenty lines later.

Two sentences described neither the code nor what a reader needs: a margin
row is told from a source row by a column value and not "by position", and
the DuckDB share refusal's `must_error: true` rests on the error being the
database's, not on which classes are absent from its `parent` chain.

**#464** -- five duplicated blocks and three missing edges. The database
guide's 27-line account of what establishes a share's source rule is a
restatement of *Lazy execution boundaries* and of the `.check_share_source`
`@param`; it keeps what a reader of that page needs and links the rest.
*Practical rules* bullets that already ended "See ... above" are one line
each. The Grouping identity guide no longer renders a third copy of the same
`simulate_postgres()` query. `completing_keys.qmd` and the `share_of_parent()`
reference now point at each other, and `summarize_with_margins()` names Get
started.

`verify-site.R` gains the anchor `grouping_identity.qmd` links, written as
the `id` attribute: it is the only man-page link from a vignette carrying a
fragment, and the heading marker already there matches the words wherever
they are written. Verified against a local render.

**#465** -- six documented features with no worked example anywhere: a bare
`grouping_id()`, `.id` under a Margin order, `.sort` on
`expand_with_margins()`, `.sort` on a lazy backend, `compute()`, and
`nest_by_with_margins()` on dtplyr. The install list's omission of
data.table is explained at the guard that makes it correct.

### Not implemented

- **#463**, `recipes.qmd`'s "contextual summary helpers": the sentence after
  the term is its gloss and the `grouping_bit()` reference is linked in the
  same section. Recorded on the issue.
- **#464**, the four anchorless `recipes.html` links and the
  `last_sent_queries()` edge: landed in #475. The README verification table
  the guide restated: given one owner by 0b91828.
- **#465**, `@family` on `last_sent_queries()`: a family of one renders as
  nothing.

### Gates

`lint_package()` (after `load_all()`), `spell_check_package()`,
`roxygenise()`, `verify-must-error.R`, `test_local()` with `NOT_CRAN` set,
and a local `altdoc` render followed by `verify-site.R`. `README.Rmd` is
untouched.

Closes #463
Closes #464
Closes #465