### PR TITLE
Fix smaller readiness findings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^AGENTS\.md$
 ^CLAUDE\.md$
 ^\.Rproj\.user$
+^\.git$
 ^LICENSE\.md$
 ^CODE_OF_CONDUCT\.md$
 ^README\.Rmd$

--- a/R/factor.R
+++ b/R/factor.R
@@ -74,15 +74,11 @@ margin_factor_levels <- function(info, .margin_name, position) {
       !(.margin_name %in% info$levels)
   )
 
-  # The assignment is this function's return value, which codetools reads as a
-  # dead store.
-  # nolint start: object_usage_linter.
-  new_levels <- if (identical(position, "first")) {
+  if (identical(position, "first")) {
     c(.margin_name, info$levels)
   } else {
     c(info$levels, .margin_name)
   }
-  # nolint end
 }
 
 restore_margin_factors <- function(.data,

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -47,15 +47,14 @@ summarize_margin_native <- function(.data,
       used_names = reserved_names,
       prefix = "..marginplyr_grouping_"
     )
-    flag_quos <- Map(
-      function(var, name) {
+    flag_quos <- lapply(
+      labelled_dimensions,
+      function(var) {
         rlang::new_quosure(
           grouping_sql_expr(var, con),
           env = rlang::empty_env()
         )
-      },
-      labelled_dimensions,
-      flag_names
+      }
     )
     names(flag_quos) <- flag_names
   } else {

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -81,7 +81,7 @@
 #' before the result is returned.
 #'
 #' @return For a local input, an ungrouped data frame with one list column,
-#'   whose class and attributes follow [dplyr::summarize()]; see *Result class
+#'   whose class and attributes follow [dplyr::mutate()]; see *Result class
 #'   and attributes*. A `dtplyr` input returns a lazy `dtplyr` step until
 #'   collected. Result row order is unspecified unless `.sort` asks for a
 #'   Margin order; see *Margin order*, or use [dplyr::arrange()] for any other

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -931,16 +931,14 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
       )
       summaries <- summary_plan$summaries
       dots <- summaries$dots
-      summary_selection_proxy <- dplyr::select(
+      selection_proxy <- summary_selection_proxy(
         operation$data_proxy,
-        dplyr::all_of(setdiff(
-          operation$data_vars,
-          unique(group_vars)
-        ))
+        data_vars = operation$data_vars,
+        group_vars = group_vars
       )
       summary_output_names <- unique(c(
         names(dots)[nzchar(names(dots))],
-        known_summary_output_names(dots, summary_selection_proxy)
+        known_summary_output_names(dots, selection_proxy)
       ))
       check_summary_group_overwrite(
         summary_output_names,

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -442,12 +442,10 @@ plan_summary_expressions <- function(dots,
   # 0007 has already captured the dots at the public verb.
   caller_labels <- summary_argument_labels(dots)
   original_dots <- dots
-  selection_proxy <- dplyr::select(
+  selection_proxy <- summary_selection_proxy(
     data_proxy,
-    dplyr::all_of(setdiff(
-      data_vars,
-      unique(group_vars)
-    ))
+    data_vars = data_vars,
+    group_vars = group_vars
   )
   dots <- resolve_summary_selections(
     dots,
@@ -530,6 +528,16 @@ find_summary_context_helpers <- function(expr) {
   )
 }
 
+# Builds the proxy every summary-selection reader sees: source columns outside
+# fixed keys and grouping dimensions. Keeping the exclusion here makes the
+# planning, rewriting, and output-name readers agree on one selection context.
+summary_selection_proxy <- function(data_proxy, data_vars, group_vars) {
+  dplyr::select(
+    data_proxy,
+    dplyr::all_of(setdiff(data_vars, unique(group_vars)))
+  )
+}
+
 # `caller_labels` is what a refusal quotes the failing dot by, and is passed in
 # rather than read off `dots`: the second resolution runs over dots this one
 # rewrote, whose labels are marginplyr's spelling and not the caller's
@@ -542,10 +550,10 @@ resolve_summary_selections <- function(dots,
                                        normalize_across_names = FALSE,
                                        skip_shares = FALSE) {
   stopifnot(length(dots) == length(caller_labels))
-  selectable_vars <- setdiff(data_vars, unique(group_vars))
-  selection_proxy <- dplyr::select(
+  selection_proxy <- summary_selection_proxy(
     data_proxy,
-    dplyr::all_of(selectable_vars)
+    data_vars = data_vars,
+    group_vars = group_vars
   )
 
   lapply(
@@ -741,12 +749,7 @@ rewrite_across_selection <- function(expr,
 }
 
 rewrite_pick_selection <- function(expr, env, data_proxy) {
-  call_args <- static_call_args(expr)
-  selection <- if (length(call_args) == 0L) {
-    rlang::expr(dplyr::everything())
-  } else {
-    rlang::call2("c", !!!call_args)
-  }
+  selection <- parse_pick_selection(expr)
   selected <- resolve_summary_selection(
     selection,
     env = env,
@@ -754,6 +757,16 @@ rewrite_pick_selection <- function(expr, env, data_proxy) {
   )
 
   rebuild_static_call(expr, list(summary_all_of_expr(selected, data_proxy)))
+}
+
+# Reads a `pick()` call's selection. An empty call selects everything, and both
+# callers need that rule to agree on the columns `pick()` can produce.
+parse_pick_selection <- function(expr) {
+  call_args <- static_call_args(expr)
+  if (length(call_args) == 0L) {
+    return(rlang::expr(dplyr::everything()))
+  }
+  rlang::call2("c", !!!call_args)
 }
 
 resolve_summary_selection <- function(expr, env, data_proxy) {
@@ -866,12 +879,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
   }
 
   if (identical(kind, "pick")) {
-    call_args <- static_call_args(expr)
-    selection <- if (length(call_args) == 0L) {
-      rlang::expr(dplyr::everything())
-    } else {
-      rlang::call2("c", !!!call_args)
-    }
+    selection <- parse_pick_selection(expr)
     return(names(resolve_summary_selection(selection, env, data_proxy)))
   }
 

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -100,7 +100,7 @@ original, pre-margin values rather than \code{.margin_label}.}
 }
 \value{
 For a local input, an ungrouped data frame with one list column,
-whose class and attributes follow \code{\link[dplyr:summarize]{dplyr::summarize()}}; see \emph{Result class
+whose class and attributes follow \code{\link[dplyr:mutate]{dplyr::mutate()}}; see \emph{Result class
 and attributes}. A \code{dtplyr} input returns a lazy \code{dtplyr} step until
 collected. Result row order is unspecified unless \code{.sort} asks for a
 Margin order; see \emph{Margin order}, or use \code{\link[dplyr:arrange]{dplyr::arrange()}} for any other

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -58,8 +58,7 @@ source(system.file("suggests", "guard.R", package = "marginplyr"))
 # the installed driver version through RSQLite.
 has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
 has_dtplyr <- marginplyr_suggest_available("dtplyr")
-has_tabsets <- marginplyr_suggest_available("knitr") &&
-  marginplyr_suggest_available("quartabs")
+has_tabsets <- marginplyr_suggest_available("quartabs")
 
 # Installs the `must_error` chunk option this document's rejected-call chunks
 # use. AGENTS.md is authoritative for what it does and why it exists.


### PR DESCRIPTION
## Summary

- Correct the nesting return contract and remove the dead vignette guard.
- Exclude linked-worktree .git metadata from source tarballs.
- Remove unused code and centralize duplicate summary-selection logic.
- Record the ADR terminology decision on issue 495.

## Validation

- Loaded-package lint: no lints.
- Context budget, must-error, and verifier-invocation checks passed.
- A linked-worktree R CMD build produced a tarball with no .git payload.
- Full test suite: 7,002 passes and 13 expected CRAN skips.

## Review

Two-axis review of b3755c7 against 863c0b8 found no remaining standards or specification issues. One naming observation was addressed before the final test run.

Closes #495