### PR TITLE
Document Arrow Margin label collisions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^AGENTS\.md$
 ^CLAUDE\.md$
 ^\.Rproj\.user$
+^\.git$
 ^LICENSE\.md$
 ^CODE_OF_CONDUCT\.md$
 ^README\.Rmd$

--- a/R/factor.R
+++ b/R/factor.R
@@ -62,13 +62,13 @@ reconstruct_factor_vector <- function(x,
 }
 
 margin_factor_levels <- function(info, .margin_name, position) {
-  # An invariant, not a Package condition (ADR-0015). A label equal to a
-  # declared level is rejected before anything executes and whatever
-  # `.check_margin_label` says (ADR 0020): every Margin verb calls
-  # `validate_margin_operation()` before the `finalize_margin_operation()` that
-  # calls `restore_margin_factors()`, which is the only caller of this. A level
-  # equal to the label would otherwise be deduplicated away and re-appended,
-  # moving it to the end of the levels for no reason a caller could see.
+  # An invariant, not a Package condition (ADR-0015). A Margin label equal to
+  # a level `info` holds has already been rejected before anything executes:
+  # every Margin verb calls `validate_margin_operation()` before the
+  # `finalize_margin_operation()` that calls `restore_margin_factors()`, which
+  # is the only caller of this. A level equal to the label would otherwise be
+  # deduplicated away and re-appended, moving it to the end of the levels for no
+  # reason a caller could see.
   stopifnot(
     "A Margin label equal to a declared factor level reached execution." =
       !(.margin_name %in% info$levels)

--- a/R/factor.R
+++ b/R/factor.R
@@ -74,15 +74,11 @@ margin_factor_levels <- function(info, .margin_name, position) {
       !(.margin_name %in% info$levels)
   )
 
-  # The assignment is this function's return value, which codetools reads as a
-  # dead store.
-  # nolint start: object_usage_linter.
-  new_levels <- if (identical(position, "first")) {
+  if (identical(position, "first")) {
     c(.margin_name, info$levels)
   } else {
     c(info$levels, .margin_name)
   }
-  # nolint end
 }
 
 restore_margin_factors <- function(.data,

--- a/R/grouping-adapter-native.R
+++ b/R/grouping-adapter-native.R
@@ -47,15 +47,14 @@ summarize_margin_native <- function(.data,
       used_names = reserved_names,
       prefix = "..marginplyr_grouping_"
     )
-    flag_quos <- Map(
-      function(var, name) {
+    flag_quos <- lapply(
+      labelled_dimensions,
+      function(var) {
         rlang::new_quosure(
           grouping_sql_expr(var, con),
           env = rlang::empty_env()
         )
-      },
-      labelled_dimensions,
-      flag_names
+      }
     )
     names(flag_quos) <- flag_names
   } else {

--- a/R/nest_with_margins.R
+++ b/R/nest_with_margins.R
@@ -81,7 +81,7 @@
 #' before the result is returned.
 #'
 #' @return For a local input, an ungrouped data frame with one list column,
-#'   whose class and attributes follow [dplyr::summarize()]; see *Result class
+#'   whose class and attributes follow [dplyr::mutate()]; see *Result class
 #'   and attributes*. A `dtplyr` input returns a lazy `dtplyr` step until
 #'   collected. Result row order is unspecified unless `.sort` asks for a
 #'   Margin order; see *Margin order*, or use [dplyr::arrange()] for any other

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -931,16 +931,14 @@ execute_margin_summary <- function(operation, dots, check_share_source) {
       )
       summaries <- summary_plan$summaries
       dots <- summaries$dots
-      summary_selection_proxy <- dplyr::select(
+      selection_proxy <- summary_selection_proxy(
         operation$data_proxy,
-        dplyr::all_of(setdiff(
-          operation$data_vars,
-          unique(group_vars)
-        ))
+        data_vars = operation$data_vars,
+        group_vars = group_vars
       )
       summary_output_names <- unique(c(
         names(dots)[nzchar(names(dots))],
-        known_summary_output_names(dots, summary_selection_proxy)
+        known_summary_output_names(dots, selection_proxy)
       ))
       check_summary_group_overwrite(
         summary_output_names,

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -50,13 +50,15 @@
 #'   named-list `.margin_label`.
 #'   Every Margin verb uses the same default: `TRUE` for local data frames and
 #'   `FALSE` for lazy inputs, which are read only when the caller asks. A label
-#'   equal to a declared factor *level* is rejected on every backend whatever
-#'   this argument says, because the levels are already known and finding it
-#'   sends no query. Left unchecked, a colliding value gives the result a
-#'   margin row and a source row that no grouping column tells apart; keeping
-#'   [grouping_bit()] or [grouping_id()] in the result distinguishes them at no
-#'   added cost. See *Display labels and grouping identity* for the factor
-#'   missing-value contract.
+#'   equal to a declared factor *level* is rejected wherever marginplyr holds
+#'   the levels, whatever this argument says, because finding it sends no
+#'   query. Arrow does not hold or restore factor levels; it checks an observed
+#'   collision only when this argument is `TRUE`. See *Result class and
+#'   attributes* for Arrow's character result. Left unchecked, a colliding
+#'   value gives the result a margin row and a source row that no grouping
+#'   column tells apart; keeping [grouping_bit()] or [grouping_id()] in the
+#'   result distinguishes them at no added cost. See *Display labels and
+#'   grouping identity* for the factor missing-value contract.
 #' @param .check_share_source A logical scalar, `TRUE` by default on every
 #'   backend, including lazy ones: establishing that a share's source summary
 #'   is an eligible type reads none of your data. `FALSE` calculates a

--- a/R/summary-selections.R
+++ b/R/summary-selections.R
@@ -442,12 +442,10 @@ plan_summary_expressions <- function(dots,
   # 0007 has already captured the dots at the public verb.
   caller_labels <- summary_argument_labels(dots)
   original_dots <- dots
-  selection_proxy <- dplyr::select(
+  selection_proxy <- summary_selection_proxy(
     data_proxy,
-    dplyr::all_of(setdiff(
-      data_vars,
-      unique(group_vars)
-    ))
+    data_vars = data_vars,
+    group_vars = group_vars
   )
   dots <- resolve_summary_selections(
     dots,
@@ -530,6 +528,16 @@ find_summary_context_helpers <- function(expr) {
   )
 }
 
+# Builds the proxy every summary-selection reader sees: source columns outside
+# fixed keys and grouping dimensions. Keeping the exclusion here makes the
+# planning, rewriting, and output-name readers agree on one selection context.
+summary_selection_proxy <- function(data_proxy, data_vars, group_vars) {
+  dplyr::select(
+    data_proxy,
+    dplyr::all_of(setdiff(data_vars, unique(group_vars)))
+  )
+}
+
 # `caller_labels` is what a refusal quotes the failing dot by, and is passed in
 # rather than read off `dots`: the second resolution runs over dots this one
 # rewrote, whose labels are marginplyr's spelling and not the caller's
@@ -542,10 +550,10 @@ resolve_summary_selections <- function(dots,
                                        normalize_across_names = FALSE,
                                        skip_shares = FALSE) {
   stopifnot(length(dots) == length(caller_labels))
-  selectable_vars <- setdiff(data_vars, unique(group_vars))
-  selection_proxy <- dplyr::select(
+  selection_proxy <- summary_selection_proxy(
     data_proxy,
-    dplyr::all_of(selectable_vars)
+    data_vars = data_vars,
+    group_vars = group_vars
   )
 
   lapply(
@@ -741,12 +749,7 @@ rewrite_across_selection <- function(expr,
 }
 
 rewrite_pick_selection <- function(expr, env, data_proxy) {
-  call_args <- static_call_args(expr)
-  selection <- if (length(call_args) == 0L) {
-    rlang::expr(dplyr::everything())
-  } else {
-    rlang::call2("c", !!!call_args)
-  }
+  selection <- parse_pick_selection(expr)
   selected <- resolve_summary_selection(
     selection,
     env = env,
@@ -754,6 +757,16 @@ rewrite_pick_selection <- function(expr, env, data_proxy) {
   )
 
   rebuild_static_call(expr, list(summary_all_of_expr(selected, data_proxy)))
+}
+
+# Reads a `pick()` call's selection. An empty call selects everything, and both
+# callers need that rule to agree on the columns `pick()` can produce.
+parse_pick_selection <- function(expr) {
+  call_args <- static_call_args(expr)
+  if (length(call_args) == 0L) {
+    return(rlang::expr(dplyr::everything()))
+  }
+  rlang::call2("c", !!!call_args)
 }
 
 resolve_summary_selection <- function(expr, env, data_proxy) {
@@ -866,12 +879,7 @@ known_data_frame_output_names <- function(expr, env, data_proxy) {
   }
 
   if (identical(kind, "pick")) {
-    call_args <- static_call_args(expr)
-    selection <- if (length(call_args) == 0L) {
-      rlang::expr(dplyr::everything())
-    } else {
-      rlang::call2("c", !!!call_args)
-    }
+    selection <- parse_pick_selection(expr)
     return(names(resolve_summary_selection(selection, env, data_proxy)))
   }
 

--- a/design/adr/0003-validate-margin-labels-before-execution.md
+++ b/design/adr/0003-validate-margin-labels-before-execution.md
@@ -20,3 +20,13 @@ label equal to an observed value requires reading, and that read is what
 `.check_margin_label` opts into. Both halves still run after the schema-aware
 preflight and immediately before low-level execution, for the reason stated
 above. See ADR 0020.
+
+## Amendment: Arrow does not hold declared factor levels
+
+The "every backend" clause in the amendment above is superseded. Arrow's
+schema supplies no factor levels for marginplyr to compare, and Arrow returns
+the dimension as character, so an unused declared level cannot itself make two
+result rows indistinguishable. An observed collision is still checked when the
+caller sets `.check_margin_label = TRUE`. ADR 0020's amendment *declared
+factor levels are not metadata on Arrow* owns this exception and the rule that
+it adds no read.

--- a/design/adr/0003-validate-margin-labels-before-execution.md
+++ b/design/adr/0003-validate-margin-labels-before-execution.md
@@ -23,10 +23,6 @@ above. See ADR 0020.
 
 ## Amendment: Arrow does not hold declared factor levels
 
-The "every backend" clause in the amendment above is superseded. Arrow's
-schema supplies no factor levels for marginplyr to compare, and Arrow returns
-the dimension as character, so an unused declared level cannot itself make two
-result rows indistinguishable. An observed collision is still checked when the
-caller sets `.check_margin_label = TRUE`. ADR 0020's amendment *declared
-factor levels are not metadata on Arrow* owns this exception and the rule that
-it adds no read.
+The "every backend" clause in the amendment above is superseded by #492.
+ADR 0020's amendment *declared factor levels are not metadata on Arrow* owns
+the Arrow exception and the rule that it adds no read.

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -227,3 +227,23 @@ this decision and refused; nothing here changed as a result.
 
 Evidence: `investigation/query-cost-across-lazy-backends.md` and
 `investigation/share-source-eligibility-on-coercing-dialects.md`.
+
+## Amendment: declared factor levels are not metadata on Arrow
+
+The declared half of the Margin-label collision check still contacts nothing
+where marginplyr holds factor-level metadata. It was too broad to say that this
+holds on every backend. Arrow's schema supplies a dictionary type but not its
+levels to the metadata marginplyr reads, and a non-missing Margin label makes
+the resulting dimension character rather than a factor.
+
+Arrow therefore does not reject a label equal to an unused declared factor
+level, whatever `.check_margin_label` says. That level has no row in the
+result, so it cannot itself make a source row and a margin row
+indistinguishable. A source value equal to the label is an observed collision,
+and Arrow rejects it when the caller sets `.check_margin_label = TRUE`.
+
+This does not add a metadata read or distinguish Arrow input classes. A
+zero-row read can reveal levels for some Arrow inputs but not for every Arrow
+table, query, or dataset, and the rule above does not permit a read the caller
+did not ask for. ADR 0003's amendment *one half of the collision check contacts
+nothing* is superseded only in its "every backend" clause.

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -231,10 +231,9 @@ Evidence: `investigation/query-cost-across-lazy-backends.md` and
 ## Amendment: declared factor levels are not metadata on Arrow
 
 The declared half of the Margin-label collision check still contacts nothing
-where marginplyr holds factor-level metadata. It was too broad to say that this
-holds on every backend. Arrow's schema supplies a dictionary type but not its
-levels to the metadata marginplyr reads, and a non-missing Margin label makes
-the resulting dimension character rather than a factor.
+where marginplyr holds factor-level metadata. #492 narrows the former
+all-backends statement for Arrow: an Arrow result carries a non-missing Margin
+label as character rather than as a factor.
 
 Arrow therefore does not reject a label equal to an unused declared factor
 level, whatever `.check_margin_label` says. That level has no row in the
@@ -242,8 +241,5 @@ result, so it cannot itself make a source row and a margin row
 indistinguishable. A source value equal to the label is an observed collision,
 and Arrow rejects it when the caller sets `.check_margin_label = TRUE`.
 
-This does not add a metadata read or distinguish Arrow input classes. A
-zero-row read can reveal levels for some Arrow inputs but not for every Arrow
-table, query, or dataset, and the rule above does not permit a read the caller
-did not ask for. ADR 0003's amendment *one half of the collision check contacts
-nothing* is superseded only in its "every backend" clause.
+This adds no read. ADR 0003's amendment *one half of the collision check
+contacts nothing* is superseded only in its "every backend" clause.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -57,13 +57,15 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
-equal to a declared factor \emph{level} is rejected on every backend whatever
-this argument says, because the levels are already known and finding it
-sends no query. Left unchecked, a colliding value gives the result a
-margin row and a source row that no grouping column tells apart; keeping
-\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
-added cost. See \emph{Display labels and grouping identity} for the factor
-missing-value contract.}
+equal to a declared factor \emph{level} is rejected wherever marginplyr holds
+the levels, whatever this argument says, because finding it sends no
+query. Arrow does not hold or restore factor levels; it checks an observed
+collision only when this argument is \code{TRUE}. See \emph{Result class and
+attributes} for Arrow's character result. Left unchecked, a colliding
+value gives the result a margin row and a source row that no grouping
+column tells apart; keeping \code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the
+result distinguishes them at no added cost. See \emph{Display labels and
+grouping identity} for the factor missing-value contract.}
 
 \item{.duplicates}{One of \code{"error"}, \code{"drop"}, or \code{"keep"}, and nothing
 else, controlling duplicate grouping sets after expansion; see \emph{Option

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -60,13 +60,15 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
-equal to a declared factor \emph{level} is rejected on every backend whatever
-this argument says, because the levels are already known and finding it
-sends no query. Left unchecked, a colliding value gives the result a
-margin row and a source row that no grouping column tells apart; keeping
-\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
-added cost. See \emph{Display labels and grouping identity} for the factor
-missing-value contract.}
+equal to a declared factor \emph{level} is rejected wherever marginplyr holds
+the levels, whatever this argument says, because finding it sends no
+query. Arrow does not hold or restore factor levels; it checks an observed
+collision only when this argument is \code{TRUE}. See \emph{Result class and
+attributes} for Arrow's character result. Left unchecked, a colliding
+value gives the result a margin row and a source row that no grouping
+column tells apart; keeping \code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the
+result distinguishes them at no added cost. See \emph{Display labels and
+grouping identity} for the factor missing-value contract.}
 
 \item{.duplicates}{\code{"error"} or \code{"drop"}, and nothing else; see \emph{Option
 arguments}. Nesting does not support the \code{"keep"} policy available in

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -60,13 +60,15 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
-equal to a declared factor \emph{level} is rejected on every backend whatever
-this argument says, because the levels are already known and finding it
-sends no query. Left unchecked, a colliding value gives the result a
-margin row and a source row that no grouping column tells apart; keeping
-\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
-added cost. See \emph{Display labels and grouping identity} for the factor
-missing-value contract.}
+equal to a declared factor \emph{level} is rejected wherever marginplyr holds
+the levels, whatever this argument says, because finding it sends no
+query. Arrow does not hold or restore factor levels; it checks an observed
+collision only when this argument is \code{TRUE}. See \emph{Result class and
+attributes} for Arrow's character result. Left unchecked, a colliding
+value gives the result a margin row and a source row that no grouping
+column tells apart; keeping \code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the
+result distinguishes them at no added cost. See \emph{Display labels and
+grouping identity} for the factor missing-value contract.}
 
 \item{.duplicates}{\code{"error"} or \code{"drop"}, and nothing else; see \emph{Option
 arguments}. Nesting does not support the \code{"keep"} policy available in

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -100,7 +100,7 @@ original, pre-margin values rather than \code{.margin_label}.}
 }
 \value{
 For a local input, an ungrouped data frame with one list column,
-whose class and attributes follow \code{\link[dplyr:summarize]{dplyr::summarize()}}; see \emph{Result class
+whose class and attributes follow \code{\link[dplyr:mutate]{dplyr::mutate()}}; see \emph{Result class
 and attributes}. A \code{dtplyr} input returns a lazy \code{dtplyr} step until
 collected. Result row order is unspecified unless \code{.sort} asks for a
 Margin order; see \emph{Margin order}, or use \code{\link[dplyr:arrange]{dplyr::arrange()}} for any other

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -78,13 +78,15 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
-equal to a declared factor \emph{level} is rejected on every backend whatever
-this argument says, because the levels are already known and finding it
-sends no query. Left unchecked, a colliding value gives the result a
-margin row and a source row that no grouping column tells apart; keeping
-\code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the result distinguishes them at no
-added cost. See \emph{Display labels and grouping identity} for the factor
-missing-value contract.}
+equal to a declared factor \emph{level} is rejected wherever marginplyr holds
+the levels, whatever this argument says, because finding it sends no
+query. Arrow does not hold or restore factor levels; it checks an observed
+collision only when this argument is \code{TRUE}. See \emph{Result class and
+attributes} for Arrow's character result. Left unchecked, a colliding
+value gives the result a margin row and a source row that no grouping
+column tells apart; keeping \code{\link[=grouping_bit]{grouping_bit()}} or \code{\link[=grouping_id]{grouping_id()}} in the
+result distinguishes them at no added cost. See \emph{Display labels and
+grouping identity} for the factor missing-value contract.}
 
 \item{.check_share_source}{A logical scalar, \code{TRUE} by default on every
 backend, including lazy ones: establishing that a share's source summary

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -985,6 +985,44 @@ test_that("DuckDB rejects a declared collision without being asked", {
   expect_identical(levels(result$g), c("a", "(all)", "b", "Total"))
 })
 
+# Arrow's schema does not give marginplyr the declared levels it needs to
+# reject the first call. Arrow also returns the dimension as character, so the
+# unused level has no source row that could be confused with its Margin label.
+test_that("Arrow checks observed, not declared, Margin label collisions", {
+  skip_if_suggest_absent("arrow")
+
+  unused_level <- arrow::Table$create(data.frame(
+    group = factor(c("a", "b"), levels = c("a", "b", "Total")),
+    value = 1:2
+  ))
+  result <- expect_no_error(dplyr::collect(summarize_with_margins(
+    unused_level,
+    n = dplyr::n(),
+    .grouping = rollup(group),
+    .margin_label = "Total",
+    .check_margin_label = TRUE
+  )))
+  expect_type(result$group, "character")
+  expect_setequal(result$group, c("a", "b", "Total"))
+
+  observed_collision <- arrow::Table$create(data.frame(
+    group = factor(c("a", "Total"), levels = c("a", "b", "Total")),
+    value = 1:2
+  ))
+  error <- expect_error(
+    summarize_with_margins(
+      observed_collision,
+      n = dplyr::n(),
+      .grouping = rollup(group),
+      .margin_label = "Total",
+      .check_margin_label = TRUE
+    ),
+    "already present in grouping column:\ni `group`",
+    fixed = TRUE
+  )
+  expect_s3_class(error, "marginplyr_error")
+})
+
 # The silence is the contract, so it is asserted rather than left to the
 # absence of a failing expectation: a later change to `.check_margin_label`'s
 # default has to fail here instead of passing quietly. SQLite is where the

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -266,12 +266,13 @@ queries your data* in the [`summarize_with_margins()`
 reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html)
 states the rule this default follows and its two exemptions.
 
-Two protections hold regardless of `.check_margin_label`, at no added query.
+Two protections hold at no added query. The first applies wherever marginplyr
+holds factor-level metadata.
 
-A label equal to a *declared* factor level is rejected on every backend,
-because the level is already known from the column's metadata and finding
-the collision reads nothing. The enum preservation above is what makes this
-visible on DuckDB: `region` below declares `"Total"` as an unused level, and
+A label equal to a *declared* factor level is rejected there, because the
+level is already known from the column's metadata and finding the collision
+reads nothing. The enum preservation above is what makes this visible on
+DuckDB: `region` below declares `"Total"` as an unused level, and
 `.margin_label = "Total"` is rejected before any query is built, even though
 `.check_margin_label` is left at its lazy default:
 
@@ -309,6 +310,13 @@ region_db |>
 
 DBI::dbDisconnect(con)
 ```
+
+Arrow is different. A factor grouping dimension there returns as character,
+so Arrow does not expose its declared levels to this check; see *Result class
+and attributes* in the [`summarize_with_margins()`
+reference](https://sayuks.github.io/marginplyr/man/summarize_with_margins.html).
+An unused declared level therefore does not make two result rows look alike.
+An observed collision still does, and `.check_margin_label = TRUE` rejects it.
 
 Keeping `grouping_bit()` or `grouping_id()` in the result is the other free
 protection: either identifies every margin row structurally, so a source row

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -58,8 +58,7 @@ source(system.file("suggests", "guard.R", package = "marginplyr"))
 # the installed driver version through RSQLite.
 has_sqlite_simulator <- marginplyr_suggest_available("RSQLite")
 has_dtplyr <- marginplyr_suggest_available("dtplyr")
-has_tabsets <- marginplyr_suggest_available("knitr") &&
-  marginplyr_suggest_available("quartabs")
+has_tabsets <- marginplyr_suggest_available("quartabs")
 
 # Installs the `must_error` chunk option this document's rejected-call chunks
 # use. AGENTS.md is authoritative for what it does and why it exists.

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -506,9 +506,11 @@ typed-missing Margin value, which can all print as `<NA>`.
 
 For local data, `.check_margin_label = TRUE` prevents an existing value such
 as `"Total"` from becoming visually ambiguous. Lazy inputs default to
-`.check_margin_label = FALSE` for that same check; a label equal to a
-declared factor level is rejected on every backend either way. Result row
-order is unspecified for both local and lazy inputs unless
+`.check_margin_label = FALSE` for that same check. A declared factor level is
+rejected wherever marginplyr holds its levels. Arrow returns factor dimensions
+as character, so it does not reject a declared level; it rejects an observed
+collision only when `.check_margin_label = TRUE`. Result row order is
+unspecified for both local and lazy inputs unless
 `.sort` asks for a Margin order; use `arrange()` for any other presentation
 order. [Put each subtotal with the rows it
 summarizes](https://sayuks.github.io/marginplyr/vignettes/recipes.html#put-each-subtotal-with-the-rows-it-summarizes)


### PR DESCRIPTION
Closes #492.\n\nDocuments Arrow's declared-versus-observed Margin label collision behavior, amends ADRs 0003 and 0020, regenerates the reference, and adds an Arrow regression test.