### PR TITLE
State the record's first answer once, where the code decides it (#494)

### DIFF
--- a/R/marginplyr-package.R
+++ b/R/marginplyr-package.R
@@ -106,46 +106,14 @@
 #' options(old)
 #' ```
 #'
-#' The record is a tibble of two character columns -- `purpose`, what the
-#' query was sent for, and `sql`, the statement as it was rendered -- with one
-#' row per query, in the order the queries were sent. It belongs to a single
-#' call, being emptied at the start of every one.
-#'
-#' `"result"` is the one `purpose` promised: the query a Margin verb returns
-#' unexecuted, which your own [dplyr::collect()] is still what runs. Every
-#' other row is a query marginplyr sends for its own reasons, and the names
-#' those rows carry are not fixed.
-#'
-#' A query is recorded before it is sent, so the record holds what was sent
-#' rather than what succeeded, and a call that fails leaves readable every
-#' query it had already sent.
-#'
-#' What is recorded is the SQL marginplyr sent, not the execution marginplyr
-#' caused. An audited call on a data frame, a dtplyr table, or an Arrow table
-#' therefore records nothing, and that zero-row answer is correct rather than
-#' a hole.
-#'
 #' There is one capture, `dbplyr::sql_render()`. It renders in your own
 #' session and sends nothing the call did not already send, so what
 #' *[When marginplyr queries your data][summarize_with_margins]* enumerates is
 #' the same whether or not you are recording.
 #'
-#' [last_sent_queries()] gives four answers, and each of the three that could
-#' look like an empty record is told apart from the others:
-#'
-#' - Nothing has been recorded in this session -- neither a Margin verb nor
-#'   [inspect_grouping()] has run -- and the call is refused with a
-#'   `"marginplyr_error"`.
-#' - The last call was not audited, the option being unset or holding a value
-#'   other than `TRUE` when the call began, and the call is refused with a
-#'   `"marginplyr_error"` naming `marginplyr.audit_sql`. The option is read
-#'   once, as the call begins; setting it afterwards does not audit a call
-#'   already made.
-#' - The call was audited and sent nothing: a zero-row tibble, the only answer
-#'   with zero rows.
-#' - A statement had no SQL form on this backend -- a translation dbplyr
-#'   refuses when the query is rendered -- and its row holds `NA` in `sql`.
-#'   The call itself is unaffected.
+#' What the record holds, which calls keep one, and the four answers it gives
+#' -- three of them could otherwise look alike -- are stated in
+#' [last_sent_queries()]'s own reference.
 #'
 #' @section Guides:
 #' - [Get started][g1]

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -54,11 +54,11 @@ record_sent_query <- function(purpose, query) {
   invisible(NULL)
 }
 
-# The four answers below refer to the list of calls the description names
-# rather than repeating it, so the page holds one enumeration and the two
-# cannot disagree (ADR 0027, *one page states the contract and two point at
-# it*). `test-documentation.R` holds that list to the entry points the code
-# has.
+# The first of the four answers below refers to the list of calls the
+# description names rather than repeating it, so the page holds one enumeration
+# and the two cannot disagree (ADR 0027, *one page states the contract and two
+# point at it*). `test-documentation.R` holds that list to the entry points the
+# code has.
 
 #' Read back the SQL marginplyr sent in the last call
 #'

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -56,10 +56,9 @@ record_sent_query <- function(purpose, query) {
 
 # The four answers below refer to the list of calls the description names
 # rather than repeating it, so the page holds one enumeration and the two
-# cannot disagree (#494). `test-documentation.R` holds that list to the entry
-# points the code has, and `test-sent-queries.R` runs each of them against the
-# answer it moves the session to. Neither reads whether a sentence on this page
-# is true.
+# cannot disagree (ADR 0027, *one page states the contract and two point at
+# it*). `test-documentation.R` holds that list to the entry points the code
+# has.
 
 #' Read back the SQL marginplyr sent in the last call
 #'

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -54,12 +54,12 @@ record_sent_query <- function(purpose, query) {
   invisible(NULL)
 }
 
-# The record's contract is written on this page and nowhere else: `?marginplyr`
-# and the database-backends guide point at it rather than restating it (#494).
-# The one enumeration it holds is of the calls that keep a record, which the
-# four answers refer to rather than repeat. `test-documentation.R` holds that
-# list to the entry points the code has, and `test-sent-queries.R` runs each of
-# them against the answer it moves the session to.
+# The four answers below refer to the list of calls the description names
+# rather than repeating it, so the page holds one enumeration and the two
+# cannot disagree (#494). `test-documentation.R` holds that list to the entry
+# points the code has, and `test-sent-queries.R` runs each of them against the
+# answer it moves the session to. Neither reads whether a sentence on this page
+# is true.
 
 #' Read back the SQL marginplyr sent in the last call
 #'
@@ -104,10 +104,11 @@ record_sent_query <- function(purpose, query) {
 #' call made in this process and not one made in a worker.
 #'
 #' @section Four answers:
-#' - Nothing has been recorded in this session -- none of the calls listed
-#'   above has begun -- and the call is refused with a `"marginplyr_error"`. A
-#'   call that began and then refused your arguments has begun, so what is read
-#'   after one is its own record, empty, and not this refusal.
+#' - Nothing has been recorded in this session -- none of the calls the
+#'   description above lists has begun -- and the call is refused with a
+#'   `"marginplyr_error"`. A call that began and then refused your arguments
+#'   has begun, so what is read after one is its own record, empty, and not
+#'   this refusal.
 #' - The last call was not audited, the option being unset or holding a value
 #'   other than `TRUE` when the call began, and the call is refused with a
 #'   `"marginplyr_error"` naming `marginplyr.audit_sql`. The option is read

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -54,6 +54,13 @@ record_sent_query <- function(purpose, query) {
   invisible(NULL)
 }
 
+# The record's contract is written on this page and nowhere else: `?marginplyr`
+# and the database-backends guide point at it rather than restating it (#494).
+# The one enumeration it holds is of the calls that keep a record, which the
+# four answers refer to rather than repeat. `test-documentation.R` holds that
+# list to the entry points the code has, and `test-sent-queries.R` runs each of
+# them against the answer it moves the session to.
+
 #' Read back the SQL marginplyr sent in the last call
 #'
 #' A Margin verb applied to a SQL backend returns its result unexecuted and
@@ -97,10 +104,10 @@ record_sent_query <- function(purpose, query) {
 #' call made in this process and not one made in a worker.
 #'
 #' @section Four answers:
-#' - Nothing has been recorded in this session -- no Margin verb has begun --
-#'   and the call is refused with a `"marginplyr_error"`. A verb that began and
-#'   then refused your call has begun, so what is read after one is its own
-#'   record, empty, and not this refusal.
+#' - Nothing has been recorded in this session -- none of the calls listed
+#'   above has begun -- and the call is refused with a `"marginplyr_error"`. A
+#'   call that began and then refused your arguments has begun, so what is read
+#'   after one is its own record, empty, and not this refusal.
 #' - The last call was not audited, the option being unset or holding a value
 #'   other than `TRUE` when the call began, and the call is refused with a
 #'   `"marginplyr_error"` naming `marginplyr.audit_sql`. The option is read

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -443,10 +443,15 @@ decision's record of them and not a copy of that page.
 What the fix rests on is that the page enumerates the calls once, in its
 description, and the first answer refers to that list rather than repeating
 it. `test-documentation.R` holds the list to the exported functions taking
-`.grouping`, reading the description alone because `\seealso` links two of
-those names for reasons of its own. Whether a sentence about the record is
-true is not a thing either gate reads, and `test-sent-queries.R` runs every
-entry point against the answer it moves the session to for that reason.
+`.grouping`, reading the description alone for the reason it states. Whether a
+sentence about the record is true is not a thing either gate reads, and
+`test-sent-queries.R` runs every entry point against the answer it moves the
+session to for that reason.
+
+One claim in the section above was already wrong before this branch reached
+it: "It names one capture" is true of `?marginplyr`'s section and not of the
+reference, which named none then and names none now. The paragraph describes
+the two pages together, which is the shape this amendment ends.
 
 ## Related decisions
 

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -434,13 +434,11 @@ unaudited `inspect_grouping()` alone therefore moves the answer to the second,
 and the page #23's User Story 35 makes canonical was the copy that was wrong
 (#494).
 
-`?last_sent_queries` now states the contract alone: what the record holds,
-which calls keep one, and what each of the four answers means. `?marginplyr`
-keeps that the record is off by default and that there is one capture, the
-guide keeps the live-backend walkthrough and the point that `"result"` is a
-render and not an execution, and both point at the reference for the rest.
-*Four answers, distinguished* above is this decision's record of them and not
-a copy of that page.
+`?last_sent_queries` now states the contract: what the record holds, which
+calls keep one, what each of the four answers means, and how to write a record
+out. `?marginplyr` and the guide each keep what their own audience needs and
+point at it for the contract. *Four answers, distinguished* above is this
+decision's record of them and not a copy of that page.
 
 What the fix rests on is that the page enumerates the calls once, in its
 description, and the first answer refers to that list rather than repeating

--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -423,6 +423,33 @@ capture, there being one. `vignettes/database_backends.qmd` carries the same
 material against a live backend, with the point that `"result"` is a render and
 not an execution — the caller's own `collect()` is still what runs it.
 
+## Amendment: one page states the contract and two point at it
+
+*Documentation consequences* above spreads one contract over three pages, and
+it drifted. `?last_sent_queries`'s first answer said the record is empty while
+"no Margin verb has begun", where the accessor refuses on
+`sent_queries$recorded` — set by `reset_sent_queries()`, which every exported
+function taking `.grouping` calls, `inspect_grouping()` among them. An
+unaudited `inspect_grouping()` alone therefore moves the answer to the second,
+and the page #23's User Story 35 makes canonical was the copy that was wrong
+(#494).
+
+`?last_sent_queries` now states the contract alone: what the record holds,
+which calls keep one, and what each of the four answers means. `?marginplyr`
+keeps that the record is off by default and that there is one capture, the
+guide keeps the live-backend walkthrough and the point that `"result"` is a
+render and not an execution, and both point at the reference for the rest.
+*Four answers, distinguished* above is this decision's record of them and not
+a copy of that page.
+
+What the fix rests on is that the page enumerates the calls once, in its
+description, and the first answer refers to that list rather than repeating
+it. `test-documentation.R` holds the list to the exported functions taking
+`.grouping`, reading the description alone because `\seealso` links two of
+those names for reasons of its own. Whether a sentence about the record is
+true is not a thing either gate reads, and `test-sent-queries.R` runs every
+entry point against the answer it moves the session to for that reason.
+
 ## Related decisions
 
 ADR 0020 is the rule this decision does not amend, and its *Related decisions*

--- a/man/last_sent_queries.Rd
+++ b/man/last_sent_queries.Rd
@@ -53,10 +53,11 @@ call made in this process and not one made in a worker.
 \section{Four answers}{
 
 \itemize{
-\item Nothing has been recorded in this session -- none of the calls listed
-above has begun -- and the call is refused with a \code{"marginplyr_error"}. A
-call that began and then refused your arguments has begun, so what is read
-after one is its own record, empty, and not this refusal.
+\item Nothing has been recorded in this session -- none of the calls the
+description above lists has begun -- and the call is refused with a
+\code{"marginplyr_error"}. A call that began and then refused your arguments
+has begun, so what is read after one is its own record, empty, and not
+this refusal.
 \item The last call was not audited, the option being unset or holding a value
 other than \code{TRUE} when the call began, and the call is refused with a
 \code{"marginplyr_error"} naming \code{marginplyr.audit_sql}. The option is read

--- a/man/last_sent_queries.Rd
+++ b/man/last_sent_queries.Rd
@@ -53,10 +53,10 @@ call made in this process and not one made in a worker.
 \section{Four answers}{
 
 \itemize{
-\item Nothing has been recorded in this session -- no Margin verb has begun --
-and the call is refused with a \code{"marginplyr_error"}. A verb that began and
-then refused your call has begun, so what is read after one is its own
-record, empty, and not this refusal.
+\item Nothing has been recorded in this session -- none of the calls listed
+above has begun -- and the call is refused with a \code{"marginplyr_error"}. A
+call that began and then refused your arguments has begun, so what is read
+after one is its own record, empty, and not this refusal.
 \item The last call was not audited, the option being unset or holding a value
 other than \code{TRUE} when the call began, and the call is refused with a
 \code{"marginplyr_error"} naming \code{marginplyr.audit_sql}. The option is read

--- a/man/marginplyr-package.Rd
+++ b/man/marginplyr-package.Rd
@@ -118,47 +118,14 @@ last_sent_queries()
 options(old)
 }\if{html}{\out{</div>}}
 
-The record is a tibble of two character columns -- \code{purpose}, what the
-query was sent for, and \code{sql}, the statement as it was rendered -- with one
-row per query, in the order the queries were sent. It belongs to a single
-call, being emptied at the start of every one.
-
-\code{"result"} is the one \code{purpose} promised: the query a Margin verb returns
-unexecuted, which your own \code{\link[dplyr:collect]{dplyr::collect()}} is still what runs. Every
-other row is a query marginplyr sends for its own reasons, and the names
-those rows carry are not fixed.
-
-A query is recorded before it is sent, so the record holds what was sent
-rather than what succeeded, and a call that fails leaves readable every
-query it had already sent.
-
-What is recorded is the SQL marginplyr sent, not the execution marginplyr
-caused. An audited call on a data frame, a dtplyr table, or an Arrow table
-therefore records nothing, and that zero-row answer is correct rather than
-a hole.
-
 There is one capture, \code{dbplyr::sql_render()}. It renders in your own
 session and sends nothing the call did not already send, so what
 \emph{\link[=summarize_with_margins]{When marginplyr queries your data}} enumerates is
 the same whether or not you are recording.
 
-\code{\link[=last_sent_queries]{last_sent_queries()}} gives four answers, and each of the three that could
-look like an empty record is told apart from the others:
-\itemize{
-\item Nothing has been recorded in this session -- neither a Margin verb nor
-\code{\link[=inspect_grouping]{inspect_grouping()}} has run -- and the call is refused with a
-\code{"marginplyr_error"}.
-\item The last call was not audited, the option being unset or holding a value
-other than \code{TRUE} when the call began, and the call is refused with a
-\code{"marginplyr_error"} naming \code{marginplyr.audit_sql}. The option is read
-once, as the call begins; setting it afterwards does not audit a call
-already made.
-\item The call was audited and sent nothing: a zero-row tibble, the only answer
-with zero rows.
-\item A statement had no SQL form on this backend -- a translation dbplyr
-refuses when the query is rendered -- and its row holds \code{NA} in \code{sql}.
-The call itself is unaffected.
-}
+What the record holds, which calls keep one, and the four answers it gives
+-- three of them could otherwise look alike -- are stated in
+\code{\link[=last_sent_queries]{last_sent_queries()}}'s own reference.
 }
 
 \section{Guides}{

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -153,10 +153,10 @@ rd_topic_of <- function(topics, name) {
   sub("[.]Rd$", "", documented)
 }
 
-# `?last_sent_queries`'s four answers refer to the list of calls its
-# description gives rather than repeating it (ADR 0027, *one page states the
-# contract and two point at it*), so that list is what a seventh entry point
-# has to reach to be covered by the first answer. This fires when one does not,
+# The first of `?last_sent_queries`'s four answers refers to the list of calls
+# its description gives rather than repeating it (ADR 0027, *one page states
+# the contract and two point at it*), so that list is what a seventh entry
+# point has to reach to be covered by it. This fires when one does not,
 # reading the set from the signatures as `test-sent-queries.R` reads it from
 # the bodies. Whether a sentence about the record is true is not something it
 # reads.

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -123,6 +123,49 @@ test_that("the Grouping-identity comparison has exactly one canonical home", {
   expect_equal(names(topics)[carries_table], "grouping_bit.Rd")
 })
 
+# The topic documenting `name`, which is not always a page of its own:
+# `summarise_with_margins()` is an alias on `summarize_with_margins.Rd`, and a
+# page linking that topic has named it.
+rd_topic_of <- function(topics, name) {
+  alias <- paste0("\\alias{", name, "}")
+  documented <- names(topics)[vapply(
+    topics,
+    function(text) grepl(alias, text, fixed = TRUE),
+    logical(1)
+  )]
+  sub("[.]Rd$", "", documented)
+}
+
+# `?last_sent_queries` owns the record's contract (#494), and the one
+# enumeration it holds is of the calls that keep a record. Its four answers
+# refer to that list rather than restating it, so a seventh entry point missing
+# from the list is missing from the first answer too -- which is what this
+# fires on, reading the set from the signatures as `test-sent-queries.R` reads
+# it from the bodies.
+#
+# What it cannot read is whether a sentence about the record is true: the
+# drift #494 found was a bullet naming a narrower condition than the code
+# uses, on a page that already listed all six calls. *Any entry point moves the
+# session off the first answer* in `test-sent-queries.R` is what holds that
+# condition, by running it.
+test_that("the record's owner names every call that keeps one", {
+  topics <- rd_topics()
+  skip_if(is.null(topics), "No Rd sources available")
+
+  page <- topics[["last_sent_queries.Rd"]]
+  expect_type(page, "character")
+
+  unnamed <- Filter(
+    function(name) {
+      links <- paste0("\\link[=", rd_topic_of(topics, name), "]")
+      !any(vapply(links, grepl, logical(1), x = page, fixed = TRUE))
+    },
+    verbs_taking(".grouping")
+  )
+
+  expect_identical(unnamed, character())
+})
+
 # Every guard in the shipped documentation decides whether optional code runs,
 # and `requireNamespace()` cannot make that decision correctly: it reports an
 # installed-but-too-old package usable, and the guarded code then calls an API

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -154,26 +154,21 @@ rd_topic_of <- function(topics, name) {
 }
 
 # `?last_sent_queries`'s four answers refer to the list of calls its
-# description gives rather than repeating it (#494), so the list is what a
-# seventh entry point has to reach to be covered by the first answer. This
-# fires when one does not, reading the set from the signatures as
-# `test-sent-queries.R` reads it from the bodies.
+# description gives rather than repeating it (ADR 0027, *one page states the
+# contract and two point at it*), so that list is what a seventh entry point
+# has to reach to be covered by the first answer. This fires when one does not,
+# reading the set from the signatures as `test-sent-queries.R` reads it from
+# the bodies. Whether a sentence about the record is true is not something it
+# reads.
 #
 # The description alone, not the page: `\seealso` links
 # `summarize_with_margins` for an unrelated reason, so a scan over the whole
 # topic passes two of the six verbs with the list deleted outright.
-#
-# What no scan here reads is whether a sentence about the record is true. The
-# drift #494 found was a bullet naming a narrower condition than the code uses,
-# on a page whose list already held all six calls, and *any entry point moves
-# the session off the first answer* in `test-sent-queries.R` is what holds that
-# condition, by running it.
 test_that("the record's owner lists every call that keeps one", {
   topics <- rd_topics()
   skip_if(is.null(topics), "No Rd sources available")
 
   described <- rd_description(topics[["last_sent_queries.Rd"]])
-  expect_type(described, "character")
 
   unlisted <- Filter(
     function(name) {

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -123,6 +123,23 @@ test_that("the Grouping-identity comparison has exactly one canonical home", {
   expect_equal(names(topics)[carries_table], "grouping_bit.Rd")
 })
 
+# The `\description{}` block of one Rd topic, or `""` where the topic has none
+# -- which fails whatever reads the block rather than passing it an empty page.
+#
+# The block holds braces of its own, every `\code{}` in it one, so what bounds
+# the match is roxygen2 writing the closing brace of a top-level block on a
+# line of its own.
+rd_description <- function(text) {
+  block <- regmatches(
+    text,
+    regexpr("(?s)\\\\description\\{\\n.*?\\n\\}\\n", text, perl = TRUE)
+  )
+  if (length(block) == 0L) {
+    return("")
+  }
+  block
+}
+
 # The topic documenting `name`, which is not always a page of its own:
 # `summarise_with_margins()` is an alias on `summarize_with_margins.Rd`, and a
 # page linking that topic has named it.
@@ -136,34 +153,37 @@ rd_topic_of <- function(topics, name) {
   sub("[.]Rd$", "", documented)
 }
 
-# `?last_sent_queries` owns the record's contract (#494), and the one
-# enumeration it holds is of the calls that keep a record. Its four answers
-# refer to that list rather than restating it, so a seventh entry point missing
-# from the list is missing from the first answer too -- which is what this
-# fires on, reading the set from the signatures as `test-sent-queries.R` reads
-# it from the bodies.
+# `?last_sent_queries`'s four answers refer to the list of calls its
+# description gives rather than repeating it (#494), so the list is what a
+# seventh entry point has to reach to be covered by the first answer. This
+# fires when one does not, reading the set from the signatures as
+# `test-sent-queries.R` reads it from the bodies.
 #
-# What it cannot read is whether a sentence about the record is true: the
-# drift #494 found was a bullet naming a narrower condition than the code
-# uses, on a page that already listed all six calls. *Any entry point moves the
-# session off the first answer* in `test-sent-queries.R` is what holds that
+# The description alone, not the page: `\seealso` links
+# `summarize_with_margins` for an unrelated reason, so a scan over the whole
+# topic passes two of the six verbs with the list deleted outright.
+#
+# What no scan here reads is whether a sentence about the record is true. The
+# drift #494 found was a bullet naming a narrower condition than the code uses,
+# on a page whose list already held all six calls, and *any entry point moves
+# the session off the first answer* in `test-sent-queries.R` is what holds that
 # condition, by running it.
-test_that("the record's owner names every call that keeps one", {
+test_that("the record's owner lists every call that keeps one", {
   topics <- rd_topics()
   skip_if(is.null(topics), "No Rd sources available")
 
-  page <- topics[["last_sent_queries.Rd"]]
-  expect_type(page, "character")
+  described <- rd_description(topics[["last_sent_queries.Rd"]])
+  expect_type(described, "character")
 
-  unnamed <- Filter(
+  unlisted <- Filter(
     function(name) {
       links <- paste0("\\link[=", rd_topic_of(topics, name), "]")
-      !any(vapply(links, grepl, logical(1), x = page, fixed = TRUE))
+      !any(vapply(links, grepl, logical(1), x = described, fixed = TRUE))
     },
     verbs_taking(".grouping")
   )
 
-  expect_identical(unnamed, character())
+  expect_identical(unlisted, character())
 })
 
 # Every guard in the shipped documentation decides whether optional code runs,

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -25,31 +25,27 @@ sent_queries_table <- function(con) {
   dplyr::tbl(con, "sent_queries")
 }
 
-expect_unaudited <- function() {
+# Which of the accessor's two refusals it raised: `TRUE` for the unaudited one,
+# `FALSE` for the session's first, and `NA` where it answered rather than
+# refusing. Both refusals are marginplyr errors, so naming
+# `marginplyr.audit_sql` is the whole of what tells them apart.
+refusal_names_the_option <- function() {
   condition <- rlang::catch_cnd(
     last_sent_queries(),
     classes = "marginplyr_error"
   )
-  expect_s3_class(condition, "marginplyr_error")
-  expect_match(
-    conditionMessage(condition),
-    "marginplyr.audit_sql",
-    fixed = TRUE
-  )
+  if (is.null(condition)) {
+    return(NA)
+  }
+  grepl("marginplyr.audit_sql", conditionMessage(condition), fixed = TRUE)
 }
 
-# The session's first refusal, told apart from the unaudited one by what its
-# message does not name. Both are marginplyr errors, so a read asserting only
-# the class passes on either.
+expect_unaudited <- function() {
+  expect_identical(refusal_names_the_option(), TRUE)
+}
+
 expect_nothing_recorded <- function() {
-  condition <- rlang::catch_cnd(
-    last_sent_queries(),
-    classes = "marginplyr_error"
-  )
-  expect_s3_class(condition, "marginplyr_error")
-  expect_false(
-    grepl("marginplyr.audit_sql", conditionMessage(condition), fixed = TRUE)
-  )
+  expect_identical(refusal_names_the_option(), FALSE)
 }
 
 expect_sent_nothing <- function() {
@@ -816,6 +812,12 @@ test_that("a call refused before its plan is a call the session recorded", {
 # and this is what holds it: an entry point that stopped recording would leave
 # the session answering the first where the page promises the second.
 test_that("any entry point moves the session off the first answer", {
+  # The wrappers are what this runs, so the two are held to each other here as
+  # every other caller holds them (`helper-margin-verbs.R`): a seventh verb
+  # missing from the list would otherwise leave the loop covering six of seven
+  # under a name saying it covers every entry point.
+  expect_setequal(names(forwarded_verbs), verbs_taking(".grouping"))
+
   data <- data.frame(g = c("a", "a", "b"), value = 1:3)
 
   # The entry point still answering the session's first refusal, rather than
@@ -829,15 +831,7 @@ test_that("any entry point moves the session off the first answer", {
       # the second and its message names `marginplyr.audit_sql`.
       expect_null(getOption("marginplyr.audit_sql"))
       forwarded_verbs[[name]](data, grouping = rollup(g))
-      condition <- rlang::catch_cnd(
-        last_sent_queries(),
-        classes = "marginplyr_error"
-      )
-      if (
-        is.null(condition) ||
-          !grepl("marginplyr.audit_sql", conditionMessage(condition),
-                 fixed = TRUE)
-      ) {
+      if (!isTRUE(refusal_names_the_option())) {
         first <- c(first, name)
       }
     })

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -38,6 +38,20 @@ expect_unaudited <- function() {
   )
 }
 
+# The session's first refusal, told apart from the unaudited one by what its
+# message does not name. Both are marginplyr errors, so a read asserting only
+# the class passes on either.
+expect_nothing_recorded <- function() {
+  condition <- rlang::catch_cnd(
+    last_sent_queries(),
+    classes = "marginplyr_error"
+  )
+  expect_s3_class(condition, "marginplyr_error")
+  expect_false(
+    grepl("marginplyr.audit_sql", conditionMessage(condition), fixed = TRUE)
+  )
+}
+
 expect_sent_nothing <- function() {
   record <- last_sent_queries()
   expect_s3_class(record, "tbl_df")
@@ -751,10 +765,10 @@ test_that("a call refused before its plan reads the option for itself", {
   expect_sent_nothing()
 })
 
-test_that("a call refused before its plan is a call the session recorded", {
-  # The one reading a later call cannot restore, so the whole record is saved
-  # and put back: emptying it is how the session's first call is reached
-  # twice.
+# `expr` evaluated against a record holding nothing, which is put back
+# afterwards. The state a later call cannot restore is the session's first, so
+# reaching it more than once means saving the whole record and emptying it.
+with_empty_record <- function(expr) {
   saved <- as.list(sent_queries, all.names = TRUE)
   empty_the_record <- function() {
     rm(list = names(saved), envir = sent_queries)
@@ -768,25 +782,68 @@ test_that("a call refused before its plan is a call the session recorded", {
   )
 
   empty_the_record()
-  # The control: with nothing recorded, the accessor refuses rather than
-  # answering, which is what makes the read after the refusal an assertion.
-  expect_error(last_sent_queries(), class = "marginplyr_error")
+  force(expr)
+}
 
-  with_audit_option(TRUE, {
-    expect_error(
-      summarize_with_margins(
-        sent_queries_data(),
-        total = sum(v, na.rm = TRUE),
-        .grouping = rollup(g),
-        .duplicates = "bogus"
-      ),
-      class = "marginplyr_error"
-    )
+test_that("a call refused before its plan is a call the session recorded", {
+  with_empty_record({
+    # The control: with nothing recorded, the accessor refuses rather than
+    # answering, which is what makes the read after the refusal an assertion.
+    expect_nothing_recorded()
+
+    with_audit_option(TRUE, {
+      expect_error(
+        summarize_with_margins(
+          sent_queries_data(),
+          total = sum(v, na.rm = TRUE),
+          .grouping = rollup(g),
+          .duplicates = "bogus"
+        ),
+        class = "marginplyr_error"
+      )
+    })
+
+    # A verb that began and then refused the call has begun, so the answer is
+    # its own empty record and not the session's first (ADR 0027).
+    expect_sent_nothing()
   })
+})
 
-  # A verb that began and then refused the call has begun, so the answer is
-  # its own empty record and not the session's first (ADR 0027).
-  expect_sent_nothing()
+# The first of the four answers is reached when nothing has been recorded, and
+# every entry point moves the session off it -- `inspect_grouping()` included,
+# which compiles a Grouping plan without a Margin operation and empties the
+# record like the rest (ADR 0027). The reference states that condition once,
+# and this is what holds it: an entry point that stopped recording would leave
+# the session answering the first where the page promises the second.
+test_that("any entry point moves the session off the first answer", {
+  data <- data.frame(g = c("a", "a", "b"), value = 1:3)
+
+  # The entry point still answering the session's first refusal, rather than
+  # one expectation per verb: which one it is not otherwise in the report.
+  first <- character()
+
+  for (name in names(forwarded_verbs)) {
+    with_empty_record({
+      expect_nothing_recorded()
+      # Unaudited, the option being unset, so the answer the call moves to is
+      # the second and its message names `marginplyr.audit_sql`.
+      expect_null(getOption("marginplyr.audit_sql"))
+      forwarded_verbs[[name]](data, grouping = rollup(g))
+      condition <- rlang::catch_cnd(
+        last_sent_queries(),
+        classes = "marginplyr_error"
+      )
+      if (
+        is.null(condition) ||
+          !grepl("marginplyr.audit_sql", conditionMessage(condition),
+                 fixed = TRUE)
+      ) {
+        first <- c(first, name)
+      }
+    })
+  }
+
+  expect_identical(first, character())
 })
 
 # --- the reset site, structurally --------------------------------------------

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -820,9 +820,11 @@ test_that("any entry point moves the session off the first answer", {
 
   data <- data.frame(g = c("a", "a", "b"), value = 1:3)
 
-  # The entry point still answering the session's first refusal, rather than
-  # one expectation per verb: which one it is not otherwise in the report.
-  first <- character()
+  # The entry point after which the accessor did not give the unaudited
+  # refusal -- the session either still answering its first or answering with
+  # rows -- rather than one expectation per verb: which one it is not otherwise
+  # in the report.
+  unmoved <- character()
 
   for (name in names(forwarded_verbs)) {
     with_empty_record({
@@ -832,12 +834,12 @@ test_that("any entry point moves the session off the first answer", {
       expect_null(getOption("marginplyr.audit_sql"))
       forwarded_verbs[[name]](data, grouping = rollup(g))
       if (!isTRUE(refusal_names_the_option())) {
-        first <- c(first, name)
+        unmoved <- c(unmoved, name)
       }
     })
   }
 
-  expect_identical(first, character())
+  expect_identical(unmoved, character())
 })
 
 # --- the reset site, structurally --------------------------------------------

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -692,26 +692,14 @@ which renders in your session and sends nothing, so the `"selection_proxy"`
 row above was sent whether or not you were recording. *When marginplyr queries
 your data* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
-is what enumerates those queries and says which backends receive them. Names
-other than `"result"` are marginplyr's own and are not fixed, so match on
-`"result"` and read the rest as context.
+is what enumerates those queries and says which backends receive them. Match
+on `"result"` and read the rest as context.
 
 `last_sent_queries()` gives four answers, and three of them could otherwise
 look like an empty record. What tells them apart, which calls keep a record,
-and what the record you are holding belongs to are stated in the
+what the record you are holding belongs to, and how to write one out are
+stated in the
 [`last_sent_queries()` reference](https://sayuks.github.io/marginplyr/man/last_sent_queries.html).
-
-marginplyr writes no file. The tibble is what you write, in whatever format
-your audit takes:
-
-```{r}
-#| eval: false
-
-utils::write.csv(last_sent_queries(), "sent-queries.csv")
-```
-
-The record is per call and nothing accumulates on your behalf, so a batch is
-read one call at a time and bound afterwards.
 
 ```{r}
 #| eval: !expr has_duckdb

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -706,22 +706,9 @@ other than `"result"` are marginplyr's own and are not fixed, so match on
 `"result"` and read the rest as context.
 
 `last_sent_queries()` gives four answers, and three of them could otherwise
-look alike:
-
-- **Nothing has been recorded in this session**, neither a Margin verb nor
-  `inspect_grouping()` having run: refused with a marginplyr error.
-
-- **The last call was not audited**: refused with a marginplyr error naming
-  `marginplyr.audit_sql`. The option is read once as a call begins, so setting
-  it afterwards cannot audit a call already made.
-
-- **An audited call sent nothing**: a zero-row tibble, the only answer with
-  zero rows. A data frame, a dtplyr table, and an Arrow table send no SQL, so
-  an audited call on one records nothing, and that is correct rather than a
-  hole.
-
-- **A statement dbplyr refuses to translate for the backend**: its row is kept
-  with `NA` in `sql`, and the call itself is unaffected.
+look like an empty record. What tells them apart is stated in the
+[`last_sent_queries()` reference](https://sayuks.github.io/marginplyr/man/last_sent_queries.html),
+which is also where the record's contract is written.
 
 Each row is written before its query is sent, so a call that fails leaves
 readable every query it had already sent.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -668,18 +668,9 @@ sent <- last_sent_queries()
 sent$purpose
 ```
 
-The record is a tibble of two character columns, `purpose` and `sql`, holding
-one row per query in the order it was sent. It belongs to that one call: the
-next call to a Margin verb — or to
-[`inspect_grouping()`](https://sayuks.github.io/marginplyr/man/inspect_grouping.html),
-which compiles a Grouping plan and sends queries of its own — empties it and
-starts again.
-Piping one Margin verb into another is two such calls, and the record you read
-afterwards is the outer one's: the input runs first, and the outer call empties
-what it left.
+Those are the purposes this one call sent under, in the order it sent them.
 
-`"result"` is the only `purpose` marginplyr promises, and it is the query
-`audit_query` holds:
+`"result"` is the query `audit_query` holds:
 
 ```{r}
 #| eval: !expr has_duckdb
@@ -706,12 +697,9 @@ other than `"result"` are marginplyr's own and are not fixed, so match on
 `"result"` and read the rest as context.
 
 `last_sent_queries()` gives four answers, and three of them could otherwise
-look like an empty record. What tells them apart is stated in the
-[`last_sent_queries()` reference](https://sayuks.github.io/marginplyr/man/last_sent_queries.html),
-which is also where the record's contract is written.
-
-Each row is written before its query is sent, so a call that fails leaves
-readable every query it had already sent.
+look like an empty record. What tells them apart, which calls keep a record,
+and what the record you are holding belongs to are stated in the
+[`last_sent_queries()` reference](https://sayuks.github.io/marginplyr/man/last_sent_queries.html).
 
 marginplyr writes no file. The tibble is what you write, in whatever format
 your audit takes:


### PR DESCRIPTION
Closes #494.

## What was wrong

`?last_sent_queries`'s first answer said the record is empty when "no Margin
verb has begun". The code's condition is `sent_queries$recorded`, set by
`reset_sent_queries()`, which every exported function taking `.grouping` calls
— `inspect_grouping()` among them. An unaudited `inspect_grouping()` alone
therefore moves the answer to the second, and the diagnostic itself says so.

## What changed

- **The false clause is deleted, not restated.** The bullet now refers to the
  list of calls the page's description already carries, so the page holds one
  enumeration rather than two, and a call that keeps a record cannot be in one
  and missing from the other.
- **One owner, two references.** `?marginplyr` and *Record the SQL marginplyr
  sends* in the database-backends guide each restated the whole record
  contract — the tibble's columns, the `"result"` promise,
  recorded-before-sent, the zero-row case, and the four answers. Each now keeps
  what its own audience needs (the package page its one-capture argument, the
  guide its walkthrough of the rows it just printed) and points at the
  reference for the contract.
- **Two gates, where nothing held the page to the code before.**
  `test-sent-queries.R` runs every entry point out of `forwarded_verbs` against
  a session with an empty record and asserts the answer it moves to is the
  unaudited one; its control now reads the refusal's message, both answers
  being marginplyr errors. `test-documentation.R` holds the page's enumeration
  to `verbs_taking(".grouping")`, resolving each verb to the topic documenting
  it so that the `summarise_with_margins()` alias is named by its own page.
  Neither can read whether a sentence about the record is true, and the comment
  above the block says so.

## Checks

`lintr::lint_package()`, `roxygen2::roxygenise()`, `spelling::spell_check_package()`,
`verify-context-budget.R`, `verify-must-error.R`, and the full suite under
`NOT_CRAN=true` all pass locally.