### PR TITLE
Keep ADR 0027's amendment to the current decision

### DIFF
--- a/design/adr/0027-record-the-sql-marginplyr-sends.md
+++ b/design/adr/0027-record-the-sql-marginplyr-sends.md
@@ -425,33 +425,12 @@ not an execution — the caller's own `collect()` is still what runs it.
 
 ## Amendment: one page states the contract and two point at it
 
-*Documentation consequences* above spreads one contract over three pages, and
-it drifted. `?last_sent_queries`'s first answer said the record is empty while
-"no Margin verb has begun", where the accessor refuses on
-`sent_queries$recorded` — set by `reset_sent_queries()`, which every exported
-function taking `.grouping` calls, `inspect_grouping()` among them. An
-unaudited `inspect_grouping()` alone therefore moves the answer to the second,
-and the page #23's User Story 35 makes canonical was the copy that was wrong
-(#494).
-
-`?last_sent_queries` now states the contract: what the record holds, which
-calls keep one, what each of the four answers means, and how to write a record
-out. `?marginplyr` and the guide each keep what their own audience needs and
-point at it for the contract. *Four answers, distinguished* above is this
-decision's record of them and not a copy of that page.
-
-What the fix rests on is that the page enumerates the calls once, in its
-description, and the first answer refers to that list rather than repeating
-it. `test-documentation.R` holds the list to the exported functions taking
-`.grouping`, reading the description alone for the reason it states. Whether a
-sentence about the record is true is not a thing either gate reads, and
-`test-sent-queries.R` runs every entry point against the answer it moves the
-session to for that reason.
-
-One claim in the section above was already wrong before this branch reached
-it: "It names one capture" is true of `?marginplyr`'s section and not of the
-reference, which named none then and names none now. The paragraph describes
-the two pages together, which is the shape this amendment ends.
+#494 moves the package documentation's single statement of the contract to
+`?last_sent_queries`: what the record holds, which calls keep one, what each of
+the four answers means, and how to write a record out. `?marginplyr` and the
+guide each keep what their own audience needs and point at that page for the
+contract. *Four answers, distinguished* above remains this decision's record
+of the answers rather than another copy of the reference page.
 
 ## Related decisions
 


### PR DESCRIPTION
## Summary

- keep ADR 0027's amendment to the current documentation decision and what moved
- remove the duplicated cause, test rationale, and historical wording already owned by #494
- preserve #494 as the reason's authoritative reference

## Verification

- `Rscript .github/scripts/verify-context-budget.R`
- `Rscript .github/scripts/verify-doc-references.R`
- `git diff --check`
- fresh Standards and Spec review against `main`

Closes #501
