### PR TITLE
Add a non-mutating CRAN preflight command

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,6 +8,7 @@
 ^README\.Rmd$
 ^dev$
 ^data-raw$
+^tools$
 ^\.github$
 ^\.claude$
 ^docs$

--- a/.github/scripts/check-tarball.R
+++ b/.github/scripts/check-tarball.R
@@ -9,13 +9,13 @@
 # reviewed place rather than in six copies of an inline step. And a matrix job
 # cannot pass R arguments, so configuration arrives through the environment.
 #
-# Exits non-zero on any ERROR or WARNING. An unexpected NOTE is annotated and
-# written to the job summary but does not fail the job: R-devel and CRAN
-# incoming checks introduce NOTEs that are outside this package's control, and
-# a gate that cries wolf gets ignored. Judging the recorded NOTEs is part of
-# the release review.
+# Exits non-zero on any ERROR or WARNING. An unexpected NOTE is always
+# annotated and written to the job summary. It also fails a manually dispatched
+# strict release run; routine push and pull-request checks retain their
+# lower-noise reporting behavior (#505).
 
 source(".github/scripts/ci-helpers.R")
+source(".github/scripts/cran-note-policy.R")
 
 # Asserts that this job's library holds the optional backends it declared and
 # no others, and stops before the check when it does not. It runs here rather
@@ -39,33 +39,6 @@ split_words <- function(value) {
   words[nzchar(words)]
 }
 
-# NOTEs this package has already accounted for. Each entry pairs a literal
-# fragment of the NOTE's text with the reason it is expected, so the job
-# summary explains itself without a reviewer reconstructing the history.
-#
-# Fragments are matched literally and kept narrow on purpose. Matching the
-# "checking CRAN incoming feasibility" header instead would classify every
-# future incoming finding -- misspellings, unreachable URLs -- as understood,
-# which is the opposite of what this list is for.
-understood_notes <- c(
-  "New submission" =
-    "marginplyr 0.1.0 is a first CRAN release, so incoming checks say so.",
-  "Days since last update" =
-    "Only meaningful for resubmissions during a review cycle."
-)
-
-describe_note <- function(note) {
-  matched <- vapply(
-    names(understood_notes),
-    function(fragment) grepl(fragment, note, fixed = TRUE),
-    logical(1)
-  )
-  if (!any(matched)) {
-    return(NA_character_)
-  }
-  understood_notes[[which(matched)[1]]]
-}
-
 tarballs <- list.files(tarball_dir, pattern = "[.]tar[.]gz$", full.names = TRUE)
 if (length(tarballs) != 1L) {
   stop(sprintf(
@@ -75,6 +48,11 @@ if (length(tarballs) != 1L) {
   ))
 }
 message("Checking source tarball: ", tarballs)
+cran_status <- cran_status_from_tarball(tarballs)
+strict_release <- identical(
+  tolower(Sys.getenv("MARGINPLYR_STRICT_RELEASE", "false")),
+  "true"
+)
 
 result <- rcmdcheck::rcmdcheck(
   tarballs,
@@ -116,19 +94,30 @@ append_section <- function(lines, heading, entries) {
 summary_lines <- append_section(summary_lines, "Errors", result$errors)
 summary_lines <- append_section(summary_lines, "Warnings", result$warnings)
 
+classifications <- lapply(
+  result$notes,
+  classify_cran_note,
+  cran_status = cran_status
+)
 unexpected <- character()
-for (note in result$notes) {
-  reason <- describe_note(note)
-  heading <- if (is.na(reason)) "Unexpected NOTE" else "Understood NOTE"
+for (index in seq_along(result$notes)) {
+  note <- result$notes[[index]]
+  classification <- classifications[[index]]
+  allowed <- identical(classification$status, "allowed-note")
+  heading <- if (allowed) "Allowed NOTE" else "Unexpected NOTE"
   summary_lines <- c(
     summary_lines,
     sprintf("### %s", heading),
     "",
-    if (is.na(reason)) "No recorded explanation for this NOTE." else reason,
+    if (allowed) {
+      classification$rationale
+    } else {
+      "No release-policy allowance matches this complete NOTE."
+    },
     "",
     as_summary_block(note)
   )
-  if (is.na(reason)) {
+  if (!allowed) {
     unexpected <- c(unexpected, note)
   }
 }
@@ -151,5 +140,13 @@ if (length(result$errors) > 0L || length(result$warnings) > 0L) {
     label,
     length(result$errors),
     length(result$warnings)
+  ))
+}
+
+if (cran_notes_block(classifications, strict_release)) {
+  stop(sprintf(
+    "%s failed strict release classification with %d unknown NOTE(s).",
+    label,
+    length(unexpected)
   ))
 }

--- a/.github/scripts/cran-note-policy.R
+++ b/.github/scripts/cran-note-policy.R
@@ -1,0 +1,98 @@
+# Classifies the complete normalized text of one R CMD check NOTE. Local
+# preflight and release-matrix checks source this file so strict release policy
+# has one allowlist (#505).
+
+# Removes presentation-only variation while retaining every substantive line.
+# The allowlist patterns below are anchored against this representation, so a
+# second incoming finding cannot inherit the disposition of the first.
+normalize_cran_note <- function(note) {
+  note <- gsub("\033\\[[0-9;]*[[:alpha:]]", "", note)
+  lines <- strsplit(gsub("\r\n?", "\n", note), "\n", fixed = TRUE)[[1L]]
+  lines <- trimws(lines)
+  if (length(lines) > 0L) {
+    lines[[1L]] <- sub("^[*][[:space:]]+", "", lines[[1L]])
+  }
+  paste(lines[nzchar(lines)], collapse = "\n")
+}
+
+# Every entry carries the evidence needed to apply it and to explain it. The
+# signature describes the whole normalized NOTE rather than a fragment.
+cran_note_policy <- function() {
+  list(
+    new_submission = list(
+      signature = paste0(
+        "^checking CRAN incoming feasibility [.]{3} NOTE\\n",
+        "Maintainer: '[^'\\n]+ <[^>\\n]+>'\\n",
+        "New submission$"
+      ),
+      states = "unpublished",
+      rationale = paste(
+        "CRAN reports an initial submission before marginplyr is published."
+      ),
+      marker = "New submission"
+    )
+  )
+}
+
+# Returns the release disposition and the policy evidence for one NOTE.
+classify_cran_note <- function(note, cran_status) {
+  normalized <- normalize_cran_note(note)
+  policies <- cran_note_policy()
+  matched <- vapply(
+    policies,
+    function(policy) {
+      cran_status %in% policy$states &&
+        grepl(policy$signature, normalized, perl = TRUE)
+    },
+    logical(1)
+  )
+  if (!any(matched)) {
+    return(list(
+      status = "unknown-note",
+      normalized = normalized,
+      policy = NA_character_,
+      rationale = NA_character_,
+      marker = NA_character_
+    ))
+  }
+
+  name <- names(policies)[which(matched)[[1L]]]
+  policy <- policies[[name]]
+  list(
+    status = "allowed-note",
+    normalized = normalized,
+    policy = name,
+    rationale = policy$rationale,
+    marker = policy$marker
+  )
+}
+
+# Routine CI reports unknown NOTEs without turning a moving R-devel signal into
+# noise. A manually dispatched release run fails closed on the same result.
+cran_notes_block <- function(classifications, strict) {
+  isTRUE(strict) && any(vapply(
+    classifications,
+    function(note) identical(note$status, "unknown-note"),
+    logical(1)
+  ))
+}
+
+# Reads submission state from the artifact being checked, not from the checkout
+# beside it. A release-matrix job therefore classifies the tarball it received.
+cran_status_from_tarball <- function(tarball) {
+  contents <- utils::untar(tarball, list = TRUE)
+  descriptions <- contents[grepl("^[^/]+/DESCRIPTION$", contents)]
+  if (length(descriptions) != 1L) {
+    stop("The source tarball must contain exactly one package DESCRIPTION.")
+  }
+  extracted <- tempfile("marginplyr-description-")
+  dir.create(extracted)
+  on.exit(unlink(extracted, recursive = TRUE), add = TRUE)
+  utils::untar(tarball, files = descriptions, exdir = extracted)
+  description <- read.dcf(file.path(extracted, descriptions))
+  field <- "Config/marginplyr/cran-status"
+  if (!(field %in% colnames(description))) {
+    stop("The source tarball DESCRIPTION is missing `", field, "`.")
+  }
+  trimws(description[[1L, field]])
+}

--- a/.github/scripts/cran-note-policy.R
+++ b/.github/scripts/cran-note-policy.R
@@ -7,6 +7,7 @@
 # second incoming finding cannot inherit the disposition of the first.
 normalize_cran_note <- function(note) {
   note <- gsub("\033\\[[0-9;]*[[:alpha:]]", "", note)
+  note <- chartr("‘’", "''", note)
   lines <- strsplit(gsub("\r\n?", "\n", note), "\n", fixed = TRUE)[[1L]]
   lines <- trimws(lines)
   if (length(lines) > 0L) {

--- a/.github/scripts/verify-cran-preflight.R
+++ b/.github/scripts/verify-cran-preflight.R
@@ -1,0 +1,491 @@
+# Exercises the release-policy helpers with fixtures that need neither a
+# package installation nor a network service. The local preflight and release
+# matrix both source the same policy, so this verifier is where changes to its
+# deliberately narrow NOTE allowance fail before either expensive gate runs.
+
+source(".github/scripts/cran-note-policy.R")
+source("tools/cran-preflight-lib.R")
+
+expect_identical <- function(actual, expected, label) {
+  if (!identical(actual, expected)) {
+    stop(
+      sprintf(
+        "%s: expected %s, got %s.",
+        label,
+        paste(deparse(expected), collapse = " "),
+        paste(deparse(actual), collapse = " ")
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+expect_true <- function(actual, label) {
+  expect_identical(isTRUE(actual), TRUE, label)
+}
+
+new_submission <- paste(
+  "* checking CRAN incoming feasibility ... NOTE",
+  "Maintainer: 'Yusuke Sasaki <sayuks.dev@gmail.com>'",
+  "",
+  "New submission",
+  sep = "\n"
+)
+
+allowed <- classify_cran_note(new_submission, "unpublished")
+expect_identical(
+  allowed$status,
+  "allowed-note",
+  "the initial-submission NOTE"
+)
+expect_identical(
+  allowed$marker,
+  "New submission",
+  "the required cran-comments marker"
+)
+
+near_miss <- paste(new_submission, "Possibly misspelled words", sep = "\n")
+expect_identical(
+  classify_cran_note(near_miss, "unpublished")$status,
+  "unknown-note",
+  "an incoming NOTE with another finding"
+)
+expect_identical(
+  classify_cran_note(new_submission, "published")$status,
+  "unknown-note",
+  "the initial-submission NOTE in the wrong state"
+)
+expect_identical(
+  classify_cran_note("Days since last update: 1", "unpublished")$status,
+  "unknown-note",
+  "the former resubmission allowance"
+)
+unknown <- classify_cran_note("An unknown NOTE", "unpublished")
+expect_identical(
+  cran_notes_block(list(unknown), strict = FALSE),
+  FALSE,
+  "an unknown NOTE in routine CI"
+)
+expect_identical(
+  cran_notes_block(list(unknown), strict = TRUE),
+  TRUE,
+  "an unknown NOTE in a manual release run"
+)
+expect_identical(
+  cran_notes_block(list(allowed), strict = TRUE),
+  FALSE,
+  "an allowed NOTE in a manual release run"
+)
+
+description <- read_description("DESCRIPTION")
+preflight_requirements <- dependency_requirements(description_value(
+  description,
+  "Config/Needs/preflight"
+))
+expect_identical(
+  preflight_requirements$package,
+  c("checktor", "rcmdcheck", "urlchecker"),
+  "the preflight-only dependency set"
+)
+checktor_requirement <- preflight_requirements[
+  preflight_requirements$package == "checktor",
+  ,
+  drop = FALSE
+]
+expect_identical(
+  checktor_requirement$operator,
+  ">=",
+  "the checktor baseline operator"
+)
+expect_identical(
+  checktor_requirement$version,
+  "0.1.0",
+  "the checktor baseline version"
+)
+package_requirements <- rbind(
+  dependency_requirements(description_value(description, "Imports")),
+  dependency_requirements(description_value(description, "Suggests"))
+)
+expect_identical(
+  intersect(preflight_requirements$package, package_requirements$package),
+  character(),
+  "preflight-only packages outside Imports and Suggests"
+)
+
+build_ignore <- readLines(".Rbuildignore", warn = FALSE)
+expect_true("^tools$" %in% build_ignore, "the tools tarball exclusion")
+
+preflight_sources <- paste(
+  unlist(lapply(
+    c("tools/cran-preflight.R", "tools/cran-preflight-lib.R"),
+    readLines,
+    warn = FALSE
+  )),
+  collapse = "\n"
+)
+forbidden_calls <- c(
+  "roxygenise(", "render(\"README.Rmd\"", "att_amend_desc(",
+  "att_from_namespace(", "url_update(", "use_release_issue(",
+  "test_dir(", "run_examples(", "build_vignettes(", "covr::"
+)
+for (call in forbidden_calls) {
+  expect_identical(
+    grepl(call, preflight_sources, fixed = TRUE),
+    FALSE,
+    paste("the prohibited preflight call", call)
+  )
+}
+expect_identical(
+  lengths(regmatches(
+    preflight_sources,
+    gregexpr("spelling::spell_check_package", preflight_sources, fixed = TRUE)
+  )),
+  1L,
+  "one spelling invocation"
+)
+expect_identical(
+  lengths(regmatches(
+    preflight_sources,
+    gregexpr("rcmdcheck::rcmdcheck", preflight_sources, fixed = TRUE)
+  )),
+  1L,
+  "one R CMD check invocation"
+)
+expect_identical(
+  grepl("--no-manual", preflight_sources, fixed = TRUE),
+  FALSE,
+  "the full PDF manual check"
+)
+expect_true(
+  grepl("_R_CHECK_CRAN_INCOMING_REMOTE_", preflight_sources, fixed = TRUE),
+  "the incoming remote check setting"
+)
+
+url_fixture <- data.frame(
+  Status = c("404", "500", "429", "", "301"),
+  Message = c(
+    "Not Found", "Internal Server Error", "Too Many Requests",
+    "Could not resolve host", "Moved Permanently"
+  ),
+  New = c("", "", "", "", "https://example.invalid/new"),
+  stringsAsFactors = FALSE
+)
+expect_identical(
+  classify_url_results(url_fixture),
+  c("failed", "unavailable", "unavailable", "unavailable", "failed"),
+  "URL retry classifications"
+)
+expect_true(
+  check_reports_url_problem(list(
+    errors = character(),
+    warnings = "* checking URLs in DESCRIPTION ... WARNING",
+    notes = character()
+  )),
+  "a check URL finding"
+)
+
+lint_workflow <- paste(
+  readLines(".github/workflows/lint.yaml", warn = FALSE),
+  collapse = "\n"
+)
+expect_true(
+  grepl(
+    "Rscript .github/scripts/verify-cran-preflight.R",
+    lint_workflow,
+    fixed = TRUE
+  ),
+  "the preflight verifier workflow invocation"
+)
+
+fixture_root <- tempfile("marginplyr-preflight-fixture-")
+dir.create(fixture_root)
+on.exit(unlink(fixture_root, recursive = TRUE), add = TRUE)
+
+package_dir <- file.path(fixture_root, "marginplyr")
+dir.create(package_dir)
+writeLines(
+  c(
+    "Package: marginplyr",
+    "Version: 0.1.0",
+    "Config/marginplyr/cran-status: unpublished"
+  ),
+  file.path(package_dir, "DESCRIPTION")
+)
+tarball <- file.path(fixture_root, "marginplyr_0.1.0.tar.gz")
+old_wd <- setwd(fixture_root)
+utils::tar(basename(tarball), basename(package_dir), compression = "gzip")
+setwd(old_wd)
+unpacked <- file.path(fixture_root, "unpacked")
+identity <- verify_candidate_tarball(
+  tarball,
+  expected_package = "marginplyr",
+  expected_version = "0.1.0",
+  unpack_dir = unpacked
+)
+expect_identical(identity$package, "marginplyr", "the tarball package")
+expect_identical(identity$version, "0.1.0", "the tarball version")
+expect_true(nzchar(identity$sha256), "the tarball SHA-256")
+expect_identical(
+  cran_status_from_tarball(tarball),
+  "unpublished",
+  "the tarball CRAN status"
+)
+
+comments <- file.path(fixture_root, "cran-comments.md")
+writeLines(
+  c(
+    "## R CMD check results",
+    "",
+    "0 errors | 0 warnings | 1 note",
+    "",
+    "New submission"
+  ),
+  comments
+)
+counts <- c(errors = 0L, warnings = 0L, notes = 1L)
+expect_identical(
+  cran_comments_problems(comments, counts, list(allowed)),
+  character(),
+  "matching cran-comments"
+)
+expect_true(
+  length(cran_comments_problems(
+    comments,
+    c(errors = 0L, warnings = 1L, notes = 1L),
+    list(allowed)
+  )) > 0L,
+  "mismatched cran-comments counts"
+)
+writeLines("0 errors | 0 warnings | 1 note", comments)
+expect_true(
+  length(cran_comments_problems(comments, counts, list(allowed))) > 0L,
+  "a missing allowed-NOTE explanation"
+)
+
+expect_identical(
+  preflight_exit_code(candidate_failed = FALSE, tool_failed = FALSE),
+  0L,
+  "a successful preflight exit"
+)
+expect_identical(
+  preflight_exit_code(candidate_failed = TRUE, tool_failed = FALSE),
+  1L,
+  "a candidate failure exit"
+)
+expect_identical(
+  preflight_exit_code(candidate_failed = TRUE, tool_failed = TRUE),
+  2L,
+  "a tooling failure exit"
+)
+expect_identical(
+  preflight_exit_code(
+    candidate_failed = TRUE,
+    tool_failed = TRUE,
+    interrupted = TRUE
+  ),
+  130L,
+  "an interrupted preflight exit"
+)
+expect_true(
+  worktree_is_unchanged("", ""),
+  "an unchanged clean worktree"
+)
+expect_identical(
+  worktree_is_unchanged("", "?? unexpected"),
+  FALSE,
+  "a mutated clean worktree"
+)
+
+evidence <- file.path(fixture_root, "evidence")
+dir.create(evidence)
+state <- new_preflight_state(evidence)
+state$candidate_sha <- paste(rep("a", 40L), collapse = "")
+state$package <- "marginplyr"
+state$version <- "0.1.0"
+state$cran_status <- "unpublished"
+state$tarball <- basename(tarball)
+state$tarball_sha256 <- identity$sha256
+state$counts <- counts
+state$worktree_before <- ""
+state$worktree_after <- ""
+record_preflight_step(
+  state,
+  "fixture",
+  "passed",
+  elapsed = 0.1,
+  evidence = basename(tarball),
+  detail = "fixture completed"
+)
+write_preflight_evidence(state, exit_code = 0L)
+expect_true(file.exists(file.path(evidence, "summary.md")), "the human summary")
+expect_true(
+  file.exists(file.path(evidence, "results.dcf")),
+  "the machine result"
+)
+expect_true(file.exists(file.path(evidence, "steps.tsv")), "the step results")
+
+run_in_dir <- function(path, command, args, stdout) {
+  old <- setwd(path)
+  on.exit(setwd(old), add = TRUE)
+  status <- suppressWarnings(system2(
+    command,
+    vapply(args, shQuote, character(1)),
+    stdout = stdout,
+    stderr = stdout
+  ))
+  if (is.null(status) || length(status) == 0L) {
+    return(0L)
+  }
+  if (is.character(status)) {
+    code <- attr(status, "status")
+    return(if (is.null(code)) 0L else as.integer(code))
+  }
+  as.integer(status)
+}
+
+cli_root <- file.path(fixture_root, "cli")
+dir.create(file.path(cli_root, "tools"), recursive = TRUE)
+dir.create(file.path(cli_root, ".github", "scripts"), recursive = TRUE)
+copied_tools <- file.copy(
+  c("tools/cran-preflight.R", "tools/cran-preflight-lib.R"),
+  file.path(cli_root, "tools")
+)
+expect_true(all(copied_tools), "the fixture tool copies")
+copied_policy <- file.copy(
+  ".github/scripts/cran-note-policy.R",
+  file.path(cli_root, ".github", "scripts")
+)
+expect_true(copied_policy, "the fixture policy copy")
+writeLines(
+  c(
+    "Package: marginplyr",
+    "Title: CRAN Preflight Fixture",
+    "Version: 0.1.0",
+    "Authors@R: person('Preflight', 'Fixture', role = c('aut', 'cre'),",
+    "    email = 'fixture@example.invalid')",
+    paste(
+      "Description: A minimal package used to exercise the source-tarball",
+      "preflight fixture."
+    ),
+    "License: MIT",
+    "Suggests: marginplyrFixtureMissing",
+    "Config/marginplyr/cran-status: unpublished",
+    "Config/Needs/preflight: marginplyrFixtureMissing",
+    "Encoding: UTF-8"
+  ),
+  file.path(cli_root, "DESCRIPTION")
+)
+writeLines("^tools$", file.path(cli_root, ".Rbuildignore"))
+dir.create(file.path(cli_root, "R"))
+writeLines("fixture <- function() TRUE", file.path(cli_root, "R", "fixture.R"))
+writeLines("export(fixture)", file.path(cli_root, "NAMESPACE"))
+expect_identical(
+  run_in_dir(cli_root, "git", c("init", "--quiet"), TRUE),
+  0L,
+  "fixture git init"
+)
+expect_identical(
+  run_in_dir(cli_root, "git", c("add", "."), TRUE),
+  0L,
+  "fixture git add"
+)
+expect_identical(run_in_dir(
+  cli_root,
+  "git",
+  c(
+    "-c", "user.name=Preflight Fixture",
+    "-c", "user.email=fixture@example.invalid",
+    "commit", "--quiet", "-m", "fixture"
+  ),
+  TRUE
+), 0L, "fixture git commit")
+
+build_evidence <- file.path(fixture_root, "build-evidence")
+dir.create(build_evidence)
+built_tarball <- build_candidate_tarball(
+  cli_root,
+  build_evidence,
+  "marginplyr",
+  "0.1.0"
+)
+built_identity <- verify_candidate_tarball(
+  built_tarball,
+  "marginplyr",
+  "0.1.0",
+  file.path(fixture_root, "built-unpacked")
+)
+expect_true(nzchar(built_identity$sha256), "the built fixture SHA-256")
+built_contents <- utils::untar(built_tarball, list = TRUE)
+expect_identical(
+  any(startsWith(built_contents, "marginplyr/tools/")),
+  FALSE,
+  "the built tarball's tools exclusion"
+)
+
+rscript <- file.path(R.home("bin"), "Rscript")
+clean_log <- file.path(fixture_root, "clean.log")
+clean_status <- run_in_dir(
+  cli_root,
+  rscript,
+  c(
+    "tools/cran-preflight.R",
+    "--output",
+    file.path(fixture_root, "clean-evidence")
+  ),
+  clean_log
+)
+expect_identical(clean_status, 2L, "a missing-prerequisite subprocess")
+expect_identical(
+  readLines(file.path(fixture_root, "clean-evidence", "worktree-before.txt")),
+  readLines(file.path(fixture_root, "clean-evidence", "worktree-after.txt")),
+  "the tool-failure worktree invariant"
+)
+
+writeLines("dirty", file.path(cli_root, "untracked.txt"))
+dirty_log <- file.path(fixture_root, "dirty.log")
+dirty_status <- run_in_dir(
+  cli_root,
+  rscript,
+  c(
+    "tools/cran-preflight.R",
+    "--output",
+    file.path(fixture_root, "dirty-evidence")
+  ),
+  dirty_log
+)
+expect_identical(dirty_status, 1L, "a dirty-worktree subprocess")
+expect_identical(
+  readLines(file.path(fixture_root, "dirty-evidence", "worktree-before.txt")),
+  readLines(file.path(fixture_root, "dirty-evidence", "worktree-after.txt")),
+  "the candidate-failure worktree invariant"
+)
+unlink(file.path(cli_root, "untracked.txt"))
+
+wrong_root_log <- file.path(fixture_root, "wrong-root.log")
+wrong_root_status <- run_in_dir(
+  fixture_root,
+  rscript,
+  c(
+    file.path(cli_root, "tools", "cran-preflight.R"),
+    "--output",
+    file.path(fixture_root, "wrong-root-evidence")
+  ),
+  wrong_root_log
+)
+expect_identical(wrong_root_status, 2L, "a wrong-root subprocess")
+
+command_failure <- run_system(
+  rscript,
+  c("-e", "quit(status = 7L)"),
+  stdout = file.path(fixture_root, "command-failure.log")
+)
+expect_identical(
+  command_failure$status,
+  7L,
+  "a checker subprocess failure status"
+)
+
+message(
+  "Verified the CRAN preflight contract against policy, artifact, and ",
+  "subprocess fixtures."
+)

--- a/.github/scripts/verify-cran-preflight.R
+++ b/.github/scripts/verify-cran-preflight.R
@@ -6,6 +6,8 @@
 source(".github/scripts/cran-note-policy.R")
 source("tools/cran-preflight-lib.R")
 
+# Stops with a fixture label when a contract returns a different value.
+# Callers supply values whose attributes and types are part of the assertion.
 expect_identical <- function(actual, expected, label) {
   if (!identical(actual, expected)) {
     stop(
@@ -20,6 +22,8 @@ expect_identical <- function(actual, expected, label) {
   }
 }
 
+# Asserts one scalar truth without weakening `expect_identical()`'s strictness
+# for fixtures whose exact value matters.
 expect_true <- function(actual, label) {
   expect_identical(isTRUE(actual), TRUE, label)
 }
@@ -42,6 +46,17 @@ expect_identical(
   allowed$marker,
   "New submission",
   "the required cran-comments marker"
+)
+curly_quoted_submission <- sub(
+  "'Yusuke Sasaki <sayuks.dev@gmail.com>'",
+  "‘Yusuke Sasaki <sayuks.dev@gmail.com>’",
+  new_submission,
+  fixed = TRUE
+)
+expect_identical(
+  classify_cran_note(curly_quoted_submission, "unpublished")$status,
+  "allowed-note",
+  "the initial-submission NOTE rendered with R quotes"
 )
 
 near_miss <- paste(new_submission, "Possibly misspelled words", sep = "\n")
@@ -94,7 +109,7 @@ checktor_requirement <- preflight_requirements[
 ]
 expect_identical(
   checktor_requirement$operator,
-  ">=",
+  "==",
   "the checktor baseline operator"
 )
 expect_identical(
@@ -295,6 +310,11 @@ expect_identical(
   FALSE,
   "a mutated clean worktree"
 )
+expect_identical(
+  worktree_is_unchanged(NA_character_, NA_character_),
+  FALSE,
+  "two unavailable worktree records"
+)
 
 evidence <- file.path(fixture_root, "evidence")
 dir.create(evidence)
@@ -322,30 +342,33 @@ expect_true(
   file.exists(file.path(evidence, "results.dcf")),
   "the machine result"
 )
+machine_result <- read.dcf(file.path(evidence, "results.dcf"))
+expect_true(
+  nzchar(machine_result[[1L, "Pending-Stages"]]),
+  "the machine-readable pending stages"
+)
 expect_true(file.exists(file.path(evidence, "steps.tsv")), "the step results")
 
+# Runs the shared subprocess adapter from a fixture directory and returns only
+# its exit status, which is the public observation these CLI fixtures assert.
 run_in_dir <- function(path, command, args, stdout) {
   old <- setwd(path)
   on.exit(setwd(old), add = TRUE)
-  status <- suppressWarnings(system2(
-    command,
-    vapply(args, shQuote, character(1)),
-    stdout = stdout,
-    stderr = stdout
-  ))
-  if (is.null(status) || length(status) == 0L) {
-    return(0L)
-  }
-  if (is.character(status)) {
-    code <- attr(status, "status")
-    return(if (is.null(code)) 0L else as.integer(code))
-  }
-  as.integer(status)
+  run_system(command, args, stdout = stdout)$status
 }
 
 cli_root <- file.path(fixture_root, "cli")
 dir.create(file.path(cli_root, "tools"), recursive = TRUE)
 dir.create(file.path(cli_root, ".github", "scripts"), recursive = TRUE)
+repository_link <- file.path(fixture_root, "repository-link")
+expect_true(
+  file.symlink(cli_root, repository_link),
+  "the repository symlink fixture"
+)
+expect_true(
+  path_is_inside(file.path(repository_link, "new-evidence"), cli_root),
+  "an unresolved path below a symlink into the repository"
+)
 copied_tools <- file.copy(
   c("tools/cran-preflight.R", "tools/cran-preflight-lib.R"),
   file.path(cli_root, "tools")
@@ -379,6 +402,38 @@ writeLines("^tools$", file.path(cli_root, ".Rbuildignore"))
 dir.create(file.path(cli_root, "R"))
 writeLines("fixture <- function() TRUE", file.path(cli_root, "R", "fixture.R"))
 writeLines("export(fixture)", file.path(cli_root, "NAMESPACE"))
+writeLines(
+  c(
+    "source('.github/scripts/cran-note-policy.R')",
+    "source('tools/cran-preflight-lib.R')",
+    "args <- commandArgs(trailingOnly = TRUE)",
+    "scenario <- args[[1L]]",
+    "output <- args[[2L]]",
+    "pipeline <- switch(",
+    "  scenario,",
+    "  success = function(state, repository_root, description) {",
+    "    state$counts <- c(errors = 0L, warnings = 0L, notes = 0L)",
+    "  },",
+    "  interrupt = function(state, repository_root, description) {",
+    "    condition <- structure(",
+    "      list(message = 'fixture interrupt', call = NULL),",
+    "      class = c('interrupt', 'condition')",
+    "    )",
+    "    stop(condition)",
+    "  },",
+    "  mutation = function(state, repository_root, description) {",
+    "    writeLines('mutation', file.path(repository_root, 'mutation.txt'))",
+    "  }",
+    ")",
+    "status <- cran_preflight_cli(",
+    "  c('--output', output),",
+    "  expected_root = getwd(),",
+    "  pipeline = pipeline",
+    ")",
+    "quit(status = status, save = 'no')"
+  ),
+  file.path(cli_root, "preflight-driver.R")
+)
 expect_identical(
   run_in_dir(cli_root, "git", c("init", "--quiet"), TRUE),
   0L,
@@ -423,6 +478,49 @@ expect_identical(
 )
 
 rscript <- file.path(R.home("bin"), "Rscript")
+success_status <- run_in_dir(
+  cli_root,
+  rscript,
+  c(
+    "preflight-driver.R",
+    "success",
+    file.path(fixture_root, "success-evidence")
+  ),
+  file.path(fixture_root, "success.log")
+)
+expect_identical(success_status, 0L, "a successful pipeline subprocess")
+
+interrupt_status <- run_in_dir(
+  cli_root,
+  rscript,
+  c(
+    "preflight-driver.R",
+    "interrupt",
+    file.path(fixture_root, "interrupt-evidence")
+  ),
+  file.path(fixture_root, "interrupt.log")
+)
+expect_identical(interrupt_status, 130L, "an interrupted pipeline subprocess")
+
+mutation_status <- run_in_dir(
+  cli_root,
+  rscript,
+  c(
+    "preflight-driver.R",
+    "mutation",
+    file.path(fixture_root, "mutation-evidence")
+  ),
+  file.path(fixture_root, "mutation.log")
+)
+expect_identical(mutation_status, 2L, "a mutating pipeline subprocess")
+expect_true(
+  nzchar(paste(readLines(
+    file.path(fixture_root, "mutation-evidence", "worktree-after.txt")
+  ), collapse = "\n")),
+  "the recorded mutation"
+)
+unlink(file.path(cli_root, "mutation.txt"))
+
 clean_log <- file.path(fixture_root, "clean.log")
 clean_status <- run_in_dir(
   cli_root,

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,20 @@ jobs:
       - name: Verify every path a maintained document names exists
         run: Rscript .github/scripts/verify-doc-references.R
 
+  # The preflight's policy and fixture checks use only base R and local git.
+  # Keeping them beside the other repository-hygiene jobs makes the release
+  # contract fail before a package dependency installation or remote check.
+  preflight-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Verify the local CRAN preflight contract
+        run: Rscript .github/scripts/verify-cran-preflight.R
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -121,6 +121,10 @@ concurrency:
 
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  # A manual run is release evidence and fails closed on every NOTE not matched
+  # by the shared state-scoped policy. Push and pull-request runs keep their
+  # lower-noise annotation behavior for moving R-devel output (#505).
+  MARGINPLYR_STRICT_RELEASE: ${{ github.event_name == 'workflow_dispatch' }}
   # `--as-cran` otherwise queries CRAN on every run. That adds network
   # flakiness and NOTEs about clock skew or momentarily unreachable URLs which
   # say nothing about the change under test, and each one would be annotated as

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,10 @@ Suggests:
     tibble,
     tidyr
 Config/marginplyr/cran-status: unpublished
+Config/Needs/preflight:
+    checktor (>= 0.1.0),
+    rcmdcheck,
+    urlchecker
 Config/testthat/edition: 3
 VignetteBuilder:
     quarto

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Suggests:
     tidyr
 Config/marginplyr/cran-status: unpublished
 Config/Needs/preflight:
-    checktor (>= 0.1.0),
+    checktor (== 0.1.0),
     rcmdcheck,
     urlchecker
 Config/testthat/edition: 3

--- a/tools/cran-preflight-lib.R
+++ b/tools/cran-preflight-lib.R
@@ -1,0 +1,1496 @@
+# Implementation of the non-mutating, tarball-based CRAN preflight command.
+# `cran-preflight.R` is the public command; functions live here so deterministic
+# policy and subprocess fixtures can exercise them without running a full check.
+
+preflight_exit_code <- function(
+  candidate_failed,
+  tool_failed,
+  interrupted = FALSE
+) {
+  if (isTRUE(interrupted)) {
+    return(130L)
+  }
+  if (isTRUE(tool_failed)) {
+    return(2L)
+  }
+  if (isTRUE(candidate_failed)) {
+    return(1L)
+  }
+  0L
+}
+
+worktree_is_unchanged <- function(before, after) {
+  identical(before, after)
+}
+
+new_preflight_state <- function(evidence_path) {
+  state <- new.env(parent = emptyenv())
+  state$started <- Sys.time()
+  state$evidence_path <- normalizePath(evidence_path, mustWork = TRUE)
+  state$steps <- data.frame(
+    step = character(),
+    status = character(),
+    elapsed_seconds = numeric(),
+    evidence = character(),
+    detail = character(),
+    stringsAsFactors = FALSE
+  )
+  state$candidate_failed <- FALSE
+  state$tool_failed <- FALSE
+  state$interrupted <- FALSE
+  state$candidate_sha <- NA_character_
+  state$package <- NA_character_
+  state$version <- NA_character_
+  state$cran_status <- NA_character_
+  state$tarball <- NA_character_
+  state$tarball_sha256 <- NA_character_
+  state$counts <- c(
+    errors = NA_integer_,
+    warnings = NA_integer_,
+    notes = NA_integer_
+  )
+  state$note_classifications <- list()
+  state$tool_versions <- character()
+  state$worktree_before <- NA_character_
+  state$worktree_after <- NA_character_
+  state
+}
+
+record_preflight_step <- function(
+  state,
+  step,
+  status,
+  elapsed,
+  evidence,
+  detail = ""
+) {
+  permitted <- c("passed", "failed", "allowed-note", "unavailable", "skipped")
+  if (!(status %in% permitted)) {
+    stop("Unknown preflight step status: ", status, call. = FALSE)
+  }
+  state$steps <- rbind(
+    state$steps,
+    data.frame(
+      step = step,
+      status = status,
+      elapsed_seconds = round(as.numeric(elapsed), 3L),
+      evidence = as.character(evidence),
+      detail = as.character(detail),
+      stringsAsFactors = FALSE
+    )
+  )
+  invisible(status)
+}
+
+single_line <- function(value) {
+  value <- if (length(value) == 0L || is.na(value[[1L]])) "" else value[[1L]]
+  gsub("[\r\n\t]+", " ", as.character(value))
+}
+
+display_or <- function(value, missing) {
+  rendered <- single_line(value)
+  if (nzchar(rendered)) rendered else missing
+}
+
+printable_worktree_status <- function(status) {
+  if (is.na(status)) {
+    return("<unavailable>")
+  }
+  if (!nzchar(status)) {
+    return("<clean>")
+  }
+  gsub("\n", "; ", status, fixed = TRUE)
+}
+
+write_preflight_evidence <- function(state, exit_code) {
+  evidence_path <- state$evidence_path
+  utils::write.table(
+    state$steps,
+    file.path(evidence_path, "steps.tsv"),
+    sep = "\t",
+    row.names = FALSE,
+    quote = TRUE,
+    na = ""
+  )
+
+  tool_versions <- if (length(state$tool_versions) == 0L) {
+    ""
+  } else {
+    paste(
+      names(state$tool_versions),
+      state$tool_versions,
+      sep = "=",
+      collapse = "; "
+    )
+  }
+  machine <- data.frame(
+    `Exit-Code` = as.character(exit_code),
+    `Candidate-SHA` = single_line(state$candidate_sha),
+    Package = single_line(state$package),
+    Version = single_line(state$version),
+    `CRAN-Status` = single_line(state$cran_status),
+    Tarball = single_line(state$tarball),
+    `Tarball-SHA256` = single_line(state$tarball_sha256),
+    Errors = single_line(state$counts[["errors"]]),
+    Warnings = single_line(state$counts[["warnings"]]),
+    Notes = single_line(state$counts[["notes"]]),
+    `Tool-Versions` = single_line(tool_versions),
+    `Worktree-Before` = single_line(printable_worktree_status(
+      state$worktree_before
+    )),
+    `Worktree-After` = single_line(printable_worktree_status(
+      state$worktree_after
+    )),
+    `Evidence-Path` = evidence_path,
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+  write.dcf(machine, file.path(evidence_path, "results.dcf"))
+
+  notes <- if (length(state$note_classifications) == 0L) {
+    "- None recorded."
+  } else {
+    unlist(lapply(seq_along(state$note_classifications), function(index) {
+      note <- state$note_classifications[[index]]
+      c(
+        sprintf("- NOTE %d: `%s`", index, note$status),
+        sprintf("  - Policy: %s", single_line(note$policy)),
+        sprintf("  - Rationale: %s", single_line(note$rationale)),
+        "",
+        "  ```text",
+        paste0("  ", strsplit(note$normalized, "\n", fixed = TRUE)[[1L]]),
+        "  ```"
+      )
+    }))
+  }
+
+  steps <- if (nrow(state$steps) == 0L) {
+    "| _No steps recorded._ |  |  |  |"
+  } else {
+    c(
+      "| Step | Status | Seconds | Evidence |",
+      "|---|---:|---:|---|",
+      apply(state$steps, 1L, function(row) {
+        sprintf(
+          "| %s | %s | %s | `%s` |",
+          row[["step"]], row[["status"]], row[["elapsed_seconds"]],
+          row[["evidence"]]
+        )
+      })
+    )
+  }
+  if (nrow(state$steps) == 0L) {
+    steps <- c(
+      "| Step | Status | Seconds | Evidence |",
+      "|---|---:|---:|---|",
+      steps
+    )
+  }
+
+  summary <- c(
+    "# marginplyr CRAN preflight",
+    "",
+    sprintf("**Exit code: %d**", exit_code),
+    "",
+    sprintf("- Candidate SHA: `%s`", single_line(state$candidate_sha)),
+    sprintf(
+      "- Package: `%s` `%s` (`%s`)",
+      single_line(state$package), single_line(state$version),
+      single_line(state$cran_status)
+    ),
+    sprintf("- Tarball: `%s`", display_or(state$tarball, "not produced")),
+    sprintf(
+      "- SHA-256: `%s`",
+      display_or(state$tarball_sha256, "not calculated")
+    ),
+    sprintf(
+      "- Check counts: %s ERROR(s), %s WARNING(s), %s NOTE(s)",
+      display_or(state$counts[["errors"]], "not run"),
+      display_or(state$counts[["warnings"]], "not run"),
+      display_or(state$counts[["notes"]], "not run")
+    ),
+    sprintf("- Tool versions: %s", single_line(tool_versions)),
+    sprintf(
+      "- Worktree before: `%s`",
+      single_line(printable_worktree_status(state$worktree_before))
+    ),
+    sprintf(
+      "- Worktree after: `%s`",
+      single_line(printable_worktree_status(state$worktree_after))
+    ),
+    sprintf("- Evidence: `%s`", evidence_path),
+    "",
+    "## Steps",
+    "",
+    steps,
+    "",
+    "## NOTE classifications",
+    "",
+    notes,
+    "",
+    "## Pending release stages",
+    "",
+    "- Required CI for this exact SHA.",
+    "- Semantic CRAN review for the frozen candidate.",
+    "- Targeted R-hub v2 and exact-tarball win-builder checks.",
+    "- Human release issue, comments, submission, and publication actions."
+  )
+  writeLines(summary, file.path(evidence_path, "summary.md"))
+  invisible(summary)
+}
+
+read_description <- function(path) {
+  description <- read.dcf(path)
+  if (nrow(description) != 1L) {
+    stop("DESCRIPTION must contain exactly one DCF record.", call. = FALSE)
+  }
+  description
+}
+
+description_value <- function(description, field, required = TRUE) {
+  if (!(field %in% colnames(description))) {
+    if (required) {
+      stop("DESCRIPTION is missing `", field, "`.", call. = FALSE)
+    }
+    return(NA_character_)
+  }
+  trimws(description[[1L, field]])
+}
+
+dependency_requirements <- function(field) {
+  if (length(field) == 0L || is.na(field) || !nzchar(field)) {
+    return(data.frame(
+      package = character(),
+      operator = character(),
+      version = character()
+    ))
+  }
+  entries <- trimws(strsplit(gsub("\n", " ", field), ",", fixed = TRUE)[[1L]])
+  pattern <- paste0(
+    "^([A-Za-z][A-Za-z0-9.]*)",
+    "(?:[[:space:]]*\\((>=|<=|==|>|<)[[:space:]]*([^()]+)\\))?$"
+  )
+  matched <- regexec(pattern, entries, perl = TRUE)
+  parts <- regmatches(entries, matched)
+  if (any(lengths(parts) == 0L)) {
+    stop(
+      "Cannot parse dependency requirement(s): ",
+      paste(entries[lengths(parts) == 0L], collapse = ", "),
+      call. = FALSE
+    )
+  }
+  data.frame(
+    package = vapply(parts, `[[`, character(1), 2L),
+    operator = vapply(parts, function(part) {
+      if (length(part) >= 3L) part[[3L]] else ""
+    }, character(1)),
+    version = vapply(parts, function(part) {
+      if (length(part) >= 4L) trimws(part[[4L]]) else ""
+    }, character(1)),
+    stringsAsFactors = FALSE
+  )
+}
+
+version_satisfies <- function(installed, operator, required) {
+  if (!nzchar(operator)) {
+    return(TRUE)
+  }
+  installed <- package_version(installed)
+  required <- package_version(required)
+  switch(
+    operator,
+    `>=` = installed >= required,
+    `<=` = installed <= required,
+    `==` = installed == required,
+    `>` = installed > required,
+    `<` = installed < required,
+    FALSE
+  )
+}
+
+check_package_requirements <- function(requirements) {
+  if (nrow(requirements) == 0L) {
+    return(data.frame(
+      package = character(), required = character(), installed = character(),
+      available = logical(), stringsAsFactors = FALSE
+    ))
+  }
+  rows <- lapply(seq_len(nrow(requirements)), function(index) {
+    package <- requirements$package[[index]]
+    available <- requireNamespace(package, quietly = TRUE)
+    installed <- if (available) {
+      as.character(utils::packageVersion(package))
+    } else {
+      ""
+    }
+    required <- paste(
+      requirements$operator[[index]],
+      requirements$version[[index]]
+    )
+    required <- trimws(required)
+    satisfies <- available && version_satisfies(
+      installed,
+      requirements$operator[[index]],
+      requirements$version[[index]]
+    )
+    data.frame(
+      package = package,
+      required = required,
+      installed = installed,
+      available = satisfies,
+      stringsAsFactors = FALSE
+    )
+  })
+  do.call(rbind, rows)
+}
+
+sha256_file <- function(path) {
+  sha256sum <- get0("sha256sum", envir = asNamespace("tools"), inherits = FALSE)
+  if (is.null(sha256sum)) {
+    stop("This R installation cannot calculate SHA-256.", call. = FALSE)
+  }
+  unname(as.character(sha256sum(path)))
+}
+
+verify_candidate_tarball <- function(
+  tarball,
+  expected_package,
+  expected_version,
+  unpack_dir
+) {
+  contents <- utils::untar(tarball, list = TRUE)
+  descriptions <- contents[grepl("^[^/]+/DESCRIPTION$", contents)]
+  if (length(descriptions) != 1L) {
+    stop(
+      "The source tarball must contain exactly one package DESCRIPTION.",
+      call. = FALSE
+    )
+  }
+  top <- sub("/DESCRIPTION$", "", descriptions[[1L]])
+  expected_top <- expected_package
+  if (!identical(top, expected_top)) {
+    stop(
+      "The source tarball directory is `", top,
+      "`, expected `", expected_top, "`.",
+      call. = FALSE
+    )
+  }
+  dir.create(unpack_dir, recursive = TRUE, showWarnings = FALSE)
+  utils::untar(tarball, exdir = unpack_dir)
+  package_path <- file.path(unpack_dir, top)
+  description <- read_description(file.path(package_path, "DESCRIPTION"))
+  package <- description_value(description, "Package")
+  version <- description_value(description, "Version")
+  identity_matches <- identical(package, expected_package) &&
+    identical(version, expected_version)
+  if (!identity_matches) {
+    stop(
+      "The tarball DESCRIPTION does not match the candidate identity.",
+      call. = FALSE
+    )
+  }
+  expected_name <- paste0(expected_package, "_", expected_version, ".tar.gz")
+  if (!identical(basename(tarball), expected_name)) {
+    stop(
+      "The source tarball name does not match its DESCRIPTION.",
+      call. = FALSE
+    )
+  }
+  list(
+    package = package,
+    version = version,
+    package_path = normalizePath(package_path, mustWork = TRUE),
+    sha256 = sha256_file(tarball)
+  )
+}
+
+cran_comments_problems <- function(path, counts, allowed_notes) {
+  if (!file.exists(path)) {
+    return("cran-comments.md does not exist.")
+  }
+  lines <- readLines(path, warn = FALSE)
+  count_pattern <- paste0(
+    "^([0-9]+) errors? \\| ([0-9]+) warnings? \\| ([0-9]+) notes?$"
+  )
+  positions <- grep(count_pattern, lines, ignore.case = TRUE)
+  problems <- character()
+  if (length(positions) != 1L) {
+    problems <- c(
+      problems,
+      "cran-comments.md must contain exactly one leading check-count line."
+    )
+  } else {
+    matched <- regmatches(lines[[positions]], regexec(
+      count_pattern,
+      lines[[positions]],
+      ignore.case = TRUE
+    ))[[1L]]
+    recorded <- as.integer(matched[2L:4L])
+    names(recorded) <- c("errors", "warnings", "notes")
+    if (!identical(unname(recorded), as.integer(counts))) {
+      problems <- c(
+        problems,
+        sprintf(
+          paste0(
+            "cran-comments.md records %d/%d/%d ERROR/WARNING/NOTE, ",
+            "but the check produced %d/%d/%d."
+          ),
+          recorded[[1L]], recorded[[2L]], recorded[[3L]],
+          counts[["errors"]], counts[["warnings"]], counts[["notes"]]
+        )
+      )
+    }
+  }
+
+  for (note in allowed_notes) {
+    marker <- note$marker
+    if (is.na(marker) || !nzchar(marker)) {
+      next
+    }
+    if (!any(grepl(marker, lines, fixed = TRUE))) {
+      problems <- c(
+        problems,
+        paste0(
+          "cran-comments.md does not explain allowed NOTE marker `",
+          marker,
+          "`."
+        )
+      )
+    }
+  }
+  problems
+}
+
+path_is_inside <- function(path, directory) {
+  path <- normalizePath(path, winslash = "/", mustWork = FALSE)
+  directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
+  identical(path, directory) || startsWith(path, paste0(directory, "/"))
+}
+
+parse_preflight_args <- function(args) {
+  output <- NULL
+  while (length(args) > 0L) {
+    argument <- args[[1L]]
+    args <- args[-1L]
+    if (identical(argument, "--output")) {
+      if (length(args) == 0L) {
+        stop("`--output` requires a directory path.", call. = FALSE)
+      }
+      output <- args[[1L]]
+      args <- args[-1L]
+    } else if (startsWith(argument, "--output=")) {
+      output <- sub("^--output=", "", argument)
+    } else {
+      stop("Unknown argument: ", argument, call. = FALSE)
+    }
+  }
+  if (!is.null(output) && !nzchar(output)) {
+    stop("`--output` requires a non-empty directory path.", call. = FALSE)
+  }
+  list(output = output)
+}
+
+run_system <- function(
+  command,
+  args = character(),
+  stdout = TRUE,
+  env = character()
+) {
+  quoted <- vapply(args, shQuote, character(1))
+  status <- suppressWarnings(system2(
+    command,
+    quoted,
+    stdout = stdout,
+    stderr = stdout,
+    env = env
+  ))
+  if (is.character(status)) {
+    code <- attr(status, "status")
+    if (is.null(code)) {
+      code <- 0L
+    }
+    return(list(status = as.integer(code), output = status))
+  }
+  list(status = as.integer(status), output = character())
+}
+
+git_output <- function(args) {
+  result <- run_system("git", args)
+  if (result$status != 0L) {
+    stop(paste(result$output, collapse = "\n"), call. = FALSE)
+  }
+  result$output
+}
+
+git_status_record <- function() {
+  paste(
+    git_output(c("status", "--porcelain=v1", "--untracked-files=all")),
+    collapse = "\n"
+  )
+}
+
+default_evidence_path <- function() {
+  root <- file.path(tools::R_user_dir("marginplyr", "cache"), "cran-preflight")
+  stamp <- format(Sys.time(), "%Y%m%dT%H%M%S")
+  file.path(root, paste0(stamp, "-", Sys.getpid()))
+}
+
+create_evidence_path <- function(requested, repository_root) {
+  path <- if (is.null(requested)) default_evidence_path() else requested
+  path <- path.expand(path)
+  if (path_is_inside(path, repository_root)) {
+    stop(
+      "The evidence directory must be outside the repository.",
+      call. = FALSE
+    )
+  }
+  if (file.exists(path) || dir.exists(path)) {
+    stop("The evidence path already exists: ", path, call. = FALSE)
+  }
+  if (!dir.create(path, recursive = TRUE, showWarnings = FALSE)) {
+    stop("Cannot create the evidence directory: ", path, call. = FALSE)
+  }
+  normalizePath(path, mustWork = TRUE)
+}
+
+write_text_record <- function(value, path) {
+  if (is.na(value) || !nzchar(value)) {
+    writeLines(character(), path)
+  } else {
+    writeLines(strsplit(value, "\n", fixed = TRUE)[[1L]], path)
+  }
+}
+
+checker_versions <- function(packages) {
+  versions <- vapply(packages, function(package) {
+    if (requireNamespace(package, quietly = TRUE)) {
+      as.character(utils::packageVersion(package))
+    } else {
+      "MISSING"
+    }
+  }, character(1))
+  c(
+    R = R.version.string,
+    platform = R.version$platform,
+    versions
+  )
+}
+
+preflight_prerequisites <- function(description, package, version) {
+  suggests <- dependency_requirements(description_value(
+    description,
+    "Suggests",
+    required = FALSE
+  ))
+  preflight <- dependency_requirements(description_value(
+    description,
+    "Config/Needs/preflight",
+    required = FALSE
+  ))
+  if (nrow(preflight) == 0L) {
+    stop(
+      "DESCRIPTION declares no `Config/Needs/preflight` packages.",
+      call. = FALSE
+    )
+  }
+  requirements <- rbind(suggests, preflight)
+  requirements <- requirements[
+    !duplicated(requirements$package),
+    ,
+    drop = FALSE
+  ]
+  package_requirements <- check_package_requirements(requirements)
+
+  self_available <- requireNamespace(package, quietly = TRUE)
+  self_version <- if (self_available) {
+    as.character(utils::packageVersion(package))
+  } else {
+    ""
+  }
+  self_ok <- self_available && identical(self_version, version)
+
+  executables <- Sys.which(c("quarto", "pdflatex", "makeindex"))
+  quarto <- if (nzchar(executables[["quarto"]])) {
+    run_system(executables[["quarto"]], "--version")
+  } else {
+    list(status = 1L, output = character())
+  }
+  pandoc <- if (nzchar(executables[["quarto"]])) {
+    run_system(executables[["quarto"]], c("pandoc", "--version"))
+  } else {
+    list(status = 1L, output = character())
+  }
+
+  missing <- package_requirements$package[!package_requirements$available]
+  problems <- character()
+  if (length(missing) > 0L) {
+    problems <- c(
+      problems,
+      paste0(
+        "Missing or too-old R packages: ",
+        paste(missing, collapse = ", "),
+        "."
+      )
+    )
+  }
+  if (!self_ok) {
+    problems <- c(
+      problems,
+      paste0(
+        "Installed `", package, "` must be version ", version,
+        " so Quarto can build this candidate's vignettes."
+      )
+    )
+  }
+  missing_executables <- names(executables)[!nzchar(executables)]
+  if (length(missing_executables) > 0L) {
+    problems <- c(
+      problems,
+      paste0(
+        "Missing command-line prerequisites: ",
+        paste(missing_executables, collapse = ", "),
+        "."
+      )
+    )
+  }
+  if (quarto$status != 0L || pandoc$status != 0L) {
+    problems <- c(
+      problems,
+      "Quarto or its bundled Pandoc could not report a version."
+    )
+  }
+
+  quarto_version <- if (length(quarto$output) > 0L) quarto$output[[1L]] else ""
+  pandoc_version <- if (length(pandoc$output) > 0L) pandoc$output[[1L]] else ""
+
+  list(
+    problems = problems,
+    package_requirements = package_requirements,
+    self_version = if (self_available) self_version else "MISSING",
+    quarto_version = quarto_version,
+    pandoc_version = pandoc_version,
+    preflight_packages = preflight$package,
+    suggest_packages = suggests$package
+  )
+}
+
+build_candidate_tarball <- function(
+  repository_root,
+  evidence_path,
+  package,
+  version
+) {
+  workspace <- file.path(evidence_path, "build-workspace")
+  source <- file.path(workspace, "source")
+  dir.create(source, recursive = TRUE)
+  archive <- file.path(workspace, "candidate.tar")
+  archive_log <- file.path(evidence_path, "git-archive.log")
+  original_directory <- setwd(repository_root)
+  on.exit(setwd(original_directory), add = TRUE)
+  archive_result <- run_system(
+    "git",
+    c("archive", "--format=tar", paste0("--output=", archive), "HEAD"),
+    stdout = archive_log
+  )
+  if (archive_result$status != 0L) {
+    stop(
+      "git archive could not create the disposable source tree.",
+      call. = FALSE
+    )
+  }
+  setwd(original_directory)
+  utils::untar(archive, exdir = source)
+
+  build_log <- file.path(evidence_path, "build.log")
+  setwd(workspace)
+  build_result <- run_system(
+    file.path(R.home("bin"), "R"),
+    c("CMD", "build", source),
+    stdout = build_log
+  )
+  if (build_result$status != 0L) {
+    stop("R CMD build failed; see build.log.", call. = FALSE)
+  }
+  tarballs <- list.files(
+    workspace,
+    pattern = "[.]tar[.]gz$",
+    full.names = TRUE
+  )
+  if (length(tarballs) != 1L) {
+    stop(
+      sprintf(
+        "R CMD build produced %d source tarballs; expected exactly one.",
+        length(tarballs)
+      ),
+      call. = FALSE
+    )
+  }
+  expected <- paste0(package, "_", version, ".tar.gz")
+  destination <- file.path(evidence_path, expected)
+  if (!file.rename(tarballs[[1L]], destination)) {
+    stop(
+      "Cannot retain the candidate tarball in the evidence bundle.",
+      call. = FALSE
+    )
+  }
+  destination
+}
+
+capture_console <- function(path, code) {
+  connection <- file(path, open = "wt")
+  sink(connection, type = "output")
+  sink(connection, type = "message")
+  on.exit({
+    sink(type = "message")
+    sink(type = "output")
+    close(connection)
+  }, add = TRUE)
+  force(code)
+}
+
+run_spelling_check <- function(package_path, evidence_path) {
+  log <- file.path(evidence_path, "spelling.log")
+  findings <- capture_console(
+    log,
+    spelling::spell_check_package(
+      package_path,
+      vignettes = TRUE,
+      use_wordlist = TRUE
+    )
+  )
+  table_path <- file.path(evidence_path, "spelling.tsv")
+  utils::write.table(
+    as.data.frame(findings),
+    table_path,
+    sep = "\t",
+    row.names = FALSE,
+    quote = TRUE,
+    na = ""
+  )
+  list(findings = findings, evidence = table_path)
+}
+
+run_checktor <- function(repository_root, tarball, evidence_path) {
+  report <- file.path(evidence_path, "checktor-report.md")
+  log <- file.path(evidence_path, "checktor.log")
+  old <- setwd(repository_root)
+  on.exit(setwd(old), add = TRUE)
+  result <- run_system(
+    file.path(R.home("bin"), "Rscript"),
+    c(
+      file.path(".github", "scripts", "check-cran-readiness.R"),
+      tarball,
+      report
+    ),
+    stdout = log
+  )
+  report_text <- if (file.exists(report)) {
+    paste(readLines(report, warn = FALSE), collapse = "\n")
+  } else {
+    ""
+  }
+  list(
+    status = result$status,
+    tooling_failure = grepl(
+      "checktor could not complete:",
+      report_text,
+      fixed = TRUE
+    ) ||
+      !file.exists(report),
+    report = report,
+    log = log
+  )
+}
+
+run_rcmdcheck <- function(tarball, evidence_path) {
+  check_dir <- file.path(evidence_path, "check")
+  dir.create(check_dir)
+  console <- file.path(evidence_path, "rcmdcheck-console.log")
+  result <- capture_console(
+    console,
+    rcmdcheck::rcmdcheck(
+      tarball,
+      args = "--as-cran",
+      build_args = NULL,
+      check_dir = check_dir,
+      error_on = "never",
+      env = c(
+        `_R_CHECK_CRAN_INCOMING_REMOTE_` = "true",
+        `_R_CHECK_FORCE_SUGGESTS_` = "true",
+        `_R_CHECK_DEPENDS_ONLY_` = "false"
+      )
+    )
+  )
+  list(result = result, check_dir = check_dir, console = console)
+}
+
+check_reports_url_problem <- function(result) {
+  conditions <- c(result$errors, result$warnings, result$notes)
+  if (length(conditions) == 0L) {
+    return(FALSE)
+  }
+  patterns <- c(
+    "checking URLs",
+    "invalid URL",
+    "URL.*(?:unavailable|redirect|status|timeout|resolve)",
+    "Found the following.*URL"
+  )
+  any(vapply(patterns, function(pattern) {
+    any(grepl(pattern, conditions, ignore.case = TRUE, perl = TRUE))
+  }, logical(1)))
+}
+
+character_url_results <- function(results) {
+  data <- as.data.frame(results)
+  data[] <- lapply(data, function(column) {
+    if (is.list(column)) {
+      vapply(column, paste, character(1), collapse = "; ")
+    } else {
+      as.character(column)
+    }
+  })
+  data
+}
+
+classify_url_results <- function(results) {
+  data <- character_url_results(results)
+  if (nrow(data) == 0L) {
+    return(character())
+  }
+  vapply(seq_len(nrow(data)), function(index) {
+    value <- function(name) {
+      if (name %in% names(data)) data[[name]][[index]] else ""
+    }
+    status <- suppressWarnings(as.integer(value("Status")))
+    text <- paste(value("Status"), value("Message"), value("New"))
+    if (nzchar(value("New")) || identical(status, 301L)) {
+      return("failed")
+    }
+    if (
+      !is.na(status) && status >= 400L && status < 500L &&
+        !(status %in% c(408L, 429L))
+    ) {
+      return("failed")
+    }
+    if (grepl(
+      "malformed|invalid|contains spaces|not in canonical form",
+      text,
+      ignore.case = TRUE
+    )) {
+      return("failed")
+    }
+    service_status <- !is.na(status) &&
+      (status >= 500L || status %in% c(408L, 429L))
+    unavailable_message <- grepl(
+      "timeout|timed out|rate.?limit|could not resolve|name resolution|DNS",
+      text,
+      ignore.case = TRUE
+    )
+    if (service_status || unavailable_message) {
+      return("unavailable")
+    }
+    "unavailable"
+  }, character(1))
+}
+
+run_url_diagnostic <- function(package_path, evidence_path, delay = 5) {
+  Sys.sleep(delay)
+  log <- file.path(evidence_path, "url-diagnostic.log")
+  results <- capture_console(log, {
+    setTimeLimit(elapsed = 120, transient = TRUE)
+    on.exit(
+      setTimeLimit(cpu = Inf, elapsed = Inf, transient = FALSE),
+      add = TRUE
+    )
+    urlchecker::url_check(
+      package_path,
+      parallel = TRUE,
+      progress = FALSE,
+      fail = FALSE
+    )
+  })
+  table <- character_url_results(results)
+  table_path <- file.path(evidence_path, "url-diagnostic.tsv")
+  utils::write.table(
+    table,
+    table_path,
+    sep = "\t",
+    row.names = FALSE,
+    quote = TRUE,
+    na = ""
+  )
+  list(
+    classifications = classify_url_results(results),
+    evidence = table_path,
+    log = log
+  )
+}
+
+write_note_results <- function(classifications, evidence_path) {
+  data <- if (length(classifications) == 0L) {
+    data.frame(
+      status = character(), policy = character(), rationale = character(),
+      marker = character(), normalized = character(), stringsAsFactors = FALSE
+    )
+  } else {
+    do.call(rbind, lapply(classifications, function(note) {
+      data.frame(
+        status = note$status,
+        policy = single_line(note$policy),
+        rationale = single_line(note$rationale),
+        marker = single_line(note$marker),
+        normalized = single_line(note$normalized),
+        stringsAsFactors = FALSE
+      )
+    }))
+  }
+  path <- file.path(evidence_path, "notes.tsv")
+  utils::write.table(
+    data,
+    path,
+    sep = "\t",
+    row.names = FALSE,
+    quote = TRUE,
+    na = ""
+  )
+  path
+}
+
+record_problem <- function(state, kind) {
+  if (identical(kind, "candidate")) {
+    state$candidate_failed <- TRUE
+  } else {
+    state$tool_failed <- TRUE
+  }
+  invisible(kind)
+}
+
+run_preflight_pipeline <- function(state, repository_root, description) {
+  evidence <- state$evidence_path
+  transient_directories <- file.path(
+    evidence,
+    c("build-workspace", "candidate-source")
+  )
+  on.exit(unlink(transient_directories, recursive = TRUE), add = TRUE)
+
+  started <- proc.time()[["elapsed"]]
+  prerequisites <- preflight_prerequisites(
+    description,
+    state$package,
+    state$version
+  )
+  versions <- checker_versions(unique(c(
+    prerequisites$preflight_packages,
+    "spelling"
+  )))
+  state$tool_versions <- c(
+    versions,
+    Quarto = prerequisites$quarto_version,
+    Pandoc = prerequisites$pandoc_version,
+    TeX = unname(Sys.which("pdflatex"))
+  )
+  prerequisite_table <- file.path(evidence, "prerequisites.tsv")
+  utils::write.table(
+    prerequisites$package_requirements,
+    prerequisite_table,
+    sep = "\t",
+    row.names = FALSE,
+    quote = TRUE,
+    na = ""
+  )
+  if (length(prerequisites$problems) > 0L) {
+    record_preflight_step(
+      state,
+      "prerequisites",
+      "unavailable",
+      proc.time()[["elapsed"]] - started,
+      prerequisite_table,
+      paste(prerequisites$problems, collapse = " ")
+    )
+    cat(paste(prerequisites$problems, collapse = "\n"), "\n", file = stderr())
+    cat(
+      "Preflight-tool hint: install Config/Needs/preflight packages: ",
+      paste(prerequisites$preflight_packages, collapse = ", "), ".\n",
+      file = stderr(),
+      sep = ""
+    )
+    cat(
+      "Full-Suggests hint: install every declared Suggest at its recorded ",
+      "minimum version. Preflight installs nothing.\n",
+      file = stderr(),
+      sep = ""
+    )
+    record_problem(state, "tool")
+    return(invisible(NULL))
+  }
+  record_preflight_step(
+    state,
+    "prerequisites",
+    "passed",
+    proc.time()[["elapsed"]] - started,
+    prerequisite_table,
+    "All declared tools, Suggests, Quarto, Pandoc, and TeX are available."
+  )
+
+  started <- proc.time()[["elapsed"]]
+  tarball <- tryCatch(
+    build_candidate_tarball(
+      repository_root,
+      evidence,
+      state$package,
+      state$version
+    ),
+    error = function(cnd) cnd
+  )
+  if (inherits(tarball, "condition")) {
+    record_preflight_step(
+      state,
+      "build",
+      "failed",
+      proc.time()[["elapsed"]] - started,
+      file.path(evidence, "build.log"),
+      conditionMessage(tarball)
+    )
+    record_problem(state, "candidate")
+    return(invisible(NULL))
+  }
+  record_preflight_step(
+    state,
+    "build",
+    "passed",
+    proc.time()[["elapsed"]] - started,
+    tarball,
+    "Built exactly one source tarball from git archive HEAD."
+  )
+
+  started <- proc.time()[["elapsed"]]
+  unpacked <- file.path(evidence, "candidate-source")
+  identity <- tryCatch(
+    verify_candidate_tarball(
+      tarball,
+      state$package,
+      state$version,
+      unpacked
+    ),
+    error = function(cnd) cnd
+  )
+  if (inherits(identity, "condition")) {
+    record_preflight_step(
+      state,
+      "tarball-identity",
+      "failed",
+      proc.time()[["elapsed"]] - started,
+      tarball,
+      conditionMessage(identity)
+    )
+    record_problem(state, "tool")
+    return(invisible(NULL))
+  }
+  state$tarball <- basename(tarball)
+  state$tarball_sha256 <- identity$sha256
+  manifest <- file.path(evidence, "SHA256SUMS")
+  writeLines(paste(identity$sha256, basename(tarball)), manifest)
+  record_preflight_step(
+    state,
+    "tarball-identity",
+    "passed",
+    proc.time()[["elapsed"]] - started,
+    manifest,
+    "Tarball name, directory, DESCRIPTION, and SHA-256 agree."
+  )
+
+  started <- proc.time()[["elapsed"]]
+  spelling <- tryCatch(
+    run_spelling_check(identity$package_path, evidence),
+    error = function(cnd) cnd
+  )
+  if (inherits(spelling, "condition")) {
+    record_preflight_step(
+      state,
+      "spelling",
+      "unavailable",
+      proc.time()[["elapsed"]] - started,
+      file.path(evidence, "spelling.log"),
+      conditionMessage(spelling)
+    )
+    record_problem(state, "tool")
+  } else {
+    spelling_failed <- nrow(as.data.frame(spelling$findings)) > 0L
+    record_preflight_step(
+      state,
+      "spelling",
+      if (spelling_failed) "failed" else "passed",
+      proc.time()[["elapsed"]] - started,
+      spelling$evidence,
+      if (spelling_failed) {
+        "Unrecognized words were found."
+      } else {
+        "No unrecognized words."
+      }
+    )
+    if (spelling_failed) {
+      record_problem(state, "candidate")
+    }
+  }
+
+  started <- proc.time()[["elapsed"]]
+  checktor <- tryCatch(
+    run_checktor(repository_root, tarball, evidence),
+    error = function(cnd) cnd
+  )
+  if (inherits(checktor, "condition")) {
+    record_preflight_step(
+      state,
+      "checktor",
+      "unavailable",
+      proc.time()[["elapsed"]] - started,
+      file.path(evidence, "checktor.log"),
+      conditionMessage(checktor)
+    )
+    record_problem(state, "tool")
+  } else if (checktor$status != 0L) {
+    kind <- if (checktor$tooling_failure) "tool" else "candidate"
+    record_preflight_step(
+      state,
+      "checktor",
+      if (identical(kind, "tool")) "unavailable" else "failed",
+      proc.time()[["elapsed"]] - started,
+      checktor$report,
+      "The shared checktor gate did not pass."
+    )
+    record_problem(state, kind)
+  } else {
+    record_preflight_step(
+      state,
+      "checktor",
+      "passed",
+      proc.time()[["elapsed"]] - started,
+      checktor$report,
+      "The reviewed checktor baseline matched exactly."
+    )
+  }
+
+  started <- proc.time()[["elapsed"]]
+  check <- tryCatch(
+    run_rcmdcheck(tarball, evidence),
+    error = function(cnd) cnd
+  )
+  if (inherits(check, "condition")) {
+    record_preflight_step(
+      state,
+      "R-CMD-check",
+      "unavailable",
+      proc.time()[["elapsed"]] - started,
+      file.path(evidence, "rcmdcheck-console.log"),
+      conditionMessage(check)
+    )
+    record_problem(state, "tool")
+    return(invisible(NULL))
+  }
+
+  result <- check$result
+  state$counts <- c(
+    errors = length(result$errors),
+    warnings = length(result$warnings),
+    notes = length(result$notes)
+  )
+  classifications <- lapply(
+    result$notes,
+    classify_cran_note,
+    cran_status = state$cran_status
+  )
+  state$note_classifications <- classifications
+  note_path <- write_note_results(classifications, evidence)
+  unknown_notes <- vapply(
+    classifications,
+    function(note) identical(note$status, "unknown-note"),
+    logical(1)
+  )
+  has_failures <- state$counts[["errors"]] > 0L ||
+    state$counts[["warnings"]] > 0L || any(unknown_notes)
+  has_allowed <- length(classifications) > 0L && !any(unknown_notes)
+  check_status <- if (has_failures) {
+    "failed"
+  } else if (has_allowed) {
+    "allowed-note"
+  } else {
+    "passed"
+  }
+  record_preflight_step(
+    state,
+    "R-CMD-check",
+    check_status,
+    proc.time()[["elapsed"]] - started,
+    check$check_dir,
+    sprintf(
+      "%d ERROR(s), %d WARNING(s), %d NOTE(s); classifications: %s.",
+      state$counts[["errors"]], state$counts[["warnings"]],
+      state$counts[["notes"]], note_path
+    )
+  )
+  if (has_failures) {
+    record_problem(state, "candidate")
+  }
+
+  started <- proc.time()[["elapsed"]]
+  if (check_reports_url_problem(result)) {
+    diagnostic <- tryCatch(
+      run_url_diagnostic(identity$package_path, evidence),
+      error = function(cnd) cnd
+    )
+    if (inherits(diagnostic, "condition")) {
+      record_preflight_step(
+        state,
+        "URL-diagnostic",
+        "unavailable",
+        proc.time()[["elapsed"]] - started,
+        file.path(evidence, "url-diagnostic.log"),
+        conditionMessage(diagnostic)
+      )
+      record_problem(state, "tool")
+    } else {
+      statuses <- diagnostic$classifications
+      status <- if (any(statuses == "unavailable")) {
+        "unavailable"
+      } else if (any(statuses == "failed")) {
+        "failed"
+      } else {
+        "passed"
+      }
+      record_preflight_step(
+        state,
+        "URL-diagnostic",
+        status,
+        proc.time()[["elapsed"]] - started,
+        diagnostic$evidence,
+        "One bounded read-only retry followed the check's URL finding."
+      )
+      if (identical(status, "unavailable")) {
+        record_problem(state, "tool")
+      } else if (identical(status, "failed")) {
+        record_problem(state, "candidate")
+      }
+    }
+  } else {
+    record_preflight_step(
+      state,
+      "URL-diagnostic",
+      "skipped",
+      proc.time()[["elapsed"]] - started,
+      "",
+      "R CMD check reported no URL problem."
+    )
+  }
+
+  started <- proc.time()[["elapsed"]]
+  allowed_notes <- Filter(
+    function(note) identical(note$status, "allowed-note"),
+    classifications
+  )
+  comments_problems <- cran_comments_problems(
+    file.path(repository_root, "cran-comments.md"),
+    state$counts,
+    allowed_notes
+  )
+  comments_evidence <- file.path(evidence, "cran-comments-result.txt")
+  writeLines(
+    if (length(comments_problems) == 0L) "Passed." else comments_problems,
+    comments_evidence
+  )
+  record_preflight_step(
+    state,
+    "cran-comments",
+    if (length(comments_problems) == 0L) "passed" else "failed",
+    proc.time()[["elapsed"]] - started,
+    comments_evidence,
+    if (length(comments_problems) == 0L) {
+      "Counts and allowed-NOTE explanations match."
+    } else {
+      paste(comments_problems, collapse = " ")
+    }
+  )
+  if (length(comments_problems) > 0L) {
+    record_problem(state, "candidate")
+  }
+  invisible(NULL)
+}
+
+cran_preflight_cli <- function(args, expected_root) {
+  parsed <- tryCatch(parse_preflight_args(args), error = function(cnd) cnd)
+  if (inherits(parsed, "condition")) {
+    cat(conditionMessage(parsed), "\n", file = stderr())
+    return(2L)
+  }
+
+  expected_root <- normalizePath(expected_root, mustWork = TRUE)
+  actual_root <- tryCatch(
+    normalizePath(
+      git_output(c("rev-parse", "--show-toplevel"))[[1L]],
+      mustWork = TRUE
+    ),
+    error = function(cnd) cnd
+  )
+  current_root <- normalizePath(getwd(), mustWork = TRUE)
+  root_matches <- !inherits(actual_root, "condition") &&
+    identical(actual_root, expected_root) &&
+    identical(current_root, expected_root)
+  if (!root_matches) {
+    cat(
+      paste0(
+        "Run `Rscript tools/cran-preflight.R` from the marginplyr ",
+        "repository root.\n"
+      ),
+      file = stderr()
+    )
+    return(2L)
+  }
+
+  description <- tryCatch(
+    read_description(file.path(expected_root, "DESCRIPTION")),
+    error = function(cnd) cnd
+  )
+  is_marginplyr <- !inherits(description, "condition") &&
+    identical(description_value(description, "Package"), "marginplyr")
+  if (!is_marginplyr) {
+    cat(
+      "The current directory is not the marginplyr repository root.\n",
+      file = stderr()
+    )
+    return(2L)
+  }
+
+  evidence <- tryCatch(
+    create_evidence_path(parsed$output, expected_root),
+    error = function(cnd) cnd
+  )
+  if (inherits(evidence, "condition")) {
+    cat(conditionMessage(evidence), "\n", file = stderr())
+    return(2L)
+  }
+  state <- new_preflight_state(evidence)
+  state$package <- description_value(description, "Package")
+  state$version <- description_value(description, "Version")
+  state$cran_status <- description_value(
+    description,
+    "Config/marginplyr/cran-status"
+  )
+  state$candidate_sha <- tryCatch(
+    git_output(c("rev-parse", "HEAD"))[[1L]],
+    error = function(cnd) NA_character_
+  )
+  state$worktree_before <- tryCatch(
+    git_status_record(),
+    error = function(cnd) NA_character_
+  )
+  write_text_record(
+    state$worktree_before,
+    file.path(evidence, "worktree-before.txt")
+  )
+
+  if (is.na(state$worktree_before)) {
+    record_preflight_step(
+      state, "worktree-before", "unavailable", 0,
+      file.path(evidence, "worktree-before.txt"),
+      "git status could not be recorded."
+    )
+    state$tool_failed <- TRUE
+  } else if (nzchar(state$worktree_before)) {
+    record_preflight_step(
+      state, "worktree-before", "failed", 0,
+      file.path(evidence, "worktree-before.txt"),
+      paste0(
+        "The release candidate has tracked, index, or untracked non-ignored ",
+        "changes."
+      )
+    )
+    state$candidate_failed <- TRUE
+  } else {
+    record_preflight_step(
+      state, "worktree-before", "passed", 0,
+      file.path(evidence, "worktree-before.txt"),
+      "The candidate is clean."
+    )
+  }
+
+  if (!state$candidate_failed && !state$tool_failed) {
+    tryCatch(
+      run_preflight_pipeline(state, expected_root, description),
+      interrupt = function(cnd) {
+        state$interrupted <- TRUE
+        record_preflight_step(
+          state,
+          "interruption",
+          "unavailable",
+          difftime(Sys.time(), state$started, units = "secs"),
+          evidence,
+          "The preflight was interrupted."
+        )
+      },
+      error = function(cnd) {
+        state$tool_failed <- TRUE
+        record_preflight_step(
+          state,
+          "preflight",
+          "unavailable",
+          difftime(Sys.time(), state$started, units = "secs"),
+          evidence,
+          conditionMessage(cnd)
+        )
+      }
+    )
+  }
+
+  after_started <- proc.time()[["elapsed"]]
+  state$worktree_after <- tryCatch(
+    git_status_record(),
+    error = function(cnd) NA_character_
+  )
+  write_text_record(
+    state$worktree_after,
+    file.path(evidence, "worktree-after.txt")
+  )
+  unchanged <- !is.na(state$worktree_after) && worktree_is_unchanged(
+    state$worktree_before,
+    state$worktree_after
+  )
+  record_preflight_step(
+    state,
+    "worktree-after",
+    if (unchanged) "passed" else "failed",
+    proc.time()[["elapsed"]] - after_started,
+    file.path(evidence, "worktree-after.txt"),
+    if (unchanged) {
+      "The byte-for-byte git status record is unchanged."
+    } else {
+      paste0(
+        "The repository status changed while preflight ran; this is a tool ",
+        "failure."
+      )
+    }
+  )
+  if (!unchanged) {
+    state$tool_failed <- TRUE
+  }
+
+  exit_code <- preflight_exit_code(
+    state$candidate_failed,
+    state$tool_failed,
+    state$interrupted
+  )
+  evidence_result <- tryCatch(
+    write_preflight_evidence(state, exit_code),
+    error = function(cnd) cnd
+  )
+  if (inherits(evidence_result, "condition")) {
+    cat(
+      "Could not finish the evidence bundle: ",
+      conditionMessage(evidence_result),
+      "\n",
+      file = stderr(),
+      sep = ""
+    )
+    exit_code <- if (state$interrupted) 130L else 2L
+  }
+  cat("CRAN preflight evidence: ", evidence, "\n", sep = "")
+  exit_code
+}

--- a/tools/cran-preflight-lib.R
+++ b/tools/cran-preflight-lib.R
@@ -2,6 +2,8 @@
 # `cran-preflight.R` is the public command; functions live here so deterministic
 # policy and subprocess fixtures can exercise them without running a full check.
 
+# Maps the accumulated candidate, tool, and interruption state to the public
+# exit-code contract.
 preflight_exit_code <- function(
   candidate_failed,
   tool_failed,
@@ -19,10 +21,26 @@ preflight_exit_code <- function(
   0L
 }
 
+# Answers whether two available git status records are byte-identical.
 worktree_is_unchanged <- function(before, after) {
-  identical(before, after)
+  !is.na(before) && !is.na(after) && identical(before, after)
 }
 
+# Names every release stage that remains external to the local command.
+preflight_pending_stages <- function() {
+  c(
+    CI = "Required CI for this exact SHA.",
+    semantic = "Semantic CRAN review for the frozen candidate.",
+    remote = paste(
+      "Targeted R-hub v2 and exact-tarball win-builder checks."
+    ),
+    human = paste(
+      "Human release issue, comments, submission, and publication actions."
+    )
+  )
+}
+
+# Allocates the mutable record every preflight step appends to.
 new_preflight_state <- function(evidence_path) {
   state <- new.env(parent = emptyenv())
   state$started <- Sys.time()
@@ -56,6 +74,7 @@ new_preflight_state <- function(evidence_path) {
   state
 }
 
+# Appends one completed step whose status belongs to the summary vocabulary.
 record_preflight_step <- function(
   state,
   step,
@@ -82,16 +101,19 @@ record_preflight_step <- function(
   invisible(status)
 }
 
+# Collapses one optional value for safe storage in a DCF field or table cell.
 single_line <- function(value) {
   value <- if (length(value) == 0L || is.na(value[[1L]])) "" else value[[1L]]
   gsub("[\r\n\t]+", " ", as.character(value))
 }
 
+# Renders an optional value, substituting the caller's explicit absence label.
 display_or <- function(value, missing) {
   rendered <- single_line(value)
   if (nzchar(rendered)) rendered else missing
 }
 
+# Renders a recorded git status without making an empty clean state invisible.
 printable_worktree_status <- function(status) {
   if (is.na(status)) {
     return("<unavailable>")
@@ -102,8 +124,10 @@ printable_worktree_status <- function(status) {
   gsub("\n", "; ", status, fixed = TRUE)
 }
 
+# Writes the human and machine summaries from a completed state record.
 write_preflight_evidence <- function(state, exit_code) {
   evidence_path <- state$evidence_path
+  pending_stages <- preflight_pending_stages()
   utils::write.table(
     state$steps,
     file.path(evidence_path, "steps.tsv"),
@@ -135,6 +159,12 @@ write_preflight_evidence <- function(state, exit_code) {
     Warnings = single_line(state$counts[["warnings"]]),
     Notes = single_line(state$counts[["notes"]]),
     `Tool-Versions` = single_line(tool_versions),
+    `Pending-Stages` = paste(
+      names(pending_stages),
+      pending_stages,
+      sep = "=",
+      collapse = "; "
+    ),
     `Worktree-Before` = single_line(printable_worktree_status(
       state$worktree_before
     )),
@@ -230,15 +260,13 @@ write_preflight_evidence <- function(state, exit_code) {
     "",
     "## Pending release stages",
     "",
-    "- Required CI for this exact SHA.",
-    "- Semantic CRAN review for the frozen candidate.",
-    "- Targeted R-hub v2 and exact-tarball win-builder checks.",
-    "- Human release issue, comments, submission, and publication actions."
+    paste0("- ", unname(pending_stages))
   )
   writeLines(summary, file.path(evidence_path, "summary.md"))
   invisible(summary)
 }
 
+# Reads exactly one DESCRIPTION record from the path supplied by its caller.
 read_description <- function(path) {
   description <- read.dcf(path)
   if (nrow(description) != 1L) {
@@ -247,6 +275,7 @@ read_description <- function(path) {
   description
 }
 
+# Reads one trimmed DESCRIPTION field, optionally admitting its absence.
 description_value <- function(description, field, required = TRUE) {
   if (!(field %in% colnames(description))) {
     if (required) {
@@ -257,6 +286,7 @@ description_value <- function(description, field, required = TRUE) {
   trimws(description[[1L, field]])
 }
 
+# Parses one DCF dependency field into package, operator, and version columns.
 dependency_requirements <- function(field) {
   if (length(field) == 0L || is.na(field) || !nzchar(field)) {
     return(data.frame(
@@ -291,6 +321,7 @@ dependency_requirements <- function(field) {
   )
 }
 
+# Answers whether one installed version satisfies its declared comparison.
 version_satisfies <- function(installed, operator, required) {
   if (!nzchar(operator)) {
     return(TRUE)
@@ -308,6 +339,7 @@ version_satisfies <- function(installed, operator, required) {
   )
 }
 
+# Reports installation and version status for every parsed requirement.
 check_package_requirements <- function(requirements) {
   if (nrow(requirements) == 0L) {
     return(data.frame(
@@ -344,6 +376,7 @@ check_package_requirements <- function(requirements) {
   do.call(rbind, rows)
 }
 
+# Calculates the candidate hash with the SHA-256 implementation supplied by R.
 sha256_file <- function(path) {
   sha256sum <- get0("sha256sum", envir = asNamespace("tools"), inherits = FALSE)
   if (is.null(sha256sum)) {
@@ -352,6 +385,8 @@ sha256_file <- function(path) {
   unname(as.character(sha256sum(path)))
 }
 
+# Verifies tarball naming and DESCRIPTION identity, then returns its unpacked
+# path and SHA-256.
 verify_candidate_tarball <- function(
   tarball,
   expected_package,
@@ -404,6 +439,8 @@ verify_candidate_tarball <- function(
   )
 }
 
+# Reports every mismatch between check results, allowed NOTE markers, and the
+# release comments the caller supplied.
 cran_comments_problems <- function(path, counts, allowed_notes) {
   if (!file.exists(path)) {
     return("cran-comments.md does not exist.")
@@ -461,12 +498,33 @@ cran_comments_problems <- function(path, counts, allowed_notes) {
   problems
 }
 
+# Resolves symlinks through the nearest existing ancestor of a prospective path.
+resolve_prospective_path <- function(path) {
+  ancestor <- path.expand(path)
+  suffix <- character()
+  while (!file.exists(ancestor) && !dir.exists(ancestor)) {
+    parent <- dirname(ancestor)
+    if (identical(parent, ancestor)) {
+      break
+    }
+    suffix <- c(basename(ancestor), suffix)
+    ancestor <- parent
+  }
+  resolved <- normalizePath(ancestor, winslash = "/", mustWork = TRUE)
+  if (length(suffix) == 0L) {
+    return(resolved)
+  }
+  do.call(file.path, c(list(resolved), as.list(suffix)))
+}
+
+# Answers whether a prospective path resolves at or below the repository root.
 path_is_inside <- function(path, directory) {
-  path <- normalizePath(path, winslash = "/", mustWork = FALSE)
+  path <- resolve_prospective_path(path)
   directory <- normalizePath(directory, winslash = "/", mustWork = TRUE)
   identical(path, directory) || startsWith(path, paste0(directory, "/"))
 }
 
+# Parses the sole diagnostic option without changing the gate's pass criteria.
 parse_preflight_args <- function(args) {
   output <- NULL
   while (length(args) > 0L) {
@@ -490,6 +548,7 @@ parse_preflight_args <- function(args) {
   list(output = output)
 }
 
+# Runs one subprocess, returning its normalized exit status and captured output.
 run_system <- function(
   command,
   args = character(),
@@ -514,6 +573,7 @@ run_system <- function(
   list(status = as.integer(status), output = character())
 }
 
+# Runs a read-only git query and returns its output or refuses its failure.
 git_output <- function(args) {
   result <- run_system("git", args)
   if (result$status != 0L) {
@@ -522,6 +582,7 @@ git_output <- function(args) {
   result$output
 }
 
+# Captures tracked, index, and untracked non-ignored status as one exact record.
 git_status_record <- function() {
   paste(
     git_output(c("status", "--porcelain=v1", "--untracked-files=all")),
@@ -529,12 +590,14 @@ git_status_record <- function() {
   )
 }
 
+# Selects a persistent user-cache location for a uniquely named evidence bundle.
 default_evidence_path <- function() {
   root <- file.path(tools::R_user_dir("marginplyr", "cache"), "cran-preflight")
   stamp <- format(Sys.time(), "%Y%m%dT%H%M%S")
   file.path(root, paste0(stamp, "-", Sys.getpid()))
 }
 
+# Creates one new evidence directory after proving it is outside the repository.
 create_evidence_path <- function(requested, repository_root) {
   path <- if (is.null(requested)) default_evidence_path() else requested
   path <- path.expand(path)
@@ -553,6 +616,7 @@ create_evidence_path <- function(requested, repository_root) {
   normalizePath(path, mustWork = TRUE)
 }
 
+# Writes a possibly empty multi-line status record without substituting prose.
 write_text_record <- function(value, path) {
   if (is.na(value) || !nzchar(value)) {
     writeLines(character(), path)
@@ -561,6 +625,7 @@ write_text_record <- function(value, path) {
   }
 }
 
+# Returns installed versions for the checker packages named by its caller.
 checker_versions <- function(packages) {
   versions <- vapply(packages, function(package) {
     if (requireNamespace(package, quietly = TRUE)) {
@@ -576,6 +641,8 @@ checker_versions <- function(packages) {
   )
 }
 
+# Checks full-Suggests, preflight-tool, package, Quarto, Pandoc, and TeX
+# availability without installing any of them.
 preflight_prerequisites <- function(description, package, version) {
   suggests <- dependency_requirements(description_value(
     description,
@@ -674,6 +741,8 @@ preflight_prerequisites <- function(description, package, version) {
   )
 }
 
+# Archives the repository's clean HEAD and builds exactly one source tarball in
+# the external evidence workspace.
 build_candidate_tarball <- function(
   repository_root,
   evidence_path,
@@ -736,6 +805,7 @@ build_candidate_tarball <- function(
   destination
 }
 
+# Evaluates one expression while sending its output and messages to one log.
 capture_console <- function(path, code) {
   connection <- file(path, open = "wt")
   sink(connection, type = "output")
@@ -748,6 +818,7 @@ capture_console <- function(path, code) {
   force(code)
 }
 
+# Runs shipped spelling policy against the unpacked candidate and retains rows.
 run_spelling_check <- function(package_path, evidence_path) {
   log <- file.path(evidence_path, "spelling.log")
   findings <- capture_console(
@@ -770,6 +841,7 @@ run_spelling_check <- function(package_path, evidence_path) {
   list(findings = findings, evidence = table_path)
 }
 
+# Runs the repository's shared checktor wrapper against the candidate tarball.
 run_checktor <- function(repository_root, tarball, evidence_path) {
   report <- file.path(evidence_path, "checktor-report.md")
   log <- file.path(evidence_path, "checktor.log")
@@ -802,6 +874,7 @@ run_checktor <- function(repository_root, tarball, evidence_path) {
   )
 }
 
+# Runs the sole full R CMD check against an already-built candidate tarball.
 run_rcmdcheck <- function(tarball, evidence_path) {
   check_dir <- file.path(evidence_path, "check")
   dir.create(check_dir)
@@ -824,6 +897,7 @@ run_rcmdcheck <- function(tarball, evidence_path) {
   list(result = result, check_dir = check_dir, console = console)
 }
 
+# Answers whether any structured check condition reports a URL problem.
 check_reports_url_problem <- function(result) {
   conditions <- c(result$errors, result$warnings, result$notes)
   if (length(conditions) == 0L) {
@@ -840,6 +914,7 @@ check_reports_url_problem <- function(result) {
   }, logical(1)))
 }
 
+# Converts urlchecker's list columns into cells safe for a retained TSV.
 character_url_results <- function(results) {
   data <- as.data.frame(results)
   data[] <- lapply(data, function(column) {
@@ -852,6 +927,7 @@ character_url_results <- function(results) {
   data
 }
 
+# Classifies each failed URL observation as actionable or unavailable.
 classify_url_results <- function(results) {
   data <- character_url_results(results)
   if (nrow(data) == 0L) {
@@ -893,6 +969,7 @@ classify_url_results <- function(results) {
   }, character(1))
 }
 
+# Performs the one bounded, read-only URL retry and retains its observations.
 run_url_diagnostic <- function(package_path, evidence_path, delay = 5) {
   Sys.sleep(delay)
   log <- file.path(evidence_path, "url-diagnostic.log")
@@ -926,6 +1003,7 @@ run_url_diagnostic <- function(package_path, evidence_path, delay = 5) {
   )
 }
 
+# Writes every NOTE disposition and its complete normalized signature to TSV.
 write_note_results <- function(classifications, evidence_path) {
   data <- if (length(classifications) == 0L) {
     data.frame(
@@ -956,6 +1034,7 @@ write_note_results <- function(classifications, evidence_path) {
   path
 }
 
+# Marks the state with one candidate or tooling failure.
 record_problem <- function(state, kind) {
   if (identical(kind, "candidate")) {
     state$candidate_failed <- TRUE
@@ -965,6 +1044,7 @@ record_problem <- function(state, kind) {
   invisible(kind)
 }
 
+# Executes every required check in release order after preconditions hold.
 run_preflight_pipeline <- function(state, repository_root, description) {
   evidence <- state$evidence_path
   transient_directories <- file.path(
@@ -1315,7 +1395,13 @@ run_preflight_pipeline <- function(state, repository_root, description) {
   invisible(NULL)
 }
 
-cran_preflight_cli <- function(args, expected_root) {
+# Owns invocation validation, worktree bracketing, final evidence, and the
+# public exit code.
+cran_preflight_cli <- function(
+  args,
+  expected_root,
+  pipeline = run_preflight_pipeline
+) {
   parsed <- tryCatch(parse_preflight_args(args), error = function(cnd) cnd)
   if (inherits(parsed, "condition")) {
     cat(conditionMessage(parsed), "\n", file = stderr())
@@ -1414,7 +1500,7 @@ cran_preflight_cli <- function(args, expected_root) {
 
   if (!state$candidate_failed && !state$tool_failed) {
     tryCatch(
-      run_preflight_pipeline(state, expected_root, description),
+      pipeline(state, expected_root, description),
       interrupt = function(cnd) {
         state$interrupted <- TRUE
         record_preflight_step(
@@ -1449,7 +1535,7 @@ cran_preflight_cli <- function(args, expected_root) {
     state$worktree_after,
     file.path(evidence, "worktree-after.txt")
   )
-  unchanged <- !is.na(state$worktree_after) && worktree_is_unchanged(
+  unchanged <- worktree_is_unchanged(
     state$worktree_before,
     state$worktree_after
   )

--- a/tools/cran-preflight.R
+++ b/tools/cran-preflight.R
@@ -1,0 +1,26 @@
+#!/usr/bin/env Rscript
+
+# Runs the one local release gate described by issue #505. It reads a clean
+# commit into an external evidence directory and never installs, documents,
+# updates, dispatches, submits, or releases anything.
+
+file_argument <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+if (length(file_argument) != 1L) {
+  cat("Unable to locate tools/cran-preflight.R.\n", file = stderr())
+  quit(status = 2L, save = "no")
+}
+
+script_path <- normalizePath(
+  sub("^--file=", "", file_argument[[1L]]),
+  mustWork = TRUE
+)
+repository_path <- dirname(dirname(script_path))
+
+source(file.path(repository_path, ".github", "scripts", "cran-note-policy.R"))
+source(file.path(repository_path, "tools", "cran-preflight-lib.R"))
+
+status <- cran_preflight_cli(
+  commandArgs(trailingOnly = TRUE),
+  expected_root = repository_path
+)
+quit(status = status, save = "no")

--- a/tools/cran-preflight.md
+++ b/tools/cran-preflight.md
@@ -1,0 +1,71 @@
+# Local CRAN preflight
+
+Run the release gate from a clean repository root:
+
+```sh
+Rscript tools/cran-preflight.R
+```
+
+The command archives clean `HEAD` into an external disposable source tree,
+builds exactly one source tarball, and retains that tarball and its SHA-256 with
+the full evidence bundle. `--output <new-directory>` selects another external
+bundle location; it changes neither checks nor pass criteria.
+
+The command installs and edits nothing. Before running it, install every
+`Suggests` entry at the version declared in `DESCRIPTION`, plus the packages in
+`Config/Needs/preflight`, and install Quarto, Pandoc, and a TeX toolchain. The
+installed `marginplyr` version must equal the candidate version because the
+Quarto vignette build runs in a child R process. A missing prerequisite exits
+with an installation hint rather than changing the library.
+
+The invariant local gate performs, once each:
+
+1. shipped spelling against the unpacked candidate;
+2. the shared checktor baseline against the candidate tarball;
+3. full `R CMD check --as-cran` through rcmdcheck, against that same tarball,
+   with the manual, rebuilt vignettes, full Suggests, and incoming remote
+   checks;
+4. one bounded read-only URL diagnostic only when the check reports a URL
+   problem; and
+5. byte-for-byte comparison of the repository's before/after `git status`
+   record.
+
+Every ERROR and WARNING blocks. Every NOTE blocks unless the complete,
+normalized NOTE matches the state-scoped policy in
+`.github/scripts/cran-note-policy.R`; an allowed NOTE remains visible and must
+have matching counts and its explanation marker in `cran-comments.md`.
+checktor's baseline is an independent policy surface.
+
+The evidence summary uses exit `0` for a passing candidate, `1` for a candidate
+or release-policy failure, `2` for invocation, prerequisite, tooling, or
+infrastructure failure, and `130` for interruption. Every nonzero result blocks
+release. The printed external bundle path contains the tarball, hash manifest,
+machine-readable results and step table, human summary, full check directory
+and logs, checktor report, and the conditional URL diagnostic.
+
+## Release sequence
+
+`usethis::use_release_issue()` remains the separate human checklist. Record the
+candidate SHA and then complete these stages in order:
+
+1. Run this local preflight.
+2. Push the same SHA and record all required CI results, including the routine
+   matrix, documentation, lint, site, coverage, release/devel/oldrel tarball,
+   depends-only, suite-coverage, library-isolation, and live backend evidence.
+3. Complete the cited, non-mutating semantic CRAN review and disposition every
+   finding.
+4. Run one targeted current R-devel R-hub v2 platform, then upload the retained
+   tarball to win-builder R-devel after verifying its SHA-256.
+5. Complete `cran-comments.md`, version, submission, confirmation, publication,
+   and follow-up as distinct human actions.
+
+For an initial submission, the recorded `unpublished` state admits only the
+narrow `New submission` NOTE and requires the unpublished installation route.
+For an update, record current CRAN results, reverse-dependency evidence,
+downstream communication where needed, and the update rationale; it gets no
+weaker command mode or permanent rapid-resubmission NOTE allowance.
+
+Evidence is valid only for its recorded commit. A later tracked change to
+metadata, documentation, examples, dependencies or guards, executable sources,
+or `cran-comments.md` restarts the applicable local, CI, semantic, and remote
+stages. The command never dispatches those stages or performs a submission.


### PR DESCRIPTION
## Summary

- add `Rscript tools/cran-preflight.R` as a clean-HEAD, non-mutating, source-tarball CRAN gate
- share strict CRAN NOTE classification between the local preflight and release-matrix checks
- retain human- and machine-readable evidence, including exact artifact identity and pending external release stages
- add subprocess fixtures for exit codes, worktree preservation, symlink containment, and candidate identity
- document the local-to-CI-to-remote-to-human release sequence

## Testing

- `testthat::test_local(".", reporter = "summary", stop_on_failure = TRUE)`
- `R CMD build .`
- `R CMD check --as-cran marginplyr_0.1.0.tar.gz` (one expected incoming-feasibility `New submission` NOTE)
- `Rscript .github/scripts/verify-cran-preflight.R`
- `Rscript .github/scripts/verify-context-budget.R`
- `Rscript .github/scripts/verify-doc-references.R`
- `Rscript .github/scripts/verify-verifier-invocation.R`
- package-aware `lintr::lint_package()` and auxiliary-script lint
- `git diff --check`

Not run locally: `jarl check .` because `jarl` is not installed in this environment; the lint workflow installs and runs it.

Closes #505