### PR TITLE
Capitalize a House term in R/, and lowercase what it borrows (#479)

### DIFF
--- a/.github/scripts/verify-site.R
+++ b/.github/scripts/verify-site.R
@@ -434,7 +434,7 @@ markers <- list(
     "Database backend coverage",
     "Microsoft SQL Server",
     "NA is already a factor level",
-    "cannot select any column named in the complete grouping plan",
+    "cannot select any column named in the complete Grouping plan",
     "cur_group_id"
   ),
   # `@keywords internal` on the `"_PACKAGE"` topic takes it out of

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -8,7 +8,7 @@
 #' @section Relationship to dplyr:
 #' This function is not a variant of [dplyr::union_all()]. That function
 #' combines two data frames supplied by the caller; [expand_with_margins()]
-#' consumes one data frame and a grouping plan, then emits the corresponding
+#' consumes one data frame and a Grouping plan, then emits the corresponding
 #' row copies. Naming the public operation for row expansion keeps the SQL
 #' implementation strategy out of the user-facing API.
 #'

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -410,7 +410,7 @@ summarize_margin_union <- function(.data,
   #
   # `n()` and not a literal, because the placeholder has to aggregate: a
   # constant in a `summarize()` over no groups renders as `SELECT 1 AS x FROM
-  # t`, one row per source row, where `COUNT(*)` is the single Grand total row
+  # t`, one row per source row, where `COUNT(*)` is the single grand total row
   # the branch stands for.
   placeholder_name <- new_margin_internal_names(
     1L,

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -98,7 +98,7 @@ abort_mutable_dtplyr_step <- function() {
   abort_marginplyr(c(
     "{.arg .data} comes from {.code dtplyr::lazy_dt(immutable = FALSE)}.",
     i = paste0(
-      "A margin verb builds one branch per grouping set from the same step, ",
+      "A Margin verb builds one branch per grouping set from the same step, ",
       "and data.table writes each branch to your table by reference."
     ),
     i = "Rebuild the input with {.code dtplyr::lazy_dt(immutable = TRUE)}."

--- a/R/grouping-context.R
+++ b/R/grouping-context.R
@@ -24,12 +24,12 @@
 #' and it contributes a zero bit to [grouping_id()].
 #'
 #' @section Grouping identity values:
-#' marginplyr exposes four related values. Two describe *where* a Grouping-set
+#' marginplyr exposes four related values. Two describe *where* a grouping-set
 #' occurrence sits in one ordered Grouping plan; two describe *which*
 #' dimensions are absent from a row. Only the first pair can tell repeated
-#' identical Grouping sets apart:
+#' identical grouping sets apart:
 #'
-#' | Value | Meaning | Duplicate Grouping-set occurrences |
+#' | Value | Meaning | Duplicate grouping-set occurrences |
 #' |---|---|---|
 #' | `.id` | One-based position in the resolved Grouping plan | Distinct with `.duplicates = "keep"` | # nolint: line_length_linter
 #' | [inspect_grouping()] `$set_id` | The same position before execution | Distinct with `.duplicates = "keep"` | # nolint: line_length_linter
@@ -76,7 +76,7 @@
 #'
 #' @return A grouping flag or identifier when used inside
 #'   [summarize_with_margins()]. Local data frames and `dtplyr` steps return R
-#'   integers, because the value is known for each Grouping-set branch and is
+#'   integers, because the value is known for each grouping-set branch and is
 #'   substituted before execution. Arrow and every backend taking the portable
 #'   `UNION ALL` path receive that same constant as a literal in their own
 #'   query. Only a backend actually running native `GROUP BY GROUPING SETS`
@@ -100,7 +100,7 @@
 #'   .grouping = rollup(region, store)
 #' )
 #'
-#' # Keeping typed missing values makes the grouping bits essential: source
+#' # Keeping typed missing values makes the Grouping bits essential: source
 #' # missing values, factor NA levels, and generated margins may all print as
 #' # NA even though their structural identities differ.
 #' summarize_with_margins(

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -30,7 +30,7 @@ validate_grouping_spec_early <- function(grouping_spec) {
 }
 
 abort_invalid_grouping_spec <- function() {
-  abort_marginplyr("Invalid grouping specification.")
+  abort_marginplyr("Invalid Grouping specification.")
 }
 
 # The kind an object carrying the specification class says it is, or `NULL`
@@ -901,7 +901,7 @@ compile_grouping_spec_impl <- function(preflight,
 expand_grouping_family <- function(preflight, data_proxy) {
   rule <- find_grouping_kind_rule(preflight$spec$type)
   if (is.null(rule)) {
-    stop("Unknown grouping specification kind.", call. = FALSE)
+    stop("Unknown Grouping specification kind.", call. = FALSE)
   }
   rule$expand(preflight, data_proxy)
 }
@@ -1440,7 +1440,7 @@ abort_ambiguous_nested_name <- function(name) {
   abort_marginplyr(c(
     paste0(
       "{.var {name}} is both a column of the input and a name bound to a ",
-      "grouping specification, so a nested position cannot tell which one ",
+      "Grouping specification, so a nested position cannot tell which one ",
       "you mean."
     ),
     i = "For the column, write {.code {column}}.",
@@ -1451,7 +1451,7 @@ abort_ambiguous_nested_name <- function(name) {
 abort_nested_grouping_spec <- function(label) {
   abort_marginplyr(c(
     paste0(
-      "{.code {label}} is a grouping specification, but a nested position ",
+      "{.code {label}} is a Grouping specification, but a nested position ",
       "recognizes one only when it is a call to ",
       "{.or {.fun {grouping_constructor_names()}}}, or a name bound to a ",
       "specification."

--- a/R/grouping-spec.R
+++ b/R/grouping-spec.R
@@ -1,4 +1,4 @@
-#' Build a grouping specification
+#' Build a Grouping specification
 #'
 #' These constructors describe SQL-style grouping operations for the
 #' `.grouping` argument of [summarize_with_margins()] and related verbs.
@@ -41,7 +41,7 @@
 #'   argument gets, and what is refused rather than read either way, is *How an
 #'   argument is read*.
 #'
-#' @return A grouping specification for use in `.grouping`.
+#' @return A Grouping specification for use in `.grouping`.
 #'
 #' @section How an argument is read:
 #' A nested Grouping specification is recognized by how it is written: a
@@ -88,7 +88,7 @@
 #' @family grouping plans and grouping identity
 #' @seealso [summarize_with_margins()], [expand_with_margins()],
 #'   [nest_with_margins()], and [nest_by_with_margins()], the Margin verbs
-#'   that consume a grouping specification.
+#'   that consume a Grouping specification.
 #' @export
 #' @examples
 #' # The operations team needs store, region, and company totals for each
@@ -253,7 +253,7 @@ print.margin_grouping_spec <- function(x, ...) {
   # count, and states what reading through a shared function costs.
   kind <- grouping_spec_kind(x)
   cat(
-    "<marginplyr grouping specification: ",
+    "<marginplyr Grouping specification: ",
     grouping_kind_printed_name(kind),
     ">\n",
     sep = ""

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -39,7 +39,7 @@
 #' 31 variable dimensions, while `grouping_bits` remains complete.
 #'
 #' [grouping_bit()] is the canonical reference for how these four values
-#' relate and which of them distinguish duplicate Grouping-set occurrences.
+#' relate and which of them distinguish duplicate grouping-set occurrences.
 #'
 #' @section Formats and ordinary tibble behavior:
 #' The default `.format = "text"` represents column collections as `()`,

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -23,13 +23,13 @@
 #' @section Next steps:
 #' - **Grouping specifications**: [grouping_set()], [grouping_sets()],
 #'   [rollup()], [cube()], and [grouping_spec()] describe which grouping
-#'   sets a margin operation computes.
+#'   sets a Margin operation computes.
 #' - **Margin operations**: [summarize_with_margins()],
 #'   [expand_with_margins()], [nest_with_margins()], and
-#'   [nest_by_with_margins()] apply a grouping specification to data.
+#'   [nest_by_with_margins()] apply a Grouping specification to data.
 #' - **Grouping-plan inspection and grouping identities**:
 #'   [inspect_grouping()], [grouping_bit()], and [grouping_id()] resolve and
-#'   identify grouping sets before or after running a margin operation.
+#'   identify grouping sets before or after running a Margin operation.
 #' - **Contextual shares**: [share_of_parent()] and [share_of_total()]
 #'   calculate a summary's ratio to its immediate rollup parent, or to the
 #'   grand total.
@@ -70,7 +70,7 @@
 #'
 #' marginplyr itself raises no warning: it states what it will not do by
 #' refusing. What a Margin verb does adjust, for an error and a warning alike,
-#' is the context reported around one, because a margin operation may summarize
+#' is the context reported around one, because a Margin operation may summarize
 #' your expression once per grouping set. Such a condition reports its grouping
 #' values under the columns you named rather than under internal ones, quotes
 #' the argument as you spelled it rather than as marginplyr rewrote it to

--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -2,7 +2,7 @@
 #'
 #' marginplyr extends [dplyr::summarize()] with SQL-style `GROUPING SETS`,
 #' `ROLLUP`, and `CUBE` summaries: totals, subtotals, and arbitrary grouping
-#' combinations, with grouping identifiers to tell the resulting grains
+#' combinations, with Grouping identifiers to tell the resulting grains
 #' apart. Local data frames and lazy tables are supported. Confirmed
 #' database backends use native grouping sets; other lazy backends use a
 #' `UNION ALL` fallback with the same semantics.

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -31,7 +31,7 @@
 #' `.keep = TRUE` also puts the original grouping keys in that inner data
 #' frame. This corresponds to selecting those keys in [tidyr::nest()] (for
 #' example, `nest(data = everything(), .by = region)`), but uses a logical
-#' argument because margin dimensions must remain visible outside to identify
+#' argument because Margin dimensions must remain visible outside to identify
 #' detail, subtotal, and total rows.
 #'
 #' [nest_with_margins()] does not implement the full `...` column

--- a/R/share.R
+++ b/R/share.R
@@ -23,7 +23,7 @@
 #' ```
 #'
 #' A helper is contextual because its denominator belongs to another
-#' Grouping-set row, so it can be used only inside
+#' grouping-set row, so it can be used only inside
 #' [summarize_with_margins()]. Direct calls, ordinary [dplyr::summarize()]
 #' calls, and [dplyr::mutate()] calls are rejected.
 #'
@@ -269,7 +269,7 @@
 #' synthesizes or completes keys. A missing numerator, missing denominator, or
 #' zero denominator gives `NA_real_`; local `NaN` is missing. Other finite
 #' ratios are unclamped doubles, so negative values and values above one are
-#' retained. Denominator matching uses internal Grouping set metadata rather
+#' retained. Denominator matching uses internal grouping set metadata rather
 #' than `.id` or displayed Margin labels, and missing fixed or variable keys
 #' are matched with missing-safe identity rather than ordinary SQL
 #' `NULL = NULL`.
@@ -277,13 +277,13 @@
 #' A Parent share's denominator is the immediate strictly less detailed
 #' [rollup()] level. Composite dimensions are added or removed together. The
 #' Grand total set has no parent, so its Parent share is `1.0`, even when its
-#' source is zero or missing. Duplicate Grouping set occurrences remain in the
+#' source is zero or missing. Duplicate grouping set occurrences remain in the
 #' result but are skipped while finding the next coarser parent, because a
 #' parent must be strictly less detailed.
 #'
 #' A Total share's denominator is the Grand total set. Every row of it,
 #' duplicate occurrences included, has a Total share of `1.0`, even when its
-#' source is zero or missing. Duplicate Grand total occurrences aggregate the
+#' source is zero or missing. Duplicate grand total occurrences aggregate the
 #' same rows and therefore hold the same values, so they are interchangeable
 #' rather than skipped and which one supplies the denominator is not
 #' specified.
@@ -690,7 +690,7 @@ abort_ambiguous_parent <- function(call = rlang::caller_call()) {
       ),
       i = paste0(
         "{.fun grouping_sets}, {.fun cube}, {.fun grouping_spec}, and other ",
-        "grouping specifications do not define one unambiguous parent."
+        "Grouping specifications do not define one unambiguous parent."
       ),
       i = paste0(
         "Rewrite {.arg .grouping} as one {.fun rollup} or omit the Parent ",
@@ -2726,7 +2726,7 @@ build_parent_denominator <- function(result,
 }
 
 # A Total share's denominator depends on `.by` and nothing else, so its
-# mapping is the Grand total rows reduced to one row per fixed partition and
+# mapping is the grand total rows reduced to one row per fixed partition and
 # matched on the fixed keys alone. See ADR 0017.
 build_total_denominator <- function(result,
                                     plan,
@@ -2931,7 +2931,7 @@ check_share_source_types <- function(values, requests, call) {
   invisible(NULL)
 }
 
-# The Grand total occurrences of a plan: those omitting every variable
+# The grand total occurrences of a plan: those omitting every variable
 # grouping dimension. There is at most one unless duplicates were kept. Named
 # for the occurrences it returns, because `total_set_ids()` below returns the
 # other shape — one denominator per occurrence, in plan order.
@@ -2942,7 +2942,7 @@ grand_total_occurrence_ids <- function(plan) {
 
 # The denominator occurrence of every grouping set, in the shape
 # `parent_set_ids()` returns: `NA` where the row is its own denominator, and
-# otherwise the occurrence supplying it. Duplicate Grand total occurrences
+# otherwise the occurrence supplying it. Duplicate grand total occurrences
 # hold the same values, so any of them answers for every other set; which one
 # is used is not part of the contract.
 total_set_ids <- function(plan) {

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -22,7 +22,7 @@
 #'   implicit fixed keys. A fixed key is a column of the input, so a selection
 #'   cannot rename it: `c(area = region)` is an error rather than a fixed key
 #'   named `area`. Rename the result afterwards with [dplyr::rename()].
-#' @param .grouping A grouping specification made with [grouping_set()],
+#' @param .grouping A Grouping specification made with [grouping_set()],
 #'   [grouping_sets()], [rollup()], [cube()], or [grouping_spec()]. `NULL`
 #'   represents one empty grouping set. Any expression returning a
 #'   specification can be written here, while a specification nested inside
@@ -125,7 +125,7 @@
 #'
 #' These forms are not completely interchangeable in the current
 #' implementation. A column supplied through `.grouping` is treated as a
-#' margin dimension even when every expanded grouping set contains it.
+#' Margin dimension even when every expanded grouping set contains it.
 #' Consequently, it participates in `.margin_label` type conversion and
 #' collision checks. Use `.by` for columns that must always remain fixed, and
 #' use `.grouping` for dimensions that may become totals.
@@ -243,9 +243,9 @@
 #'
 #' @section Grouping set identifiers:
 #' When `.id` names an output column, each result row receives the one-based
-#' position of its Grouping set occurrence after applying `.duplicates`.
+#' position of its grouping set occurrence after applying `.duplicates`.
 #' `"drop"` renumbers retained occurrences, while supported `"keep"` paths give
-#' identical duplicate sets distinct identifiers. One Grouping set has
+#' identical duplicate sets distinct identifiers. One grouping set has
 #' identifier `1L`, and a zero-row result retains an integer `.id` column.
 #'
 #' Output columns are ordered as fixed keys, variable dimensions, `.id`, then
@@ -349,7 +349,7 @@
 #' is bound to where you wrote it.
 #'
 #' [dplyr::across()] and [dplyr::pick()] cannot select any column named in the
-#' complete grouping plan. This extends dplyr's grouping-column rule across
+#' complete Grouping plan. This extends dplyr's grouping-column rule across
 #' every branch: a dimension remains excluded even in a grouping set from
 #' which it is omitted.
 #'
@@ -445,7 +445,7 @@
 #' [rollup()]; composite dimensions move together, and duplicate occurrences
 #' skip identical sets when choosing the parent. [share_of_total()] divides by
 #' the Grand total set, so it accepts any Grouping specification whose plan
-#' contains one, including [cube()]; duplicate Grand total occurrences hold
+#' contains one, including [cube()]; duplicate grand total occurrences hold
 #' the same values and are interchangeable.
 #'
 #' Arrow inputs reject both after expression planning and common
@@ -461,7 +461,7 @@
 #' and displayed Margin labels do not determine the denominator.
 #'
 #' The source must be a unique, preceding, self-contained integer or double
-#' scalar summary. Lazy execution preserves collision-safe Grouping set
+#' scalar summary. Lazy execution preserves collision-safe grouping set
 #' metadata through ordinary aggregation, calculates the requested shares
 #' through one shared mapping per denominator kind, and then removes the
 #' metadata before returning the requested column order.
@@ -790,7 +790,7 @@
 #'   type = typeof(empty_partitions$revenue_share)
 #' )
 #'
-#' # across() and pick() treat every fixed key and margin dimension as a
+#' # across() and pick() treat every fixed key and Margin dimension as a
 #' # grouping column, including dimensions omitted from a subtotal branch.
 #' summarize_with_margins(
 #'   .data = retail_sales,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -383,7 +383,7 @@ dplyr_auto_name <- function(expr) {
 # what a rewritten one hands it is marginplyr's spelling: a branch-local `0L`
 # or `1L` where the caller wrote `grouping_bit()` or `grouping_id()`, and a
 # qualified `all_of()` literal where they wrote a selection helper. The first
-# spelled a different column name in each Grouping-set branch, which is what
+# spelled a different column name in each grouping-set branch, which is what
 # the union's column invariant refused; the second named the column after the
 # rewrite. `...` is documented as `dplyr::summarize()`'s name-value pairs, so
 # the name is settled from the caller's own expression here instead (#430).

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,7 +53,7 @@ assert_string_scalar <- function(x) {
 # `toString()` comma both replace was neutral between the two readings.
 #
 # `expand_with_margins()` is not named beside `dplyr::collect()`, under the
-# rule ADR 0012's second amendment states. It takes the same grouping
+# rule ADR 0012's second amendment states. It takes the same Grouping
 # specification and stays lazy, but it returns rows rather than the list column
 # this call asked for, and `assert_lazy_table()` refuses a `RecordBatchReader`
 # that reaches this refusal.

--- a/design/adr/0008-centralize-grouping-specification-kind-rules.md
+++ b/design/adr/0008-centralize-grouping-specification-kind-rules.md
@@ -320,7 +320,7 @@ name asks the value's own `is.na()` and `length()` methods. Either can raise
 instead of answering, and what came out of the guard was then whatever the
 object raised — `simpleError` for a `stop()` in the method, a class of the
 object's own where it aborted with one — in place of the
-`Invalid grouping specification.` refusal below it. The class such a call
+`Invalid Grouping specification.` refusal below it. The class such a call
 raises therefore moves to `marginplyr_error`, for the same reason #262 gives:
 this is the guard's own answer arriving rather than a new one being chosen,
 since ADR 0015 already assigns a malformed specification reaching this guard a
@@ -544,7 +544,7 @@ because the first is already R's own reading of a character vector: a
   `grouping_set`, the kind being `set` and the class carrying a method that was
   never relevant to it.
 - The guards in `validate_grouping_spec_early()` admit it, where they refused
-  it. The `Invalid grouping specification.` refusal still answers every kind
+  it. The `Invalid Grouping specification.` refusal still answers every kind
   that is no name — two strings, none, or the missing one — and answers it on
   the stripped value, so a `length()` claiming `1` over two strings does not
   reach the decision.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -26,7 +26,7 @@ implicit fixed keys. A fixed key is a column of the input, so a selection
 cannot rename it: \code{c(area = region)} is an error rather than a fixed key
 named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
-\item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
+\item{.grouping}{A Grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
@@ -106,7 +106,7 @@ implement it by vertically combining branches with SQL \verb{UNION ALL}.
 
 This function is not a variant of \code{\link[dplyr:union_all]{dplyr::union_all()}}. That function
 combines two data frames supplied by the caller; \code{\link[=expand_with_margins]{expand_with_margins()}}
-consumes one data frame and a grouping plan, then emits the corresponding
+consumes one data frame and a Grouping plan, then emits the corresponding
 row copies. Naming the public operation for row expansion keeps the SQL
 implementation strategy out of the user-facing API.
 }
@@ -138,7 +138,7 @@ use \code{.by}. For example, \code{.by = year} is structurally equivalent to
 
 These forms are not completely interchangeable in the current
 implementation. A column supplied through \code{.grouping} is treated as a
-margin dimension even when every expanded grouping set contains it.
+Margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
@@ -263,9 +263,9 @@ carried through by dplyr and vctrs unchanged.
 \section{Grouping set identifiers}{
 
 When \code{.id} names an output column, each result row receives the one-based
-position of its Grouping set occurrence after applying \code{.duplicates}.
+position of its grouping set occurrence after applying \code{.duplicates}.
 \code{"drop"} renumbers retained occurrences, while supported \code{"keep"} paths give
-identical duplicate sets distinct identifiers. One Grouping set has
+identical duplicate sets distinct identifiers. One grouping set has
 identifier \code{1L}, and a zero-row result retains an integer \code{.id} column.
 
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then

--- a/man/grouping_bit.Rd
+++ b/man/grouping_bit.Rd
@@ -18,7 +18,7 @@ column of the resolved plan.}
 \value{
 A grouping flag or identifier when used inside
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}. Local data frames and \code{dtplyr} steps return R
-integers, because the value is known for each Grouping-set branch and is
+integers, because the value is known for each grouping-set branch and is
 substituted before execution. Arrow and every backend taking the portable
 \verb{UNION ALL} path receive that same constant as a literal in their own
 query. Only a backend actually running native \verb{GROUP BY GROUPING SETS}
@@ -54,11 +54,11 @@ and it contributes a zero bit to \code{\link[=grouping_id]{grouping_id()}}.
 }
 \section{Grouping identity values}{
 
-marginplyr exposes four related values. Two describe \emph{where} a Grouping-set
+marginplyr exposes four related values. Two describe \emph{where} a grouping-set
 occurrence sits in one ordered Grouping plan; two describe \emph{which}
 dimensions are absent from a row. Only the first pair can tell repeated
-identical Grouping sets apart:\tabular{lll}{
-   Value \tab Meaning \tab Duplicate Grouping-set occurrences \cr
+identical grouping sets apart:\tabular{lll}{
+   Value \tab Meaning \tab Duplicate grouping-set occurrences \cr
    \code{.id} \tab One-based position in the resolved Grouping plan \tab Distinct with \code{.duplicates = "keep"} \cr
    \code{\link[=inspect_grouping]{inspect_grouping()}} \verb{$set_id} \tab The same position before execution \tab Distinct with \code{.duplicates = "keep"} \cr
    \code{\link[=grouping_bit]{grouping_bit()}} \tab Whether one chosen dimension is absent \tab The same for identical absence patterns \cr
@@ -112,7 +112,7 @@ summarize_with_margins(
   .grouping = rollup(region, store)
 )
 
-# Keeping typed missing values makes the grouping bits essential: source
+# Keeping typed missing values makes the Grouping bits essential: source
 # missing values, factor NA levels, and generated margins may all print as
 # NA even though their structural identities differ.
 summarize_with_margins(

--- a/man/grouping_set.Rd
+++ b/man/grouping_set.Rd
@@ -6,7 +6,7 @@
 \alias{rollup}
 \alias{cube}
 \alias{grouping_spec}
-\title{Build a grouping specification}
+\title{Build a Grouping specification}
 \usage{
 grouping_set(...)
 
@@ -36,7 +36,7 @@ argument gets, and what is refused rather than read either way, is \emph{How an
 argument is read}.}
 }
 \value{
-A grouping specification for use in \code{.grouping}.
+A Grouping specification for use in \code{.grouping}.
 }
 \description{
 These constructors describe SQL-style grouping operations for the
@@ -216,7 +216,7 @@ postgres_sales |>
 \seealso{
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}},
 \code{\link[=nest_with_margins]{nest_with_margins()}}, and \code{\link[=nest_by_with_margins]{nest_by_with_margins()}}, the Margin verbs
-that consume a grouping specification.
+that consume a Grouping specification.
 
 Other grouping plans and grouping identity:
 \code{\link[=grouping_bit]{grouping_bit()}},

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -57,7 +57,7 @@ that absence pattern as a bit mask. \code{grouping_id} is \code{NA_integer_} bey
 31 variable dimensions, while \code{grouping_bits} remains complete.
 
 \code{\link[=grouping_bit]{grouping_bit()}} is the canonical reference for how these four values
-relate and which of them distinguish duplicate Grouping-set occurrences.
+relate and which of them distinguish duplicate grouping-set occurrences.
 }
 
 \section{Formats and ordinary tibble behavior}{

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -8,7 +8,7 @@
 \description{
 marginplyr extends \code{\link[dplyr:summarize]{dplyr::summarize()}} with SQL-style \verb{GROUPING SETS},
 \code{ROLLUP}, and \code{CUBE} summaries: totals, subtotals, and arbitrary grouping
-combinations, with grouping identifiers to tell the resulting grains
+combinations, with Grouping identifiers to tell the resulting grains
 apart. Local data frames and lazy tables are supported. Confirmed
 database backends use native grouping sets; other lazy backends use a
 \verb{UNION ALL} fallback with the same semantics.

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -32,13 +32,13 @@ summarize_with_margins(
 \itemize{
 \item \strong{Grouping specifications}: \code{\link[=grouping_set]{grouping_set()}}, \code{\link[=grouping_sets]{grouping_sets()}},
 \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, and \code{\link[=grouping_spec]{grouping_spec()}} describe which grouping
-sets a margin operation computes.
+sets a Margin operation computes.
 \item \strong{Margin operations}: \code{\link[=summarize_with_margins]{summarize_with_margins()}},
 \code{\link[=expand_with_margins]{expand_with_margins()}}, \code{\link[=nest_with_margins]{nest_with_margins()}}, and
-\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} apply a grouping specification to data.
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} apply a Grouping specification to data.
 \item \strong{Grouping-plan inspection and grouping identities}:
 \code{\link[=inspect_grouping]{inspect_grouping()}}, \code{\link[=grouping_bit]{grouping_bit()}}, and \code{\link[=grouping_id]{grouping_id()}} resolve and
-identify grouping sets before or after running a margin operation.
+identify grouping sets before or after running a Margin operation.
 \item \strong{Contextual shares}: \code{\link[=share_of_parent]{share_of_parent()}} and \code{\link[=share_of_total]{share_of_total()}}
 calculate a summary's ratio to its immediate rollup parent, or to the
 grand total.
@@ -81,7 +81,7 @@ change to your call can avoid; please report those at
 
 marginplyr itself raises no warning: it states what it will not do by
 refusing. What a Margin verb does adjust, for an error and a warning alike,
-is the context reported around one, because a margin operation may summarize
+is the context reported around one, because a Margin operation may summarize
 your expression once per grouping set. Such a condition reports its grouping
 values under the columns you named rather than under internal ones, quotes
 the argument as you spelled it rather than as marginplyr rewrote it to

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -29,7 +29,7 @@ implicit fixed keys. A fixed key is a column of the input, so a selection
 cannot rename it: \code{c(area = region)} is an error rather than a fixed key
 named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
-\item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
+\item{.grouping}{A Grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
@@ -130,7 +130,7 @@ use \code{.by}. For example, \code{.by = year} is structurally equivalent to
 
 These forms are not completely interchangeable in the current
 implementation. A column supplied through \code{.grouping} is treated as a
-margin dimension even when every expanded grouping set contains it.
+Margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
@@ -255,9 +255,9 @@ carried through by dplyr and vctrs unchanged.
 \section{Grouping set identifiers}{
 
 When \code{.id} names an output column, each result row receives the one-based
-position of its Grouping set occurrence after applying \code{.duplicates}.
+position of its grouping set occurrence after applying \code{.duplicates}.
 \code{"drop"} renumbers retained occurrences, while supported \code{"keep"} paths give
-identical duplicate sets distinct identifiers. One Grouping set has
+identical duplicate sets distinct identifiers. One grouping set has
 identifier \code{1L}, and a zero-row result retains an integer \code{.id} column.
 
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then
@@ -460,7 +460,7 @@ frame, and puts all non-key columns into one list column. Setting
 \code{.keep = TRUE} also puts the original grouping keys in that inner data
 frame. This corresponds to selecting those keys in \code{\link[tidyr:nest]{tidyr::nest()}} (for
 example, \code{nest(data = everything(), .by = region)}), but uses a logical
-argument because margin dimensions must remain visible outside to identify
+argument because Margin dimensions must remain visible outside to identify
 detail, subtotal, and total rows.
 
 \code{\link[=nest_with_margins]{nest_with_margins()}} does not implement the full \code{...} column

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -29,7 +29,7 @@ implicit fixed keys. A fixed key is a column of the input, so a selection
 cannot rename it: \code{c(area = region)} is an error rather than a fixed key
 named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
-\item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
+\item{.grouping}{A Grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
@@ -119,7 +119,7 @@ frame, and puts all non-key columns into one list column. Setting
 \code{.keep = TRUE} also puts the original grouping keys in that inner data
 frame. This corresponds to selecting those keys in \code{\link[tidyr:nest]{tidyr::nest()}} (for
 example, \code{nest(data = everything(), .by = region)}), but uses a logical
-argument because margin dimensions must remain visible outside to identify
+argument because Margin dimensions must remain visible outside to identify
 detail, subtotal, and total rows.
 
 \code{\link[=nest_with_margins]{nest_with_margins()}} does not implement the full \code{...} column
@@ -183,7 +183,7 @@ use \code{.by}. For example, \code{.by = year} is structurally equivalent to
 
 These forms are not completely interchangeable in the current
 implementation. A column supplied through \code{.grouping} is treated as a
-margin dimension even when every expanded grouping set contains it.
+Margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
@@ -308,9 +308,9 @@ carried through by dplyr and vctrs unchanged.
 \section{Grouping set identifiers}{
 
 When \code{.id} names an output column, each result row receives the one-based
-position of its Grouping set occurrence after applying \code{.duplicates}.
+position of its grouping set occurrence after applying \code{.duplicates}.
 \code{"drop"} renumbers retained occurrences, while supported \code{"keep"} paths give
-identical duplicate sets distinct identifiers. One Grouping set has
+identical duplicate sets distinct identifiers. One grouping set has
 identifier \code{1L}, and a zero-row result retains an integer \code{.id} column.
 
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -41,7 +41,7 @@ total_share = share_of_total(revenue)
 }\if{html}{\out{</div>}}
 
 A helper is contextual because its denominator belongs to another
-Grouping-set row, so it can be used only inside
+grouping-set row, so it can be used only inside
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}. Direct calls, ordinary \code{\link[dplyr:summarize]{dplyr::summarize()}}
 calls, and \code{\link[dplyr:mutate]{dplyr::mutate()}} calls are rejected.
 
@@ -282,7 +282,7 @@ Both helpers divide within each fixed \code{.by} partition, and neither ever
 synthesizes or completes keys. A missing numerator, missing denominator, or
 zero denominator gives \code{NA_real_}; local \code{NaN} is missing. Other finite
 ratios are unclamped doubles, so negative values and values above one are
-retained. Denominator matching uses internal Grouping set metadata rather
+retained. Denominator matching uses internal grouping set metadata rather
 than \code{.id} or displayed Margin labels, and missing fixed or variable keys
 are matched with missing-safe identity rather than ordinary SQL
 \code{NULL = NULL}.
@@ -290,13 +290,13 @@ are matched with missing-safe identity rather than ordinary SQL
 A Parent share's denominator is the immediate strictly less detailed
 \code{\link[=rollup]{rollup()}} level. Composite dimensions are added or removed together. The
 Grand total set has no parent, so its Parent share is \code{1.0}, even when its
-source is zero or missing. Duplicate Grouping set occurrences remain in the
+source is zero or missing. Duplicate grouping set occurrences remain in the
 result but are skipped while finding the next coarser parent, because a
 parent must be strictly less detailed.
 
 A Total share's denominator is the Grand total set. Every row of it,
 duplicate occurrences included, has a Total share of \code{1.0}, even when its
-source is zero or missing. Duplicate Grand total occurrences aggregate the
+source is zero or missing. Duplicate grand total occurrences aggregate the
 same rows and therefore hold the same values, so they are interchangeable
 rather than skipped and which one supplies the denominator is not
 specified.

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -47,7 +47,7 @@ implicit fixed keys. A fixed key is a column of the input, so a selection
 cannot rename it: \code{c(area = region)} is an error rather than a fixed key
 named \code{area}. Rename the result afterwards with \code{\link[dplyr:rename]{dplyr::rename()}}.}
 
-\item{.grouping}{A grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
+\item{.grouping}{A Grouping specification made with \code{\link[=grouping_set]{grouping_set()}},
 \code{\link[=grouping_sets]{grouping_sets()}}, \code{\link[=rollup]{rollup()}}, \code{\link[=cube]{cube()}}, or \code{\link[=grouping_spec]{grouping_spec()}}. \code{NULL}
 represents one empty grouping set. Any expression returning a
 specification can be written here, while a specification nested inside
@@ -169,7 +169,7 @@ use \code{.by}. For example, \code{.by = year} is structurally equivalent to
 
 These forms are not completely interchangeable in the current
 implementation. A column supplied through \code{.grouping} is treated as a
-margin dimension even when every expanded grouping set contains it.
+Margin dimension even when every expanded grouping set contains it.
 Consequently, it participates in \code{.margin_label} type conversion and
 collision checks. Use \code{.by} for columns that must always remain fixed, and
 use \code{.grouping} for dimensions that may become totals.
@@ -294,9 +294,9 @@ carried through by dplyr and vctrs unchanged.
 \section{Grouping set identifiers}{
 
 When \code{.id} names an output column, each result row receives the one-based
-position of its Grouping set occurrence after applying \code{.duplicates}.
+position of its grouping set occurrence after applying \code{.duplicates}.
 \code{"drop"} renumbers retained occurrences, while supported \code{"keep"} paths give
-identical duplicate sets distinct identifiers. One Grouping set has
+identical duplicate sets distinct identifiers. One grouping set has
 identifier \code{1L}, and a zero-row result retains an integer \code{.id} column.
 
 Output columns are ordered as fixed keys, variable dimensions, \code{.id}, then
@@ -401,7 +401,7 @@ evaluated because of how it is spelled, but what runs is whatever \code{rollup}
 is bound to where you wrote it.
 
 \code{\link[dplyr:across]{dplyr::across()}} and \code{\link[dplyr:pick]{dplyr::pick()}} cannot select any column named in the
-complete grouping plan. This extends dplyr's grouping-column rule across
+complete Grouping plan. This extends dplyr's grouping-column rule across
 every branch: a dimension remains excluded even in a grouping set from
 which it is omitted.
 
@@ -501,7 +501,7 @@ immediate less detailed \code{\link[=rollup]{rollup()}} level, so it requires on
 \code{\link[=rollup]{rollup()}}; composite dimensions move together, and duplicate occurrences
 skip identical sets when choosing the parent. \code{\link[=share_of_total]{share_of_total()}} divides by
 the Grand total set, so it accepts any Grouping specification whose plan
-contains one, including \code{\link[=cube]{cube()}}; duplicate Grand total occurrences hold
+contains one, including \code{\link[=cube]{cube()}}; duplicate grand total occurrences hold
 the same values and are interchangeable.
 
 Arrow inputs reject both after expression planning and common
@@ -517,7 +517,7 @@ are not clamped. Matching is structural, so \code{.id}, missing grouping values,
 and displayed Margin labels do not determine the denominator.
 
 The source must be a unique, preceding, self-contained integer or double
-scalar summary. Lazy execution preserves collision-safe Grouping set
+scalar summary. Lazy execution preserves collision-safe grouping set
 metadata through ordinary aggregation, calculates the requested shares
 through one shared mapping per denominator kind, and then removes the
 metadata before returning the requested column order.
@@ -852,7 +852,7 @@ c(
   type = typeof(empty_partitions$revenue_share)
 )
 
-# across() and pick() treat every fixed key and margin dimension as a
+# across() and pick() treat every fixed key and Margin dimension as a
 # grouping column, including dimensions omitted from a subtotal branch.
 summarize_with_margins(
   .data = retail_sales,

--- a/tests/testthat/_snaps/grouping-backends.md
+++ b/tests/testthat/_snaps/grouping-backends.md
@@ -6,7 +6,7 @@
     Condition
       Error in `summarize_with_margins()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 
 ---
@@ -17,7 +17,7 @@
     Condition
       Error in `summarise_with_margins()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 
 ---
@@ -28,7 +28,7 @@
     Condition
       Error in `expand_with_margins()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 
 ---
@@ -39,7 +39,7 @@
     Condition
       Error in `nest_with_margins()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 
 ---
@@ -50,7 +50,7 @@
     Condition
       Error in `nest_by_with_margins()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 
 ---
@@ -61,6 +61,6 @@
     Condition
       Error in `inspect_grouping()`:
       ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
+      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -113,7 +113,7 @@ test_that("the Grouping-identity comparison has exactly one canonical home", {
 
   # The table is recognised by its own header cells rather than by a section
   # title, so a copy pasted into another topic is still detected.
-  header <- "Value \\tab Meaning \\tab Duplicate Grouping-set occurrences"
+  header <- "Value \\tab Meaning \\tab Duplicate grouping-set occurrences"
   carries_table <- vapply(
     topics,
     function(text) grepl(header, text, fixed = TRUE),

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -221,7 +221,7 @@ test_that("a nested specification from a caller's function names its verb", {
     expect_match(
       conditionMessage(error),
       paste0(
-        "`spec_from_caller(a)` is a grouping specification, but a nested ",
+        "`spec_from_caller(a)` is a Grouping specification, but a nested ",
         "position recognizes one only when it is a call to"
       ),
       fixed = TRUE
@@ -1687,7 +1687,7 @@ test_that("a printed Grouping specification names the constructor called", {
     expect_identical(spec$type, kind, info = kind)
     expect_identical(
       utils::capture.output(print(spec)),
-      paste0("<marginplyr grouping specification: ", constructor, ">"),
+      paste0("<marginplyr Grouping specification: ", constructor, ">"),
       info = kind
     )
   }
@@ -1696,7 +1696,7 @@ test_that("a printed Grouping specification names the constructor called", {
   # one. Printing it still names something rather than nothing.
   expect_identical(
     utils::capture.output(print(new_grouping_spec("nonesuch", list()))),
-    "<marginplyr grouping specification: nonesuch>"
+    "<marginplyr Grouping specification: nonesuch>"
   )
 })
 
@@ -1712,7 +1712,7 @@ test_that("a printed Grouping specification names the constructor called", {
 expect_empty_name_line <- function(spec, info = NULL) {
   expect_identical(
     utils::capture.output(returned <- withVisible(print(spec))),
-    "<marginplyr grouping specification: >",
+    "<marginplyr Grouping specification: >",
     info = info
   )
   expect_identical(returned, list(value = spec, visible = FALSE), info = info)
@@ -1808,7 +1808,7 @@ test_that("a printed Grouping specification never asks a kind's methods", {
     )
     expect_identical(
       utils::capture.output(print(new_grouping_spec(kind, list()))),
-      "<marginplyr grouping specification: grouping_set>",
+      "<marginplyr Grouping specification: grouping_set>",
       info = generic
     )
   }
@@ -1839,7 +1839,7 @@ test_that("a printed Grouping specification never asks a kind's methods", {
       invokeRestart("muffleWarning")
     }
   )
-  expect_identical(line, "<marginplyr grouping specification: grouping_set>")
+  expect_identical(line, "<marginplyr Grouping specification: grouping_set>")
   expect_setequal(raised, "reading this kind warns")
 })
 
@@ -1891,7 +1891,7 @@ test_that("a printed Grouping specification asks for its kind once", {
   with_rule <- count_reads("set")
   expect_identical(
     with_rule$line,
-    "<marginplyr grouping specification: grouping_set>"
+    "<marginplyr Grouping specification: grouping_set>"
   )
   expect_identical(with_rule$reads, 1L)
 
@@ -1899,7 +1899,7 @@ test_that("a printed Grouping specification asks for its kind once", {
   without_rule <- count_reads("nonesuch")
   expect_identical(
     without_rule$line,
-    "<marginplyr grouping specification: nonesuch>"
+    "<marginplyr Grouping specification: nonesuch>"
   )
   expect_identical(without_rule$reads, 1L)
 
@@ -1908,7 +1908,7 @@ test_that("a printed Grouping specification asks for its kind once", {
   without_name <- count_reads(1:3)
   expect_identical(
     without_name$line,
-    "<marginplyr grouping specification: >"
+    "<marginplyr Grouping specification: >"
   )
   expect_identical(without_name$reads, 1L)
 })

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2,7 +2,7 @@
 # asserted: the compiler tests below and the Margin verb one, which is the same
 # diagnostic reaching a caller by the route they meet it on.
 ambiguous_s_message <- paste0(
-  "`s` is both a column of the input and a name bound to a grouping ",
+  "`s` is both a column of the input and a name bound to a Grouping ",
   "specification, so a nested position cannot tell which one you mean.\n",
   "i For the column, write `all_of(\"s\")`.\n",
   "i For the specification, write `!!s`."
@@ -202,7 +202,7 @@ test_that("a nested specification position recognizes a spelling or a name", {
   expect_identical(
     conditionMessage(refused),
     paste0(
-      "`spec_from_caller(region)` is a grouping specification, but a nested ",
+      "`spec_from_caller(region)` is a Grouping specification, but a nested ",
       "position recognizes one only when it is a call to `grouping_set()`, ",
       "`grouping_sets()`, `rollup()`, `cube()`, or `grouping_spec()`, or a ",
       "name bound to a specification.\n",
@@ -236,7 +236,7 @@ test_that("a nested specification position recognizes a spelling or a name", {
     expect_s3_class(error, "marginplyr_error")
     expect_match(
       conditionMessage(error),
-      "is a grouping specification, but a nested position",
+      "is a Grouping specification, but a nested position",
       fixed = TRUE
     )
   }
@@ -258,7 +258,7 @@ test_that("a nested specification position recognizes a spelling or a name", {
 test_that("a nested specification stored as a function is refused", {
   data_vars <- c("region", "grade", "value")
   refusal <- paste0(
-    "is a grouping specification, but a nested position recognizes one only ",
+    "is a Grouping specification, but a nested position recognizes one only ",
     "when it is a call to `grouping_set()`, `grouping_sets()`, `rollup()`, ",
     "`cube()`, or `grouping_spec()`, or a name bound to a specification.\n",
     "i Anything else is read as a column selection.\n",
@@ -496,7 +496,7 @@ test_that("a nested argument is read through its redundant parentheses", {
   expect_identical(
     conditionMessage(refused),
     paste0(
-      "`spec_from_caller(region)` is a grouping specification, but a nested ",
+      "`spec_from_caller(region)` is a Grouping specification, but a nested ",
       "position recognizes one only when it is a call to `grouping_set()`, ",
       "`grouping_sets()`, `rollup()`, `cube()`, or `grouping_spec()`, or a ",
       "name bound to a specification.\n",
@@ -1083,7 +1083,7 @@ test_that("a kind whose classification lies is no more a name for it", {
     expect_s3_class(error, "marginplyr_error")
     expect_identical(
       conditionMessage(error),
-      "Invalid grouping specification."
+      "Invalid Grouping specification."
     )
   }
 })
@@ -1276,7 +1276,7 @@ test_that("a nested name only one reading claims keeps that reading", {
   expect_s3_class(from_caller, "marginplyr_error")
   expect_match(
     conditionMessage(from_caller),
-    "is a grouping specification, but a nested position",
+    "is a Grouping specification, but a nested position",
     fixed = TRUE
   )
 
@@ -1894,7 +1894,7 @@ test_that("a malformed grouping specification is refused by both guards", {
       expect_s3_class(error, "marginplyr_error")
       expect_identical(
         conditionMessage(error),
-        "Invalid grouping specification."
+        "Invalid Grouping specification."
       )
     }
   }

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -362,7 +362,7 @@ sqlite_sales |>
 
 ## Parent shares use a staged lazy query
 
-`share_of_parent()` needs a denominator from another Grouping-set row, so it
+`share_of_parent()` needs a denominator from another grouping-set row, so it
 cannot be translated as one ordinary aggregate expression. marginplyr first
 computes the ordinary summaries for every grouping set, then builds one
 denominator lookup — the parent row for each result row — shared by every

--- a/vignettes/recipes.qmd
+++ b/vignettes/recipes.qmd
@@ -591,7 +591,7 @@ works through what that comparison means in practice.
 
 ## Name the grouping set on every row
 
-`.id` numbers the Grouping-set occurrence behind each row, and
+`.id` numbers the grouping-set occurrence behind each row, and
 `inspect_grouping()` returns one row per occurrence keyed by the same number.
 Joining them attaches whatever name you care to write.
 


### PR DESCRIPTION
Closes #479.

`CONTEXT.md`'s **House term** entry (#462) fixes when a term is capitalized:
where it names a concept marginplyr defines, lowercase where the same words
carry their ordinary sense, and borrowed vocabulary — *grouping set*, *grand
total*, *grain* — ordinary throughout. #462 scoped the guides, so `R/` was left
drifting the same way.

Measured over `R/` with whitespace normalized, so a term wrapped across a
roxygen line is counted:

| term | sites | wrong |
|---|---:|---:|
| grouping set (standalone) | 43 | 12 capitalized |
| grouping specification | 33 | 12 lowercase |
| margin operation | 21 | 3 lowercase |
| grouping plan | 25 | 2 lowercase |
| margin dimension | 10 | 3 lowercase |
| grouping bit | 20 | 1 lowercase |
| margin verb | 33 | 1 lowercase |

Each site is a judgement, not a pattern replacement: `GROUPING SETS` is SQL and
stays, `R/grouping-plan.R` in a comment is a path and not the term, and the
package title is title case.

## The shape #479 asked about

#479 asks for a decision on *Grand total row* and *Grand total occurrences*,
saying the entry does not reach them. It does. Neither phrase is an entry, and
the entry says borrowed vocabulary "is ordinary throughout" and "capitalizes
only inside one built on it".

`CONTEXT.md`'s own bodies write the shape out rather than contracting it —
Parent share and Total share both say "A row of the Grand total set", and
Grouping set identifier says "a grouping-set occurrence". A clause capitalizing
the contraction would therefore have had to capitalize *Grand total occurrence*
while leaving *grouping-set occurrence* lowercase, for no reason either could
state. No clause is added and the six sites lowercase instead.

That reading also finds the residue #462 left: its sweep matched `" set"` and
not `"-set"`, so two guides still wrote *Grouping-set row* and *Grouping-set
occurrence*. They render beside the reference pages, which is the split #479
names, so they are lowercased here.

## What is left alone

`@family grouping plans and grouping identity` stays. Its value is an index key
matched byte-for-byte across three files and rendered only as `Other <value>:`;
it names a set of help topics rather than the concept, and the other two
families read in the same register.

Diagnostics and the `grouping_spec` print header are in scope, since a reader
meets the term there as they meet it on a page.

## Gates that quote what moved

Each moves in the same commit:

- `man/` is generated; `roxygen2::roxygenise()` ran.
- `.github/scripts/verify-site.R` quotes `R/summarize_with_margins.R`'s
  "the complete grouping plan".
- `tests/testthat/test-documentation.R` recognizes the Grouping-identity table
  by its "Duplicate Grouping-set occurrences" header cell.
- `_snaps/grouping-backends.md` holds the mutable-step refusal, whose "A margin
  verb builds" is the one lowercase *Margin verb* in `R/`.

Prose in `design/` and in `tests/` is untouched; neither was measured here.
`design/adr/0017-*.md` and `design/architecture.md` carry *Grand total
occurrence* capitalized, which this branch's reading makes wrong — a follow-up
ticket rather than prose changed here.

Local: `testthat::test_local()`, `lintr::lint_package()`,
`spelling::spell_check_package()`, `verify-context-budget.R`,
`verify-must-error.R`, and `verify-verifier-invocation.R` all pass.