### PR TITLE
Capitalize a house term only where it names the concept

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,16 @@ consistently to local and remote data.
 
 ## Language
 
+**House term**:
+A concept this file defines. Its name is capitalized wherever it names that
+concept and left lowercase wherever the same words carry their ordinary sense,
+so one page can write "the Grouping plan expands to" and "SQL calls this idea
+grouping sets". A phrase no entry defines is ordinary English however often it
+appears: *grouping set* and *grand total* are ordinary here, and each names
+something defined only inside a longer entry — Grouping set identifier, Grand
+total set — which is capitalized whole.
+_Avoid_: Domain term, glossary term, defined term
+
 **Grain**:
 What one row of a summary stands for: the dimensions it is grouped by. An
 ordinary grouped summary has one grain; a Grouping plan produces several in
@@ -46,7 +56,7 @@ _Avoid_: Nested grouping, nested slot
 
 **Grouping plan**:
 The backend-independent grouping semantics obtained by fully expanding a
-grouping specification.
+Grouping specification.
 _Avoid_: Execution plan, backend plan
 
 **Grouping set identifier**:
@@ -67,7 +77,7 @@ _Avoid_: Missing-value flag, grouping set identifier
 
 **Margin operation**:
 One request to summarize, expand, or nest data across the grouping sets in a
-grouping plan, from preparation through finalization.
+Grouping plan, from preparation through finalization.
 _Avoid_: Grouping plan, operation context
 
 **Margin label**:
@@ -111,7 +121,7 @@ _Avoid_: Root set, root row, total row, margin row
 **Parent share**:
 For a row in a rollup result, the ratio of one named scalar summary value to
 the corresponding value in the immediately less detailed grouping set. A row
-of the Grand total set has a parent share of one. A missing numerator, zero
+of the Grand total set has a Parent share of one. A missing numerator, zero
 denominator, or missing denominator produces a missing double value. The
 source is a previously defined numeric scalar summary and the result is
 always a double; finite ratios are not clamped. Parent shares are defined for
@@ -123,7 +133,7 @@ _Avoid_: Subtotal share, percent of grand total
 **Total share**:
 For a row in a multi-grain result, the ratio of one named scalar summary
 value to the corresponding value in the Grand total set. A row of the Grand
-total set has a total share of one. A missing numerator, zero denominator, or
+total set has a Total share of one. A missing numerator, zero denominator, or
 missing denominator produces a missing double value. The source is a
 previously defined numeric scalar summary and the result is always a double;
 finite ratios are not clamped. Total shares are defined for any Grouping plan
@@ -179,7 +189,7 @@ destroy the caller's table from the ones that survive: a `filter()` and a
 same field value and fall on opposite sides. A Margin verb refuses one before
 any branch is built, because it builds one branch per grouping set from the
 same step and data.table writes each of them to the caller's table by
-reference — leaving a result in which every row carries the margin label, and
+reference — leaving a result in which every row carries the Margin label, and
 a table whose columns were dropped or whose names were permuted.
 _Avoid_: Mutable input, in-place backend
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,13 +6,15 @@ consistently to local and remote data.
 ## Language
 
 **House term**:
-A concept this file defines. Its name is capitalized wherever it names that
-concept and left lowercase wherever the same words carry their ordinary sense,
-so one page can write "the Grouping plan expands to" and "SQL calls this idea
-grouping sets". A phrase no entry defines is ordinary English however often it
-appears: *grouping set* and *grand total* are ordinary here, and each names
-something defined only inside a longer entry — Grouping set identifier, Grand
-total set — which is capitalized whole.
+A concept marginplyr itself defines, rather than one it borrows. Its name is
+capitalized wherever it names that concept and left lowercase wherever the same
+words carry their ordinary sense, so one page can write "the Grouping plan
+expands to" and "SQL calls this idea grouping sets". Borrowed vocabulary is
+ordinary throughout — *grouping set* is SQL's, *grand total* is a report's,
+*grain* is a data model's — and an entry below fixes such a word's spelling
+without making it a House term. It capitalizes only inside one built on it, as
+in Grouping set identifier and Grand total set. Having no entry does not make a
+term borrowed: Margin verb has none and is marginplyr's own.
 _Avoid_: Domain term, glossary term, defined term
 
 **Grain**:
@@ -148,7 +150,7 @@ converting it to a number rather than raising. Its opposite is a *refusing*
 dialect, which rejects the same aggregate. Which of the two a dialect is
 decides whether the eligible-type rule for a share source can be left to the
 database: a refusing dialect applies it and reports an ineligible source in
-its own diagnostic, while a converting dialect applies nothing and returns a
+its own diagnostic, while a Converting dialect applies nothing and returns a
 number whatever the source held, so a share over one is refused unless the
 caller establishes the source themselves. Which of the two a dialect is, is a
 property of the dialect and not of one connection, so it is established once and

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -686,7 +686,7 @@
 #'   .margin_label = c(region = "All regions", store = "All stores")
 #' )
 #' # The retained type is the point of `NULL`, and a plain data frame prints
-#' # the Margin row as a bare `NA` whatever `year` now holds. A tibble's type
+#' # the margin row as a bare `NA` whatever `year` now holds. A tibble's type
 #' # header is what shows that `year` is still <int> rather than character.
 #' summarize_with_margins(
 #'   .data = retail_sales,

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 ### SQL-style grouping sets, rollups, and cubes for dplyr and dbplyr
 
 Create detail rows, subtotals, and grand totals with one dplyr-style summary.
-Use the same grouping specification with a local data frame or a lazy database
+Use the same Grouping specification with a local data frame or a lazy database
 table.
 
 <!-- badges: start -->
@@ -219,7 +219,7 @@ parent_report |>
   dplyr::mutate(revenue_percent = 100 * revenue_share)
 ```
 
-A row of the Grand total set has a parent share of one, and a missing or zero
+A row of the Grand total set has a Parent share of one, and a missing or zero
 denominator gives `NA`.
 Parent matching is structural, so display labels never choose the parent.
 
@@ -227,7 +227,7 @@ Parent matching is structural, so display labels never choose the parent.
 
 `share_of_total()` is the same helper with a different denominator: the grand
 total of the same report, within each fixed `.by` group. There is never a
-question of *which* row that is, so it accepts any grouping specification that
+question of *which* row that is, so it accepts any Grouping specification that
 produces one — including the `cube()` that `share_of_parent()` rejects:
 
 ```{r}
@@ -259,7 +259,7 @@ grammar, and backend boundaries.
 
 ## Use the same report with a database
 
-The grouping plan becomes part of the lazy query. `show_query()` inspects the
+The Grouping plan becomes part of the lazy query. `show_query()` inspects the
 SQL without collecting the result:
 
 ```{r}
@@ -277,7 +277,7 @@ postgres_sales |>
 ```
 
 DuckDB and PostgreSQL use native grouping sets. Backends without confirmed
-native support use a `UNION ALL` translation with the same grouping plan.
+native support use a `UNION ALL` translation with the same Grouping plan.
 Simulation verifies generated SQL but does not claim live execution against
 every database server. The [database
 guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
@@ -323,7 +323,7 @@ These approaches solve related problems with different interfaces:
 | Repeated `dplyr::summarize()` plus row binding | A small, one-off set of totals where explicit branches are clearest | You author and combine each grouping level |
 | [`data.table`](https://rdatatable.gitlab.io/data.table/reference/groupingsets.html) grouping sets | A local data.table workflow | `rollup()`, `cube()`, and `groupingsets()` return one data.table |
 | [`rollup`](https://cran.r-project.org/package=rollup) | Its dplyr-oriented grouped-data-frame-list workflow fits the analysis | Grouping levels are represented as a list before their summaries are combined |
-| marginplyr | The same grouping plan should work locally and on a lazy source | One data frame or lazy query, with native SQL or a portable fallback |
+| marginplyr | The same Grouping plan should work locally and on a lazy source | One data frame or lazy query, with native SQL or a portable fallback |
 
 marginplyr is most useful when a report has multiple grains, when the data
 should stay in a database until `collect()`, or when subtotal identity and the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### SQL-style grouping sets, rollups, and cubes for dplyr and dbplyr
 
 Create detail rows, subtotals, and grand totals with one dplyr-style
-summary. Use the same grouping specification with a local data frame or
+summary. Use the same Grouping specification with a local data frame or
 a lazy database table.
 
 <!-- badges: start -->
@@ -286,7 +286,7 @@ parent_report |>
 #> 8  Total         Total   23300     1.0000000       100.00000
 ```
 
-A row of the Grand total set has a parent share of one, and a missing or
+A row of the Grand total set has a Parent share of one, and a missing or
 zero denominator gives `NA`. Parent matching is structural, so display
 labels never choose the parent.
 
@@ -294,7 +294,7 @@ labels never choose the parent.
 
 `share_of_total()` is the same helper with a different denominator: the
 grand total of the same report, within each fixed `.by` group. There is
-never a question of *which* row that is, so it accepts any grouping
+never a question of *which* row that is, so it accepts any Grouping
 specification that produces one — including the `cube()` that
 `share_of_parent()` rejects:
 
@@ -350,7 +350,7 @@ documents both helpers in full: the eligible sources, value rules,
 
 ## Use the same report with a database
 
-The grouping plan becomes part of the lazy query. `show_query()`
+The Grouping plan becomes part of the lazy query. `show_query()`
 inspects the SQL without collecting the result:
 
 ``` r
@@ -384,7 +384,7 @@ postgres_sales |>
 
 DuckDB and PostgreSQL use native grouping sets. Backends without
 confirmed native support use a `UNION ALL` translation with the same
-grouping plan. Simulation verifies generated SQL but does not claim live
+Grouping plan. Simulation verifies generated SQL but does not claim live
 execution against every database server. The [database
 guide](https://sayuks.github.io/marginplyr/vignettes/database_backends.html)
 shows native SQL, fallback SQL, live DuckDB execution, and `collect()`.
@@ -444,7 +444,7 @@ These approaches solve related problems with different interfaces:
 | Repeated `dplyr::summarize()` plus row binding | A small, one-off set of totals where explicit branches are clearest | You author and combine each grouping level |
 | [`data.table`](https://rdatatable.gitlab.io/data.table/reference/groupingsets.html) grouping sets | A local data.table workflow | `rollup()`, `cube()`, and `groupingsets()` return one data.table |
 | [`rollup`](https://cran.r-project.org/package=rollup) | Its dplyr-oriented grouped-data-frame-list workflow fits the analysis | Grouping levels are represented as a list before their summaries are combined |
-| marginplyr | The same grouping plan should work locally and on a lazy source | One data frame or lazy query, with native SQL or a portable fallback |
+| marginplyr | The same Grouping plan should work locally and on a lazy source | One data frame or lazy query, with native SQL or a portable fallback |
 
 marginplyr is most useful when a report has multiple grains, when the
 data should stay in a database until `collect()`, or when subtotal

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -748,7 +748,7 @@ summarize_with_margins(
   .margin_label = c(region = "All regions", store = "All stores")
 )
 # The retained type is the point of `NULL`, and a plain data frame prints
-# the Margin row as a bare `NA` whatever `year` now holds. A tibble's type
+# the margin row as a bare `NA` whatever `year` now holds. A tibble's type
 # header is what shows that `year` is still <int> rather than character.
 summarize_with_margins(
   .data = retail_sales,

--- a/vignettes/completing_keys.qmd
+++ b/vignettes/completing_keys.qmd
@@ -13,7 +13,7 @@ format:
 date: last-modified
 ---
 
-marginplyr creates the Grouping sets requested by a Grouping specification; it
+marginplyr creates the grouping sets requested by a Grouping specification; it
 does not create unobserved values within those sets. Complete absent keys
 before a Margin operation when synthetic facts should participate in detail,
 subtotal, and grand-total summaries. Replace values after a summary when the
@@ -60,7 +60,7 @@ no row behind it gives `NA_real_` rather than a number.
 
 Input completion and result completion answer different questions:
 
-- **Pre-summary synthetic facts** participate in every requested Grouping set.
+- **Pre-summary synthetic facts** participate in every requested grouping set.
   They can change counts, means, distinct counts, and user-defined summaries.
 - **Post-summary display replacement** changes how an existing result is
   shown. It does not recalculate subtotals or the grand total.
@@ -72,7 +72,7 @@ Margin operation makes the chosen semantics visible in ordinary data
 manipulation code.
 
 Completion also does not belong in a Grouping specification. A Grouping
-specification declares which Grouping sets exist; it does not declare the
+specification declares which grouping sets exist; it does not declare the
 valid value domain of each dimension or invent fact values.
 
 ## Complete local facts with `tidyr::complete()`

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -13,7 +13,7 @@ format:
 date: last-modified
 ---
 
-`marginplyr` applies one grouping plan to local data frames and supported lazy
+`marginplyr` applies one Grouping plan to local data frames and supported lazy
 tables. With a database table, the plan remains lazy: `show_query()` renders
 the SQL, while `collect()` executes it and brings the result into R.
 
@@ -92,7 +92,7 @@ local_result <- january_sales |>
 local_result
 ```
 
-The grouping specification does not change when the input becomes a lazy table:
+The Grouping specification does not change when the input becomes a lazy table:
 
 ```{r}
 postgres_sales <- dbplyr::tbl_lazy(
@@ -141,7 +141,7 @@ keeps it out of the result, so the outer query labels only the dimensions
 aggregation removed. A source `NULL` therefore stays different from a generated
 subtotal even though SQL would otherwise display both as missing.
 
-More complex grouping specifications use the same translation. The two
+More complex Grouping specifications use the same translation. The two
 rollups below are combined by Cartesian product, matching comma-separated SQL
 `GROUP BY` items:
 
@@ -343,9 +343,9 @@ show_query(sqlite_query)
 ```
 
 This SQL is longer than the native form, but it preserves the same requested
-grouping levels and margin labels. Native versus fallback translation is
+grouping levels and Margin labels. Native versus fallback translation is
 selected by the backend adapter; analysis code does not need a different
-grouping specification.
+Grouping specification.
 
 `expand_with_margins()` also stays lazy. On a fallback backend, its SQL makes
 the row-expansion branches explicit:
@@ -507,10 +507,10 @@ collect(dt_query)
 ```
 
 The step has to be built with `immutable = TRUE`, which is what `lazy_dt()`
-does by default. A margin verb builds one branch per grouping set from the
+does by default. A Margin verb builds one branch per grouping set from the
 step it is given, and when the step was built with `immutable = FALSE`
 data.table writes every one of those branches back to your own table by
-reference. That returns a result in which each row carries the margin label,
+reference. That returns a result in which each row carries the Margin label,
 and leaves you holding a table that has lost a column or had its names
 permuted. Such an input is refused before any branch is built:
 
@@ -672,7 +672,7 @@ The record is a tibble of two character columns, `purpose` and `sql`, holding
 one row per query in the order it was sent. It belongs to that one call: the
 next call to a Margin verb — or to
 [`inspect_grouping()`](https://sayuks.github.io/marginplyr/man/inspect_grouping.html),
-which compiles a grouping plan and sends queries of its own — empties it and
+which compiles a Grouping plan and sends queries of its own — empties it and
 starts again.
 Piping one Margin verb into another is two such calls, and the record you read
 afterwards is the outer one's: the input runs first, and the outer call empties

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -490,7 +490,7 @@ retail_sales |>
     .margin_label = NULL
   ) |>
   # `retail_sales` is a plain data frame and so is this result, which prints
-  # the Margin row as a bare `NA` whatever type `year` now holds. A tibble's
+  # the margin row as a bare `NA` whatever type `year` now holds. A tibble's
   # type header is what shows `year` is still <int>, which is the whole claim
   # being made here.
   dplyr::as_tibble()

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -109,7 +109,7 @@ This is valid dplyr code and can be the clearest choice for one small,
 one-off report. It becomes repetitive when the hierarchy grows, the requested
 levels change, or every branch must stay lazy on a remote source.
 
-### One grouping plan
+### One Grouping plan
 
 `rollup(region, store)` describes the same three levels directly:
 
@@ -123,7 +123,7 @@ january_report <- january_sales |>
 january_report
 ```
 
-The result is one ordinary data frame. The grouping plan expands to:
+The result is one ordinary data frame. The Grouping plan expands to:
 
 ```text
 (region, store)  store detail
@@ -153,7 +153,7 @@ monthly_report |>
 ```
 
 Columns in `.by` belong to every grouping set. They retain their input types
-and never receive the margin label. The empty set from `rollup()` still
+and never receive the Margin label. The empty set from `rollup()` still
 includes the fixed `.by` columns, so it produces one company total per year
 and month.
 
@@ -387,7 +387,7 @@ and where the calculation runs.
 | Repeated `summarize()` plus `bind_rows()` | A one-off report has only a few levels and explicit branches are easiest to review | Every grouping level is authored and maintained separately |
 | [`data.table`](https://rdatatable.gitlab.io/data.table/reference/groupingsets.html) | The analysis is a local data.table workflow | It uses the data.table API rather than a dbplyr lazy query |
 | [`rollup`](https://cran.r-project.org/package=rollup) | Its list of grouped data frames is a natural intermediate representation | The workflow differs from marginplyr's single relational result |
-| marginplyr | One grouping plan should work locally and through dbplyr, or grouping identity and margin-aware nesting matter | Its broader semantics add concepts that a single subtotal does not need |
+| marginplyr | One Grouping plan should work locally and through dbplyr, or grouping identity and margin-aware nesting matter | Its broader semantics add concepts that a single subtotal does not need |
 
 Use the simplest approach that preserves the shape and execution model your
 analysis needs. marginplyr is particularly useful when the report has many
@@ -602,7 +602,7 @@ of the official API where arbitrary grouping sets have no portable
 interpretation. A summary may not overwrite a fixed key or grouping dimension,
 even where the local dplyr backend would allow it, because that would destroy
 grouping-set identity. `across()` and `pick()` exclude every column in the
-complete grouping plan, not only the ones active in one branch. The
+complete Grouping plan, not only the ones active in one branch. The
 `cur_group*()` family is rejected outright: a branch-local identifier, row
 position, or column set has no global meaning once several grouping sets are
 combined, so use `grouping_bit()` or `grouping_id()` to identify levels
@@ -810,7 +810,7 @@ fact markers for counts and means, same-connection dimension tables,
 
 ## Use the same plan with remote data
 
-The grouping plan can be applied to a lazy table without first collecting its
+The Grouping plan can be applied to a lazy table without first collecting its
 rows. This PostgreSQL simulation shows the native SQL without requiring a
 server:
 
@@ -901,7 +901,7 @@ nested_sections$data[[1]]
 
 Use `.keep = TRUE` when the grouping keys are also needed inside each detail
 table. The nested copies preserve their original values even when the
-corresponding outer key is a margin label:
+corresponding outer key is a Margin label:
 
 ```{r}
 nested_with_keys <- january_sales |>
@@ -1082,6 +1082,6 @@ tabbed_report |>
   )
 ```
 
-The `"Total"` tab is created by the grouping plan. The factor's level order
+The `"Total"` tab is created by the Grouping plan. The factor's level order
 makes it the first tab; `quartabs` only handles presentation, while marginplyr
 defines which source rows belong to that total.

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -14,7 +14,7 @@ date: last-modified
 ---
 
 A Margin result combines rows from several grouping sets. Visible values such
-as `"Total"` are useful for display, but they do not identify which Grouping
+as `"Total"` are useful for display, but they do not identify which grouping
 set produced a row. marginplyr provides two kinds of identifier for that
 purpose, and they answer different questions: a *Grouping set identifier* says
 where in the Grouping plan an occurrence sits, and a *Grouping identifier*
@@ -224,7 +224,7 @@ Factors make three distinct situations visible:
 1. An **NA factor level** belongs to the factor domain and can be used by an
    observation whose factor code is not missing.
 2. A **source missing value** has a missing factor code.
-3. A **typed-missing Margin value** marks a dimension omitted from a Grouping
+3. A **typed-missing Margin value** marks a dimension omitted from a grouping
    set when `.margin_label = NULL` or `NA_character_`.
 
 The first two can both print as `<NA>`:

--- a/vignettes/grouping_identity.qmd
+++ b/vignettes/grouping_identity.qmd
@@ -13,7 +13,7 @@ format:
 date: last-modified
 ---
 
-A Margin result combines rows from several Grouping sets. Visible values such
+A Margin result combines rows from several grouping sets. Visible values such
 as `"Total"` are useful for display, but they do not identify which Grouping
 set produced a row. marginplyr provides two kinds of identifier for that
 purpose, and they answer different questions: a *Grouping set identifier* says

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -565,7 +565,7 @@ retail_sales |>
 ```
 
 Two steps are required because `grouping_id()` and `grouping_bit()` are
-contextual summary helpers. They read the Grouping set that produced a row,
+contextual summary helpers. They read the grouping set that produced a row,
 which only the summary knows, so calling one inside `filter()` is rejected:
 
 ```{r}


### PR DESCRIPTION
Closes #462.

## The rule

`CONTEXT.md` capitalizes its headwords but its own definition bodies do not, so
the guides had no rule to follow and drifted. Measured over `vignettes/` and
`README.Rmd` at this branch's merge-base `1f927cb`, normalizing whitespace so a
term wrapped across a line is counted, and excluding the all-caps SQL literals:

| term | total | capitalized |
|---|---|---|
| margin order | 17 | 17 |
| grouping identifier | 10 | 10 |
| grouping bit | 6 | 6 |
| margin operation | 4 | 4 |
| margin dimension | 1 | 1 |
| parent share | 7 | 6 |
| margin label | 13 | 9 |
| grand total | 23 | 9 |
| grouping plan | 16 | 5 |
| grouping set (standalone) | 47 | 9 |

The five that never drift are the ones with no ordinary-English reading. That
is what the rule turns on, and a new **House term** entry says it: capitalized
where it names the defined concept, lowercase where the same words carry their
ordinary sense. A blanket sweep was the alternative and it is wrong — it would
capitalize "SQL calls this idea grouping sets".

## What the rule decides

The test is whether marginplyr defines the concept or borrows it, and the entry
says so directly. Having an entry below is not the test in either direction:
*Margin verb* has none and is marginplyr's own, *Grain* has one and is a data
model's. Two consequences follow, both stated in the entry because they settle
most of the sites:

- **_grouping set_ is SQL's.** `CONTEXT.md` writes it standalone at 15 sites,
  every one lowercase, so the issue's premise that `CONTEXT.md` capitalizes it
  does not hold. The 7 capitalized standalone uses in the guides are lowercased
  instead; it capitalizes only inside *Grouping set identifier*.
- **Bare _grand total_ is a report's**, the entry being *Grand total set*. The
  guides were already consistent — all 9 capitalized occurrences are "Grand
  total set" and all 14 lowercase ones are bare — so no site changes. *grain*
  is likewise a data model's and was already lowercase at all 9 sites.

That leaves the sites where the phrase does name a marginplyr concept,
capitalized here: Grouping plan (12), Grouping specification (6), Margin label
(5), Parent share (2), Total share, Margin verb, Converting dialect. Six are in
`CONTEXT.md` itself, where the new entry would otherwise be violated by the
file that holds it. `Margin row` goes the other way — it is on the *Grand total
set* entry's `_Avoid_` list, so it names nothing and lowercases.

The hyphenation bullet in the issue is dropped as decided in triage:
`Grouping-set row` and `Grouping-set occurrence` are attributive uses where the
hyphen is ordinary English, and the two sites agree with each other.

Re-scanned over `vignettes/`, `README.Rmd`, and `CONTEXT.md`, the entry now
reports three capitals, all position-initial: a table header cell, a section
heading, and a headword.

## Not in this change

`R/` drifts the same way and would carry `man/` with it. The issue measured and
scoped the guides, so that is #479. The one `R/` line here is the twin of a
vignette comment this change edits; splitting the pair is the defect #462
reports.

## Gates

`lintr::lint_package()`, `spelling::spell_check_package()`,
`testthat::test_local()`, `verify-must-error.R`, and `verify-context-budget.R`
all pass. `README.md` and `man/summarize_with_margins.Rd` are regenerated in
the commits that change their sources; the local pandoc matches
`document.yaml`'s 3.10.1 pin and the `README.md` diff is the six prose changes
only.
