### PR TITLE
Announce three user-visible features in NEWS.md (#481)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,9 +41,7 @@
   sits with the rows it summarizes rather than wherever its Margin label falls,
   and lazy inputs stay lazy. See *Margin order* in `?summarize_with_margins`.
 * Added the `retail_sales` data set, 24 rows of synthetic monthly sales that
-  the guides and examples are written against. Its online-direct records carry
-  a missing `store`, which is how the documentation tells a source missing
-  value from a subtotal. See `?retail_sales`.
+  the guides and examples are written against. See `?retail_sales`.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.
@@ -167,8 +165,8 @@
 * Added `.key` to `nest_with_margins()` and `nest_by_with_margins()`, a string
   naming the list column. Each follows the function it resembles for `NULL`:
   `nest_with_margins()` reads it as `"data"`, as `tidyr::nest()` does, and
-  `nest_by_with_margins()` refuses it, as `dplyr::nest_by()` does. See
-  *Relationship to tidyr and dplyr* in `?nest_with_margins`.
+  `nest_by_with_margins()` refuses it, as `dplyr::nest_by()` does. See `.key`
+  in `?nest_with_margins` and `?nest_by_with_margins`.
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns, and reject duplicate sets with `.duplicates = "keep"`
   because their visible outer keys would be indistinguishable.

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,10 @@
   structure of its Grouping plan rather than by displayed values, so a subtotal
   sits with the rows it summarizes rather than wherever its Margin label falls,
   and lazy inputs stay lazy. See *Margin order* in `?summarize_with_margins`.
+* Added the `retail_sales` data set, 24 rows of synthetic monthly sales that
+  the guides and examples are written against. Its online-direct records carry
+  a missing `store`, which is how the documentation tells a source missing
+  value from a subtotal. See `?retail_sales`.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.
@@ -58,6 +62,11 @@
   and `FALSE` for lazy inputs. A label equal to a declared factor level is
   rejected on every backend whatever this argument says, because the level is
   already known from the column's metadata (#122).
+* Added `.margin_label_position` to every Margin verb, taking `"last"` (the
+  default) or `"first"`. It decides where a non-missing Margin label's
+  synthetic level sits in a factor dimension's level order, and is a no-op for
+  a typed-missing Margin label (#16). See *Display labels and grouping
+  identity* in `?summarize_with_margins`.
 * Added `.check_share_source` to `summarize_with_margins()`, `TRUE` by default
   on every backend including lazy ones, because a share source's eligibility
   can be established without reading your data. See *When marginplyr queries
@@ -155,6 +164,11 @@
   warning every grouping set raises is reported once, saying how many further
   sets raised it, in place of one identical warning per set (#141, #108, #411,
   #432). See *Errors and warnings* in `?marginplyr`.
+* Added `.key` to `nest_with_margins()` and `nest_by_with_margins()`, a string
+  naming the list column. Each follows the function it resembles for `NULL`:
+  `nest_with_margins()` reads it as `"data"`, as `tidyr::nest()` does, and
+  `nest_by_with_margins()` refuses it, as `dplyr::nest_by()` does. See
+  *Relationship to tidyr and dplyr* in `?nest_with_margins`.
 * `nest_with_margins()` and `nest_by_with_margins()` now use collision-free
   internal columns, and reject duplicate sets with `.duplicates = "keep"`
   because their visible outer keys would be indistinguishable.


### PR DESCRIPTION
Closes #481.

## What changed

Three user-visible features had **no** `NEWS.md` entry at all. One bullet each now, in the shape #466 established: the user-visible change in one or two sentences, an issue number where one exists, and a pointer to the reference section that owns the argument.

| Feature | Issue | Points at |
| --- | --- | --- |
| `.margin_label_position` | #16 | *Display labels and grouping identity* in `?summarize_with_margins` |
| `retail_sales` | — | `?retail_sales` |
| `.key` | — | *Relationship to tidyr and dplyr* in `?nest_with_margins` |

Each bullet sits with the ones covering its own feature area — `.margin_label_position` after `.check_margin_label`, `retail_sales` before the guides entry, `.key` at the head of the nesting group — rather than at the end of the file, which is how #466 ordered the file it left.

## Two choices worth naming

**`.margin_label_position` does not point at *Option arguments*, which #481 named.** That section owns the string-vocabulary rule — an abbreviation and `NULL` both refused — and the existing option-arguments bullet already cites it, listing this argument as one of its examples. What the argument *does* is written in *Display labels and grouping identity*. Pointing at the section #481 named would send a reader to prose that says nothing about the argument's effect.

**The `.key` bullet carries the `NULL` asymmetry between the two nesting verbs.** `nest_with_margins()` reads `NULL` as `"data"`, as `tidyr::nest()` does; `nest_by_with_margins()` refuses it, as `dplyr::nest_by()` does. Nothing else in the file states this, and folding the two verbs into one bullet — which the neighbouring collision-free-columns bullet already does — otherwise reads as though they treat the argument alike. Both halves were confirmed against the loaded package rather than read off the roxygen:

```r
names(nest_with_margins(d, .grouping = rollup(g), .key = NULL))
#> [1] "g"    "data"
nest_by_with_margins(d, .grouping = rollup(g), .key = NULL)
#> Error: `.key` must be a character vector of length 1.
```

## Issue numbers

`.margin_label_position` came from #16. Neither `retail_sales` (added in `e5844fc`) nor `.key` (added in `4f4197a`, before issue #1) has one — `4f4197a` predates the issue tracker. #481's "an issue number where one exists" is what admits the two uncited bullets.

## `CONTEXT.md` is unchanged

Its *Margin label* entry already covers the placement this argument decides — "a synthetic level placed last by default and may be placed first explicitly" — so the bullet uses that term rather than introducing a House term for the position.

## Not in scope: #484

Confirming the three bullets above turned up **three further** changes `NEWS.md` also never announces. None is prose added here, per `design/architecture.md`'s *Answering a review* — the same rule that made #481 a ticket rather than prose in #480:

- **Per-dimension Margin labels** — the named character vector `.margin_label` accepts (#16, which #481 named only for `.margin_label_position`).
- **A per-dimension `NULL`** — the named *list* spelling, `list(region = "All regions", status = NULL)` (#371).
- **`retail_sales` shipping as a plain `data.frame`** (#55, which #481 named only for the data set's absence).

Filed as #484. The count is worth stating: the first pass here found two, and the third turned up only on a second look at what `NEWS.md` says about `.margin_label` — which is the failure #481 was itself created by, one step out.

## Gates

- `testthat::test_local()` — pass, exit 0, no failures, warnings, or skips.
- `pkgload::load_all()` → `lintr::lint_package()` — no lints.
- `spelling::spell_check_package()` — no spelling errors.
- `verify-doc-references.R` — 176 paths across 153 documents, all resolve.
- `verify-context-budget.R` — 22005 bytes, within 22005.

No gate checks that a `*Section*` in `` `?topic` `` citation resolves — `verify-doc-references.R` reads only `/`-bearing paths in prose. The three section names were matched by hand against `man/summarize_with_margins.Rd`, `man/nest_with_margins.Rd`, and `man/retail_sales.Rd`.
