### PR TITLE
Delete a clause `?retail_sales` already owns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,8 +40,8 @@
   structure of its Grouping plan rather than by displayed values, so a subtotal
   sits with the rows it summarizes rather than wherever its Margin label falls,
   and lazy inputs stay lazy. See *Margin order* in `?summarize_with_margins`.
-* Added the `retail_sales` data set, 24 rows of synthetic monthly sales that
-  the guides and examples are written against. See `?retail_sales`.
+* Added the `retail_sales` data set, 24 rows of synthetic monthly sales.
+  See `?retail_sales`.
 * Added guides for Grouping identity and explicit key completion, and made the
   function references the canonical source of the Margin, Parent-share, and
   Margin-label contracts.


### PR DESCRIPTION
Follows #483, which merged while its third review round was still running.

## Why this is a separate PR

#483's merge took `1dac813`, not the `f6fcec4` that carried this fix, so the clause below reached `main`. Nothing on `main` is broken by that: every commit the merge took passed every gate, both round-1 defects are fixed there, and the three bullets #481 asked for are present and correct. This is the one clause that did not make it.

## What changed

```diff
-* Added the `retail_sales` data set, 24 rows of synthetic monthly sales that
-  the guides and examples are written against. See `?retail_sales`.
+* Added the `retail_sales` data set, 24 rows of synthetic monthly sales.
+  See `?retail_sales`.
```

## The clause failed two different tests in two rounds

**Round 2 — false as a universal.** It said the data set is what "the guides and examples are written against". `vignettes/completing_keys.qmd` builds a `facts` tibble of its own and names `retail_sales` nowhere.

**Round 3 — duplication, after narrowing.** Narrowing it to "the documentation is written against" made it true; the round-3 Standards axis confirmed as much by counting every documentation surface (11/11 `man/*.Rd`, `README.Rmd`, 4/5 vignettes, no extra page in the site nav — 16 of 17 files). But it left the defect that matters: `?retail_sales` opens

> A small synthetic data set used throughout the package documentation.

and the bullet asserting that same fact points at that very topic. That is the duplication #466 removed 178 lines to fix.

So the clause goes rather than being narrowed a second time. #483's *first* review round had already applied that disposition to the identical defect one sentence over — `1dac813` deleted a sentence for "restating the Description of the very topic the bullet points at". Round 2 met the same kind of finding on the adjacent clause and rewrote instead, which is what produced round 3's finding. What survives names the change — a data set was added, and its size — which is what #466's shape asks a bullet for.

## Where the overclaim came from

#481's own Problem paragraph: "`retail_sales` — `LazyData: true`, `man/retail_sales.Rd`, **used by every guide and example**." Adopted without checking. That is the second sentence of that ticket #483 could not take verbatim; the first was its *Option arguments* pointer, which names where `.margin_label_position` is *mentioned* rather than what owns it. Both were caught by review, neither by a gate.

## Gates

- `testthat::test_local()` — running at the time this description was written; result posted as a comment below.
- `spelling::spell_check_package()` — no spelling errors.
- `verify-doc-references.R` — 176 paths across 153 documents, all resolve.
- `verify-context-budget.R` — 22005 bytes, within 22005.
- `lintr::lint_package()` — no lints.

## Review

Three rounds ran on #483, the third landing after its merge; this PR is that round's answer. Round 3 also verified the rest of the merged diff from scratch and found it clean — `.margin_label_position` on all four verbs with #16 correctly cited and its section owning both sentences, `.key`'s asymmetry owned by both `\item{.key}` entries and confirmed by execution, House terms correct, and the three differing pointer forms each citing what owns its own claim rather than being an inconsistency.
