### PR TITLE
Fix portable window ordering

### DIFF
--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -386,7 +386,8 @@ summarize_margin_union <- function(.data,
                                    reserved_names,
                                    set_id_name = NULL,
                                    set_id_is_internal = FALSE,
-                                   call = NULL) {
+                                   call = NULL,
+                                   input_window_order = list()) {
   dots <- summaries$dots
   group_vars <- unique(c(plan$by, plan$dimensions))
   key_names <- new_margin_internal_names(
@@ -523,7 +524,28 @@ summarize_margin_union <- function(.data,
     plan$set_ids
   )
 
-  combine_margin_branches(branches)
+  restore_input_window_order(
+    combine_margin_branches(branches),
+    input_window_order
+  )
+}
+
+# Restores the input's usable dbplyr window ordering after `UNION ALL` has
+# dropped it. ADR 0018's `.sort = "none"` amendment and #493 decide the
+# contract; terms the result cannot name follow the native adapter and vanish.
+restore_input_window_order <- function(result, input_window_order) {
+  if (length(input_window_order) == 0L) {
+    return(result)
+  }
+  result_names <- get_col_names(result, dplyr::everything())
+  usable <- Filter(
+    function(term) all(all.vars(term) %in% result_names),
+    input_window_order
+  )
+  if (length(usable) == 0L) {
+    return(result)
+  }
+  dbplyr::window_order(result, !!!usable)
 }
 
 # `backend` is the operation's own, and it sits among the required arguments

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -1058,6 +1058,11 @@ stage_margin_summaries <- function(operation,
           set_id_is_internal = set_id_is_internal
         )
       } else {
+        input_window_order <- if (operation$backend$records_window_order) {
+          dbplyr::op_sort(operation$data)
+        } else {
+          list()
+        }
         summarize_margin_union(
           operation$data,
           summaries = summaries,
@@ -1067,7 +1072,8 @@ stage_margin_summaries <- function(operation,
           reserved_names = reserved_names,
           set_id_name = set_id_name,
           set_id_is_internal = set_id_is_internal,
-          call = operation$call
+          call = operation$call,
+          input_window_order = input_window_order
         )
       }
     },

--- a/design/adr/0018-order-margin-results-by-grouping-structure.md
+++ b/design/adr/0018-order-margin-results-by-grouping-structure.md
@@ -176,6 +176,20 @@ The default is not data dependent. The removed option defaulted to
 lazy results unordered. Row order is where such a split is hardest to
 notice.
 
+## Amendment: no Margin order preserves usable window ordering
+
+`.sort = "none"` asks for no Margin order. It also leaves every usable dbplyr
+window-order term the input carried available to a later window expression,
+on both the native and portable adapters (#493). A term whose column is not
+in the result is discarded as dbplyr normally discards it; marginplyr adds no
+rule of its own for that case.
+
+A window ordering is metadata for a later window expression, not a physical
+row order. The portable adapter therefore restores it on the final lazy
+result rather than adding an `ORDER BY` or a per-branch subquery. This does
+not alter the existing rule for `.sort = "first"` or `"last"`: those choices
+request a Margin order and clear a window ordering that cannot reproduce it.
+
 ## Considered options
 
 **`.bits`, an argument adding one Grouping bit column per dimension, leaving

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -705,7 +705,7 @@ test_that("`.sort = \"none\"` clears no window ordering", {
   query <- summarize_with_margins(
     remote,
     units = sum(units, na.rm = TRUE),
-    .grouping = grouping_spec(region),
+    .grouping = rollup(region),
     .sort = "none"
   )
   # Asking for no order reaches neither the ordering nor the clearing that
@@ -716,6 +716,46 @@ test_that("`.sort = \"none\"` clears no window ordering", {
     dbplyr::sql_render(dplyr::mutate(query, running = cumsum(units)))
   )
   expect_match(windowed, "OVER (ORDER BY", fixed = TRUE)
+})
+
+test_that("`.sort = \"none\"` preserves portable window ordering", {
+  skip_if_no_sqlite_simulation()
+  remote <- dbplyr::window_order(
+    dbplyr::tbl_lazy(margin_order_data(), con = dbplyr::simulate_sqlite()),
+    region
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region),
+    .sort = "none"
+  )
+  expect_false(grepl("ORDER BY", dbplyr::sql_render(query), fixed = TRUE))
+  windowed <- suppressWarnings(
+    dbplyr::sql_render(dplyr::mutate(query, running = cumsum(units)))
+  )
+  expect_match(windowed, "OVER (ORDER BY", fixed = TRUE)
+})
+
+test_that("portable window ordering keeps only summary columns", {
+  skip_if_no_sqlite_simulation()
+  remote <- dbplyr::window_order(
+    dbplyr::tbl_lazy(margin_order_data(), con = dbplyr::simulate_sqlite()),
+    store,
+    dplyr::desc(region)
+  )
+
+  query <- summarize_with_margins(
+    remote,
+    units = sum(units, na.rm = TRUE),
+    .grouping = rollup(region),
+    .sort = "none"
+  )
+  windowed <- suppressWarnings(
+    dbplyr::sql_render(dplyr::mutate(query, running = cumsum(units)))
+  )
+  expect_match(windowed, "OVER (ORDER BY `region` DESC", fixed = TRUE)
 })
 
 # The live backend contracts follow.


### PR DESCRIPTION
## Summary

- preserve usable input window ordering through the portable UNION ALL summary path
- keep only terms that remain in the summary result, matching dbplyr native behavior
- cover native and portable rollup paths without adding a physical ORDER BY

## Verification

- `pkgload::load_all(".", quiet = TRUE); lintr::lint_package()`
- `devtools::test()` (7,030 passed)

Closes #493