### PR TITLE
Record why the dtplyr reference pages stay unqualified (#470)

### DIFF
--- a/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
+++ b/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
@@ -129,22 +129,30 @@ and the one the Arrow refusal beside it already takes.
 that page already promises.
 
 The reference pages are unchanged too, and that is decided rather than passed
-over (#470). A Mutable step is a dtplyr step, so `nest_with_margins()`'s
-`@param .data` — *A local data frame or a `dtplyr` step* — is broader than
-what is accepted, and it is left broader. This is where the parallel with ADR
-0025 stops. There the page had to carry what a caller could not otherwise know,
-which summaries Arrow absorbs being Arrow's to decide and moving with its
-version; here the refusal is reached only by a caller who wrote `immutable =
-FALSE` themselves, against `lazy_dt()`'s default, and the diagnostic names the
-one rewrite. A clause would have to go on every `@param .data` definition in
-the package, the refusal being raised for every verb `verbs_taking(".grouping")`
-returns, and nothing would hold those copies in step — an amendment here would
-leave the ones it did not reach standing and wrong.
+over (#470). A Mutable step is a dtplyr step, so the three sentences #470 names
+that claim the class are broader than what is accepted, and they are left
+broader: `nest_with_margins()`'s `@param .data` — *A local data frame or a
+`dtplyr` step* — its *It works with local data frames and `dtplyr` steps*, and
+*Share execution supports local data frames and lazy dbplyr and dtplyr inputs*.
 
-The other pages #470 names describe an input that was accepted: when a
-`dtplyr` result is collected to be made row-wise, the integers a step returns
+This is where the parallel with ADR 0025 stops. There the page had to carry
+what a caller could not otherwise know; here the refusal is reached only by a
+caller who wrote `immutable = FALSE` themselves, against `lazy_dt()`'s default,
+and the diagnostic names the one rewrite.
+
+`@param .data` is also not where this package documents a refusal. The two
+definitions naming no backend — `summarize_with_margins()`'s and
+`inspect_grouping()`'s *A data frame or lazy table* — name none of the
+refusals a Margin verb already raises, the Arrow ones being carried by sections
+instead.
+So `nest_with_margins()`'s is the only definition a dtplyr clause would fit,
+and putting it there alone would say the refusal is nesting's when it is raised
+for every verb `verbs_taking(".grouping")` returns.
+
+The other three sentences #470 names describe an input that was accepted: when
+a `dtplyr` result is collected to be made row-wise, the integers a step returns
 for a grouping identity, and what establishes the share source rules on one.
-None of them claims what may be passed, so none of them is what this decision
+None of the three claims what may be passed, so none is what this decision
 would qualify.
 
 ## Test strategy

--- a/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
+++ b/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
@@ -128,6 +128,25 @@ and the one the Arrow refusal beside it already takes.
 `?marginplyr` is unchanged: what a caller catches is the `marginplyr_error`
 that page already promises.
 
+The reference pages are unchanged too, and that is decided rather than passed
+over (#470). A Mutable step is a dtplyr step, so `nest_with_margins()`'s
+`@param .data` — *A local data frame or a `dtplyr` step* — is broader than
+what is accepted, and it is left broader. This is where the parallel with ADR
+0025 stops. There the page had to carry what a caller could not otherwise know,
+which summaries Arrow absorbs being Arrow's to decide and moving with its
+version; here the refusal is reached only by a caller who wrote `immutable =
+FALSE` themselves, against `lazy_dt()`'s default, and the diagnostic names the
+one rewrite. A clause would have to go on every `@param .data` definition in
+the package, the refusal being raised for every verb `verbs_taking(".grouping")`
+returns, and nothing would hold those copies in step — an amendment here would
+leave the ones it did not reach standing and wrong.
+
+The other pages #470 names describe an input that was accepted: when a
+`dtplyr` result is collected to be made row-wise, the integers a step returns
+for a grouping identity, and what establishes the share source rules on one.
+None of them claims what may be passed, so none of them is what this decision
+would qualify.
+
 ## Test strategy
 
 The tests sit where the backend-kind contracts do and are guarded by


### PR DESCRIPTION
Closes #470.

## What was decided

The reference pages that name `dtplyr` as a supported input keep their wording, and ADR 0029's *Documentation consequences* now records that as a decision with its reason. #470 offered either that or a clause added to those pages; this takes the first.

The reason has two halves, both checkable:

- ADR 0025's page edit — the precedent #470 cites — carried what a caller could not otherwise know. The Mutable step refusal is reached only by a caller who wrote `dtplyr::lazy_dt(immutable = FALSE)` themselves, against that argument's default of `TRUE`, and the diagnostic names the one rewrite.
- `@param .data` is not where this package documents a refusal. `summarize_with_margins()`'s and `inspect_grouping()`'s *A data frame or lazy table* name none of the refusals a Margin verb already raises — the Arrow ones are carried by sections. So `nest_with_margins()`'s is the only definition a dtplyr clause would fit, and there it would read as nesting's refusal rather than one raised for every verb `verbs_taking(".grouping")` returns.

## What #470 got wrong

Three of the six sites it lists claim nothing about what may be passed, and the ADR now says so rather than leaving them to be re-filed:

- `R/nest_by_with_margins.R` — when a `dtplyr` *result* is collected to be made row-wise.
- `R/grouping-context.R` — the integers a step *returns* for a grouping identity.
- The `share.R` backend table — what establishes the source rules on an input that was accepted. A Mutable step never reaches share execution.

The other three do claim the class, and the ADR names each and leaves it broader.

## Checks

No R source changed, so `man/`, `NAMESPACE`, and `README.md` are untouched and `document.yaml` has nothing to regenerate. Nothing under `tests/` or `.github/scripts/` reads `design/adr/`. `devtools::test()`: 6981 pass, 0 fail, 0 skip. `Rscript .github/scripts/verify-context-budget.R` passes (22005 bytes, at the baseline — ADRs are outside the always-loaded closure).

The review record is in a comment below.