### PR TITLE
Measure cran-comments.md against the tree it describes (#65)

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -23,12 +23,14 @@ Quarto 1.9.38.
   pass. Every skipped test is an `expect_snapshot()` diagnostic, which
   testthat skips on CRAN by default.
 * `_R_CHECK_DEPENDS_ONLY_=true _R_CHECK_FORCE_SUGGESTS_=false R CMD check
-  --as-cran`, Suggested packages withheld. Examples, tests, and vignettes all
+  --as-cran`, against a library holding only marginplyr's hard dependencies,
+  testthat, the declared `VignetteBuilder`, and what those require; every
+  other Suggested package is absent. Examples, tests, and vignettes all
   complete. Every skipped test is either one of those same snapshot
   diagnostics or a test whose optional backend is absent, and the testthat
   output names the missing package for each of the latter.
   `_R_CHECK_FORCE_SUGGESTS_=false` is what stops `--as-cran` from treating the
-  deliberately withheld packages as a failure.
+  absent packages as a failure.
 
 Neither entry quotes a test count, deliberately: a count is accurate on the day
 it is measured and silently wrong afterwards. What these runs are offered as

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -9,36 +9,50 @@ Maintainer: 'Yusuke Sasaki <sayuks.dev@gmail.com>'
 New submission
 ```
 
-This is the expected new-submission NOTE; the run reports nothing else.
+This is the expected new-submission NOTE; both runs below report it and
+nothing else.
 
 ## Test environments
 
-Both runs below check the built source tarball, not the development tree, on
-R 4.6.1, aarch64-apple-darwin23, macOS Tahoe 26.5.2, with Quarto 1.9.38.
+Both runs check one source tarball produced by `R CMD build`, not the
+development tree, on R 4.6.1, aarch64-apple-darwin23, macOS Tahoe 26.6.2, with
+Quarto 1.9.38.
 
-* Fully provisioned `R CMD check --as-cran`, every Suggested package
-  installed: 0 errors, 0 warnings, 1 note. Installation, examples, tests,
-  vignette re-building, and the PDF and HTML manuals all pass. 1487 tests
-  pass; the 3 skips are the `expect_snapshot()` diagnostics that testthat
-  skips on CRAN by default.
-* `_R_CHECK_DEPENDS_ONLY_=true R CMD check`, Suggested packages absent:
-  status OK, no notes. Examples, tests, and vignettes all complete. 1083
-  tests pass; 66 of the 68 skips are backend tests whose optional package is
-  missing, and the other 2 are the same snapshot skips as above.
+* `R CMD check --as-cran`, every Suggested package installed. Installation,
+  examples, tests, vignette re-building, and the PDF and HTML manuals all
+  pass. Every skipped test is an `expect_snapshot()` diagnostic, which
+  testthat skips on CRAN by default.
+* `_R_CHECK_DEPENDS_ONLY_=true _R_CHECK_FORCE_SUGGESTS_=false R CMD check
+  --as-cran`, Suggested packages withheld. Examples, tests, and vignettes all
+  complete. Every skipped test is either one of those same snapshot
+  diagnostics or a test whose optional backend is absent, and the testthat
+  output names the missing package for each of the latter.
+  `_R_CHECK_FORCE_SUGGESTS_=false` is what stops `--as-cran` from treating the
+  deliberately withheld packages as a failure.
+
+Neither entry quotes a test count, deliberately. A count changes whenever a
+test is added, so one written here is accurate on the day it is measured and
+silently wrong afterwards, and a stale count reads exactly like a fresh one.
+What these runs are offered as evidence for is the status line above and the
+account of the skips, and both of those survive a test being added.
 
 ## Optional backends
 
-arrow, DBI, dtplyr, duckdb, and RSQLite are Suggests, and marginplyr works
-without them: local data frames need none of them, and each backend adds one
-optional lazy path. Every example, test, and vignette section that uses one of
-these packages is guarded, so a platform whose binaries are unavailable still
-checks cleanly with only the corresponding coverage skipped. The
-dependency-only run above is the evidence, because none of those backends is
+arrow, data.table, dtplyr, duckdb, and RSQLite are Suggests, and marginplyr
+works without them: local data frames need none of them, and each backend adds
+one optional lazy path. Every example, test, and vignette section that uses one
+of these packages is guarded, so a platform whose binaries are unavailable
+still checks cleanly with only the corresponding coverage skipped. The
+dependency-only run above is the evidence, because none of those packages is
 installed in it.
+
+DBI is a Suggest too, and is the one this argument does not reach: marginplyr
+calls it directly, so it is declared, but dbplyr imports it, so it is present
+in the dependency-only run and nothing there skips for its absence.
 
 ## Vignettes and Quarto
 
-The four vignettes are Quarto documents, which is why `SystemRequirements`
+The vignettes are Quarto documents, which is why `SystemRequirements`
 declares the Quarto command line tool. `R CMD build` renders them with Quarto,
 so the tarball ships the rendered `inst/doc/*.html` files alongside the `.qmd`
 sources; no `.html` file is committed to the repository.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -9,8 +9,8 @@ Maintainer: 'Yusuke Sasaki <sayuks.dev@gmail.com>'
 New submission
 ```
 
-This is the expected new-submission NOTE; both runs below report it and
-nothing else.
+This is the expected new-submission NOTE, and it is the only note either run
+below reports.
 
 ## Test environments
 
@@ -30,25 +30,24 @@ Quarto 1.9.38.
   `_R_CHECK_FORCE_SUGGESTS_=false` is what stops `--as-cran` from treating the
   deliberately withheld packages as a failure.
 
-Neither entry quotes a test count, deliberately. A count changes whenever a
-test is added, so one written here is accurate on the day it is measured and
-silently wrong afterwards, and a stale count reads exactly like a fresh one.
-What these runs are offered as evidence for is the status line above and the
-account of the skips, and both of those survive a test being added.
+Neither entry quotes a test count, deliberately: a count is accurate on the day
+it is measured and silently wrong afterwards. What these runs are offered as
+evidence for is the status line above and the account of the skips, and both of
+those survive a test being added.
 
 ## Optional backends
 
 arrow, data.table, dtplyr, duckdb, and RSQLite are Suggests, and marginplyr
-works without them: local data frames need none of them, and each backend adds
-one optional lazy path. Every example, test, and vignette section that uses one
-of these packages is guarded, so a platform whose binaries are unavailable
-still checks cleanly with only the corresponding coverage skipped. The
-dependency-only run above is the evidence, because none of those packages is
-installed in it.
+works without them: a plain data frame needs none of them, and each adds one
+optional path — a lazy backend for arrow, dtplyr, duckdb, and RSQLite, and an
+accepted input class for data.table. Every example, test, and vignette section
+that uses one of these packages is guarded, so a platform whose binaries are
+unavailable still checks cleanly with only the corresponding coverage skipped.
+The dependency-only run above is the evidence, because none of those packages
+is installed in it.
 
-DBI is a Suggest too, and is the one this argument does not reach: marginplyr
-calls it directly, so it is declared, but dbplyr imports it, so it is present
-in the dependency-only run and nothing there skips for its absence.
+DBI is a Suggest too, and the dependency-only run says nothing about it: dbplyr
+imports DBI, so that run has it installed.
 
 ## Vignettes and Quarto
 


### PR DESCRIPTION
Closes #65.

## What changed

`cran-comments.md` reported test counts no current run produces — 1487 and
1083, accurate when #37 wrote them and moved by every test added since. It
also called five vignettes four, named DBI among the packages the
dependency-only run proves absent, and omitted data.table.

Both runs were re-measured against **one** tarball built by `R CMD build`
from this tree.

| | |
| --- | --- |
| R | 4.6.1 |
| Platform | aarch64-apple-darwin23 |
| OS | macOS Tahoe 26.6.2 |
| Quarto | 1.9.38 |

| Run | Command | Result |
| --- | --- | --- |
| Fully provisioned | `R CMD check --as-cran` | `Status: 1 NOTE` (new submission). `FAIL 0 | WARN 0 | SKIP 13 | PASS 6953`; all 13 skips are `On CRAN`. |
| Dependency-only | `_R_CHECK_DEPENDS_ONLY_=true _R_CHECK_FORCE_SUGGESTS_=false R CMD check --as-cran` | `Status: 1 NOTE` (new submission). `FAIL 0 | WARN 0 | SKIP 215 | PASS 5257`; dtplyr 84, arrow 39, duckdb 39, RSQLite 38, data.table 8, `On CRAN` 7. |

The dependency-only entry previously claimed "status OK, no notes". That was
true of a run without `--as-cran`; with the command the acceptance criteria
name, the incoming-feasibility NOTE appears in both runs, so the file's
`0 errors | 0 warnings | 1 note` heading now covers both.

The tarball was built from a `git archive` export rather than in place: in a
git worktree `.git` is a regular file, which `R CMD build`'s exclusion does not
catch, and the resulting tarball draws a hidden-files NOTE that a submission
built from an ordinary clone would not.

## Acceptance criteria

- [x] Counts match a check of the tarball built from the tree being submitted,
      and the file names R version, platform, and Quarto version.
- [x] Both commands are stated precisely enough to re-run, against one
      `R CMD build` tarball. `_R_CHECK_FORCE_SUGGESTS_=false` is named too:
      without it `--as-cran` treats the deliberately withheld Suggests as a
      failure, so the command as previously written could not be re-run.
- [x] **The file stops quoting exact counts**, and says what it is claiming
      instead. Rationale is in `cran-comments.md` itself.
- [x] Answered in https://github.com/sayuks/marginplyr/issues/65#issuecomment-5562726900:
      `design/review-dispositions.md` was deleted by #288, so there is no
      section 8 to update, and this pull request is the record #288 put in its
      place.

### Why the counts go rather than get a refresh step

A count is accurate on the day it is measured and silently wrong afterwards;
nothing in this repository can check one; and a stale count reads exactly like
a fresh one. The ticket's alternative — making a refresh a named step of the
release procedure — has no home that is not worse:

1. a new `design/release.md` is the unchecked maintained file #288 retired;
2. `AGENTS.md` spends always-loaded context budget on a step only a release
   reaches, against that file's own rule for where an argument goes;
3. the *Publication day* comment in `tests/testthat/test-documentation.R`
   explicitly draws the line at "not when `cran-comments.md` is written".

What the runs are actually offered as evidence for — the status line and the
account of the skips — survives a test being added, and is what the file now
states.

## An additional correction the measurement forced

The *Optional backends* section claimed "none of those backends is installed
in [the dependency-only run]" while listing DBI. dbplyr imports DBI, so it is
installed in that run and nothing there skips for its absence — the fact
`optional_suggest_spec()` records as `DBI = FALSE` and `AGENTS.md` states under
*Dependency metadata*. data.table, which the run does withhold, was missing
from the list. The section now names the five packages actually withheld and
states DBI's position separately.

## Review

Run after this branch is pushed; the record follows in a comment.