### PR TITLE
Qualify internal heads in deferred expressions (#491)

### DIFF
--- a/R/factor.R
+++ b/R/factor.R
@@ -127,15 +127,19 @@ reconstruct_factor.data.frame <- function(data,
   # against the data mask first, so a source column called `new_levels`,
   # `ord`, or `missing_sentinel` would supply the argument instead of the
   # local, silently rebuilding the factor from the wrong levels.
+  #
+  # The head is qualified rather than bare for the separate reason
+  # `marginplyr_private_call()` gives: the dtplyr method below shares this
+  # body, and dtplyr defers the expression into an environment where a bare
+  # name is not bound (#491).
   dplyr::mutate(
     .data = data,
-    "{col}" := !!rlang::expr(
-      reconstruct_factor_vector(
-        !!margin_column_pronoun(col),
-        new_levels = !!new_levels,
-        ordered = !!ord,
-        missing_sentinel = !!missing_sentinel
-      )
+    "{col}" := !!rlang::call2(
+      marginplyr_private_call("reconstruct_factor_vector"),
+      margin_column_pronoun(col),
+      new_levels = new_levels,
+      ordered = ord,
+      missing_sentinel = missing_sentinel
     )
   )
 }

--- a/R/factor.R
+++ b/R/factor.R
@@ -128,10 +128,9 @@ reconstruct_factor.data.frame <- function(data,
   # `ord`, or `missing_sentinel` would supply the argument instead of the
   # local, silently rebuilding the factor from the wrong levels.
   #
-  # The head is qualified rather than bare for the separate reason
-  # `marginplyr_private_call()` gives: the dtplyr method below shares this
-  # body, and dtplyr defers the expression into an environment where a bare
-  # name is not bound (#491).
+  # The head is qualified for a separate reason: the dtplyr method below shares
+  # this body, and dtplyr defers the expression
+  # (`marginplyr_private_call()`, #491).
   dplyr::mutate(
     .data = data,
     "{col}" := !!rlang::call2(

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -433,9 +433,8 @@ label_margin_branch <- function(.data,
       encoded_factors,
       function(info) {
         col <- info$col
-        # The head is qualified for the reason `marginplyr_private_call()`
-        # gives: dtplyr defers this expression into an environment where a
-        # bare name is not bound (#491).
+        # The head is qualified because dtplyr defers this expression
+        # (`marginplyr_private_call()`, #491).
         rlang::call2(
           marginplyr_private_call("encode_factor_for_margin"),
           margin_column_pronoun(col),

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -433,12 +433,14 @@ label_margin_branch <- function(.data,
       encoded_factors,
       function(info) {
         col <- info$col
-        rlang::expr(
-          encode_factor_for_margin(
-            !!margin_column_pronoun(col),
-            missing_sentinel = !!sentinels[[col]],
-            preserve_missing_value = TRUE
-          )
+        # The head is qualified for the reason `marginplyr_private_call()`
+        # gives: dtplyr defers this expression into an environment where a
+        # bare name is not bound (#491).
+        rlang::call2(
+          marginplyr_private_call("encode_factor_for_margin"),
+          margin_column_pronoun(col),
+          missing_sentinel = sentinels[[col]],
+          preserve_missing_value = TRUE
         )
       }
     )

--- a/R/share.R
+++ b/R/share.R
@@ -971,7 +971,7 @@ wrap_share_sources <- function(dots,
         source_summaries
       )
       wrapped <- rlang::call2(
-        share_private_call("check_share_across"),
+        marginplyr_private_call("check_share_across"),
         expr,
         share_outputs = share_outputs,
         share_kinds = share_kinds
@@ -980,7 +980,7 @@ wrap_share_sources <- function(dots,
       check <- checks[[1L]]
       is_dtplyr <- identical(backend_kind, "dtplyr")
       wrapped <- rlang::call2(
-        share_private_call(if (is_dtplyr) {
+        marginplyr_private_call(if (is_dtplyr) {
           "check_dtplyr_share_source"
         } else {
           "check_share_scalar"
@@ -1152,18 +1152,18 @@ wrap_dtplyr_share_function <- function(fn, mapping, forwarded_args, call) {
     )
   }
   input <- rlang::call2(
-    share_private_call("dtplyr_share_input_name"),
+    marginplyr_private_call("dtplyr_share_input_name"),
     dtplyr_lambda_pronoun()
   )
   mapping_expr <- rlang::call2(
-    share_private_call("new_share_validation_mapping"),
+    marginplyr_private_call("new_share_validation_mapping"),
     inputs = mapping$inputs,
     share_outputs = mapping$share_outputs,
     source_summaries = mapping$source_summaries,
     share_kinds = mapping$share_kinds
   )
   validator <- rlang::call2(
-    share_private_call("check_dtplyr_share_scalar"),
+    marginplyr_private_call("check_dtplyr_share_scalar"),
     value,
     input = input,
     mapping = mapping_expr,
@@ -1224,14 +1224,6 @@ new_share_validation_mapping <- function(inputs,
     share_outputs = share_outputs,
     source_summaries = source_summaries,
     share_kinds = share_kinds
-  )
-}
-
-share_private_call <- function(name) {
-  rlang::call2(
-    ":::",
-    rlang::sym("marginplyr"),
-    rlang::sym(name)
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,27 @@ margin_column_pronoun <- function(name) {
   rlang::call2("[[", rlang::sym(".data"), name)
 }
 
+# How an internal function is spelled as the head of an expression a backend
+# defers. `name` is that function's name in this namespace.
+#
+# A bare symbol is resolved where the deferred expression runs, which is not
+# where marginplyr built it. dplyr resolves one below the quosure's own
+# environment, so the local backend hides the difference; dtplyr translates
+# the expression into a `data.table` call evaluated in the environment the
+# caller wrote the pipeline in, where no internal name is bound and the call
+# fails for every user (#491).
+#
+# `:::` and not `::`, because none of these functions is exported. The call is
+# built rather than written, so this package's source carries no literal
+# `marginplyr:::` for `R CMD check` to raise its NOTE over.
+marginplyr_private_call <- function(name) {
+  rlang::call2(
+    ":::",
+    rlang::sym("marginplyr"),
+    rlang::sym(name)
+  )
+}
+
 assert_logical_scalar <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.

--- a/tests/testthat/helper-namespace-walk.R
+++ b/tests/testthat/helper-namespace-walk.R
@@ -19,8 +19,9 @@
 # - `test-query-policy.R`, ADR 0020's rule about which functions reach an
 #   execution entry point, and the capability table read out of the source;
 # - `test-utils.R`, that no walk over a call's arguments binds one to a name,
-#   in either the `for` spelling or the `<-` spelling, and that no reader
-#   restarts on a pair of parentheses it cannot shrink;
+#   in either the `for` spelling or the `<-` spelling, that no reader restarts
+#   on a pair of parentheses it cannot shrink, and that no expression a backend
+#   defers names an internal function bare;
 # - `helper-diagnostic-sites.R`, for the two diagnostics gates it serves.
 #
 # That list is a courtesy and not the record: `test-namespace-walk.R` derives

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -172,7 +172,7 @@ test_that("dtplyr obeys the eight-case contract as the local backend does", {
 # One verb call, written so the same expression serves both backends: `INPUT`
 # stands where the verb's data argument goes and is replaced with the
 # expression that produces it.
-factor_user_env_call <- function(call, input) {
+factor_call_with_input <- function(call, input) {
   do.call(substitute, list(call, list(INPUT = input)))
 }
 
@@ -257,7 +257,7 @@ test_that("dtplyr rebuilds a factor dimension outside the namespace", {
         data,
         rlang::call2(
           "collect",
-          factor_user_env_call(calls[[verb]], quote(dtplyr::lazy_dt(data))),
+          factor_call_with_input(calls[[verb]], quote(dtplyr::lazy_dt(data))),
           .ns = "dplyr"
         )
       )
@@ -269,10 +269,15 @@ test_that("dtplyr rebuilds a factor dimension outside the namespace", {
         info = info
       )
       expect_identical(
-        sort(as.character(result$group)),
-        sort(as.character(
-          eval(factor_user_env_call(calls[[verb]], quote(data)))$group
-        )),
+        # `na.last` because the default drops a missing value from both sides,
+        # which is the one difference these cases are here to see.
+        sort(as.character(result$group), na.last = TRUE),
+        sort(
+          as.character(
+            eval(factor_call_with_input(calls[[verb]], quote(data)))$group
+          ),
+          na.last = TRUE
+        ),
         info = info
       )
     }

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -169,6 +169,116 @@ test_that("dtplyr obeys the eight-case contract as the local backend does", {
   }
 })
 
+# One verb call, written so the same expression serves both backends: `INPUT`
+# stands where the verb's data argument goes and is replaced with the
+# expression that produces it.
+factor_user_env_call <- function(call, input) {
+  do.call(substitute, list(call, list(INPUT = input)))
+}
+
+# Evaluates `call` where marginplyr's own bindings do not resolve. This is the
+# whole of what the test below adds over the cases above, and simplifying it
+# into an ordinary call makes that test pass on an unfixed tree.
+#
+# `testthat::test_env("marginplyr")` is `env_clone(asNamespace("marginplyr"))`,
+# so a test written in the ordinary way builds its `lazy_dt()` where every
+# internal symbol resolves. dtplyr evaluates its translation in the
+# environment the pipeline was written in, not where the verb ran, so such a
+# test finds a head a Margin operation injects while a user's session does not:
+# the eight-case test above exercises the failing combination and passed
+# against a tree that errored for every caller (#491).
+#
+# The parent is the search path below `package:marginplyr`, not `globalenv()`
+# where a user writes one, because `pkgload::load_all()` attaches every
+# internal name to `package:marginplyr` and an environment above it resolves
+# them all. Starting below withholds them under `devtools::test()` and against
+# an installed package alike, and still reaches `utils::head()`, which dtplyr's
+# own translation calls and an environment parented on `baseenv()` would not
+# supply. Every name the calls below use is therefore `::`-qualified.
+factor_in_user_env <- function(data, call) {
+  below_marginplyr <- match("package:marginplyr", search()) + 1L
+  env <- new.env(parent = as.environment(below_marginplyr))
+  env$data <- data
+  eval(call, env)
+}
+
+# The four verbs against a factor and an ordered-factor dimension, on dtplyr,
+# with the default `.margin_label` -- the combination #491 reported.
+#
+# Only the dimension is compared across backends. The payload a nesting verb
+# builds is a `data.table` on one side and a tibble on the other, which is
+# ADR 0016's per-backend converter and not what these cases assert; the
+# dimension's class, levels, and values are what the documented factor
+# exception promises.
+test_that("dtplyr rebuilds a factor dimension outside the namespace", {
+  skip_if_suggest_absent("dtplyr")
+
+  calls <- list(
+    summarize_with_margins = quote(
+      marginplyr::summarize_with_margins(
+        INPUT,
+        n = dplyr::n(),
+        .grouping = marginplyr::rollup(group)
+      )
+    ),
+    expand_with_margins = quote(
+      marginplyr::expand_with_margins(
+        INPUT,
+        .grouping = marginplyr::rollup(group)
+      )
+    ),
+    nest_with_margins = quote(
+      marginplyr::nest_with_margins(
+        INPUT,
+        .grouping = marginplyr::rollup(group)
+      )
+    ),
+    nest_by_with_margins = quote(
+      marginplyr::nest_by_with_margins(
+        INPUT,
+        .grouping = marginplyr::rollup(group)
+      )
+    )
+  )
+
+  for (ordered in c(FALSE, TRUE)) {
+    data <- data.frame(
+      group = factor(
+        c("lo", "hi", "lo"),
+        levels = c("lo", "hi"),
+        ordered = ordered
+      ),
+      v = c(1, 2, 3)
+    )
+
+    for (verb in names(calls)) {
+      info <- paste0(verb, "/ordered=", ordered)
+      result <- factor_in_user_env(
+        data,
+        rlang::call2(
+          "collect",
+          factor_user_env_call(calls[[verb]], quote(dtplyr::lazy_dt(data))),
+          .ns = "dplyr"
+        )
+      )
+      expect_true(is.factor(result$group), info = info)
+      expect_identical(is.ordered(result$group), ordered, info = info)
+      expect_identical(
+        levels(result$group),
+        c("lo", "hi", "Total"),
+        info = info
+      )
+      expect_identical(
+        sort(as.character(result$group)),
+        sort(as.character(
+          eval(factor_user_env_call(calls[[verb]], quote(data)))$group
+        )),
+        info = info
+      )
+    }
+  }
+})
+
 # The eight cases above declare an NA level that no value uses, so they assert
 # the level survives and not that a value on it stays distinguishable from the
 # typed missing a margin row carries. That distinction is the whole of what

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -176,20 +176,19 @@ is_call_arguments <- function(expr, locals) {
     (is.symbol(expr) && as.character(expr) %in% locals)
 }
 
-# The scan all three gates below are, once the predicate is taken out of it: of
+# The scan all four gates below are, once the predicate is taken out of it: of
 # the functions a namespace binds, the names of those whose body the predicate
-# matches. Every predicate handed to it here matches a walk over an expression,
-# which is what the name says; what it returns is a set of names, named rather
-# than counted so a failure says which walk to rewrite.
+# matches. What it returns is a set of names, named rather than counted so a
+# failure says which function to rewrite.
 #
 # The predicate is the only thing it takes for itself. The two it deliberately
 # does not take are the witness and the message: each gate's witness names what
 # that gate reads -- `static_call_args` for the `for` scan,
 # `parse_across_arguments` for the `<-` scan, `unparenthesized_value` for the
-# restart scan -- and each remedy is written for its own spelling, so an
-# argument for either would exist only to be different, and would make the
-# three look interchangeable. They stay in the `test_that()` block that means
-# them.
+# restart scan, `marginplyr_private_call` for the deferred-head scan -- and each
+# remedy is written for its own spelling, so an argument for either would exist
+# only to be different, and would make the four look interchangeable. They stay
+# in the `test_that()` block that means them.
 #
 # The enumeration and the namespace come from the caller rather than from
 # defaults here. A gate then asserts its witness against the very set this
@@ -199,7 +198,7 @@ is_call_arguments <- function(expr, locals) {
 #
 # Local to this source rather than in `helper-namespace-walk.R`: that file
 # exists because testthat gives each test file its own environment, so one
-# file's gate cannot see a reader another defined, and all three gates here are
+# file's gate cannot see a reader another defined, and all four gates here are
 # in one file. The other scan of this shape, in `test-grouping-plan.R`, decides
 # by deparsing rather than by walking and says so where it stands, so a shared
 # home would be a home for one caller.
@@ -570,6 +569,188 @@ test_that("the restart scan detects the shape it is written to forbid", {
   # An empty argument in the scanned code must not abort the scan, which is the
   # bug the gates in this file exist for.
   expect_false(restarts_on_an_unshrunk_pair(quote(sum(value[]))))
+})
+
+# The fourth gate over the same namespace, and the one whose subject is the
+# environment an expression is finally read in rather than the walk that built
+# it. A backend that defers an expression evaluates it where marginplyr did not
+# write it: dplyr resolves a bare head below the quosure's own environment, so
+# the local backend finds every internal name, while dtplyr translates the
+# expression into a `data.table` call evaluated in the environment the caller
+# wrote the pipeline in, where none of them is bound (#491).
+#
+# A gate rather than the one-off scan #491 asked for, for the reason the gates
+# above are scans: what a grep does not read it reports clean. That reading is
+# what let the two sites #491 names ship -- `test-margin-label.R`'s eight-case
+# dtplyr contract test exercises the failing combination, and passed, because
+# `testthat::test_env()` clones the namespace it would have to withhold.
+#
+# `marginplyr_private_call()` is the spelling that holds on both backends, and
+# is what the remedy names.
+
+# Which builder a call is, by the name under any qualifier it carries. `""`
+# for a head that is not a name at all, which no builder is written as.
+expression_builder_name <- function(head) {
+  if (is.symbol(head)) {
+    return(as.character(head))
+  }
+  if (rlang::is_call(head, "::") && length(head) == 3L) {
+    return(as.character(head[[3L]]))
+  }
+  ""
+}
+
+# Whether `expr` is an unquoted subtree, which the builder evaluates while it
+# runs rather than leaving for the backend. `!!x` parses as `!(!x)` and `!!!x`
+# as `!(!(!x))`, so the doubled negation is what separates either from the
+# ordinary one a deferred expression may hold.
+is_unquoted_part <- function(expr) {
+  rlang::is_call(expr, "!", n = 1) && rlang::is_call(expr[[2L]], "!", n = 1)
+}
+
+# The heads of every call a captured expression leaves for the backend, which
+# is every call below `expr` that no unquote reaches. By subscript and through
+# `lapply()`, for the reason `visit_calls()` gives: a captured expression is
+# exactly the code that may carry R's empty argument.
+captured_call_heads <- function(expr) {
+  if (!is.call(expr) || is_unquoted_part(expr)) {
+    return(list())
+  }
+  c(
+    list(expr[[1L]]),
+    unlist(
+      lapply(as.list(expr), captured_call_heads),
+      recursive = FALSE
+    )
+  )
+}
+
+# The names of the internal functions a body leaves as the bare head of a
+# deferred expression.
+#
+# `rlang::expr()` and `quote()` capture their whole argument, so every head
+# inside one is deferred; `rlang::call2()` is handed its head as its first
+# argument alone, its remaining arguments being values the builder evaluates.
+# `call2()` also accepts a string there, which is the same hazard spelled
+# differently, so both spellings are read.
+bare_internal_deferred_heads <- function(expr, internal) {
+  found <- character()
+  named <- function(head) {
+    (is.symbol(head) && as.character(head) %in% internal) ||
+      (is.character(head) && length(head) == 1L && head %in% internal)
+  }
+  visit_calls(expr, function(node) {
+    builder <- expression_builder_name(node[[1L]])
+    if (length(node) < 2L) {
+      return(invisible(NULL))
+    }
+    heads <- if (builder %in% c("expr", "quo", "quote")) {
+      captured_call_heads(node[[2L]])
+    } else if (identical(builder, "call2")) {
+      list(node[[2L]])
+    } else {
+      list()
+    }
+    for (index in seq_along(heads)) {
+      head <- heads[[index]]
+      if (named(head)) {
+        found <<- unique(c(found, as.character(head)))
+      }
+    }
+  })
+  found
+}
+
+test_that("no deferred expression names an internal function bare", {
+  ns <- asNamespace("marginplyr")
+  functions <- namespace_functions(ns)
+  internal <- setdiff(functions, getNamespaceExports(ns))
+  # The scan iterates over this set, so a set that arrived empty is a set that
+  # passes. `marginplyr_private_call()` is both a member of the set and the
+  # remedy, so one witness answers for the enumeration and for the spelling.
+  expect_true("marginplyr_private_call" %in% internal)
+
+  expect_equal(
+    walks_matching(
+      function(body) length(bare_internal_deferred_heads(body, internal)) > 0L,
+      functions,
+      ns
+    ),
+    character(),
+    info = paste(
+      "Spell the head with `marginplyr_private_call()` instead --",
+      "it builds the `marginplyr:::` qualifier, which resolves wherever the",
+      "backend evaluates the expression."
+    )
+  )
+})
+
+test_that("the deferred-head scan detects the shape it is written to forbid", {
+  # Asserted before the scan's verdict means anything, for the reason the three
+  # gates above assert their own: a scan that stopped matching reports exactly
+  # what a clean package reports. The shapes are #491's two sites and the
+  # spelling that replaced them.
+  internal <- c("encode_factor_for_margin", "margin_column_pronoun")
+  offending <- function(col) {
+    rlang::expr(encode_factor_for_margin(!!margin_column_pronoun(col)))
+  }
+  by_string <- function(col) {
+    rlang::call2("encode_factor_for_margin", margin_column_pronoun(col))
+  }
+  under_mutate <- function(data, col) {
+    dplyr::mutate(data, "{col}" := !!rlang::expr(
+      encode_factor_for_margin(!!margin_column_pronoun(col))
+    ))
+  }
+  compliant <- function(col) {
+    rlang::call2(
+      marginplyr_private_call("encode_factor_for_margin"),
+      margin_column_pronoun(col)
+    )
+  }
+
+  expect_identical(
+    bare_internal_deferred_heads(body(offending), internal),
+    "encode_factor_for_margin"
+  )
+  expect_identical(
+    bare_internal_deferred_heads(body(by_string), internal),
+    "encode_factor_for_margin"
+  )
+  expect_identical(
+    bare_internal_deferred_heads(body(under_mutate), internal),
+    "encode_factor_for_margin"
+  )
+  expect_identical(
+    bare_internal_deferred_heads(body(compliant), internal),
+    character()
+  )
+  # A builder's own arguments are values it evaluates, so an internal name
+  # standing in one is not the shape: the unquoted pronoun above appears in
+  # every case and is named by none of them, and `call2()` defers its head
+  # alone.
+  expect_identical(
+    bare_internal_deferred_heads(
+      quote(rlang::call2("c", margin_column_pronoun(col))),
+      internal
+    ),
+    character()
+  )
+  # An ordinary negation inside a deferred expression is not an unquote, or
+  # the scan would read past every head below one.
+  expect_identical(
+    bare_internal_deferred_heads(
+      quote(rlang::expr(!encode_factor_for_margin(x))),
+      internal
+    ),
+    "encode_factor_for_margin"
+  )
+  # An empty argument in the scanned code must not abort the scan, which is the
+  # bug the gates in this file exist for.
+  expect_identical(
+    bare_internal_deferred_heads(quote(rlang::expr(sum(value[]))), internal),
+    character()
+  )
 })
 
 test_that("every shared reader answers an empty call part", {


### PR DESCRIPTION
Closes #491.

## What was wrong

Every Margin verb failed on a `dtplyr` input whose Grouping plan named a
factor or ordered-factor dimension with a non-missing `.margin_label` —
the default:

```
Error in encode_factor_for_margin(g, ...) :
  could not find function "encode_factor_for_margin"
```

Two sites injected an unexported internal function as the *bare* head of
an expression `dtplyr` defers: `R/margin-label.R` (`encode_factor_for_margin`)
and `R/factor.R` (`reconstruct_factor_vector`). dplyr resolves such a head
below the quosure’s own environment, so the local backend never showed it;
`dtplyr` evaluates its translation in the environment the caller wrote the
pipeline in, where the name is not bound.

## The fix

`share_private_call()` already built a `marginplyr:::` head for exactly this
reason. It moves to `R/utils.R` as `marginplyr_private_call()`, gains the
header its contract needs, and is used at both sites. A scan over every
`rlang::expr()` and `rlang::call2()` reachable from a loaded namespace found
no third unqualified internal head.

## Why no gate caught it

`testthat::test_env("marginplyr")` is `env_clone(asNamespace("marginplyr"))`,
so a test written in the ordinary way builds its `lazy_dt()` where every
internal symbol resolves — which is why the existing eight-case dtplyr
contract test exercises the failing combination and stayed green.

The regression test therefore evaluates in an environment parented *below*
`package:marginplyr` on the search path. `globalenv()`, which is what a user
has, is not enough on its own: `pkgload::load_all()` attaches every internal
name to `package:marginplyr`, so under `devtools::test()` an environment
above it resolves them all. Starting below withholds them either way, and
still reaches `utils::head()`, which dtplyr’s own translation calls.

It covers all four verbs against a factor and an ordered-factor dimension,
and requires `dtplyr` and no other member of `optional_backends()`.

## Checks

- `lintr::lint_package()` — clean
- full suite with `NOT_CRAN=true` — 7013 pass, 0 fail, 0 skip
- `verify-suite-coverage.R`, `verify-verifier-invocation.R`,
  `verify-context-budget.R` — pass
- `roxygen2::roxygenise()` — no diff
