### PR TITLE
Capitalize a House term outside R/, and lowercase what it borrows (#486)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R:
            role = c("aut", "cre", "cph"))
 Description: Provides 'dplyr'-compatible tools for SQL-style 'GROUPING SETS',
     'ROLLUP', and 'CUBE' summaries, including arbitrary grouping sets, totals,
-    subtotals, and grouping identifiers. Confirmed database backends use native
+    subtotals, and Grouping identifiers. Confirmed database backends use native
     grouping sets; other lazy backends use a 'UNION ALL' fallback. Local data
     frames and lazy tables are supported.
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Initial CRAN submission.
 * Added `grouping_set()`, `grouping_sets()`, `rollup()`, `cube()`, and
-  `grouping_spec()` for arbitrary SQL-style grouping plans, including empty
+  `grouping_spec()` for arbitrary SQL-style Grouping plans, including empty
   sets, nesting, Cartesian products, and composite dimensions.
 * A nested argument a Grouping specification constructor cannot read is refused
   with marginplyr's own diagnostic naming the spelling that works, in place of
@@ -32,7 +32,7 @@
   argument gives `"text"` for compact display values or `"list"` for the exact
   character vectors to program against. See *Formats and ordinary tibble
   behavior* in `?inspect_grouping`.
-* Added `.id` to every Margin verb for one-based Grouping set occurrence
+* Added `.id` to every Margin verb for one-based grouping set occurrence
   identifiers, including duplicate-aware local, lazy, expansion, and nesting
   paths.
 * Added `.sort` to every Margin verb for an opt-in Margin order, taking
@@ -74,7 +74,7 @@
 * `summarize_with_margins()`, `summarise_with_margins()`,
   `expand_with_margins()`,
   `nest_with_margins()`, and `nest_by_with_margins()` now share one normalized
-  grouping-plan implementation.
+  Grouping-plan implementation.
 * Existing `dplyr::group_by()` columns act as implicit fixed `.by` keys across
   local and lazy backends. Grouped input cannot also supply `.by`; margin
   summaries, row expansions, and regular nests return ungrouped results, while
@@ -105,7 +105,7 @@
   stay refused for a collision, as is a named one colliding by its own name.
 * Dynamically named data-frame summaries now reserve collision-free internal
   grouping names, and opaque collisions fail with a targeted diagnostic.
-  Lazy margin-label checks use portable numeric `CASE` aggregates across
+  Lazy Margin-label checks use portable numeric `CASE` aggregates across
   supported SQL dialects.
 * Backend detection now validates the documented Arrow and dtplyr minimum
   versions, centralizes backend capabilities, and reports incompatible dbplyr

--- a/design/adr/0009-distinguish-grouping-set-identifiers-from-grouping-identifiers.md
+++ b/design/adr/0009-distinguish-grouping-set-identifiers-from-grouping-identifiers.md
@@ -91,13 +91,13 @@ older mask (#366).
 
 `grouping_id()` written with no columns now reads every Grouping dimension of
 the resolved plan, in plan order. That gives the second correspondence: a bare
-`grouping_id()` is exactly `inspect_grouping()$grouping_id` for the Grouping
+`grouping_id()` is exactly `inspect_grouping()$grouping_id` for the grouping
 set the row came from, as `.id` is exactly `set_id` for its occurrence. The
 retyped spelling is unchanged and remains the way to encode a subset of the
 dimensions, or to fix an order other than the plan's.
 
 Fixed `.by` columns are excluded from that default. A `.by` column belongs to
-every Grouping set, so it contributes a zero bit wherever it appears, and
+every grouping set, so it contributes a zero bit wherever it appears, and
 leading zero bits leave the value alone — the exclusion is observable only at
 the 31-column cap, which is where it earns itself: a plan of 31 dimensions
 beside a fixed column is one the default can encode. Passing a `.by` column

--- a/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
+++ b/design/adr/0010-compute-parent-shares-as-a-contextual-summary.md
@@ -1,6 +1,6 @@
 # Compute Parent shares as a contextual summary
 
-`share_of_parent()` will be an exported contextual helper used only inside
+`share_of_parent()` will be an exported Contextual helper used only inside
 `summarize_with_margins()`. It will take one previously defined, named numeric
 scalar summary and return its ratio to the corresponding value in the
 immediately less detailed grouping set. It will be supported only when
@@ -82,7 +82,7 @@ or a statically named column produced by a preceding `across()`. A named
 column under that name, so the name stands for the pack rather than for one of
 the columns in it, and the error says to drop the name instead of adding one.
 A column expanded from an unnamed data-frame-valued summary is not eligible,
-although such summaries otherwise retain their existing margin-summary
+although such summaries otherwise retain their existing Margin-summary
 behavior. The expanded column's provenance, type, and expression position are
 not consistently available for static dependency validation across local and
 lazy backends. The error shows how to rewrite it as top-level named summaries
@@ -375,7 +375,7 @@ direct call, one `across()` call, and one post-summary `mutate()` example.
 The summary reference's empty-input section will include the Parent share
 column and its type for both fixed-key cases.
 The grouping-identity article will explain that Parent lookup uses internal
-Grouping set identity and bits rather than displayed Margin labels, and link
+grouping set identity and bits rather than displayed Margin labels, and link
 back to the helper's full value and expression contract.
 Database documentation will explain that the ordinary summaries and Parent
 shares are separate lazy query stages without requiring callers to understand
@@ -419,7 +419,7 @@ Parent share, the source summary, and the original public call. An invalid
 source therefore fails at collection rather than emitting a wrong row.
 
 Local execution uses the same wrapper for the same reason: validating inside
-the ordinary summary is what removes the full input rescan per Grouping set
+the ordinary summary is what removes the full input rescan per grouping set
 that a separate cardinality query would need. General dbplyr keeps the
 relaxation this decision already granted it: no extra schema or cardinality
 query, no implicit collection, and an incompatible type or non-scalar result
@@ -464,7 +464,7 @@ the result's meaning. A `.subtotals = "one"` mode was rejected because forcing
 subtotal rows to `1` is a presentation rule and obscures the immediate-parent
 definition, especially in rollups with three or more dimensions.
 
-A post-summary `add_rollup_share()` verb was rejected because the grouping
+A post-summary `add_rollup_share()` verb was rejected because the Grouping
 plan and parent mapping are already available inside the Margin operation.
 Allowing `cube()` or arbitrary grouping sets was deferred until an explicit
 parent-selection model exists. That deferral is about selecting a parent, and

--- a/design/adr/0011-keep-key-completion-outside-margin-operations.md
+++ b/design/adr/0011-keep-key-completion-outside-margin-operations.md
@@ -31,7 +31,7 @@ use `tidyr::complete()` or a key relation joined before
 `summarize_with_margins()`. To retain observed keys that are absent from an
 explicit scaffold, callers can union the scaffold with distinct fact keys
 before the join. Inserted fact values then flow through every requested
-Grouping set in the usual way. A fact marker or fact identifier can distinguish
+grouping set in the usual way. A fact marker or fact identifier can distinguish
 inserted rows when calculating counts or other summaries that must ignore
 them.
 
@@ -45,7 +45,7 @@ completion data implicitly.
 
 ## Why completion is not part of the Grouping specification
 
-A Grouping specification declares which Grouping sets exist. It does not
+A Grouping specification declares which grouping sets exist. It does not
 declare the valid value domain of grouping dimensions, create fact rows, or
 assign summary values. Putting completion options on `rollup()` would mix
 those responsibilities, leave `cube()` and arbitrary grouping sets without a
@@ -53,7 +53,7 @@ consistent interface, and make a data-independent specification depend on
 summary output names.
 
 `inspect_grouping()` consequently remains an inspection of the
-backend-independent Grouping plan. Completion does not add Grouping sets or
+backend-independent Grouping plan. Completion does not add grouping sets or
 change Grouping set identifiers, Grouping identifiers, or Grouping bits, so
 it does not belong in that function's interface.
 

--- a/design/adr/0013-inspect-grouping-plans-as-ordinary-tibbles.md
+++ b/design/adr/0013-inspect-grouping-plans-as-ordinary-tibbles.md
@@ -43,7 +43,7 @@ The columns are:
 - `grouping_id`, the SQL-compatible bit mask for those dimensions.
 
 With `.format = "text"`, `fixed`, `included`, and `omitted` use a
-parenthesized Grouping set display: `()` for zero columns, `(region)` for one,
+parenthesized grouping set display: `()` for zero columns, `(region)` for one,
 and `(region, store)` for more than one. Names appear in Grouping-plan order
 without quotes or backticks. `grouping_bits` is named text such as
 `region=0, store=0, product=1`, without outer parentheses.

--- a/design/adr/0017-calculate-total-shares-against-the-grand-total-set.md
+++ b/design/adr/0017-calculate-total-shares-against-the-grand-total-set.md
@@ -1,4 +1,4 @@
-# Calculate Total shares against the grand total set
+# Calculate Total shares against the Grand total set
 
 `share_of_total()` is a second contextual summary helper for
 `summarize_with_margins()`. It divides one preceding named numeric scalar
@@ -60,7 +60,7 @@ result, and the invariant is kept rather than excepted.
 
 ### Duplicate grand total occurrences are interchangeable
 
-Which Grand total occurrence supplies the denominator is not specified.
+Which grand total occurrence supplies the denominator is not specified.
 
 Duplicate occurrences arise only under `.duplicates = "keep"`. Two Grand
 total sets are two occurrences of the same grouping mask, so `"error"`
@@ -95,7 +95,7 @@ construction would union one relation to itself once per non-root occurrence
 staged result — and would synthesize a join key column per dimension whose
 value is `NULL` on both sides, since the Grand total set contains no
 dimension to match on. A Total share's denominator depends on `.by` and
-nothing else, so its mapping is the Grand total rows reduced to one row per
+nothing else, so its mapping is the grand total rows reduced to one row per
 fixed partition, joined on the fixed keys with the same missing-safe
 identity.
 
@@ -143,9 +143,9 @@ the caller spelled the specification.
 between pooled and partitioned. Rejected above; an argument would make every
 caller decide something the invariant already answers.
 
-**Naming the first Grand total occurrence in plan order.** Rejected above.
+**Naming the first grand total occurrence in plan order.** Rejected above.
 
-**Erroring when a plan has more than one Grand total occurrence.** Rejected:
+**Erroring when a plan has more than one grand total occurrence.** Rejected:
 it refuses a case whose value is unambiguous, and the caller has no way to
 read the refusal as anything but arbitrary.
 

--- a/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
+++ b/design/adr/0019-resolve-contextual-helper-names-by-static-spelling.md
@@ -59,7 +59,7 @@ recorded with the name.
 | `cur_group`, `cur_group_id`, `cur_group_rows`, `cur_data`, `cur_data_all` | Contextual helper — refused |
 | `across`, `if_any`, `if_all`, `pick` | Contextual helper |
 | `where` | Contextual helper |
-| `grouping_set`, `grouping_sets`, `rollup`, `cube`, `grouping_spec` | ordinary lookup; the spelling gates *evaluation only*, in a nested specification position |
+| `grouping_set`, `grouping_sets`, `rollup`, `cube`, `grouping_spec` | ordinary lookup; the spelling gates *evaluation only*, in a Nested specification position |
 | `n`, and every other name | ordinary lookup |
 
 `n()` is the case that shows the criterion is doing work rather than describing

--- a/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
+++ b/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
@@ -8,14 +8,14 @@ a Margin verb cannot use it, and the one rewrite that fixes it:
 
 `CONTEXT.md` defines *Mutable step*. What the refusal answers is measured in
 #451: over such an input `expand_with_margins()` returned a result in which
-every row carried the margin label, and left the caller holding a table whose
+every row carried the Margin label, and left the caller holding a table whose
 column *names* had been permuted while its column *data* had not — so
 `dtx$region` afterwards held the integers that had been `dtx$year`. A
 `select()` in the input's own pipeline lost the caller a column outright.
 
 ## Why this is marginplyr's to refuse
 
-The hazard is dtplyr's. `union_all(mutate(l, region = "T"), l)` over a mutable
+The hazard is dtplyr's. `union_all(mutate(l, region = "T"), l)` over a Mutable
 step returns the same wrong answer with no marginplyr involved, so a
 multi-branch query over a step data.table may write to is broken wherever it is
 written. That report is filed separately and this refusal does not wait on it.
@@ -176,7 +176,7 @@ The last assertion below is the one that is not about behaviour:
 - The caller's table is unchanged after a refusal, in names, columns, and rows.
   That is what the refusal is for, and a refusal raised after the damage would
   otherwise pass every other assertion.
-- A grouped mutable step reaches this refusal rather than the fixed-key
+- A grouped Mutable step reaches this refusal rather than the fixed-key
   rejection its groups used to earn, the refusal sitting above key resolution.
   That is a consequence of the placement above and is pinned rather than left
   to be rediscovered.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -358,7 +358,7 @@ The responsibilities divide as follows:
   where the parent set includes it and is missing otherwise — computed by the
   same expression on both sides, and never from a displayed Margin label or
   the caller-visible `.id`. A Total share's denominator depends on `.by` and
-  nothing else, so its mapping is one read of the Grand total occurrence
+  nothing else, so its mapping is one read of the grand total occurrence
   matched on the fixed keys alone, with a constant column standing in when
   there are none.
 - **Calculation** builds one shared mapping per requested kind, joins each

--- a/tests/testthat/test-branch-union.R
+++ b/tests/testthat/test-branch-union.R
@@ -207,7 +207,7 @@ test_that("a union-path query is one flat `UNION ALL` over every branch", {
 # and the local backend is the one that holds rows without columns natively.
 # Comparing to local also keeps this to one optional backend, as AGENTS.md
 # requires.
-test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
+test_that("a zero-column dtplyr input gains no row with the grouping set id", {
   skip_if_suggest_absent("dtplyr")
 
   empty <- data.frame()
@@ -269,7 +269,7 @@ test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
 
   # A summary branch with no summaries either is the one column-less branch
   # whose row is not fabricated: with no keys and nothing to calculate it is
-  # the Grand total group, which local dplyr also answers with one row. Fixing
+  # the grand total group, which local dplyr also answers with one row. Fixing
   # the expansion by counting rows would have taken this row away.
   expect_identical(
     dplyr::collect(summarize_with_margins(dtplyr::lazy_dt(empty), .id = "s")),
@@ -279,7 +279,7 @@ test_that("a zero-column dtplyr input gains no row with the Grouping set id", {
 
 # The neighbour of the case above, and the boundary it runs into rather than a
 # second instance of the defect. Asked for no summaries and given no key,
-# `dtplyr` has no column to carry the Grand total row on, and a one-row,
+# `dtplyr` has no column to carry the grand total row on, and a one-row,
 # zero-column `data.table` does not exist -- `dim()` reads the row count from
 # the first column. Nothing in the union adapter decides it: it is what
 # `dplyr::summarize()` already answers for the same lazy input, which is what
@@ -321,7 +321,7 @@ test_that("a column-less dtplyr summary keeps dtplyr's own empty answer", {
   )
 })
 
-# The Grand total branch of a summary with nothing to summarize groups by
+# The grand total branch of a summary with nothing to summarize groups by
 # nothing and selects nothing, and the label and identifier `mutate()`s layered
 # on that query gave dbplyr a `lazy_select_query` it could not render: the
 # collect failed inside dbplyr's own star expansion, naming neither the
@@ -403,7 +403,7 @@ test_that("a no-summary union branch renders off the native path", {
 
 # The boundary the branch above stops at, and dbplyr's rather than this
 # package's: with no dimension and no identifier there is no column left to put
-# the Grand total row on, and a SQL table of no columns cannot be written. It
+# the grand total row on, and a SQL table of no columns cannot be written. It
 # is compared against what `dplyr::summarize()` answers for the same input, as
 # the `dtplyr` half of the same limit is, so a dbplyr that gained the shape
 # reports here and the documented promise is what changes.
@@ -477,7 +477,7 @@ test_that("Parent shares combine their denominator mappings the same way", {
   expect_identical(result$total[is_grand_total], grand_total)
   expect_identical(result$parent[is_grand_total], 1)
 
-  # The set one dimension finer than the Grand total divides by it, and the
+  # The set one dimension finer than the grand total divides by it, and the
   # one below that divides by its own region.
   by_region <- result[
     result$channel == "Total" & result$sku == "Total" & !is_grand_total,

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -431,7 +431,7 @@ test_that("the NA-level refusal pluralizes its grouping column noun", {
 # arm exists under both kinds and is plural-only, since two distinct label
 # values need two columns, so both are recorded and neither stands in for the
 # other.
-test_that("the margin label collision pluralizes its grouping column noun", {
+test_that("the Margin label collision pluralizes its grouping column noun", {
   declared <- data.frame(
     a = factor(c("All", "x")),
     b = factor(c("All", "y")),

--- a/tests/testthat/test-execution-conditions.R
+++ b/tests/testthat/test-execution-conditions.R
@@ -1066,7 +1066,7 @@ test_that("an ambiguous label is restored only where it is unique", {
 # because it is this module's, and directly because neither consumer's
 # diagnostic would report a traversal that changed shape: the share-selection
 # reader answers the same empty vector for a chain read in the wrong order as
-# for one naming nothing, and the grouping-specification predicate the same
+# for one naming nothing, and the Grouping-specification predicate the same
 # `FALSE`. Unlike the Condition context above, it is reached without a verb --
 # a chain is what a caller's own selection failure arrives as, and building one
 # is what states the shape the reader is written for.

--- a/tests/testthat/test-expand-operation.R
+++ b/tests/testthat/test-expand-operation.R
@@ -268,7 +268,7 @@ test_that("expand preserves duplicate grouping-set policies", {
   expect_identical(names(kept), names(data))
 })
 
-test_that("expand rejects unsupported sources with a package condition", {
+test_that("expand rejects unsupported sources with a Package condition", {
   skip_if_suggest_absent("arrow")
 
   error <- expect_error(

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -861,7 +861,7 @@ margin_label_check_data <- function() {
 # fixture, once per lazy backend that can execute the check. The call is written
 # out in each rather than wrapped in a shared expectation, because a closure
 # would put `first` and `second` somewhere `codetools` cannot follow them.
-test_that("dtplyr checks margin labels across all dimensions", {
+test_that("dtplyr checks Margin labels across all dimensions", {
   skip_if_suggest_absent("dtplyr")
   expect_error(
     summarize_with_margins(
@@ -874,7 +874,7 @@ test_that("dtplyr checks margin labels across all dimensions", {
   )
 })
 
-test_that("Arrow checks margin labels across all dimensions", {
+test_that("Arrow checks Margin labels across all dimensions", {
   skip_if_suggest_absent("arrow")
   expect_error(
     summarize_with_margins(
@@ -887,7 +887,7 @@ test_that("Arrow checks margin labels across all dimensions", {
   )
 })
 
-test_that("DuckDB checks margin labels across all dimensions", {
+test_that("DuckDB checks Margin labels across all dimensions", {
   skip_if_suggest_absent("duckdb", "DBI")
   con <- duckdb_test_connection()
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
@@ -909,7 +909,7 @@ test_that("DuckDB checks margin labels across all dimensions", {
   )
 })
 
-test_that("lazy margin label checks aggregate portable numeric values", {
+test_that("lazy Margin label checks aggregate portable numeric values", {
   registerS3method(
     "db_collect",
     "margin_check_connection",
@@ -948,7 +948,7 @@ test_that("lazy margin label checks aggregate portable numeric values", {
   ))
 })
 
-test_that("documented SQL dialects use portable margin label checks", {
+test_that("documented SQL dialects use portable Margin label checks", {
   registerS3method(
     "db_collect",
     "margin_check_connection",
@@ -2192,7 +2192,7 @@ mutable_step_data <- function() {
   )
 }
 
-test_that("every margin verb refuses a mutable dtplyr step", {
+test_that("every Margin verb refuses a mutable dtplyr step", {
   skip_if_suggest_absent("dtplyr")
   expect_setequal(names(forwarded_verbs), verbs_taking(".grouping"))
 
@@ -2288,7 +2288,7 @@ test_that("an immutable dtplyr step answers as the local input does", {
   expect_equal(as.data.frame(table_result), as.data.frame(local_result))
 })
 
-test_that("a grouped mutable step is refused before its groups are read", {
+test_that("a grouped Mutable step is refused before its groups are read", {
   skip_if_suggest_absent("dtplyr")
   data <- mutable_step_data()
   grouped <- dplyr::group_by(

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1,4 +1,4 @@
-test_that("rollup uses Total and exposes SQL-compatible grouping bits", {
+test_that("rollup uses Total and exposes SQL-compatible Grouping bits", {
   data <- data.frame(
     a = c("x", NA_character_),
     b = c("u", "u"),
@@ -123,7 +123,7 @@ test_that("grouping grammar errors retain each public verb call", {
   }
 })
 
-test_that("Grouping plan errors use the package condition seam", {
+test_that("Grouping plan errors use the Package condition seam", {
   data <- data.frame(a = c("x", "y"), value = 1:2)
 
   error <- expect_error(
@@ -305,7 +305,7 @@ test_that("duplicate policies affect result cardinality", {
   expect_equal(nrow(kept), 4L)
 })
 
-test_that("margin labels are display-only and can be disabled", {
+test_that("Margin labels are display-only and can be disabled", {
   collision <- data.frame(a = c("Total", "x"), value = 1:2)
   expect_error(
     summarize_with_margins(
@@ -350,7 +350,7 @@ test_that("margin labels are display-only and can be disabled", {
   expect_true(any(is.na(typed$a) & typed$gid == 15L))
 })
 
-test_that("all Margin verbs eagerly check local margin-label collisions", {
+test_that("all Margin verbs eagerly check local Margin-label collisions", {
   data <- data.frame(group = c("Total", "x"), value = 1:2)
   operations <- list(
     summarize = function(data) {
@@ -402,7 +402,7 @@ test_that("Margin verbs skip label checks for lazy inputs by default", {
   )
 })
 
-test_that("margin label checks handle missing and non-syntactic columns", {
+test_that("Margin label checks handle missing and non-syntactic columns", {
   missing <- data.frame(
     check.names = FALSE,
     "first group" = c(NA_character_, "x"),
@@ -682,7 +682,7 @@ test_that("a bare grouping_id() reaches the column cap on dimensions alone", {
   expect_s3_class(capped, "marginplyr_error")
 })
 
-test_that("expand and nest verbs consume the same grouping plan", {
+test_that("expand and nest verbs consume the same Grouping plan", {
   data <- data.frame(a = c("x", "x", "y"), b = c("u", "v", "u"), x = 1:3)
 
   expanded <- expand_with_margins(data, .grouping = rollup(a, b))

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1379,7 +1379,7 @@ test_that("an expanded data-frame summary crosses a multi-set union", {
   )
   expect_equal(names(result), c("region", "channel", "sum", "margin"))
   expect_false(anyNA(result[["sum"]]))
-  # The rows of the two sets that omit `region`: `channel` alone and the Grand
+  # The rows of the two sets that omit `region`: `channel` alone and the grand
   # total. Every other row came from a branch where the bit is `0L`.
   expect_equal(sum(result[["margin"]] == 1L), 3L)
 })

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -99,7 +99,7 @@ test_that("grouping families support union, nesting, and Cartesian product", {
   )
 })
 
-test_that("grouping specification kinds enforce the nesting grammar", {
+test_that("Grouping specification kinds enforce the nesting grammar", {
   nested_calls <- list(
     set = quote(grouping_set(a)),
     sets = quote(grouping_sets(grouping_set(a))),
@@ -174,7 +174,7 @@ test_that("grouping specification kinds enforce the nesting grammar", {
   }
 })
 
-test_that("a nested specification position recognizes a spelling or a name", {
+test_that("a Nested specification position recognizes a spelling or a name", {
   data_vars <- c("region", "grade", "value")
   spec_from_caller <- function(...) rollup(...)
   compile <- function(spec) {
@@ -1844,7 +1844,7 @@ test_that("invalid grouping input lists every supported constructor", {
 # parent, which `grouping_arg_spec()` evaluates and the preflight recurses into.
 # #262 reproduced at both, and a fix holding at one and not the other would
 # read as a fix.
-test_that("a malformed grouping specification is refused by both guards", {
+test_that("a malformed Grouping specification is refused by both guards", {
   malformed <- list(
     # A `type` that is not one name, and `args` that are not a list: the two
     # halves of the first guard's condition, which no single object fails both
@@ -1916,7 +1916,7 @@ test_that("a malformed grouping specification is refused by both guards", {
 # the reason the test above writes every object in both, and the public routes
 # as well, because that is where the defect was reported and a guard is reached
 # from them through the whole lifecycle rather than the compiler alone.
-test_that("a grouping specification kind is classified with its class off", {
+test_that("a Grouping specification kind is classified with its class off", {
   kinds <- lapply(c("is.na", "length"), function(generic) {
     kind_answering(
       stats::setNames(list(raising_kind_method), generic),
@@ -2652,7 +2652,7 @@ test_that("invalid or ambiguous specifications fail early", {
 # The public half would hold with the guard promoted back, since the public
 # path never reaches it, and the internal half is what records the demotion --
 # neither says enough alone. The upstream message stays loosely matched: ADR
-# 0015 propagates an external condition unchanged, so its wording is
+# 0015 propagates an External condition unchanged, so its wording is
 # tidyselect's to revise.
 test_that("an unknown `.by` column fails outside the public contract", {
   data <- data.frame(region = "x", value = 1)

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -76,7 +76,7 @@ test_that("list inspection preserves exact non-syntactic dimension names", {
   )
 })
 
-test_that("inspection preserves grouping bits at integer-mask boundaries", {
+test_that("inspection preserves Grouping bits at integer-mask boundaries", {
   empty_text <- inspect_grouping(data.frame(value = 1L))
   empty_list <- inspect_grouping(
     data.frame(value = 1L),
@@ -531,7 +531,7 @@ test_that("dbplyr inspection returns local plan data without a source query", {
   expect_identical(result$included, c("(group)", "()"))
 })
 
-test_that("inspect_grouping() options use the package condition seam", {
+test_that("inspect_grouping() options use the Package condition seam", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
 
   error <- expect_error(

--- a/tests/testthat/test-margin-id.R
+++ b/tests/testthat/test-margin-id.R
@@ -1,4 +1,4 @@
-test_that("summary exposes one-based Grouping set occurrence identifiers", {
+test_that("summary exposes one-based grouping set occurrence identifiers", {
   data <- data.frame(
     fixed = c(1L, 1L),
     group = c("x", "y"),
@@ -54,7 +54,7 @@ test_that("all Margin verbs validate .id consistently", {
   }
 })
 
-test_that("expand identifies retained Grouping set occurrences", {
+test_that("expand identifies retained grouping set occurrences", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   spec <- grouping_sets(grouping_set(group), grouping_set(group))
 

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -391,7 +391,7 @@ test_that("a carried factor with no NA level takes no encode route", {
   expect_identical(names(info$prototypes), "group")
 })
 
-# Rows are one per Grouping set member and ADR 0018 leaves their order to the
+# Rows are one per grouping set member and ADR 0018 leaves their order to the
 # backend, so the cells are paired by the integer codes of `outer`, which name
 # together as many columns as it takes for the tuple to be distinct per row.
 # Reading the code rather than the displayed value is also what keeps a value
@@ -1235,7 +1235,7 @@ test_that("collision checks use the displayed value of non-factor columns", {
   )
 })
 
-test_that("Margin label option errors use the package condition seam", {
+test_that("Margin label option errors use the Package condition seam", {
   data <- data.frame(
     fixed = "f",
     first = "a",

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -813,7 +813,7 @@ expect_margin_order_agrees <- function(as_input) {
       },
       columns = c("region", "units")
     ),
-    # The everyday one-occurrence plan: `.by` with no grouping specification at
+    # The everyday one-occurrence plan: `.by` with no Grouping specification at
     # all, so the key holds no dimension term either.
     single_set_by = list(
       data = margin_order_by_missing_data(),

--- a/tests/testthat/test-nest-operation.R
+++ b/tests/testthat/test-nest-operation.R
@@ -127,7 +127,7 @@ test_that("nest verbs preserve their own quosure environments", {
   expect_identical(dplyr::group_vars(nested_by), c("fixed", "group"))
 })
 
-test_that("nest preflight precedes semantic margin-label validation", {
+test_that("nest preflight precedes semantic Margin-label validation", {
   skip_if_suggest_absent("dtplyr")
   register_nest_proxy_methods()
   source <- dtplyr::lazy_dt(data.frame(group = c("Total", "x"), value = 1:2))
@@ -147,7 +147,7 @@ test_that("nest preflight precedes semantic margin-label validation", {
   expect_identical(nest_proxy_capture$n, 1L)
 })
 
-test_that("nesting option errors use the package condition seam", {
+test_that("nesting option errors use the Package condition seam", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   cases <- list(
     keep = list(
@@ -650,7 +650,7 @@ test_that("an empty dtplyr input nests into its backend's cell", {
   )
 })
 
-test_that("nesting rejects unsupported sources with a package condition", {
+test_that("nesting rejects unsupported sources with a Package condition", {
   remote <- dbplyr::tbl_lazy(
     data.frame(group = c("x", "y"), value = 1:2),
     con = dbplyr::simulate_postgres()

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -1495,7 +1495,7 @@ test_that("a query that raises for another reason is not read as a refusal", {
 
 # The control is only the price of telling two failures apart, so a dialect
 # that answers the first question is never asked a second one.
-test_that("a converting dialect is asked exactly one query", {
+test_that("a Converting dialect is asked exactly one query", {
   queries <- 0L
   verdict_counting <- function() {
     local_mocked_bindings(

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -1537,7 +1537,7 @@ test_that("Parent planning evaluates across arguments once", {
   expect_identical(parent_names_n, 1L)
 })
 
-test_that("Parent planning evaluates the grouping specification once", {
+test_that("Parent planning evaluates the Grouping specification once", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   evaluations <- 0L
   grouping <- function() {
@@ -1640,7 +1640,7 @@ test_that("Parent syntax and local execution errors precede typed metadata", {
 
 # US42 is structural, not a timing budget: the local Parent-share stage reads
 # the summarized result, never the input, so no pass over the input may be
-# proportional to the Grouping-set count. Each generic registered below counts
+# proportional to the grouping-set count. Each generic registered below counts
 # one such pass when applied to an object still carrying this class, and drops
 # the class from whatever it returns, so a derived frame is not counted and
 # only the input itself is. The list is the assertion's reach: a rescan routed
@@ -1702,7 +1702,7 @@ count_parent_input_passes <- function(data, ...) {
   list(passes = parent_scan_capture$n, result = result)
 }
 
-test_that("Parent shares add no input pass per Grouping set", {
+test_that("Parent shares add no input pass per grouping set", {
   register_parent_scan_methods()
   data <- data.frame(
     a = c("x", "y", "x", "y"),
@@ -1732,8 +1732,8 @@ test_that("Parent shares add no input pass per Grouping set", {
 
   # The counter is wired to something: a summarization does read the input.
   expect_gt(three_sets_plain$passes, 0L)
-  # Adding two Grouping sets adds no pass over the input, so no pass is
-  # proportional to the Grouping-set count.
+  # Adding two grouping sets adds no pass over the input, so no pass is
+  # proportional to the grouping-set count.
   expect_identical(five_sets_share$passes, three_sets_share$passes)
   # And Parent shares add no pass of their own at either size: they are
   # calculated from the summarized result, not from a second look at the input.
@@ -1753,7 +1753,7 @@ test_that("Parent shares add no input pass per Grouping set", {
 # they accept, which occurrence answers for every other, and that the terms
 # they are refused in are the ones the caller wrote.
 
-test_that("direct Total shares divide by the grand total set", {
+test_that("direct Total shares divide by the Grand total set", {
   data <- data.frame(
     region = c("East", "East", "West"),
     store = c("A", "B", "C"),
@@ -1816,7 +1816,7 @@ test_that("Total shares divide within each fixed partition", {
   expect_identical(grand_total$whole, c(1, 1))
 })
 
-test_that("Total shares accept every plan containing a grand total set", {
+test_that("Total shares accept every plan containing a Grand total set", {
   data <- data.frame(
     a = c("x", "x", "y", "y"),
     b = c("p", "q", "p", "q"),
@@ -1849,7 +1849,7 @@ test_that("Total shares accept every plan containing a grand total set", {
   }
 })
 
-test_that("Total shares require a plan containing a grand total set", {
+test_that("Total shares require a plan containing a Grand total set", {
   data <- data.frame(a = "x", b = "y", value = 1)
   unsupported <- list(
     grouping_set(a),
@@ -2552,7 +2552,7 @@ test_that("an ineligible share selection raises a parentless condition", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
 
   # A selection that evaluates cleanly and names something ineligible is
-  # marginplyr's own report, so it has no external condition to preserve.
+  # marginplyr's own report, so it has no External condition to preserve.
   ineligible <- expect_error(
     summarize_with_margins(
       data,

--- a/tests/testthat/test-static-expression-analysis.R
+++ b/tests/testthat/test-static-expression-analysis.R
@@ -1027,7 +1027,7 @@ test_that("a formula in a summary expression evaluates instead of aborting", {
   expect_identical(result$share, result$units / sum(data$value))
 })
 
-test_that("a formula in a grouping specification reaches tidyselect", {
+test_that("a formula in a Grouping specification reaches tidyselect", {
   # `grouping_arg_spec()` read a name to decide whether an argument is a
   # Grouping constructor call or a selection to evaluate later. It guarded each
   # read with `rlang::is_call()` separately, which #163 reads as protection --

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -82,7 +82,7 @@ test_that("invalid summary selections precede label name coverage errors", {
   )
 })
 
-test_that("shared lifecycle options use package conditions", {
+test_that("shared lifecycle options use Package conditions", {
   data <- data.frame(group = "x")
   cases <- list(
     check_margin_label = list(
@@ -264,7 +264,7 @@ test_that("dtplyr unwraps a `.fns` list of one into the function it holds", {
   expect_named(expected, c("group", "units_total", "revenue_total"))
 })
 
-test_that("summary selection errors use the package condition seam", {
+test_that("summary selection errors use the Package condition seam", {
   data <- data.frame(group = c("x", "y"), value = 1:2)
   summary_options <- list(.groups = "drop")
   cases <- list(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -68,7 +68,7 @@ test_that("assert_lazy_table() works", {
   )
 })
 
-test_that("shared argument assertions use the package condition seam", {
+test_that("shared argument assertions use the Package condition seam", {
   x <- 1
 
   logical_error <- expect_error(
@@ -633,7 +633,7 @@ test_that("every shared reader answers a pair holding an empty call part", {
   )
 })
 
-test_that("lazy-table assertions use the package condition seam", {
+test_that("lazy-table assertions use the Package condition seam", {
   skip_if_suggest_absent("arrow")
 
   error <- expect_error(

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -3,7 +3,7 @@
 # `...` accepts any named expression, so an argument name the verb does not
 # have becomes a constant summary column instead of an error; an input
 # without dplyr methods reached `group_vars()` and reported an internal
-# generic rather than the argument the caller supplied; and an option argument
+# generic rather than the argument the caller supplied; and an Option argument
 # validated with `match.arg()` accepted abbreviations nothing documents.
 
 admission_data <- function() {
@@ -507,7 +507,7 @@ test_that("a reordering of the vocabulary is refused", {
 })
 
 test_that("`NULL` is rejected by every option rather than taken as a default", {
-  # `match.arg(NULL, choices)` returns `choices[1]`, so every option argument
+  # `match.arg(NULL, choices)` returns `choices[1]`, so every Option argument
   # used to read a `NULL` as a request for its own default. #110 stopped that
   # along with the abbreviations above, and #144 settled it as a decision: the
   # *Option arguments* section on `?summarize_with_margins` states that a


### PR DESCRIPTION
Closes #486.

`CONTEXT.md`'s **House term** entry fixes when a term is capitalized. #462 scoped the guides and #485 (#479) scoped `R/`; this scopes `tests/`, `design/`, `NEWS.md`, and `DESCRIPTION`.

The commit message holds the measurement, the three places it differs from #486's table and why, the two judgements left unswept, and the `DESCRIPTION` decision #486 said it could not take from the entry alone.

Gates: `lintr::lint_package()` clean, full suite green under `NOT_CRAN=true`, `roxygen2::roxygenise()` no diff, and `verify-context-budget.R`, `verify-verifier-invocation.R`, `verify-must-error.R`, `verify-doc-references.R` all pass.