### PR TITLE
Announce the per-dimension `.margin_label` spellings (#484)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,11 @@
   (#110, #144, #210). See *Option arguments* in `?summarize_with_margins`.
 * Changed the default display label to `"Total"`; `.margin_label = NULL`
   preserves grouping-column types and typed missing values.
+* `.margin_label` also takes a per-dimension spelling: a named character
+  vector labels each resolved Margin dimension separately, and a named list
+  does the same while letting one dimension take `NULL` where another takes
+  a label (#16, #371). See *Display labels and grouping identity* in
+  `?summarize_with_margins`.
 * `.check_margin_label` controls only the half of the Margin label collision
   check that reads your data, so it defaults to `TRUE` for local data frames
   and `FALSE` for lazy inputs. A label equal to a declared factor level is


### PR DESCRIPTION
Closes #484.

`NEWS.md` mentioned `.margin_label` four times — as an option-argument
example, as the changed default paired with the scalar `NULL`, inside the
`.check_margin_label` bullet, and inside the `.margin_label_position`
bullet — and none of them said the argument takes a per-dimension label.
The named character vector shipped with #16 and the named list, which
lets one dimension take `NULL` while another takes a label, shipped with
#371; the file announced neither.

One bullet covers both, decided at triage. `NEWS.md` groups by
user-visible change and not by issue — `(#265, #365)` and
`(#110, #144, #210)` are each one bullet over several issues — and the
two spellings are one argument's per-dimension form, resolved by
`normalize_margin_label()` and documented in one reference section. The
bullet points at *Display labels and grouping identity* in
`?summarize_with_margins` rather than restating it, so the rejection
rules for a missing, unknown, duplicate, or empty name stay where they
are owned.

Nothing under `R/`, `man/`, or `vignettes/` changes: the behavior already
ships, and this is the announcement alone.

## Checks

- `Rscript .github/scripts/verify-context-budget.R` — 22005 bytes, within
  the baseline.
- `pkgload::load_all(".")` then `lintr::lint_package()` — no lints.
- `NOT_CRAN=true testthat::test_local()` — full suite passes.
- `spelling::spell_check_files("NEWS.md")` — the new lines add no word
  outside `inst/WORDLIST`.