### PR TITLE
Put usage ahead of rationale on five reference pages

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -422,11 +422,12 @@ markers <- list(
     # matches the words wherever they are written.
     "id=\"display-labels-and-grouping-identity\"",
     "Contextual shares",
-    # The section holding the two edge cases #461 moved out of `@details`. Its
-    # heading is what a later edit would fold back into the opening prose, and
-    # the two claims under it are quoted as well: neither survives a section
-    # reduced to a cross-reference, and the Arrow half is the one this page
-    # owns for `R/share.R` to point at.
+    # The section holding the two summaries a lazy backend refuses, and one
+    # claim from each half of it. The heading alone would pass a section folded
+    # back into `@details`, where it stands ahead of the usage a first reader
+    # needs (#461). Neither claim survives a section reduced to a
+    # cross-reference, and the Arrow half is the one `R/share.R` points here
+    # for.
     "Summaries a lazy backend cannot carry",
     "cannot carry back a summary with no columns in it",
     "before a row is read, and names the two rewrites that compute it",
@@ -467,9 +468,9 @@ markers <- list(
     "Direct shares",
     "Eligible source summaries",
     "Column-wise shares",
-    # The one rejection #461's checklist held that no other section did, folded
-    # into *Eligible source summaries* when the checklist went. It reaches the
-    # page as prose, so the run quoted carries no apostrophe.
+    # The one rejection *Eligible source summaries* alone states: a named
+    # `across()` is a data-frame-valued summary rather than a scalar source.
+    # It reaches the page as prose, so the run quoted carries no apostrophe.
     "packs both results into one data-frame-valued",
     "Lazy execution boundaries",
     # The page documents both denominators, and states that neither completes

--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -422,7 +422,14 @@ markers <- list(
     # matches the words wherever they are written.
     "id=\"display-labels-and-grouping-identity\"",
     "Contextual shares",
-    "Backend extension design",
+    # The section holding the two edge cases #461 moved out of `@details`. Its
+    # heading is what a later edit would fold back into the opening prose, and
+    # the two claims under it are quoted as well: neither survives a section
+    # reduced to a cross-reference, and the Arrow half is the one this page
+    # owns for `R/share.R` to point at.
+    "Summaries a lazy backend cannot carry",
+    "cannot carry back a summary with no columns in it",
+    "before a row is read, and names the two rewrites that compute it",
     "Database backend coverage",
     "Microsoft SQL Server",
     "NA is already a factor level",
@@ -460,7 +467,10 @@ markers <- list(
     "Direct shares",
     "Eligible source summaries",
     "Column-wise shares",
-    "Rejected forms and supported rewrites",
+    # The one rejection #461's checklist held that no other section did, folded
+    # into *Eligible source summaries* when the checklist went. It reaches the
+    # page as prose, so the run quoted carries no apostrophe.
+    "packs both results into one data-frame-valued",
     "Lazy execution boundaries",
     # The page documents both denominators, and states that neither completes
     # keys. Losing either would leave one helper without a contract.

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -34,7 +34,6 @@
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins Database backend coverage
 #' @inheritSection summarize_with_margins When marginplyr queries your data
-#' @inheritSection summarize_with_margins Backend extension design
 #' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its
 #'   class and attributes follow [dplyr::mutate()] combined with
 #'   [dplyr::union_all()]; see *Result class and attributes*.

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -11,7 +11,8 @@
 #' - [grouping_sets()] forms the union of its arguments.
 #' - [rollup()] creates hierarchical prefixes.
 #' - [cube()] creates every subset of its dimensions.
-#' - [grouping_spec()] forms the Cartesian product of its arguments, like
+#' - [grouping_spec()] forms the Cartesian product of its arguments — every
+#'   grouping set of one combined with every grouping set of the next — like
 #'   comma-separated SQL `GROUP BY` items.
 #'
 #' A [grouping_set()] nested directly inside [rollup()] or [cube()] is a
@@ -36,50 +37,54 @@
 #'   nested Grouping specification, and requires at least one argument.
 #'   [grouping_spec()] combines its arguments by Cartesian product, accepts any
 #'   valid nested Grouping specification, and with no arguments represents the
-#'   identity product (the empty grouping set).
-#'
-#'   A nested Grouping specification is recognized by how it is written: a
-#'   call to one of these constructors, or a name bound to a specification.
-#'   Redundant parentheses are transparent to that reading, because `(` is the
-#'   identity function: `(s)` is the specification `s` is, and
-#'   `(rollup(region))` is the call it wraps, however many pairs deep.
-#'   Any other argument is a column selection, so a call of your own that
-#'   returns a specification is refused where it is nested even though it is
-#'   accepted as `.grouping` itself. Assign what it returns to a name and use
-#'   that name: `s <- my_spec(region)`, then `grouping_sets(s, grade)`. A
-#'   specification written inside a selection, as in `c(s, grade)`, is a
-#'   selection containing something it cannot select, and is refused as one —
-#'   unless the input has a column named `s`, when the selection takes that
-#'   column, as any selection does with a name the data holds.
-#'
-#'   An argument left empty gets neither reading, and is refused naming the
-#'   constructor and the position: `grouping_sets(, region)` reports that its
-#'   first argument is empty. A trailing comma is not an empty argument,
-#'   because R captures no argument for it, so `grouping_sets(region, )` is
-#'   `grouping_sets(region)`, and passing no arguments at all means what the
-#'   first paragraph above says it means for each constructor.
-#'
-#'   A name both readings claim is refused rather than guessed. Where the
-#'   input has a column named `s` and `s` is also bound to a nested Grouping
-#'   specification the position accepts, the call names both readings and the
-#'   spelling that settles each: `all_of("s")` selects the column whatever is
-#'   bound, and `!!s` uses the specification whatever columns the input has.
-#'   What a position accepts is what decides whether there are two readings,
-#'   so a colliding name is refused in [grouping_sets()] and [grouping_spec()]
-#'   whatever specification it is bound to, in [rollup()] and [cube()] only
-#'   when it is bound to a [grouping_set()], and never in [grouping_set()],
-#'   which takes no nested Grouping specification at all. A name bound to
-#'   anything that is not a specification is a column, as it always was.
-#'
-#'   A dimension is a column of the input, so a name attached to one is
-#'   refused, whether it sits inside a selection or on the constructor's own
-#'   argument: `c(area = region)` and `rollup(area = region)` are both errors
-#'   rather than a dimension named `area`. Rename the result afterwards with
-#'   [dplyr::rename()]. A Margin verb's own argument written in a constructor
-#'   falls under that same rule, so `rollup(region, .by = year)` reports the
-#'   name instead of taking `year` as a second dimension.
+#'   identity product (the empty grouping set). Which of the two readings an
+#'   argument gets, and what is refused rather than read either way, is *How an
+#'   argument is read*.
 #'
 #' @return A grouping specification for use in `.grouping`.
+#'
+#' @section How an argument is read:
+#' A nested Grouping specification is recognized by how it is written: a
+#' call to one of these constructors, or a name bound to a specification.
+#' Redundant parentheses are transparent to that reading, because `(` is the
+#' identity function: `(s)` is the specification `s` is, and
+#' `(rollup(region))` is the call it wraps, however many pairs deep.
+#' Any other argument is a column selection, so a call of your own that
+#' returns a specification is refused where it is nested even though it is
+#' accepted as `.grouping` itself. Assign what it returns to a name and use
+#' that name: `s <- my_spec(region)`, then `grouping_sets(s, grade)`. A
+#' specification written inside a selection, as in `c(s, grade)`, is a
+#' selection containing something it cannot select, and is refused as one —
+#' unless the input has a column named `s`, when the selection takes that
+#' column, as any selection does with a name the data holds.
+#'
+#' An argument left empty gets neither reading, and is refused naming the
+#' constructor and the position: `grouping_sets(, region)` reports that its
+#' first argument is empty. A trailing comma is not an empty argument,
+#' because R captures no argument for it, so `grouping_sets(region, )` is
+#' `grouping_sets(region)`, and passing no arguments at all means what `...`
+#' above says it means for each constructor.
+#'
+#' A name both readings claim is refused rather than guessed. Where the
+#' input has a column named `s` and `s` is also bound to a nested Grouping
+#' specification the position accepts, the call names both readings and the
+#' spelling that settles each: `all_of("s")` selects the column whatever is
+#' bound, and `!!s` uses the specification whatever columns the input has.
+#' What a position accepts is what decides whether there are two readings,
+#' so a colliding name is refused in [grouping_sets()] and [grouping_spec()]
+#' whatever specification it is bound to, in [rollup()] and [cube()] only
+#' when it is bound to a [grouping_set()], and never in [grouping_set()],
+#' which takes no nested Grouping specification at all. A name bound to
+#' anything that is not a specification is a column, as it always was.
+#'
+#' A dimension is a column of the input, so a name attached to one is
+#' refused, whether it sits inside a selection or on the constructor's own
+#' argument: `c(area = region)` and `rollup(area = region)` are both errors
+#' rather than a dimension named `area`. Rename the result afterwards with
+#' [dplyr::rename()]. A Margin verb's own argument written in a constructor
+#' falls under that same rule, so `rollup(region, .by = year)` reports the
+#' name instead of taking `year` as a second dimension.
+#'
 #' @family grouping plans and grouping identity
 #' @seealso [summarize_with_margins()], [expand_with_margins()],
 #'   [nest_with_margins()], and [nest_by_with_margins()], the Margin verbs
@@ -144,15 +149,22 @@
 #'   region == "Total"
 #' )
 #'
-#' # grouping_spec() takes their Cartesian product, producing combinations
-#' # such as (year, month, region, store) and (year, region).
+#' # grouping_spec() takes their Cartesian product instead. Each of the first
+#' # rollup's three grouping sets is combined with each of the second's, so
+#' # inspect_grouping() reports 3 x 3 = 9 of them, from (year, month, region,
+#' # store) down to the grand total.
+#' combined_specification <- grouping_spec(
+#'   rollup(year, month),
+#'   rollup(region, store)
+#' )
+#' inspect_grouping(
+#'   .data = retail_sales,
+#'   .grouping = combined_specification
+#' )
 #' combined_totals <- summarize_with_margins(
 #'   .data = retail_sales,
 #'   revenue = sum(revenue),
-#'   .grouping = grouping_spec(
-#'     rollup(year, month),
-#'     rollup(region, store)
-#'   )
+#'   .grouping = combined_specification
 #' )
 #'
 #' # A nested grouping_set() is a composite dimension: region and store are

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -125,8 +125,11 @@ margin_sort_choices <- c("none", "last", "first")
 # by a caller used to select the default silently. The `identical()` guard below
 # is the whole of what refuses one now, and refusing it is a documented contract
 # rather than a leftover of the rewrite (#144): the *Option arguments* section
-# on `?summarize_with_margins` states it and says why an option vocabulary is
-# the place `NULL` does not mean "use the default".
+# on `?summarize_with_margins` states it. An option vocabulary is the one place
+# in this package where `NULL` names nothing, because every option argument
+# already has a default that does something, so a `NULL` arriving here is far
+# more often a variable that did not hold what its caller thought than a
+# request for anything.
 #
 # `rlang::arg_match()` and `rlang::arg_match0()` were measured against this
 # helper rather than adopted. They agree with it on every input but one -- both

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -124,12 +124,10 @@ margin_sort_choices <- c("none", "last", "first")
 # `match.arg(NULL, choices)` returned that first entry too, so a `NULL` written
 # by a caller used to select the default silently. The `identical()` guard below
 # is the whole of what refuses one now, and refusing it is a documented contract
-# rather than a leftover of the rewrite (#144): the *Option arguments* section
-# on `?summarize_with_margins` states it. An option vocabulary is the one place
-# in this package where `NULL` names nothing, because every option argument
-# already has a default that does something, so a `NULL` arriving here is far
-# more often a variable that did not hold what its caller thought than a
-# request for anything.
+# rather than a leftover of the rewrite (#144): `CONTEXT.md`'s *Option argument*
+# entry holds the refusal and why an Option argument is the one kind with no
+# absent case for a `NULL` to name, and the *Option arguments* section on
+# `?summarize_with_margins` states the contract to the caller.
 #
 # `rlang::arg_match()` and `rlang::arg_match0()` were measured against this
 # helper rather than adopted. They agree with it on every input but one -- both

--- a/R/nest_by_with_margins.R
+++ b/R/nest_by_with_margins.R
@@ -11,20 +11,12 @@
 #' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins When marginplyr queries your data
-#' @inheritSection summarize_with_margins Backend extension design
 #' @inheritSection nest_with_margins Relationship to tidyr and dplyr
 #' @param .key A non-missing string naming the list column. Unlike
 #'   [nest_with_margins()] and [tidyr::nest()], `NULL` is not converted to
 #'   `"data"`; this follows [dplyr::nest_by()].
 #' @details A `dtplyr` result is collected before it is made row-wise because
 #'   row-wise data frames are local objects.
-#'
-#' [dplyr::nest_by()] is not a stable upstream API and may eventually be
-#' deprecated in favor of [tidyr::nest()]. This margin-aware wrapper remains
-#' intentional because its row-wise return shape is useful for per-margin
-#' models and reports. Both public nesting interfaces use the same private
-#' margin-operation pipeline, so they share one grouping plan and nesting
-#' contract without invoking each other.
 #' @return A row-wise data frame grouped by the visible grouping columns and
 #'   `.id` when supplied. This is the return shape whatever the class of
 #'   `.data`, because a row-wise data frame is always a tibble subclass; see

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -12,7 +12,6 @@
 #' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
 #' @inheritSection summarize_with_margins When marginplyr queries your data
-#' @inheritSection summarize_with_margins Backend extension design
 #' @param .data A local data frame or a `dtplyr` step. Other lazy tables are
 #'   not supported because nesting creates list columns.
 #' @param .key A string naming the list column. As in [tidyr::nest()],

--- a/R/share.R
+++ b/R/share.R
@@ -71,8 +71,8 @@
 #' ```
 #'
 #' A direct call cannot be unnamed, use a string, use a forward reference,
-#' redefine the source name, or use a share as another share's source. Each
-#' rejected form and its rewrite are listed below.
+#' redefine the source name, or use a share as another share's source. *Eligible
+#' source summaries* writes out the rewrite for each of those.
 #'
 #' @section Eligible source summaries:
 #' The source must be defined exactly once before the share. It must be
@@ -133,6 +133,12 @@
 #' revenue_total = sum(revenue)
 #' revenue_share = share_of_parent(revenue_total)
 #' ```
+#'
+#' Naming an [dplyr::across()] does the mirror image of that:
+#' `total = across(c(revenue, units), sum)` packs both results into one
+#' data-frame-valued `total` column, so `total` is not a scalar source. Drop
+#' the name to get one statically named column per selected column, or define
+#' each summary at top level.
 #'
 #' A source name must be defined exactly once. If a later calculation was
 #' intended to refine the earlier value, combine the complete calculation into
@@ -258,86 +264,6 @@
 #' # Supported
 #' across(revenue, share_of_parent, .names = "{.col}_share")
 #' ```
-#'
-#' @section Rejected forms and supported rewrites:
-#' This checklist keeps every rejection next to the form that should replace
-#' it:
-#'
-#' - **Wrong context:** `share_of_parent(total)` by itself, inside
-#'   `dplyr::summarize()`, or inside `dplyr::mutate()` is rejected. Define
-#'   `total = sum(value)` and `share = share_of_parent(total)` inside
-#'   [summarize_with_margins()]; derive from the finished `share` in a following
-#'   `dplyr::mutate()`.
-#' - **Unsupported Grouping specification:** `grouping_sets()`, `cube()`, and
-#'   `grouping_spec()` do not define one Parent chain. For a Parent share,
-#'   replace them with one pure `rollup()` or omit the request. For a Total
-#'   share only a plan without a Grand total set is rejected; add an empty
-#'   `grouping_set()` to the `grouping_sets()` specification.
-#' - **Unnamed direct output:** `share_of_parent(total)` supplied without
-#'   `share =` is rejected. Use `share = share_of_parent(total)`.
-#' - **Non-bare source:** `share_of_parent(sum(value))`,
-#'   `share_of_parent(total + tax)`, and `share_of_parent("total")` are
-#'   rejected. First define `total = sum(value)` and then use
-#'   `share = share_of_parent(total)`.
-#' - **Forward reference:** `share = share_of_parent(total)` before
-#'   `total = sum(value)` is rejected. Move the `total` summary before
-#'   `share`.
-#' - **Repeated source name:** defining `net` twice is rejected. Use one
-#'   complete expression such as `net = sum(revenue) - sum(discount)` before
-#'   `net_share = share_of_parent(net)`.
-#' - **Unnamed data-frame-valued source:** an unnamed
-#'   `tibble::tibble(total = sum(value))` cannot provide `total`. Rewrite it as
-#'   the top-level `total = sum(value)` or create a statically named column with
-#'   a preceding `across()`.
-#' - **Named `across()` source:** `total = across(c(revenue, units), sum)`
-#'   packs both results into one data-frame-valued `total` column, so `total`
-#'   is not a scalar source. Drop the `total =` name to get one column per
-#'   selected column, or define each summary at top level.
-#' - **Summary-alias dependency:** `gross = sum(value)`,
-#'   `net = gross - sum(discount)` is rejected when `net` is a source. Use
-#'   `net = sum(value) - sum(discount)`.
-#' - **Wrapped share:** `percent = 100 * share_of_parent(total)` is
-#'   rejected. Create `share = share_of_parent(total)`, then use
-#'   `dplyr::mutate(percent = 100 * share)` on the result.
-#' - **Share dependency:** a share cannot source another share of either kind,
-#'   or an ordinary summary later in the same call. Create all requested
-#'   shares from ordinary summaries, then derive further columns in
-#'   `dplyr::mutate()`.
-#' - **Non-numeric or non-scalar source:** semantic classes, zero-length
-#'   results, and `quantile(value, c(0.25, 0.75))` are rejected. Convert only
-#'   when meaningful and create one scalar summary per output, such as
-#'   `q25 = quantile(value, 0.25)` and `q25_share = share_of_parent(q25)`.
-#' - **Ineligible `across()` selection:** source columns, grouping keys, and
-#'   previous shares are rejected. Select only preceding ordinary
-#'   summaries, for example `across(c(total, count), share_of_parent, ...)`.
-#' - **Predicate selection:** `where(is.numeric)` is rejected. Use explicit
-#'   names, `all_of()`, `any_of()`, or another name-based selector.
-#' - **Indirect `.fns`:** `~share_of_parent(.x)`,
-#'   `\(x) share_of_total(x)`, and `list(share_of_parent)` are rejected. Pass
-#'   the bare helper, or `marginplyr::share_of_parent`, directly.
-#' - **Aggregate and share in one function list:**
-#'   `across(value, list(total = sum, share = share_of_parent))` is rejected.
-#'   Use one `across(value, sum)` followed by a second
-#'   `across(value, share_of_parent, .names = "{.col}_share")`.
-#' - **Additional function arguments:** passing `na.rm = TRUE` to a share's
-#'   `across()` is rejected. Handle it in the preceding
-#'   `total = sum(value, na.rm = TRUE)`, then select `total`.
-#' - **Unpacking:** `.unpack = TRUE` is rejected. Omit `.unpack` or use
-#'   `.unpack = FALSE`.
-#' - **Missing or empty names:** omitted `.names` and `.names = ""` are
-#'   rejected. Supply a non-empty template such as
-#'   `.names = "{.col}_share"`.
-#' - **Duplicate names:** selecting multiple sources with
-#'   `.names = "share"` is rejected. Include `{.col}` in the template.
-#' - **Grouping-key collision:** `.names = "region"` (or any fixed or variable
-#'   key) is rejected. Use a new name such as `{.col}_share`.
-#' - **Ordinary-summary collision:** `.names = "{.col}"` overwrites the source
-#'   and is rejected. Use `.names = "{.col}_share"`.
-#' - **`.id` collision:** `.names = "set"` with `.id = "set"` is rejected.
-#'   Rename either output, for example `.id = "occurrence"` and
-#'   `.names = "{.col}_share"`.
-#' - **Share collision:** reusing a direct or generated share name is
-#'   rejected. Give each share one unique output name.
 #'
 #' @section Value rules:
 #' Both helpers divide within each fixed `.by` partition, and neither ever

--- a/R/share.R
+++ b/R/share.R
@@ -71,8 +71,7 @@
 #' ```
 #'
 #' A direct call cannot be unnamed, use a string, use a forward reference,
-#' redefine the source name, or use a share as another share's source. *Eligible
-#' source summaries* writes out the rewrite for each of those.
+#' redefine the source name, or use a share as another share's source.
 #'
 #' @section Eligible source summaries:
 #' The source must be defined exactly once before the share. It must be

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -111,34 +111,6 @@
 #' [summarize_with_margins()] and [summarise_with_margins()] are synonyms,
 #' following [dplyr::summarize()] and [dplyr::summarise()].
 #'
-#' Two lazy inputs cannot carry back a summary with no columns in it: asked
-#' for no summaries and given no fixed key or grouping dimension, the answer
-#' is one row holding nothing, whatever the input held. A `data.table` reads
-#' its row count from its first column, so a `dtplyr` input collects to zero
-#' rows where a local data frame returns one, and a SQL table of no columns
-#' cannot be written at all, so a database input raises the error dbplyr
-#' renders one with. Each is what [dplyr::summarize()] itself answers for that
-#' lazy input; an Arrow input answers as a local one does. Anything that puts
-#' a column in the result -- one summary, one fixed key, one grouping
-#' dimension, or `.id` -- ends the difference.
-#'
-#' One summary an Arrow table or record batch cannot carry -- or a query built
-#' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an
-#' expression by reading the whole input -- every column of it, not only the
-#' ones the summary names -- and computing it in R. marginplyr refuses it
-#' instead, before a row is read, and names the two rewrites that compute it:
-#' collect the input first, and select the columns the summary needs before
-#' collecting, which is the narrowing Arrow's own route cannot do for you.
-#'
-#' Which expressions those are is Arrow's to decide and moves with its version,
-#' so they are not listed here. Among the shapes refused are a group collapsed
-#' into a single value, such as pasting one, a subset written inside an
-#' aggregate, and a statistic over two columns at once; ordinary numeric
-#' summaries, and arithmetic over them, are evaluated by Arrow and stay lazy.
-#' An Arrow dataset, and a query built on one, raise Arrow's own refusal for
-#' the same expressions instead, because a dataset never reads itself into R;
-#' they are otherwise unaffected.
-#'
 #' @section Fixed columns and grouping dimensions:
 #' `.by` marks columns that are present in every grouping set, while
 #' `.grouping` describes dimensions that can be omitted to form margins.
@@ -224,22 +196,10 @@
 #' leaving a value passed through it alone. A wrapper that
 #' would rather not track this signature resolves the value itself and passes
 #' the one string it chose, which no later widening or reordering of the
-#' vocabulary can invalidate. [rlang::arg_match()] refuses an abbreviation there
-#' as this package does, while [base::match.arg()] resolves one, so a wrapper
-#' built on that accepts spellings this package would not.
+#' vocabulary can invalidate.
 #'
 #' Elsewhere in this package `NULL` is a documented value, and what it means is
-#' stated with the argument that takes it: it is `.grouping`'s one empty
-#' grouping set, `.margin_label`'s typed missing value in place of a display
-#' label, `.id`'s absent identifier column, and, in [nest_with_margins()], the
-#' `.key` that [tidyr::nest()] reads as `"data"` — while
-#' [nest_by_with_margins()] refuses a `NULL` `.key`, following
-#' [dplyr::nest_by()]. That each of them answers for itself is the point. Those
-#' arguments name a value, a column, or a plan, and such a name has a natural
-#' absent case to give a `NULL`. A vocabulary of options has none — every option
-#' argument already has a default that does something — so a `NULL` arriving at
-#' one is far more often a variable that did not hold what its caller thought
-#' than a request for anything, and it is reported rather than resolved.
+#' stated with the argument that takes it.
 #'
 #' @section Result class and attributes:
 #' Each Margin verb follows the same class and attribute rules as the dplyr
@@ -443,6 +403,35 @@
 #' out and text parsed from a literal, but not language a summary builds while
 #' it runs.
 #'
+#' @section Summaries a lazy backend cannot carry:
+#' Two lazy inputs cannot carry back a summary with no columns in it: asked
+#' for no summaries and given no fixed key or grouping dimension, the answer
+#' is one row holding nothing, whatever the input held. A `data.table` reads
+#' its row count from its first column, so a `dtplyr` input collects to zero
+#' rows where a local data frame returns one, and a SQL table of no columns
+#' cannot be written at all, so a database input raises the error dbplyr
+#' renders one with. Each is what [dplyr::summarize()] itself answers for that
+#' lazy input; an Arrow input answers as a local one does. Anything that puts
+#' a column in the result -- one summary, one fixed key, one grouping
+#' dimension, or `.id` -- ends the difference.
+#'
+#' One summary an Arrow table or record batch cannot carry -- or a query built
+#' on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an
+#' expression by reading the whole input -- every column of it, not only the
+#' ones the summary names -- and computing it in R. marginplyr refuses it
+#' instead, before a row is read, and names the two rewrites that compute it:
+#' collect the input first, and select the columns the summary needs before
+#' collecting, which is the narrowing Arrow's own route cannot do for you.
+#'
+#' Which expressions those are is Arrow's to decide and moves with its version,
+#' so they are not listed here. Among the shapes refused are a group collapsed
+#' into a single value, such as pasting one, a subset written inside an
+#' aggregate, and a statistic over two columns at once; ordinary numeric
+#' summaries, and arithmetic over them, are evaluated by Arrow and stay lazy.
+#' An Arrow dataset, and a query built on one, raise Arrow's own refusal for
+#' the same expressions instead, because a dataset never reads itself into R;
+#' they are otherwise unaffected.
+#'
 #' @section Contextual shares:
 #' [share_of_parent()] and [share_of_total()] calculate a preceding named
 #' numeric scalar summary's ratio to the same summary on another row of the
@@ -543,17 +532,6 @@
 #' by the declared half. Every row above is therefore decided whatever this
 #' argument says. See `.check_margin_label` above for its default and *When
 #' marginplyr queries your data* for why the two halves differ.
-#'
-#' @section Backend extension design:
-#' Unlike [dplyr::summarize()], the public margin verbs are intentionally not
-#' S3 generics. They prepare one operation around a backend-independent
-#' grouping plan, pass it to a verb-specific executor, and apply common
-#' finalization. One typed selection-metadata snapshot is acquired during
-#' preparation. Native `GROUPING SETS` and portable `UNION ALL` adapters
-#' consume the prepared plan; they do not own validation or finalization.
-#' These adapters are implementation details rather than an extension API, so
-#' support for a new backend should be added to marginplyr itself with
-#' metadata, result, laziness, and SQL-strategy contract tests.
 #'
 #' @section Database backend coverage:
 #' DuckDB and PostgreSQL use native `GROUP BY GROUPING SETS` SQL. Automated

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -36,7 +36,12 @@ Every exported Margin verb follows the same explicit lifecycle:
 `nest_with_margins()` returns the common ungrouped result.
 `nest_by_with_margins()` collects that result when necessary, preserves its
 special empty-input behavior, and adds row-wise grouping by the visible keys
-only after common finalization.
+only after common finalization. It is kept even though `dplyr::nest_by()` is
+not a stable upstream API and may eventually be deprecated in favor of
+`tidyr::nest()`, because its row-wise return shape is what a per-margin model
+or report is written against. Both nesting verbs reach the lifecycle above
+rather than one calling the other, so neither holds a second grouping plan or
+nesting contract.
 
 The lifecycle is deliberately explicit:
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -39,9 +39,8 @@ special empty-input behavior, and adds row-wise grouping by the visible keys
 only after common finalization. It is kept even though `dplyr::nest_by()` is
 not a stable upstream API and may eventually be deprecated in favor of
 `tidyr::nest()`, because its row-wise return shape is what a per-margin model
-or report is written against. Both nesting verbs reach the lifecycle above
-rather than one calling the other, so neither holds a second grouping plan or
-nesting contract.
+or report is written against. Both reach the lifecycle above rather than one
+calling the other.
 
 The lifecycle is deliberately explicit:
 

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -212,22 +212,10 @@ match, so a change to the vocabulary refuses the wrapper's own default while
 leaving a value passed through it alone. A wrapper that
 would rather not track this signature resolves the value itself and passes
 the one string it chose, which no later widening or reordering of the
-vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
-as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
-built on that accepts spellings this package would not.
+vocabulary can invalidate.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
-stated with the argument that takes it: it is \code{.grouping}'s one empty
-grouping set, \code{.margin_label}'s typed missing value in place of a display
-label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
-\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
-\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
-arguments name a value, a column, or a plan, and such a name has a natural
-absent case to give a \code{NULL}. A vocabulary of options has none — every option
-argument already has a default that does something — so a \code{NULL} arriving at
-one is far more often a variable that did not hold what its caller thought
-than a request for anything, and it is reported rather than resolved.
+stated with the argument that takes it.
 }
 
 \section{Result class and attributes}{
@@ -497,19 +485,6 @@ backend, so it defaults to \code{TRUE} there.
 \code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
 two unasked queries above are counted against a connection rather than
 taken from this page.
-}
-
-\section{Backend extension design}{
-
-Unlike \code{\link[dplyr:summarize]{dplyr::summarize()}}, the public margin verbs are intentionally not
-S3 generics. They prepare one operation around a backend-independent
-grouping plan, pass it to a verb-specific executor, and apply common
-finalization. One typed selection-metadata snapshot is acquired during
-preparation. Native \verb{GROUPING SETS} and portable \verb{UNION ALL} adapters
-consume the prepared plan; they do not own validation or finalization.
-These adapters are implementation details rather than an extension API, so
-support for a new backend should be added to marginplyr itself with
-metadata, result, laziness, and SQL-strategy contract tests.
 }
 
 \examples{

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -31,7 +31,41 @@ specifications and require at least one resolved dimension.
 nested Grouping specification, and requires at least one argument.
 \code{\link[=grouping_spec]{grouping_spec()}} combines its arguments by Cartesian product, accepts any
 valid nested Grouping specification, and with no arguments represents the
-identity product (the empty grouping set).
+identity product (the empty grouping set). Which of the two readings an
+argument gets, and what is refused rather than read either way, is \emph{How an
+argument is read}.}
+}
+\value{
+A grouping specification for use in \code{.grouping}.
+}
+\description{
+These constructors describe SQL-style grouping operations for the
+\code{.grouping} argument of \code{\link[=summarize_with_margins]{summarize_with_margins()}} and related verbs.
+Start with \code{\link[=rollup]{rollup()}} when the report follows a hierarchy such as
+store to region to company. Use \code{\link[=grouping_sets]{grouping_sets()}} for an exact selection of
+levels, and \code{\link[=cube]{cube()}} only when every combination is useful.
+}
+\details{
+\itemize{
+\item \code{\link[=grouping_set]{grouping_set()}} creates one grouping set. With no columns it represents
+the empty set \verb{()}.
+\item \code{\link[=grouping_sets]{grouping_sets()}} forms the union of its arguments.
+\item \code{\link[=rollup]{rollup()}} creates hierarchical prefixes.
+\item \code{\link[=cube]{cube()}} creates every subset of its dimensions.
+\item \code{\link[=grouping_spec]{grouping_spec()}} forms the Cartesian product of its arguments — every
+grouping set of one combined with every grouping set of the next — like
+comma-separated SQL \verb{GROUP BY} items.
+}
+
+A \code{\link[=grouping_set]{grouping_set()}} nested directly inside \code{\link[=rollup]{rollup()}} or \code{\link[=cube]{cube()}} is a
+composite dimension. Its columns are added or removed together.
+
+A resolved Grouping plan can be read back in four ways: \code{.id},
+\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
+\code{\link[=grouping_bit]{grouping_bit()}} compares them; the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} works
+through the same values with executable examples.
+}
+\section{How an argument is read}{
 
 A nested Grouping specification is recognized by how it is written: a
 call to one of these constructors, or a name bound to a specification.
@@ -51,8 +85,8 @@ An argument left empty gets neither reading, and is refused naming the
 constructor and the position: \code{grouping_sets(, region)} reports that its
 first argument is empty. A trailing comma is not an empty argument,
 because R captures no argument for it, so \code{grouping_sets(region, )} is
-\code{grouping_sets(region)}, and passing no arguments at all means what the
-first paragraph above says it means for each constructor.
+\code{grouping_sets(region)}, and passing no arguments at all means what \code{...}
+above says it means for each constructor.
 
 A name both readings claim is refused rather than guessed. Where the
 input has a column named \code{s} and \code{s} is also bound to a nested Grouping
@@ -72,37 +106,9 @@ argument: \code{c(area = region)} and \code{rollup(area = region)} are both erro
 rather than a dimension named \code{area}. Rename the result afterwards with
 \code{\link[dplyr:rename]{dplyr::rename()}}. A Margin verb's own argument written in a constructor
 falls under that same rule, so \code{rollup(region, .by = year)} reports the
-name instead of taking \code{year} as a second dimension.}
-}
-\value{
-A grouping specification for use in \code{.grouping}.
-}
-\description{
-These constructors describe SQL-style grouping operations for the
-\code{.grouping} argument of \code{\link[=summarize_with_margins]{summarize_with_margins()}} and related verbs.
-Start with \code{\link[=rollup]{rollup()}} when the report follows a hierarchy such as
-store to region to company. Use \code{\link[=grouping_sets]{grouping_sets()}} for an exact selection of
-levels, and \code{\link[=cube]{cube()}} only when every combination is useful.
-}
-\details{
-\itemize{
-\item \code{\link[=grouping_set]{grouping_set()}} creates one grouping set. With no columns it represents
-the empty set \verb{()}.
-\item \code{\link[=grouping_sets]{grouping_sets()}} forms the union of its arguments.
-\item \code{\link[=rollup]{rollup()}} creates hierarchical prefixes.
-\item \code{\link[=cube]{cube()}} creates every subset of its dimensions.
-\item \code{\link[=grouping_spec]{grouping_spec()}} forms the Cartesian product of its arguments, like
-comma-separated SQL \verb{GROUP BY} items.
+name instead of taking \code{year} as a second dimension.
 }
 
-A \code{\link[=grouping_set]{grouping_set()}} nested directly inside \code{\link[=rollup]{rollup()}} or \code{\link[=cube]{cube()}} is a
-composite dimension. Its columns are added or removed together.
-
-A resolved Grouping plan can be read back in four ways: \code{.id},
-\code{\link[=inspect_grouping]{inspect_grouping()}}\verb{$set_id}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}}.
-\code{\link[=grouping_bit]{grouping_bit()}} compares them; the \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} works
-through the same values with executable examples.
-}
 \examples{
 # The operations team needs store, region, and company totals for each
 # reporting month. Columns in `.by` remain in every grouping set.
@@ -162,15 +168,22 @@ dplyr::filter(
   region == "Total"
 )
 
-# grouping_spec() takes their Cartesian product, producing combinations
-# such as (year, month, region, store) and (year, region).
+# grouping_spec() takes their Cartesian product instead. Each of the first
+# rollup's three grouping sets is combined with each of the second's, so
+# inspect_grouping() reports 3 x 3 = 9 of them, from (year, month, region,
+# store) down to the grand total.
+combined_specification <- grouping_spec(
+  rollup(year, month),
+  rollup(region, store)
+)
+inspect_grouping(
+  .data = retail_sales,
+  .grouping = combined_specification
+)
 combined_totals <- summarize_with_margins(
   .data = retail_sales,
   revenue = sum(revenue),
-  .grouping = grouping_spec(
-    rollup(year, month),
-    rollup(region, store)
-  )
+  .grouping = combined_specification
 )
 
 # A nested grouping_set() is a composite dimension: region and store are

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -126,22 +126,10 @@ match, so a change to the vocabulary refuses the wrapper's own default while
 leaving a value passed through it alone. A wrapper that
 would rather not track this signature resolves the value itself and passes
 the one string it chose, which no later widening or reordering of the
-vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
-as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
-built on that accepts spellings this package would not.
+vocabulary can invalidate.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
-stated with the argument that takes it: it is \code{.grouping}'s one empty
-grouping set, \code{.margin_label}'s typed missing value in place of a display
-label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
-\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
-\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
-arguments name a value, a column, or a plan, and such a name has a natural
-absent case to give a \code{NULL}. A vocabulary of options has none — every option
-argument already has a default that does something — so a \code{NULL} arriving at
-one is far more often a variable that did not hold what its caller thought
-than a request for anything, and it is reported rather than resolved.
+stated with the argument that takes it.
 }
 
 \examples{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -114,13 +114,6 @@ This is the row-wise counterpart of \code{\link[=nest_with_margins]{nest_with_ma
 \details{
 A \code{dtplyr} result is collected before it is made row-wise because
 row-wise data frames are local objects.
-
-\code{\link[dplyr:nest_by]{dplyr::nest_by()}} is not a stable upstream API and may eventually be
-deprecated in favor of \code{\link[tidyr:nest]{tidyr::nest()}}. This margin-aware wrapper remains
-intentional because its row-wise return shape is useful for per-margin
-models and reports. Both public nesting interfaces use the same private
-margin-operation pipeline, so they share one grouping plan and nesting
-contract without invoking each other.
 }
 \section{Fixed columns and grouping dimensions}{
 
@@ -211,22 +204,10 @@ match, so a change to the vocabulary refuses the wrapper's own default while
 leaving a value passed through it alone. A wrapper that
 would rather not track this signature resolves the value itself and passes
 the one string it chose, which no later widening or reordering of the
-vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
-as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
-built on that accepts spellings this package would not.
+vocabulary can invalidate.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
-stated with the argument that takes it: it is \code{.grouping}'s one empty
-grouping set, \code{.margin_label}'s typed missing value in place of a display
-label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
-\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
-\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
-arguments name a value, a column, or a plan, and such a name has a natural
-absent case to give a \code{NULL}. A vocabulary of options has none — every option
-argument already has a default that does something — so a \code{NULL} arriving at
-one is far more often a variable that did not hold what its caller thought
-than a request for anything, and it is reported rather than resolved.
+stated with the argument that takes it.
 }
 
 \section{Result class and attributes}{
@@ -468,19 +449,6 @@ backend, so it defaults to \code{TRUE} there.
 \code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
 two unasked queries above are counted against a connection rather than
 taken from this page.
-}
-
-\section{Backend extension design}{
-
-Unlike \code{\link[dplyr:summarize]{dplyr::summarize()}}, the public margin verbs are intentionally not
-S3 generics. They prepare one operation around a backend-independent
-grouping plan, pass it to a verb-specific executor, and apply common
-finalization. One typed selection-metadata snapshot is acquired during
-preparation. Native \verb{GROUPING SETS} and portable \verb{UNION ALL} adapters
-consume the prepared plan; they do not own validation or finalization.
-These adapters are implementation details rather than an extension API, so
-support for a new backend should be added to marginplyr itself with
-metadata, result, laziness, and SQL-strategy contract tests.
 }
 
 \section{Relationship to tidyr and dplyr}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -257,22 +257,10 @@ match, so a change to the vocabulary refuses the wrapper's own default while
 leaving a value passed through it alone. A wrapper that
 would rather not track this signature resolves the value itself and passes
 the one string it chose, which no later widening or reordering of the
-vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
-as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
-built on that accepts spellings this package would not.
+vocabulary can invalidate.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
-stated with the argument that takes it: it is \code{.grouping}'s one empty
-grouping set, \code{.margin_label}'s typed missing value in place of a display
-label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
-\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
-\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
-arguments name a value, a column, or a plan, and such a name has a natural
-absent case to give a \code{NULL}. A vocabulary of options has none — every option
-argument already has a default that does something — so a \code{NULL} arriving at
-one is far more often a variable that did not hold what its caller thought
-than a request for anything, and it is reported rather than resolved.
+stated with the argument that takes it.
 }
 
 \section{Result class and attributes}{
@@ -514,19 +502,6 @@ backend, so it defaults to \code{TRUE} there.
 \code{\link[=last_sent_queries]{last_sent_queries()}} reports what a call actually sent, which is how the
 two unasked queries above are counted against a connection rather than
 taken from this page.
-}
-
-\section{Backend extension design}{
-
-Unlike \code{\link[dplyr:summarize]{dplyr::summarize()}}, the public margin verbs are intentionally not
-S3 generics. They prepare one operation around a backend-independent
-grouping plan, pass it to a verb-specific executor, and apply common
-finalization. One typed selection-metadata snapshot is acquired during
-preparation. Native \verb{GROUPING SETS} and portable \verb{UNION ALL} adapters
-consume the prepared plan; they do not own validation or finalization.
-These adapters are implementation details rather than an extension API, so
-support for a new backend should be added to marginplyr itself with
-metadata, result, laziness, and SQL-strategy contract tests.
 }
 
 \examples{

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -87,8 +87,8 @@ result |> dplyr::mutate(revenue_percent = 100 * revenue_share)
 }\if{html}{\out{</div>}}
 
 A direct call cannot be unnamed, use a string, use a forward reference,
-redefine the source name, or use a share as another share's source. Each
-rejected form and its rewrite are listed below.
+redefine the source name, or use a share as another share's source. \emph{Eligible
+source summaries} writes out the rewrite for each of those.
 }
 
 \section{Eligible source summaries}{
@@ -148,6 +148,12 @@ revenue_share = share_of_parent(revenue_total)
 revenue_total = sum(revenue)
 revenue_share = share_of_parent(revenue_total)
 }\if{html}{\out{</div>}}
+
+Naming an \code{\link[dplyr:across]{dplyr::across()}} does the mirror image of that:
+\code{total = across(c(revenue, units), sum)} packs both results into one
+data-frame-valued \code{total} column, so \code{total} is not a scalar source. Drop
+the name to get one statically named column per selected column, or define
+each summary at top level.
 
 A source name must be defined exactly once. If a later calculation was
 intended to refine the earlier value, combine the complete calculation into
@@ -269,89 +275,6 @@ across(revenue, share_of_parent, .names = "\{.col\}")
 # Supported
 across(revenue, share_of_parent, .names = "\{.col\}_share")
 }\if{html}{\out{</div>}}
-}
-
-\section{Rejected forms and supported rewrites}{
-
-This checklist keeps every rejection next to the form that should replace
-it:
-\itemize{
-\item \strong{Wrong context:} \code{share_of_parent(total)} by itself, inside
-\code{dplyr::summarize()}, or inside \code{dplyr::mutate()} is rejected. Define
-\code{total = sum(value)} and \code{share = share_of_parent(total)} inside
-\code{\link[=summarize_with_margins]{summarize_with_margins()}}; derive from the finished \code{share} in a following
-\code{dplyr::mutate()}.
-\item \strong{Unsupported Grouping specification:} \code{grouping_sets()}, \code{cube()}, and
-\code{grouping_spec()} do not define one Parent chain. For a Parent share,
-replace them with one pure \code{rollup()} or omit the request. For a Total
-share only a plan without a Grand total set is rejected; add an empty
-\code{grouping_set()} to the \code{grouping_sets()} specification.
-\item \strong{Unnamed direct output:} \code{share_of_parent(total)} supplied without
-\verb{share =} is rejected. Use \code{share = share_of_parent(total)}.
-\item \strong{Non-bare source:} \code{share_of_parent(sum(value))},
-\code{share_of_parent(total + tax)}, and \code{share_of_parent("total")} are
-rejected. First define \code{total = sum(value)} and then use
-\code{share = share_of_parent(total)}.
-\item \strong{Forward reference:} \code{share = share_of_parent(total)} before
-\code{total = sum(value)} is rejected. Move the \code{total} summary before
-\code{share}.
-\item \strong{Repeated source name:} defining \code{net} twice is rejected. Use one
-complete expression such as \code{net = sum(revenue) - sum(discount)} before
-\code{net_share = share_of_parent(net)}.
-\item \strong{Unnamed data-frame-valued source:} an unnamed
-\code{tibble::tibble(total = sum(value))} cannot provide \code{total}. Rewrite it as
-the top-level \code{total = sum(value)} or create a statically named column with
-a preceding \code{across()}.
-\item \strong{Named \code{across()} source:} \code{total = across(c(revenue, units), sum)}
-packs both results into one data-frame-valued \code{total} column, so \code{total}
-is not a scalar source. Drop the \verb{total =} name to get one column per
-selected column, or define each summary at top level.
-\item \strong{Summary-alias dependency:} \code{gross = sum(value)},
-\code{net = gross - sum(discount)} is rejected when \code{net} is a source. Use
-\code{net = sum(value) - sum(discount)}.
-\item \strong{Wrapped share:} \code{percent = 100 * share_of_parent(total)} is
-rejected. Create \code{share = share_of_parent(total)}, then use
-\code{dplyr::mutate(percent = 100 * share)} on the result.
-\item \strong{Share dependency:} a share cannot source another share of either kind,
-or an ordinary summary later in the same call. Create all requested
-shares from ordinary summaries, then derive further columns in
-\code{dplyr::mutate()}.
-\item \strong{Non-numeric or non-scalar source:} semantic classes, zero-length
-results, and \code{quantile(value, c(0.25, 0.75))} are rejected. Convert only
-when meaningful and create one scalar summary per output, such as
-\code{q25 = quantile(value, 0.25)} and \code{q25_share = share_of_parent(q25)}.
-\item \strong{Ineligible \code{across()} selection:} source columns, grouping keys, and
-previous shares are rejected. Select only preceding ordinary
-summaries, for example \code{across(c(total, count), share_of_parent, ...)}.
-\item \strong{Predicate selection:} \code{where(is.numeric)} is rejected. Use explicit
-names, \code{all_of()}, \code{any_of()}, or another name-based selector.
-\item \strong{Indirect \code{.fns}:} \code{~share_of_parent(.x)},
-\verb{\\(x) share_of_total(x)}, and \code{list(share_of_parent)} are rejected. Pass
-the bare helper, or \code{marginplyr::share_of_parent}, directly.
-\item \strong{Aggregate and share in one function list:}
-\code{across(value, list(total = sum, share = share_of_parent))} is rejected.
-Use one \code{across(value, sum)} followed by a second
-\code{across(value, share_of_parent, .names = "{.col}_share")}.
-\item \strong{Additional function arguments:} passing \code{na.rm = TRUE} to a share's
-\code{across()} is rejected. Handle it in the preceding
-\code{total = sum(value, na.rm = TRUE)}, then select \code{total}.
-\item \strong{Unpacking:} \code{.unpack = TRUE} is rejected. Omit \code{.unpack} or use
-\code{.unpack = FALSE}.
-\item \strong{Missing or empty names:} omitted \code{.names} and \code{.names = ""} are
-rejected. Supply a non-empty template such as
-\code{.names = "{.col}_share"}.
-\item \strong{Duplicate names:} selecting multiple sources with
-\code{.names = "share"} is rejected. Include \code{{.col}} in the template.
-\item \strong{Grouping-key collision:} \code{.names = "region"} (or any fixed or variable
-key) is rejected. Use a new name such as \verb{\{.col\}_share}.
-\item \strong{Ordinary-summary collision:} \code{.names = "{.col}"} overwrites the source
-and is rejected. Use \code{.names = "{.col}_share"}.
-\item \strong{\code{.id} collision:} \code{.names = "set"} with \code{.id = "set"} is rejected.
-Rename either output, for example \code{.id = "occurrence"} and
-\code{.names = "{.col}_share"}.
-\item \strong{Share collision:} reusing a direct or generated share name is
-rejected. Give each share one unique output name.
-}
 }
 
 \section{Value rules}{

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -87,8 +87,7 @@ result |> dplyr::mutate(revenue_percent = 100 * revenue_share)
 }\if{html}{\out{</div>}}
 
 A direct call cannot be unnamed, use a string, use a forward reference,
-redefine the source name, or use a share as another share's source. \emph{Eligible
-source summaries} writes out the rewrite for each of those.
+redefine the source name, or use a share as another share's source.
 }
 
 \section{Eligible source summaries}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -153,34 +153,6 @@ Confirmed SQL backends use one \verb{GROUP BY GROUPING SETS} query. Other lazy
 backends use a portable \verb{UNION ALL} adapter with the same semantics.
 \code{\link[=summarize_with_margins]{summarize_with_margins()}} and \code{\link[=summarise_with_margins]{summarise_with_margins()}} are synonyms,
 following \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[dplyr:summarise]{dplyr::summarise()}}.
-
-Two lazy inputs cannot carry back a summary with no columns in it: asked
-for no summaries and given no fixed key or grouping dimension, the answer
-is one row holding nothing, whatever the input held. A \code{data.table} reads
-its row count from its first column, so a \code{dtplyr} input collects to zero
-rows where a local data frame returns one, and a SQL table of no columns
-cannot be written at all, so a database input raises the error dbplyr
-renders one with. Each is what \code{\link[dplyr:summarize]{dplyr::summarize()}} itself answers for that
-lazy input; an Arrow input answers as a local one does. Anything that puts
-a column in the result -- one summary, one fixed key, one grouping
-dimension, or \code{.id} -- ends the difference.
-
-One summary an Arrow table or record batch cannot carry -- or a query built
-on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an
-expression by reading the whole input -- every column of it, not only the
-ones the summary names -- and computing it in R. marginplyr refuses it
-instead, before a row is read, and names the two rewrites that compute it:
-collect the input first, and select the columns the summary needs before
-collecting, which is the narrowing Arrow's own route cannot do for you.
-
-Which expressions those are is Arrow's to decide and moves with its version,
-so they are not listed here. Among the shapes refused are a group collapsed
-into a single value, such as pasting one, a subset written inside an
-aggregate, and a statistic over two columns at once; ordinary numeric
-summaries, and arithmetic over them, are evaluated by Arrow and stay lazy.
-An Arrow dataset, and a query built on one, raise Arrow's own refusal for
-the same expressions instead, because a dataset never reads itself into R;
-they are otherwise unaffected.
 }
 \section{Fixed columns and grouping dimensions}{
 
@@ -271,22 +243,10 @@ match, so a change to the vocabulary refuses the wrapper's own default while
 leaving a value passed through it alone. A wrapper that
 would rather not track this signature resolves the value itself and passes
 the one string it chose, which no later widening or reordering of the
-vocabulary can invalidate. \code{\link[rlang:arg_match]{rlang::arg_match()}} refuses an abbreviation there
-as this package does, while \code{\link[base:match.arg]{base::match.arg()}} resolves one, so a wrapper
-built on that accepts spellings this package would not.
+vocabulary can invalidate.
 
 Elsewhere in this package \code{NULL} is a documented value, and what it means is
-stated with the argument that takes it: it is \code{.grouping}'s one empty
-grouping set, \code{.margin_label}'s typed missing value in place of a display
-label, \code{.id}'s absent identifier column, and, in \code{\link[=nest_with_margins]{nest_with_margins()}}, the
-\code{.key} that \code{\link[tidyr:nest]{tidyr::nest()}} reads as \code{"data"} — while
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} refuses a \code{NULL} \code{.key}, following
-\code{\link[dplyr:nest_by]{dplyr::nest_by()}}. That each of them answers for itself is the point. Those
-arguments name a value, a column, or a plan, and such a name has a natural
-absent case to give a \code{NULL}. A vocabulary of options has none — every option
-argument already has a default that does something — so a \code{NULL} arriving at
-one is far more often a variable that did not hold what its caller thought
-than a request for anything, and it is reported rather than resolved.
+stated with the argument that takes it.
 }
 
 \section{Result class and attributes}{
@@ -496,6 +456,37 @@ out and text parsed from a literal, but not language a summary builds while
 it runs.
 }
 
+\section{Summaries a lazy backend cannot carry}{
+
+Two lazy inputs cannot carry back a summary with no columns in it: asked
+for no summaries and given no fixed key or grouping dimension, the answer
+is one row holding nothing, whatever the input held. A \code{data.table} reads
+its row count from its first column, so a \code{dtplyr} input collects to zero
+rows where a local data frame returns one, and a SQL table of no columns
+cannot be written at all, so a database input raises the error dbplyr
+renders one with. Each is what \code{\link[dplyr:summarize]{dplyr::summarize()}} itself answers for that
+lazy input; an Arrow input answers as a local one does. Anything that puts
+a column in the result -- one summary, one fixed key, one grouping
+dimension, or \code{.id} -- ends the difference.
+
+One summary an Arrow table or record batch cannot carry -- or a query built
+on either -- is one Arrow's own engine cannot evaluate. Arrow answers such an
+expression by reading the whole input -- every column of it, not only the
+ones the summary names -- and computing it in R. marginplyr refuses it
+instead, before a row is read, and names the two rewrites that compute it:
+collect the input first, and select the columns the summary needs before
+collecting, which is the narrowing Arrow's own route cannot do for you.
+
+Which expressions those are is Arrow's to decide and moves with its version,
+so they are not listed here. Among the shapes refused are a group collapsed
+into a single value, such as pasting one, a subset written inside an
+aggregate, and a statistic over two columns at once; ordinary numeric
+summaries, and arithmetic over them, are evaluated by Arrow and stay lazy.
+An Arrow dataset, and a query built on one, raise Arrow's own refusal for
+the same expressions instead, because a dataset never reads itself into R;
+they are otherwise unaffected.
+}
+
 \section{Contextual shares}{
 
 \code{\link[=share_of_parent]{share_of_parent()}} and \code{\link[=share_of_total]{share_of_total()}} calculate a preceding named
@@ -599,19 +590,6 @@ label is not a collision, and a label equal to a declared level is refused
 by the declared half. Every row above is therefore decided whatever this
 argument says. See \code{.check_margin_label} above for its default and \emph{When
 marginplyr queries your data} for why the two halves differ.
-}
-
-\section{Backend extension design}{
-
-Unlike \code{\link[dplyr:summarize]{dplyr::summarize()}}, the public margin verbs are intentionally not
-S3 generics. They prepare one operation around a backend-independent
-grouping plan, pass it to a verb-specific executor, and apply common
-finalization. One typed selection-metadata snapshot is acquired during
-preparation. Native \verb{GROUPING SETS} and portable \verb{UNION ALL} adapters
-consume the prepared plan; they do not own validation or finalization.
-These adapters are implementation details rather than an extension API, so
-support for a new backend should be added to marginplyr itself with
-metadata, result, laziness, and SQL-strategy contract tests.
 }
 
 \section{Database backend coverage}{

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -297,8 +297,8 @@ test_that("a formula is walked as the call to `~` that it is", {
   # cover the sites and the shapes this one does not.
 
   # A formula in the `.fns` position of `across()` is the one spelling of this
-  # that users are documented to write (the *Indirect `.fns`* bullet of
-  # `share_of_parent()`'s *Rejected forms and supported rewrites*), and it was
+  # that users are documented to write (the rejected `.fns` forms in
+  # `share_of_parent()`'s *Column-wise shares*), and it was
   # the only shape in #130's tables asserted at the walk alone. The guard is
   # where the caller meets it, so it is asserted there too: `.x` is
   # over-reported by design, and the read of `share` beside it must still be

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -510,10 +510,10 @@ test_that("`NULL` is rejected by every option rather than taken as a default", {
   # `match.arg(NULL, choices)` returns `choices[1]`, so every option argument
   # used to read a `NULL` as a request for its own default. #110 stopped that
   # along with the abbreviations above, and #144 settled it as a decision: the
-  # *Option arguments* section on `?summarize_with_margins` says which
-  # arguments do give a `NULL` a meaning and why an option vocabulary is not
-  # among them. The untouched formal is what selects a default, and it arrives
-  # as the whole vocabulary rather than as a `NULL`.
+  # *Option arguments* section on `?summarize_with_margins` states that a
+  # `NULL` is an error rather than a request for the default. The untouched
+  # formal is what selects a default, and it arrives as the whole vocabulary
+  # rather than as a `NULL`.
   for (case in option_vocabulary_cases()) {
     expect_identical(
       option_rejection_message(case$verb, case$option, NULL),

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -627,12 +627,11 @@ name in your own environment never changes what one does. `cur_group_id()`
 stays refused for that reason, where `dplyr::summarize()` would resolve it by
 ordinary lookup. Every other name, `n()` included, follows ordinary lookup.
 
-Two familiar conveniences also behave differently. Row order is unspecified
+One familiar convenience also behaves differently. Row order is unspecified
 for local and lazy results alike unless `.sort` asks for a Margin order, which
 puts each margin row with the rows it summarizes; call `arrange()` for any
-other presentation order. And the Margin verbs are not S3 generics: they share
-one validated plan, and a private adapter chooses the backend. As in dplyr,
-`summarise_with_margins()` and `summarize_with_margins()` are synonyms.
+other presentation order. As in dplyr, `summarise_with_margins()` and
+`summarize_with_margins()` are synonyms.
 
 *Relationship to dplyr summaries* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)


### PR DESCRIPTION
Closes #461.

## What moved

| Page | Before | After |
|---|---:|---:|
| `summarize_with_margins.Rd` | 932 | 915 |
| `nest_by_with_margins.Rd` | 621 | 593 |
| `nest_with_margins.Rd` | 600 | 579 |
| `expand_with_margins.Rd` | 558 | 537 |
| `share_of_parent.Rd` | 625 | 549 |

- **`@details`.** The two edge cases it opened on — a lazy summary with no
  columns in it, and an expression Arrow's engine cannot evaluate — are now
  *Summaries a lazy backend cannot carry*, placed after *Relationship to dplyr
  summaries*. The details reaches *Fixed columns and grouping dimensions* after
  three short paragraphs.
- ***Option arguments*.** The `NULL` rationale moves to the guard in
  `R/margin-operation.R` that refuses one; the
  `rlang::arg_match()`/`base::match.arg()` comparison is deleted, paragraph one
  already stating that an abbreviation is refused here. The two sites citing
  the section are re-pointed at what it now says.
- ***Backend extension design*** is deleted, not relocated: every sentence
  already stood in `design/architecture.md`. `nest_by_with_margins()`'s opening
  paragraph moves there, beside the lifecycle both nesting verbs share.
- **`share_of_parent()`'s *Rejected forms and supported rewrites***: 24 of its
  25 bullets restated sections that carry the same rejections with runnable
  code. The one that did not — a named `across()` packs its results into one
  data-frame-valued column — joins *Eligible source summaries*.
- **`grouping_set()`'s `@param ...`** keeps the contract; its diagnostics
  become *How an argument is read*.
- **`grouping_spec()`** gains a gloss and an `inspect_grouping()` call showing
  its 3 x 3 = 9 grouping sets.

`get_started.qmd` loses its "not S3 generics" clause: it pointed at a reference
section for a rule the reference no longer states.

## Dropped

The `R/grouping-context.R` item, as the issue's triage comment allows. The
definition it asks to add is the second half of the sentence it quotes, and the
subtotal-versus-detail phrasing is already the first example's comment.

## Gates

`lintr::lint_package()` (after `load_all()`), `roxygen2::roxygenise()`,
`spelling::spell_check_package()`, `testthat::test_local()`,
`verify-must-error.R`, `verify-context-budget.R`, and
`verify-verifier-invocation.R` all pass locally. `verify-site.R`'s markers for
the two deleted section headings are replaced with markers over the prose that
replaced them.