### PR TITLE
Add an agent-operated CRAN release playbook

### DIFF
--- a/.github/scripts/verify-cran-release.R
+++ b/.github/scripts/verify-cran-release.R
@@ -177,6 +177,23 @@ expect_release_error(
   "an update missing initial-only documentation"
 )
 
+published_with_badge <- published_without_claim
+published_with_badge$`README.Rmd` <- append(
+  published_with_badge$`README.Rmd`,
+  c(
+    paste0(
+      "[![CRAN status](https://www.r-pkg.org/badges/version/marginplyr)]",
+      "(https://CRAN.R-project.org/package=marginplyr)"
+    ),
+    "install.packages(\"marginplyr\")"
+  ),
+  after = 2L
+)
+expect_true(
+  release_readme_claims_cran(published_with_badge$`README.Rmd`),
+  "a published README with an install call and badge"
+)
+
 packages <- matrix(
   c("marginplyr", "0.1.0", "other", "9.9.9"),
   ncol = 2L,
@@ -280,6 +297,70 @@ expect_true(
     warn = FALSE
   )),
   "the applied generated README"
+)
+
+old_wd <- setwd(fixture_root)
+expect_identical(system2("git", c("add", ".")), 0L, "initial follow-up add")
+expect_identical(
+  system2(
+    "git",
+    c(
+      "-c", "user.name=ReleaseFixture",
+      "-c", "user.email=fixture@example.invalid",
+      "commit", "--quiet", "-m", "initial-follow-up"
+    )
+  ),
+  0L,
+  "initial follow-up commit"
+)
+setwd(old_wd)
+
+cran_release_operation(
+  "prepare",
+  "0.1.1",
+  root = fixture_root,
+  apply = TRUE
+)
+old_wd <- setwd(fixture_root)
+expect_identical(system2("git", c("add", ".")), 0L, "update preparation add")
+expect_identical(
+  system2(
+    "git",
+    c(
+      "-c", "user.name=ReleaseFixture",
+      "-c", "user.email=fixture@example.invalid",
+      "commit", "--quiet", "-m", "update-preparation"
+    )
+  ),
+  0L,
+  "update preparation commit"
+)
+setwd(old_wd)
+
+update_packages <- packages
+update_packages[update_packages[, "Package"] == "marginplyr", "Version"] <-
+  "0.1.1"
+render_state$calls <- 0L
+cran_release_operation(
+  "post-release",
+  "0.1.1",
+  root = fixture_root,
+  apply = TRUE,
+  packages = update_packages,
+  runner = successful_runner
+)
+expect_identical(
+  render_state$calls,
+  2L,
+  "the update post-release generation commands"
+)
+expect_identical(
+  release_dcf_field(
+    readLines(file.path(fixture_root, "DESCRIPTION"), warn = FALSE),
+    "Version"
+  ),
+  "0.1.1.9000",
+  "the applied update development version"
 )
 
 expect_release_error(

--- a/.github/scripts/verify-cran-release.R
+++ b/.github/scripts/verify-cran-release.R
@@ -1,0 +1,308 @@
+# Exercises the stateless CRAN release helpers against local fixtures. Remote
+# release actions stay in the playbook; these checks never create an issue,
+# dispatch a workflow, upload a tarball, or mutate CRAN/GitHub state.
+
+source("tools/cran-release.R")
+
+expect_identical <- function(actual, expected, label) {
+  if (!identical(actual, expected)) {
+    stop(
+      sprintf(
+        "%s: expected %s, got %s.",
+        label,
+        paste(deparse(expected), collapse = " "),
+        paste(deparse(actual), collapse = " ")
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+expect_true <- function(actual, label) {
+  expect_identical(isTRUE(actual), TRUE, label)
+}
+
+expect_release_error <- function(expr, status, label) {
+  error <- tryCatch(expr, marginplyr_release_error = identity)
+  expect_true(inherits(error, "marginplyr_release_error"), label)
+  expect_identical(error$status, status, paste(label, "status"))
+  invisible(error)
+}
+
+description_lines <- c(
+  "Package: marginplyr",
+  "Version: 0.1.0.9000",
+  "Config/marginplyr/cran-status: published"
+)
+news_lines <- c(
+  "# marginplyr 0.1.0.9000",
+  "",
+  "* Development changes.",
+  "",
+  "# marginplyr 0.1.0",
+  "",
+  "* Initial CRAN submission."
+)
+
+prepared <- release_prepare_files(
+  list(DESCRIPTION = description_lines, `NEWS.md` = news_lines),
+  "0.1.1"
+)
+expect_identical(
+  release_dcf_field(prepared$DESCRIPTION, "Version"),
+  "0.1.1",
+  "the update release version"
+)
+expect_identical(
+  prepared$`NEWS.md`[[1L]],
+  "# marginplyr 0.1.1",
+  "the update NEWS heading"
+)
+expect_identical(
+  release_prepare_files(prepared, "0.1.1"),
+  prepared,
+  "the idempotent preparation edit"
+)
+
+initial_files <- list(
+  DESCRIPTION = c(
+    "Package: marginplyr",
+    "Version: 0.1.0",
+    "Config/marginplyr/cran-status: unpublished"
+  ),
+  `NEWS.md` = c("# marginplyr 0.1.0", "", "* Initial submission."),
+  `README.Rmd` = c(
+    "<!-- badges: start -->",
+    "[![R-CMD-check](check.svg)](check)",
+    "<!-- badges: end -->",
+    "",
+    "## Installation",
+    "",
+    "`marginplyr` is not on CRAN yet. Install it from",
+    "[GitHub](https://github.com/sayuks/marginplyr) with:",
+    "",
+    "``` r",
+    "install.packages(\"pak\")",
+    "pak::pkg_install(\"sayuks/marginplyr\")",
+    "```",
+    "",
+    "## Usage"
+  ),
+  `README.md` = c(
+    "<!-- badges: start -->",
+    "[![R-CMD-check](check.svg)](check)",
+    "<!-- badges: end -->",
+    "",
+    "## Installation",
+    "",
+    "`marginplyr` is not on CRAN yet. Install it from",
+    "[GitHub](https://github.com/sayuks/marginplyr) with:",
+    "",
+    "``` r",
+    "install.packages(\"pak\")",
+    "pak::pkg_install(\"sayuks/marginplyr\")",
+    "```",
+    "",
+    "## Usage"
+  )
+)
+
+expect_release_error(
+  release_prepare_files(initial_files[c("DESCRIPTION", "NEWS.md")], "0.2.0"),
+  1L,
+  "an unexpected initial version"
+)
+
+post <- release_post_files(initial_files, "0.1.0")
+expect_identical(
+  release_dcf_field(post$DESCRIPTION, "Version"),
+  "0.1.0.9000",
+  "the post-release development version"
+)
+expect_identical(
+  release_dcf_field(
+    post$DESCRIPTION,
+    "Config/marginplyr/cran-status"
+  ),
+  "published",
+  "the initial publication state"
+)
+expect_identical(
+  post$`NEWS.md`[[1L]],
+  "# marginplyr 0.1.0.9000",
+  "the development NEWS heading"
+)
+expect_true(
+  any(grepl(
+    "cran.r-project.org/package=marginplyr",
+    tolower(post$`README.Rmd`),
+    fixed = TRUE
+  )),
+  "the CRAN badge or link"
+)
+expect_true(
+  "install.packages(\"marginplyr\")" %in% post$`README.Rmd`,
+  "the CRAN installation call"
+)
+expect_identical(
+  release_post_files(post, "0.1.0"),
+  post,
+  "the idempotent initial post-release edit"
+)
+
+published_without_claim <- initial_files
+published_without_claim$DESCRIPTION <- release_set_dcf_field(
+  published_without_claim$DESCRIPTION,
+  "Config/marginplyr/cran-status",
+  "published"
+)
+expect_release_error(
+  release_post_files(published_without_claim, "0.1.0"),
+  1L,
+  "an update missing initial-only documentation"
+)
+
+packages <- matrix(
+  c("marginplyr", "0.1.0", "other", "9.9.9"),
+  ncol = 2L,
+  byrow = TRUE,
+  dimnames = list(NULL, c("Package", "Version"))
+)
+expect_identical(
+  verify_cran_publication("0.1.0", packages = packages),
+  "0.1.0",
+  "a matching CRAN publication"
+)
+expect_release_error(
+  verify_cran_publication("0.1.1", packages = packages),
+  1L,
+  "a CRAN publication version mismatch"
+)
+
+fixture_root <- tempfile("marginplyr-release-fixture-")
+dir.create(fixture_root)
+on.exit(unlink(fixture_root, recursive = TRUE), add = TRUE)
+
+write_fixture <- function(root, files) {
+  for (path in names(files)) {
+    writeLines(files[[path]], file.path(root, path))
+  }
+}
+
+write_fixture(fixture_root, initial_files)
+old_wd <- setwd(fixture_root)
+on.exit(setwd(old_wd), add = TRUE)
+expect_identical(system2("git", c("init", "--quiet")), 0L, "fixture git init")
+expect_identical(system2("git", c("add", ".")), 0L, "fixture git add")
+expect_identical(
+  system2(
+    "git",
+    c(
+      "-c", "user.name=ReleaseFixture",
+      "-c", "user.email=fixture@example.invalid",
+      "commit", "--quiet", "-m", "fixture"
+    )
+  ),
+  0L,
+  "fixture git commit"
+)
+setwd(old_wd)
+
+before <- readLines(file.path(fixture_root, "DESCRIPTION"), warn = FALSE)
+preview <- capture.output(cran_release_operation(
+  "post-release",
+  "0.1.0",
+  root = fixture_root,
+  apply = FALSE,
+  packages = packages
+))
+expect_identical(
+  readLines(file.path(fixture_root, "DESCRIPTION"), warn = FALSE),
+  before,
+  "a non-mutating preview"
+)
+expect_true(
+  any(grepl("DESCRIPTION", preview, fixed = TRUE)),
+  "the previewed DESCRIPTION diff"
+)
+
+render_state <- new.env(parent = emptyenv())
+render_state$calls <- 0L
+successful_runner <- function(command, args, root) {
+  render_state$calls <- render_state$calls + 1L
+  if (render_state$calls == 2L) {
+    writeLines(
+      readLines(file.path(root, "README.Rmd"), warn = FALSE),
+      file.path(root, "README.md")
+    )
+  }
+  list(status = 0L, output = "fixture command passed")
+}
+cran_release_operation(
+  "post-release",
+  "0.1.0",
+  root = fixture_root,
+  apply = TRUE,
+  packages = packages,
+  runner = successful_runner
+)
+expect_identical(
+  render_state$calls,
+  2L,
+  "the post-release generation commands"
+)
+expect_identical(
+  release_dcf_field(
+    readLines(file.path(fixture_root, "DESCRIPTION"), warn = FALSE),
+    "Version"
+  ),
+  "0.1.0.9000",
+  "the applied development version"
+)
+expect_true(
+  release_readme_claims_cran(readLines(
+    file.path(fixture_root, "README.md"),
+    warn = FALSE
+  )),
+  "the applied generated README"
+)
+
+expect_release_error(
+  release_assert_clean(fixture_root),
+  1L,
+  "a dirty release worktree"
+)
+
+failed_runner <- function(command, args, root) {
+  list(status = 7L, output = "fixture command failed")
+}
+expect_release_error(
+  release_render_readme(fixture_root, runner = failed_runner),
+  2L,
+  "a failed generated-file command"
+)
+
+parsed <- parse_cran_release_args(c(
+  "post-release", "--version", "0.1.0", "--apply"
+))
+expect_identical(parsed$operation, "post-release", "the parsed operation")
+expect_identical(parsed$version, "0.1.0", "the parsed version")
+expect_identical(parsed$apply, TRUE, "the parsed apply flag")
+
+release_source <- paste(readLines("tools/cran-release.R"), collapse = "\n")
+forbidden <- c(
+  "codex exec", "use_release_issue(", "gh issue", "rhub_check(",
+  "win-builder", "upload", "submit"
+)
+for (marker in forbidden) {
+  expect_identical(
+    grepl(marker, release_source, fixed = TRUE),
+    FALSE,
+    paste("the absent release coordinator marker", marker)
+  )
+}
+
+message(
+  "Verified the CRAN release helpers against initial, update, preview, ",
+  "idempotence, publication, dirty-state, and command-failure fixtures."
+)

--- a/.github/scripts/verify-cran-release.R
+++ b/.github/scripts/verify-cran-release.R
@@ -150,6 +150,21 @@ expect_identical(
   "the idempotent initial post-release edit"
 )
 
+partial_initial <- initial_files
+partial_initial$`README.Rmd` <- append(
+  partial_initial$`README.Rmd`,
+  paste0(
+    "[![CRAN status](https://www.r-pkg.org/badges/version/marginplyr)]",
+    "(https://CRAN.R-project.org/package=marginplyr)"
+  ),
+  after = 2L
+)
+expect_release_error(
+  release_post_files(partial_initial, "0.1.0"),
+  1L,
+  "partial initial-only publication text"
+)
+
 published_without_claim <- initial_files
 published_without_claim$DESCRIPTION <- release_set_dcf_field(
   published_without_claim$DESCRIPTION,

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,10 +44,10 @@ jobs:
       - name: Verify every path a maintained document names exists
         run: Rscript .github/scripts/verify-doc-references.R
 
-  # The preflight's policy and fixture checks use only base R and local git.
+  # The release tools' policy and fixture checks use only base R and local git.
   # Keeping them beside the other repository-hygiene jobs makes the release
   # contract fail before a package dependency installation or remote check.
-  preflight-contract:
+  release-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -57,6 +57,9 @@ jobs:
 
       - name: Verify the local CRAN preflight contract
         run: Rscript .github/scripts/verify-cran-preflight.R
+
+      - name: Verify the CRAN release helper contract
+        run: Rscript .github/scripts/verify-cran-release.R
 
   lint:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,12 +59,12 @@ working tree first or the regenerated file shows an older package's output.
 
 Its renderer is pinned, unlike roxygen2's, because pandoc's markdown writer
 is not stable across versions while the check is a byte comparison: pandoc
-3.8.3 — what `setup-pandoc@v2` installs by default — writes a `text` info
-string on the fence holding the reporting-levels block, and 3.10.1 omits it,
-so an unpinned job reds on a README nobody touched. `document.yaml` names the
-version the committed file came from; regenerating locally against a
-different pandoc produces a diff that is a pandoc difference and not a stale
-file. Moving the pin means regenerating `README.md` in the same commit.
+3.8.3 writes a `text` info string on the fence holding the reporting-levels
+block, and 3.10.1 omits it, so an unpinned job reds on a README nobody touched.
+`document.yaml` pins 3.10.1, the version the committed file came from;
+regenerating locally against a different pandoc produces a diff that is a
+pandoc difference and not a stale file. Moving the pin means regenerating
+`README.md` in the same commit.
 
 ### Installation instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,10 +78,10 @@ package's CRAN page. Once it reads `published`, `README.md` has to carry both
 halves of what publication gives a reader: the instruction to run, and the
 badge or link saying where it goes.
 
-`tests/testthat/test-documentation.R` asserts both directions against the
-field, over the Rd topics, the vignette sources, and both halves of the README.
-Its *Publication day* comment holds the steps that flip the field, and the
-comments beside its scan hold why each is shaped as it is.
+`tools/cran-release.md` owns the publication check and the steps that flip the
+field. `tests/testthat/test-documentation.R` asserts both directions against
+the field, over the Rd topics, the vignette sources, and both halves of the
+README; its comments hold why that gate is shaped as it is.
 
 ### Chunks that must fail
 

--- a/tests/testthat/test-documentation.R
+++ b/tests/testthat/test-documentation.R
@@ -295,28 +295,11 @@ test_that("no shipped page guards on installation alone", {
 # and it is what the directions below are asserted against. It sits beside
 # `Version`, which is the line a release edits anyway.
 #
-# Publication day. The milestone is publication, not submission: the field
-# flips on the day `https://cran.r-project.org/package=marginplyr` resolves --
-# not when the tarball is uploaded, not when `cran-comments.md` is written, and
-# not when a release ticket is closed. A submission can be rejected or
-# archived, and an instruction made true by uploading one would be false for
-# however long that took. On that day:
-#
-#   1. set the field to `published`;
-#   2. restore the CRAN paragraph to `README.Rmd`'s installation section, above
-#      the GitHub route, and a CRAN badge to its badge block;
-#   3. regenerate `README.md`; and
-#   4. revisit the vignette installation blocks. They name the GitHub route
-#      only, which stays true in both states and is why nothing asserts them --
-#      but the distinction between the released and the development version
-#      becomes worth drawing again, and it is deliberately not drawn now.
-#
-# Steps 1 to 3 hold each other up rather than relying on this list being
-# followed: 1 without 2 fails the tests below, 2 without 1 fails them too, and
-# 3 is what `document.yaml` checks, so a `README.md` regenerated from a
-# `README.Rmd` that step 2 never touched fails at step 2's assertion instead.
-# Step 4 is the one a release can genuinely skip, which is why it is last and
-# why it changes prose that is true either way. No other file needs editing.
+# `tools/cran-release.md` owns the publication milestone and the edits made on
+# that day. This gate makes a partial edit fail: changing the field without the
+# README claims fails below, adding either claim while the field is unpublished
+# fails too, and `document.yaml` separately proves the generated README matches
+# its source.
 cran_status_field <- "Config/marginplyr/cran-status"
 
 # Only `unpublished` and `published` can be read. Any other value stops rather

--- a/tools/cran-preflight-lib.R
+++ b/tools/cran-preflight-lib.R
@@ -26,18 +26,9 @@ worktree_is_unchanged <- function(before, after) {
   !is.na(before) && !is.na(after) && identical(before, after)
 }
 
-# Names every release stage that remains external to the local command.
+# Points to the release authority for every stage outside the local command.
 preflight_pending_stages <- function() {
-  c(
-    CI = "Required CI for this exact SHA.",
-    semantic = "Semantic CRAN review for the frozen candidate.",
-    remote = paste(
-      "Targeted R-hub v2 and exact-tarball win-builder checks."
-    ),
-    human = paste(
-      "Human release issue, comments, submission, and publication actions."
-    )
-  )
+  c(release = "Continue with `tools/cran-release.md`.")
 }
 
 # Allocates the mutable record every preflight step appends to.

--- a/tools/cran-preflight.md
+++ b/tools/cran-preflight.md
@@ -43,29 +43,15 @@ release. The printed external bundle path contains the tarball, hash manifest,
 machine-readable results and step table, human summary, full check directory
 and logs, checktor report, and the conditional URL diagnostic.
 
-## Release sequence
+## What follows this gate
 
-`usethis::use_release_issue()` remains the separate human checklist. Record the
-candidate SHA and then complete these stages in order:
+Continue with the complete human-and-agent release sequence in
+[`tools/cran-release.md`](cran-release.md). That playbook owns CI, semantic
+review, remote checks, the release issue, CRAN submission, publication, and
+post-publication work. This command performs none of them.
 
-1. Run this local preflight.
-2. Push the same SHA and record all required CI results, including the routine
-   matrix, documentation, lint, site, coverage, release/devel/oldrel tarball,
-   depends-only, suite-coverage, library-isolation, and live backend evidence.
-3. Complete the cited, non-mutating semantic CRAN review and disposition every
-   finding.
-4. Run one targeted current R-devel R-hub v2 platform, then upload the retained
-   tarball to win-builder R-devel after verifying its SHA-256.
-5. Complete `cran-comments.md`, version, submission, confirmation, publication,
-   and follow-up as distinct human actions.
-
-For an initial submission, the recorded `unpublished` state admits only the
-narrow `New submission` NOTE and requires the unpublished installation route.
-For an update, record current CRAN results, reverse-dependency evidence,
-downstream communication where needed, and the update rationale; it gets no
-weaker command mode or permanent rapid-resubmission NOTE allowance.
-
-Evidence is valid only for its recorded commit. A later tracked change to
-metadata, documentation, examples, dependencies or guards, executable sources,
-or `cran-comments.md` restarts the applicable local, CI, semantic, and remote
-stages. The command never dispatches those stages or performs a submission.
+For a real release, `--output` must name a durable, repository-external
+directory. Keep its retained tarball available through win-builder, CRAN
+submission, and GitHub Release creation. The candidate-tree invariant above is
+the status of the repository worktree; tools may change disposable external
+build and check trees without changing that candidate.

--- a/tools/cran-release.R
+++ b/tools/cran-release.R
@@ -161,10 +161,13 @@ release_readme_cran_parts <- function(lines) {
 }
 
 release_readme_claims_cran <- function(lines) {
-  identical(
-    unname(release_readme_cran_parts(lines)),
-    c(1L, 1L, 1L)
-  )
+  parts <- release_readme_cran_parts(lines)
+  identical(unname(parts[["install"]]), 1L) &&
+    sum(parts[c("badge", "link")]) >= 1L
+}
+
+release_readme_is_canonical <- function(lines) {
+  identical(unname(release_readme_cran_parts(lines)), c(1L, 1L, 1L))
 }
 
 release_published_installation <- function() {
@@ -188,7 +191,7 @@ release_published_installation <- function() {
 
 # Adds the publication-only README source exactly once.
 release_publish_readme <- function(lines) {
-  if (release_readme_claims_cran(lines)) {
+  if (release_readme_is_canonical(lines)) {
     return(lines)
   }
   parts <- release_readme_cran_parts(lines)
@@ -573,7 +576,7 @@ cran_release_operation <- function(
   for (path in changed) {
     release_write_atomic(file.path(root, path), after[[path]])
   }
-  if ("README.Rmd" %in% changed) {
+  if (identical(operation, "post-release")) {
     release_render_readme(root, runner = runner)
     rendered <- readLines(file.path(root, "README.md"), warn = FALSE)
     if (!release_readme_claims_cran(rendered)) {

--- a/tools/cran-release.R
+++ b/tools/cran-release.R
@@ -546,6 +546,15 @@ cran_release_operation <- function(
   }
   changed <- release_changed_files(before, after)
 
+  if (identical(operation, "prepare")) {
+    message(paste0(
+      "After manual source edits, regenerate with ",
+      "`Rscript -e 'roxygen2::roxygenise()'`; install the working tree; ",
+      "then run `Rscript -e ",
+      "'rmarkdown::render(\"README.Rmd\", quiet = TRUE)'`."
+    ))
+  }
+
   if (length(changed) == 0L) {
     message(operation, " is already complete for ", version, ".")
     return(invisible(changed))

--- a/tools/cran-release.R
+++ b/tools/cran-release.R
@@ -1,0 +1,620 @@
+#!/usr/bin/env Rscript
+
+# Stateless deterministic helpers for the repository CRAN release playbook.
+# The Markdown manual owns orchestration and every external or judgement step.
+
+release_abort <- function(message, status = 1L) {
+  condition <- structure(
+    list(message = message, call = NULL, status = as.integer(status)),
+    class = c("marginplyr_release_error", "error", "condition")
+  )
+  stop(condition)
+}
+
+# Reads one single-line DCF field from already loaded DESCRIPTION lines.
+release_dcf_field <- function(lines, field) {
+  matched <- grep(paste0("^", field, ":[[:space:]]*"), lines)
+  if (length(matched) != 1L) {
+    release_abort(sprintf(
+      "DESCRIPTION must contain exactly one `%s` field.",
+      field
+    ))
+  }
+  sub(paste0("^", field, ":[[:space:]]*"), "", lines[[matched]])
+}
+
+# Replaces one single-line DCF field without reformatting the rest of the file.
+release_set_dcf_field <- function(lines, field, value) {
+  matched <- grep(paste0("^", field, ":[[:space:]]*"), lines)
+  if (length(matched) != 1L) {
+    release_abort(sprintf(
+      "DESCRIPTION must contain exactly one `%s` field.",
+      field
+    ))
+  }
+  lines[[matched]] <- paste0(field, ": ", value)
+  lines
+}
+
+release_version <- function(value, label = "version") {
+  if (
+    length(value) != 1L || is.na(value) ||
+      !grepl("^[0-9]+[.][0-9]+[.][0-9]+$", value)
+  ) {
+    release_abort(sprintf(
+      "The %s must have the release form `major.minor.patch`, not `%s`.",
+      label,
+      paste(value, collapse = ", ")
+    ), status = 2L)
+  }
+  value
+}
+
+release_status <- function(description) {
+  status <- release_dcf_field(
+    description,
+    "Config/marginplyr/cran-status"
+  )
+  if (!(status %in% c("unpublished", "published"))) {
+    release_abort(sprintf(
+      paste0(
+        "`Config/marginplyr/cran-status` must be `unpublished` or ",
+        "`published`, not `%s`."
+      ),
+      status
+    ))
+  }
+  status
+}
+
+release_news_heading <- function(version) {
+  paste("# marginplyr", version)
+}
+
+release_replace_news_heading <- function(lines, current, target) {
+  expected <- release_news_heading(current)
+  headings <- grep("^# marginplyr ", lines)
+  if (length(headings) == 0L || headings[[1L]] != 1L) {
+    release_abort("NEWS.md must begin with the current marginplyr heading.")
+  }
+  if (!identical(lines[[1L]], expected)) {
+    release_abort(sprintf(
+      "NEWS.md begins `%s`, but DESCRIPTION records version `%s`.",
+      lines[[1L]],
+      current
+    ))
+  }
+  lines[[1L]] <- release_news_heading(target)
+  lines
+}
+
+# Plans the release-version edit. An unpublished first release is already at
+# its release number; an update advances one committed development version.
+release_prepare_files <- function(files, version) {
+  version <- release_version(version)
+  description <- files$DESCRIPTION
+  news <- files$`NEWS.md`
+  current <- release_dcf_field(description, "Version")
+  status <- release_status(description)
+
+  if (identical(status, "unpublished")) {
+    if (!identical(current, version)) {
+      release_abort(sprintf(
+        paste0(
+          "The initial candidate is already version `%s`; refusing to ",
+          "prepare unrelated version `%s`."
+        ),
+        current,
+        version
+      ))
+    }
+    release_replace_news_heading(news, current, version)
+    return(files)
+  }
+
+  development <- grepl("^[0-9]+[.][0-9]+[.][0-9]+[.]9000$", current)
+  already_prepared <- identical(current, version)
+  if (!development && !already_prepared) {
+    release_abort(sprintf(
+      paste0(
+        "A published package must be at a `.9000` development version or ",
+        "the requested release version, not `%s`."
+      ),
+      current
+    ))
+  }
+
+  if (development) {
+    base <- sub("[.]9000$", "", current)
+    if (numeric_version(version) <= numeric_version(base)) {
+      release_abort(sprintf(
+        "Release version `%s` must be newer than development base `%s`.",
+        version,
+        base
+      ))
+    }
+    news <- release_replace_news_heading(news, current, version)
+    description <- release_set_dcf_field(description, "Version", version)
+  } else {
+    news <- release_replace_news_heading(news, current, version)
+  }
+
+  files$DESCRIPTION <- description
+  files$`NEWS.md` <- news
+  files
+}
+
+release_readme_claims_cran <- function(lines) {
+  any(grepl(
+    "cran.r-project.org/package=marginplyr",
+    tolower(lines),
+    fixed = TRUE
+  )) && "install.packages(\"marginplyr\")" %in% lines
+}
+
+release_published_installation <- function() {
+  c(
+    "`marginplyr` is available from",
+    "[CRAN](https://CRAN.R-project.org/package=marginplyr):",
+    "",
+    "``` r",
+    "install.packages(\"marginplyr\")",
+    "```",
+    "",
+    "Install the development version from",
+    "[GitHub](https://github.com/sayuks/marginplyr) with:",
+    "",
+    "``` r",
+    "install.packages(\"pak\")",
+    "pak::pkg_install(\"sayuks/marginplyr\")",
+    "```"
+  )
+}
+
+# Adds the publication-only README source exactly once.
+release_publish_readme <- function(lines) {
+  if (release_readme_claims_cran(lines)) {
+    return(lines)
+  }
+
+  badge_end <- which(lines == "<!-- badges: end -->")
+  if (length(badge_end) != 1L) {
+    release_abort("README.Rmd must contain exactly one badge block.")
+  }
+  badge <- paste0(
+    "[![CRAN status](https://www.r-pkg.org/badges/version/marginplyr)]",
+    "(https://CRAN.R-project.org/package=marginplyr)"
+  )
+  lines <- append(lines, badge, after = badge_end - 1L)
+
+  installation <- which(lines == "## Installation")
+  if (length(installation) != 1L) {
+    release_abort("README.Rmd must contain exactly one Installation heading.")
+  }
+  later_headings <- which(
+    seq_along(lines) > installation & grepl("^## ", lines)
+  )
+  if (length(later_headings) == 0L) {
+    release_abort(paste(
+      "README.Rmd Installation must be followed by another section."
+    ))
+  }
+  next_heading <- later_headings[[1L]]
+  c(
+    lines[seq_len(installation)],
+    "",
+    release_published_installation(),
+    "",
+    lines[next_heading:length(lines)]
+  )
+}
+
+release_add_development_news <- function(lines, release, development) {
+  if (identical(lines[[1L]], release_news_heading(development))) {
+    return(lines)
+  }
+  expected <- release_news_heading(release)
+  if (!identical(lines[[1L]], expected)) {
+    release_abort(sprintf(
+      "NEWS.md must begin `%s` before the development heading is added.",
+      expected
+    ))
+  }
+  c(release_news_heading(development), "", lines)
+}
+
+# Plans the deterministic state that follows confirmed CRAN publication.
+release_post_files <- function(files, version) {
+  version <- release_version(version)
+  description <- files$DESCRIPTION
+  status <- release_status(description)
+  current <- release_dcf_field(description, "Version")
+  development <- paste0(version, ".9000")
+
+  if (!(current %in% c(version, development))) {
+    release_abort(sprintf(
+      paste0(
+        "Post-release expected DESCRIPTION version `%s` or `%s`, not `%s`."
+      ),
+      version,
+      development,
+      current
+    ))
+  }
+
+  if (identical(status, "unpublished")) {
+    if (!identical(current, version)) {
+      release_abort("Initial-only publication edits cannot start after a bump.")
+    }
+    files$`README.Rmd` <- release_publish_readme(files$`README.Rmd`)
+    description <- release_set_dcf_field(
+      description,
+      "Config/marginplyr/cran-status",
+      "published"
+    )
+  } else if (!release_readme_claims_cran(files$`README.Rmd`)) {
+    release_abort(paste0(
+      "Published update state is missing the initial-only CRAN README text; ",
+      "refusing to recreate it as an update edit."
+    ))
+  }
+
+  description <- release_set_dcf_field(
+    description,
+    "Version",
+    development
+  )
+  files$DESCRIPTION <- description
+  files$`NEWS.md` <- release_add_development_news(
+    files$`NEWS.md`,
+    version,
+    development
+  )
+  files
+}
+
+# Verifies the requested release against the authoritative source index.
+verify_cran_publication <- function(version, packages = NULL) {
+  version <- release_version(version)
+  if (is.null(packages)) {
+    packages <- tryCatch(
+      {
+        connection <- url(
+          "https://cran.r-project.org/src/contrib/PACKAGES.rds",
+          open = "rb"
+        )
+        on.exit(close(connection), add = TRUE)
+        readRDS(connection)
+      },
+      error = function(error) {
+        release_abort(
+          paste(
+            "Could not read CRAN source package data:",
+            conditionMessage(error)
+          ),
+          status = 2L
+        )
+      }
+    )
+  }
+  if (
+    is.null(dim(packages)) ||
+      !all(c("Package", "Version") %in% colnames(packages))
+  ) {
+    release_abort("CRAN package data lacks Package and Version columns.", 2L)
+  }
+  matches <- which(packages[, "Package"] == "marginplyr")
+  if (length(matches) != 1L) {
+    release_abort(sprintf(
+      "CRAN source data contains %d marginplyr record(s), expected one.",
+      length(matches)
+    ))
+  }
+  published <- unname(packages[matches, "Version"])
+  if (!identical(published, version)) {
+    release_abort(sprintf(
+      "CRAN publishes marginplyr `%s`, not requested version `%s`.",
+      published,
+      version
+    ))
+  }
+  version
+}
+
+release_git_status <- function(root) {
+  output <- suppressWarnings(system2(
+    "git",
+    c("-C", shQuote(root), "status", "--porcelain=v1", "--untracked-files=all"),
+    stdout = TRUE,
+    stderr = TRUE
+  ))
+  status <- attr(output, "status")
+  if (is.null(status)) status <- 0L
+  if (status != 0L) {
+    release_abort(
+      paste(
+        "Could not inspect the release worktree:",
+        paste(output, collapse = "\n")
+      ),
+      status = 2L
+    )
+  }
+  output
+}
+
+release_assert_clean <- function(root) {
+  status <- release_git_status(root)
+  if (length(status) > 0L) {
+    release_abort(paste0(
+      "The release helper requires a clean worktree. Current status:\n",
+      paste(status, collapse = "\n")
+    ))
+  }
+  invisible(TRUE)
+}
+
+release_read_files <- function(root, paths) {
+  missing <- paths[!file.exists(file.path(root, paths))]
+  if (length(missing) > 0L) {
+    release_abort(paste(
+      "Missing required release file(s):",
+      paste(missing, collapse = ", ")
+    ))
+  }
+  stats::setNames(lapply(
+    file.path(root, paths),
+    readLines,
+    warn = FALSE,
+    encoding = "UTF-8"
+  ), paths)
+}
+
+release_changed_files <- function(before, after) {
+  names(after)[vapply(
+    names(after),
+    function(path) !identical(before[[path]], after[[path]]),
+    logical(1)
+  )]
+}
+
+release_print_diff <- function(path, before, after) {
+  old <- tempfile("cran-release-old-")
+  new <- tempfile("cran-release-new-")
+  on.exit(unlink(c(old, new)), add = TRUE)
+  writeLines(before, old, useBytes = TRUE)
+  writeLines(after, new, useBytes = TRUE)
+  output <- suppressWarnings(system2(
+    "diff",
+    c(
+      "-u", "--label", shQuote(paste0("a/", path)),
+      "--label", shQuote(paste0("b/", path)),
+      shQuote(old), shQuote(new)
+    ),
+    stdout = TRUE,
+    stderr = TRUE
+  ))
+  status <- attr(output, "status")
+  if (is.null(status)) status <- 0L
+  if (!(status %in% c(0L, 1L))) {
+    release_abort(
+      paste(
+        "Could not render the preview diff:",
+        paste(output, collapse = "\n")
+      ),
+      status = 2L
+    )
+  }
+  writeLines(output)
+}
+
+release_write_atomic <- function(path, lines) {
+  temporary <- tempfile("cran-release-write-", tmpdir = dirname(path))
+  on.exit(unlink(temporary), add = TRUE)
+  writeLines(lines, temporary, useBytes = TRUE)
+  if (!file.rename(temporary, path)) {
+    release_abort(paste("Could not replace", path), status = 2L)
+  }
+  invisible(path)
+}
+
+release_command <- function(command, args, root) {
+  old <- setwd(root)
+  on.exit(setwd(old), add = TRUE)
+  output <- suppressWarnings(system2(
+    command,
+    args,
+    stdout = TRUE,
+    stderr = TRUE
+  ))
+  status <- attr(output, "status")
+  if (is.null(status)) status <- 0L
+  list(status = as.integer(status), output = paste(output, collapse = "\n"))
+}
+
+# Regenerates README.md with the repository-pinned Pandoc after installing the
+# edited tree into a disposable library, so its chunks never load an old build.
+release_render_readme <- function(root, runner = release_command) {
+  library <- tempfile("marginplyr-release-library-")
+  dir.create(library)
+  on.exit(unlink(library, recursive = TRUE), add = TRUE)
+
+  install <- runner(
+    file.path(R.home("bin"), "R"),
+    c(
+      "CMD", "INSTALL", "--no-multiarch",
+      paste0("--library=", shQuote(library)),
+      shQuote(root)
+    ),
+    root
+  )
+  if (!identical(install$status, 0L)) {
+    release_abort(
+      paste("Temporary package installation failed:", install$output),
+      status = 2L
+    )
+  }
+
+  expression <- paste0(
+    ".libPaths(c(", deparse(library), ", .libPaths())); ",
+    "if (as.character(rmarkdown::pandoc_version()) != '3.10.1') ",
+    "stop('README regeneration requires Pandoc 3.10.1.'); ",
+    "rmarkdown::render('README.Rmd', quiet = TRUE)"
+  )
+  render <- runner(
+    file.path(R.home("bin"), "Rscript"),
+    c("-e", shQuote(expression)),
+    root
+  )
+  if (!identical(render$status, 0L)) {
+    release_abort(
+      paste("README regeneration failed:", render$output),
+      status = 2L
+    )
+  }
+  invisible(file.path(root, "README.md"))
+}
+
+cran_release_operation <- function(
+  operation,
+  version,
+  root = getwd(),
+  apply = FALSE,
+  packages = NULL,
+  runner = release_command
+) {
+  root <- normalizePath(root, mustWork = TRUE)
+  description <- file.path(root, "DESCRIPTION")
+  if (!file.exists(description)) {
+    release_abort(
+      "Run the release helper from the marginplyr repository root.",
+      2L
+    )
+  }
+  package <- release_dcf_field(
+    readLines(description, warn = FALSE),
+    "Package"
+  )
+  if (!identical(package, "marginplyr")) {
+    release_abort(
+      "Run the release helper from the marginplyr repository root.",
+      2L
+    )
+  }
+  release_assert_clean(root)
+
+  if (identical(operation, "verify-publication")) {
+    verified <- verify_cran_publication(version, packages = packages)
+    message("CRAN publishes marginplyr ", verified, ".")
+    return(invisible(character()))
+  }
+
+  paths <- if (identical(operation, "prepare")) {
+    c("DESCRIPTION", "NEWS.md")
+  } else if (identical(operation, "post-release")) {
+    verify_cran_publication(version, packages = packages)
+    c("DESCRIPTION", "NEWS.md", "README.Rmd")
+  } else {
+    release_abort(paste("Unknown release operation:", operation), 2L)
+  }
+  before <- release_read_files(root, paths)
+  after <- if (identical(operation, "prepare")) {
+    release_prepare_files(before, version)
+  } else {
+    release_post_files(before, version)
+  }
+  changed <- release_changed_files(before, after)
+
+  if (length(changed) == 0L) {
+    message(operation, " is already complete for ", version, ".")
+    return(invisible(changed))
+  }
+  if (!isTRUE(apply)) {
+    message("Preview only; no tracked file was changed.")
+    for (path in changed) {
+      release_print_diff(path, before[[path]], after[[path]])
+    }
+    if (identical(operation, "post-release")) {
+      message("README.md will be regenerated with Pandoc 3.10.1 on --apply.")
+    }
+    return(invisible(changed))
+  }
+
+  for (path in changed) {
+    release_write_atomic(file.path(root, path), after[[path]])
+  }
+  if ("README.Rmd" %in% changed) {
+    release_render_readme(root, runner = runner)
+    rendered <- readLines(file.path(root, "README.md"), warn = FALSE)
+    if (!release_readme_claims_cran(rendered)) {
+      release_abort(
+        "Regenerated README.md does not contain both CRAN publication claims.",
+        status = 2L
+      )
+    }
+  }
+  message(
+    "Applied ", operation, " edits: ",
+    paste(changed, collapse = ", "), "."
+  )
+  invisible(changed)
+}
+
+parse_cran_release_args <- function(args) {
+  usage <- paste(
+    "Usage:",
+    "  Rscript tools/cran-release.R prepare --version <version> [--apply]",
+    "  Rscript tools/cran-release.R verify-publication --version <version>",
+    "  Rscript tools/cran-release.R post-release --version <version> [--apply]",
+    sep = "\n"
+  )
+  if (length(args) == 1L && args[[1L]] %in% c("-h", "--help")) {
+    writeLines(usage)
+    return(list(help = TRUE))
+  }
+  if (length(args) == 0L) release_abort(usage, 2L)
+  operation <- args[[1L]]
+  args <- args[-1L]
+  version_at <- which(args == "--version")
+  if (length(version_at) != 1L || version_at[[1L]] == length(args)) {
+    release_abort(usage, 2L)
+  }
+  version <- args[[version_at + 1L]]
+  consumed <- c(version_at, version_at + 1L)
+  apply <- "--apply" %in% args
+  consumed <- c(consumed, which(args == "--apply"))
+  if (length(setdiff(seq_along(args), consumed)) > 0L) {
+    release_abort(usage, 2L)
+  }
+  if (identical(operation, "verify-publication") && apply) {
+    release_abort("verify-publication is always read-only.", 2L)
+  }
+  list(
+    operation = operation,
+    version = release_version(version),
+    apply = apply,
+    help = FALSE
+  )
+}
+
+cran_release_cli <- function(args = commandArgs(trailingOnly = TRUE)) {
+  tryCatch({
+    parsed <- parse_cran_release_args(args)
+    if (isTRUE(parsed$help)) return(0L)
+    cran_release_operation(
+      parsed$operation,
+      parsed$version,
+      apply = parsed$apply
+    )
+    0L
+  }, marginplyr_release_error = function(error) {
+    writeLines(conditionMessage(error), stderr())
+    error$status
+  }, error = function(error) {
+    writeLines(conditionMessage(error), stderr())
+    2L
+  })
+}
+
+if (sys.nframe() == 0L) {
+  quit(status = cran_release_cli(), save = "no")
+}

--- a/tools/cran-release.R
+++ b/tools/cran-release.R
@@ -144,12 +144,27 @@ release_prepare_files <- function(files, version) {
   files
 }
 
+release_readme_cran_parts <- function(lines) {
+  c(
+    badge = sum(grepl(
+      "badges/version/marginplyr",
+      lines,
+      fixed = TRUE
+    )),
+    link = sum(grepl(
+      "[CRAN](https://CRAN.R-project.org/package=marginplyr)",
+      lines,
+      fixed = TRUE
+    )),
+    install = sum(lines == "install.packages(\"marginplyr\")")
+  )
+}
+
 release_readme_claims_cran <- function(lines) {
-  any(grepl(
-    "cran.r-project.org/package=marginplyr",
-    tolower(lines),
-    fixed = TRUE
-  )) && "install.packages(\"marginplyr\")" %in% lines
+  identical(
+    unname(release_readme_cran_parts(lines)),
+    c(1L, 1L, 1L)
+  )
 }
 
 release_published_installation <- function() {
@@ -175,6 +190,13 @@ release_published_installation <- function() {
 release_publish_readme <- function(lines) {
   if (release_readme_claims_cran(lines)) {
     return(lines)
+  }
+  parts <- release_readme_cran_parts(lines)
+  if (any(parts != 0L)) {
+    release_abort(paste0(
+      "README.Rmd has partial or duplicated CRAN publication text; ",
+      "refusing to guess which initial-only edit is intended."
+    ))
   }
 
   badge_end <- which(lines == "<!-- badges: end -->")

--- a/tools/cran-release.md
+++ b/tools/cran-release.md
@@ -1,0 +1,621 @@
+# CRAN release playbook
+
+This is the durable release authority for marginplyr. A local Codex agent
+normally operates the commands, interprets their evidence, and updates one
+English GitHub issue per release. A human can follow the same procedure without
+Codex. The process prepares one candidate commit and one retained source
+tarball, proves them, leaves CRAN submission to the maintainer, and follows the
+published release for 72 hours.
+
+The release is not resumable state hidden in a script. The repository, the
+external preflight bundle, and the release issue are the records. After an
+interruption, read them, verify the candidate identity again, and continue at
+the first unchecked stage whose evidence still belongs to that candidate.
+
+## Work and approval at a glance
+
+| Kind | Meaning | Examples |
+|---|---|---|
+| Automatic | A command computes or checks deterministic local state. It may run without approval when read-only. | helper preview, local preflight, publication lookup |
+| Agent-operated | Codex runs a documented command, reads its result, and summarizes it. A human can run the same command instead. | CI inspection, semantic review, R-hub inspection |
+| Approval-gated | Codex stops immediately before changing tracked or external state and states the exact target and action. | tracked edits, commit/push, workflow dispatch, issue update, win-builder send, tag/Release, PR |
+| Human-only | Codex may prepare evidence but cannot perform the action. | CRAN upload, confirmation/rejection/follow-up email |
+
+The helper previews tracked edits by default. `--apply` is an explicit local
+mechanism, not approval: an agent must still obtain human approval immediately
+before using it. The same applies to direct `git`, `gh`, R-hub, and web actions.
+There is no global `--yes` setting or approval database.
+
+## Roles and durable artifacts
+
+- [`tools/cran-release.R`](cran-release.R) makes only deterministic preparation
+  and post-publication edits and performs a read-only CRAN publication lookup.
+  It is stateless and requires a clean worktree.
+- [`tools/cran-preflight.R`](cran-preflight.R) remains the directly invoked,
+  non-mutating candidate gate. It neither calls the release helper nor performs
+  an external release action.
+- One release issue is the current checklist and evidence ledger. It records
+  durable summaries and URLs, never credentials, authentication material, raw
+  local logs, or an unexpired private win-builder result URL.
+- The repository-external preflight bundle holds the canonical candidate
+  tarball, raw logs, and machine-readable evidence. Keep it until monitoring is
+  complete and the GitHub Release assets have been verified.
+
+Every approval request must name the operation, exact branch/SHA/file or remote
+target, and expected effect. Approval for one checkpoint does not authorize a
+later one.
+
+## Initial release and update release
+
+Both use the same stages below. `Config/marginplyr/cran-status` selects the
+genuinely different work:
+
+| Concern | Initial release (`unpublished`) | Update (`published`) |
+|---|---|---|
+| Preparation version | Already at the first release version | Advance the `.9000` development version to the chosen release version |
+| CRAN comments | Explain `New submission` | Give the update rationale and all current NOTE dispositions |
+| External evidence | No existing CRAN results or reverse dependencies | Inspect current CRAN flavors; run reverse-dependency checks when applicable and record downstream communication |
+| Publication-only edit | Change status to `published`; add CRAN install text and badge | Preserve the already-published status and CRAN text |
+| Follow-up version | `<release>.9000` | Corresponding `<release>.9000` development version |
+
+The publication-only initial edits never run merely because CRAN accepted an
+upload. They run only after the public CRAN source index contains the expected
+version.
+
+## Helper interface
+
+All mutating operations preview first:
+
+```sh
+Rscript tools/cran-release.R prepare --version 0.1.0
+Rscript tools/cran-release.R prepare --version 0.1.0 --apply
+
+Rscript tools/cran-release.R verify-publication --version 0.1.0
+
+Rscript tools/cran-release.R post-release --version 0.1.0
+Rscript tools/cran-release.R post-release --version 0.1.0 --apply
+```
+
+`prepare` changes only deterministic version and NEWS headings. The maintainer
+still writes release notes, metadata, and `cran-comments.md`. `post-release`
+first verifies CRAN publication, then conditionally adds the initial-only CRAN
+README text, sets the development version, adds its NEWS heading, and regenerates
+`README.md` with the repository-pinned Pandoc 3.10.1. It installs the edited tree
+into a disposable library for rendering, so the README cannot load an older
+installed marginplyr.
+
+If a helper refuses dirty or unexpected state, inspect `git status --short` and
+the named file. Do not bypass the refusal. If `--apply` is interrupted or a
+generation command fails, inspect `git diff`; either fix the named prerequisite
+and rerun after committing the intended partial edit, or restore only the
+helper-owned files from the disposable release branch and retry. Never reset an
+unrelated working tree.
+
+## Complete sequence
+
+### 1. Inspect prerequisites and state
+
+Purpose: establish whether this is an initial or update release and whether the
+local and hosted tools can produce valid evidence.
+
+Prerequisites: repository root, clean default branch, `gh` authenticated,
+current release/R-patched R, Quarto, Pandoc 3.10.1, TeX, all `Suggests`, and
+`Config/Needs/preflight` installed. Show the branch and remote update to be
+integrated and obtain approval before synchronizing with `git pull --ff-only`.
+
+Agent-operated, read-only commands:
+
+```sh
+git status --short
+git branch --show-current
+sed -n '1,80p' DESCRIPTION
+sed -n '1,80p' NEWS.md
+sed -n '1,160p' cran-comments.md
+gh auth status
+gh run list --limit 20
+Rscript .github/scripts/verify-context-budget.R
+```
+
+For an update, also open the package's current CRAN check page and inspect every
+flavor before choosing the version. Determine whether reverse dependencies now
+exist and record the required check/communication plan.
+
+Success evidence: clean status, current default branch, valid publication state,
+version and NEWS that agree, authenticated GitHub access, and a written list of
+missing prerequisites or none. Block on unexplained dirty state, an invalid
+publication field, an unresolved current CRAN ERROR/WARNING/NOTE, or a missing
+required tool. Recovery: install/fix prerequisites or move work into a clean
+disposable worktree; rerun the inspection. A human fallback is to run and read
+the same commands and CRAN page.
+
+### 2. Create the release checklist issue
+
+Purpose: create the one-run checklist and evidence ledger. Posit's
+`create-release-checklist` and `usethis::use_release_issue()` are checklist
+inputs, not workflow engines or runtime dependencies.
+
+Approval-gated external action: after showing the proposed English title and
+body, create it with:
+
+```sh
+release_issue_body=$(mktemp)
+# Copy the ledger template below into "$release_issue_body" and adapt it.
+gh issue create \
+  --title "Release marginplyr 0.1.0 to CRAN" \
+  --body-file "$release_issue_body"
+```
+
+Use the template under [Release issue ledger](#release-issue-ledger). Success
+evidence is the issue URL and an unchecked “Next human action” naming stage 3.
+Block if an open issue already owns the same version, the version is unsettled,
+or approval is absent. Recovery: edit the existing issue after approval rather
+than creating a duplicate. Human fallback: create the issue in GitHub's UI with
+the same title and template.
+
+### 3. Prepare and merge the release PR
+
+Purpose: make version, NEWS, `cran-comments.md`, metadata, and generated files
+reviewable without disturbing the maintainer's normal checkout.
+
+Prerequisites: stages 1–2 complete and a chosen version. Create a disposable
+branch/worktree after approval:
+
+```sh
+git fetch origin
+git worktree add ../marginplyr-release-0.1.0 -b release/0.1.0 origin/main
+cd ../marginplyr-release-0.1.0
+Rscript tools/cran-release.R prepare --version 0.1.0
+```
+
+Show the preview. Obtain approval for the exact tracked edits, then run:
+
+```sh
+Rscript tools/cran-release.R prepare --version 0.1.0 --apply
+```
+
+Write/review NEWS, `cran-comments.md`, DESCRIPTION metadata, examples, and any
+other necessary release content. Regenerate after source edits, using the
+repository authorities:
+
+```sh
+Rscript -e 'roxygen2::roxygenise()'
+Rscript -e 'rmarkdown::render("README.Rmd", quiet = TRUE)'
+git diff --check
+git diff
+```
+
+The README command requires Pandoc 3.10.1 and the working tree installed first,
+as `AGENTS.md` documents. Obtain separate approvals before commit, push, and PR
+creation:
+
+```sh
+git add <reviewed-paths>
+git commit -m "Prepare marginplyr 0.1.0 for CRAN (#507)"
+git push -u origin release/0.1.0
+gh pr create --fill
+```
+
+Success evidence: reviewed PR, generated files equal their sources, required PR
+checks green, and merge commit on the default branch. Block on unresolved
+metadata/content, generated diffs, failing checks, or missing approval. Recovery:
+amend the branch and rerun affected generation/checks; if abandoned, remove only
+this disposable worktree/branch. Human fallback: make the same edits and PR by
+hand, using helper preview as a checklist.
+
+### 4. Freeze the candidate SHA
+
+Purpose: bind every later artifact and result to one merged commit.
+
+After the preparation PR is merged, show the remote/default-branch target and
+obtain approval before the switch/pull. Then run:
+
+```sh
+git switch main
+git pull --ff-only
+candidate_sha=$(git rev-parse HEAD)
+git status --short
+printf '%s\n' "$candidate_sha"
+```
+
+This is read-only after the pull. Success evidence is a 40-character SHA on the
+clean default branch, recorded in the release issue after approval. Block if the
+preparation PR is not merged or status is dirty. Recovery: synchronize or use a
+clean worktree at the merge commit, then recompute. Human fallback is the same
+commands or GitHub's merged-commit page.
+
+Any later tracked change to metadata, documentation, examples, dependencies or
+guards, executable source, or `cran-comments.md` creates a new candidate and
+invalidates all applicable evidence below.
+
+### 5. Run the exact-tarball local preflight
+
+Purpose: produce and check the canonical source tarball without changing the
+candidate worktree.
+
+Choose a durable absolute directory outside the repository:
+
+```sh
+Rscript tools/cran-preflight.R \
+  --output /absolute/external/path/marginplyr-0.1.0-preflight
+```
+
+This automatic local gate is specified in
+[`tools/cran-preflight.md`](cran-preflight.md). Success evidence: exit 0, the
+candidate SHA, retained tarball path, SHA-256 manifest, passing/allowed result
+summary, and identical before/after worktree records. Record only the SHA,
+digest, and durable summary in the issue after approval; keep raw evidence
+external. Block on every nonzero exit. Recovery follows the preflight summary;
+fix candidate defects through a new PR/SHA, or repair tooling/infrastructure and
+rerun into a new external directory. Human fallback is the same command.
+
+### 6. Require CI for the candidate
+
+Purpose: prove the pushed candidate in each existing CI owner; hosted archives
+are bound to the commit but are not assumed byte-identical to the retained
+tarball.
+
+Inspect without changing remote state:
+
+```sh
+gh run list --commit "$candidate_sha" \
+  --json databaseId,name,event,status,conclusion,headSha,url
+```
+
+Require routine R CMD check, documentation, lint (including both release
+contract verifiers), site, coverage, and the release matrix's release/devel/
+oldrel, depends-only, suite-coverage, library-isolation, and live backend jobs.
+If no strict manual release-matrix result exists for this SHA, obtain approval
+before dispatch:
+
+```sh
+gh workflow run release-matrix.yaml --ref main
+gh run list --workflow release-matrix.yaml --limit 5
+gh run watch <run-id> --exit-status
+```
+
+Verify `headSha` with `gh run view <run-id> --json headSha,conclusion,url`.
+Success evidence is every required green URL at the candidate SHA. Block on a
+failure, cancellation, SHA mismatch, or missing job. Recovery: rerun a transient
+infrastructure failure after approval and record both outcomes; a package change
+requires a new PR and restarts at stage 4. Human fallback: dispatch and inspect
+the Actions UI.
+
+### 7. Perform the semantic CRAN review
+
+Purpose: review requirements deterministic checks cannot decide. This is a
+non-mutating agent review; every finding needs a human disposition.
+
+Use the commit-pinned Posit `cran-extrachecks` rubric at
+[`b58a92e`](https://github.com/posit-dev/skills/blob/b58a92e7c479b7795f4f003490b046c01e345fce/r-lib/cran-extrachecks/SKILL.md)
+as a checklist. CRAN policy and marginplyr repository rules take precedence.
+Record that rubric SHA and the candidate SHA. Review:
+
+- DESCRIPTION Title/Description, software/package naming, URLs, acronyms,
+  `Authors@R`, copyright holder role, license, and bundled license;
+- meaningful runnable exported examples and every `\dontrun{}`/`\donttest{}`;
+- references for implemented methods/algorithms and citation form;
+- user/global state, filesystem, external-resource, and parallelism risks;
+- `cran-comments.md`, optional-backend explanations, and installation text;
+- for updates, update rationale, current CRAN results, reverse-dependency
+  evidence, and downstream communication.
+
+Each finding cites a candidate file/location and an authority, or says
+“heuristic.” Before updating the issue, show the proposed finding table and get
+approval. Success evidence is a disposition of `fix`, `accept`, or `not
+applicable` for every item. Concrete policy conflicts, missing required content,
+and reproducible defects block. Heuristics remain advisory but cannot be left
+undispositioned. Recovery: fix through a PR/new candidate or record the approved
+reason for acceptance. Human fallback: open the pinned rubric and perform the
+same file-by-file review.
+
+Repeat this stage only when a later change touches DESCRIPTION, NAMESPACE, `R/`,
+manual sources, examples, vignettes, README, NEWS, licensing, dependencies or
+guards, or `cran-comments.md`.
+
+### 8. Dispatch one targeted R-hub v2 check
+
+Purpose: cover one current R-devel Linux environment not duplicated by routine
+CI. Prerequisites: stages 5–7 green/dispositioned, pushed candidate SHA, existing
+R-hub workflow, authenticated GitHub access, and `rhub::rhub_doctor()` passing.
+
+Resolve by capability each release rather than assuming a stale alias:
+
+```r
+platforms <- rhub::rhub_platforms()
+platforms[, c("name", "type", "os_type", "os_name", "r_version")]
+```
+
+Choose one container whose OS is non-Ubuntu Linux and whose R is R-devel; at the
+time this manual was written, `atlas` satisfied that rule. If none exists,
+choose the current Ubuntu-clang R-devel container. Do not add no-Suggests,
+sanitizer, LTO, valgrind, `rchk`, or all-platform checks without a concrete new
+risk. Show the resolved platform and branch, obtain approval, then run:
+
+```r
+rhub::rhub_check(platforms = "<resolved-name>", branch = "main")
+```
+
+Inspect the resulting Actions run and verify its `headSha` equals the candidate.
+Success evidence: SHA, resolved image/platform, date, green result URL. Block on
+SHA mismatch, unavailable current target, or check failure. Recovery: choose the
+documented fallback or rerun transient infrastructure after approval; a package
+fix restarts at stage 4. Human fallback: run the same R calls interactively and
+inspect Actions.
+
+### 9. Send the retained tarball to win-builder R-devel
+
+Purpose: test the exact candidate archive on CRAN-like Windows-devel
+infrastructure. Prerequisites: stages 5–8 complete and the external bundle still
+intact.
+
+Verify identity first:
+
+```sh
+shasum -a 256 /absolute/path/marginplyr_0.1.0.tar.gz
+cat /absolute/path/SHA256SUMS
+```
+
+Show the exact path and matching digest and obtain approval before the external
+send. A human or approved agent browser then opens
+`https://win-builder.r-project.org/upload.aspx`, chooses R-devel, and selects
+that exact retained tarball. Add release/oldrelease only for a concrete
+Windows-specific risk or missing CI coverage.
+
+Success evidence: matching digest, environment/date, and a passing emailed
+result. Archive the result into the external evidence bundle before it expires;
+record a durable summary in the issue, not the unexpired private URL. Block on a
+digest mismatch, unexpected archive, send failure, or check finding. Recovery:
+never rebuild silently—locate the retained archive or restart at stage 5; retry
+transient service failure only after approval. Human fallback is the same web
+form and email handling.
+
+### 10. Present the final readiness decision
+
+Purpose: make the last pre-submission decision explicit. Codex or the maintainer
+summarizes, without mutating state:
+
+- candidate SHA and clean status;
+- retained tarball name/path and SHA-256;
+- required CI and strict matrix URLs with matching SHA;
+- semantic findings and every disposition;
+- R-hub platform/SHA/result and win-builder environment/result;
+- `cran-comments.md` status and initial/update-specific evidence;
+- remaining human-only upload and email steps.
+
+The result is exactly `READY` or `NOT READY`, with blockers listed. Update the
+release issue only after approval. Success evidence is `READY` with no open
+blocker and “Next human action: upload the retained tarball to CRAN.” Recovery:
+return to the stage named by each blocker. Human fallback: assemble the same
+ledger entries manually.
+
+### 11. Human CRAN upload and email handling
+
+Purpose: submit the proven bytes. This stage is human-only. The maintainer opens
+`https://cran.r-project.org/submit.html`, selects the retained tarball whose
+digest appears in stage 10, submits it, and handles confirmation, rejection, or
+follow-up email.
+
+Record submission time and a non-secret summary in the issue after approval.
+Do not paste authentication, private email headers, or private links. An
+acceptance email is evidence of acceptance, not publication. Block on any CRAN
+question or requested change until the maintainer decides the response.
+
+If rejected or changes are requested, keep the issue open. A textual answer that
+does not change the candidate may retain evidence after human review; any
+tracked change gets a PR/new candidate and restarts at stage 4. If submission is
+withdrawn, record why and the next action. Human fallback is intrinsic: no agent
+performs this stage.
+
+### 12. Verify public CRAN publication
+
+Purpose: prove the expected version appears in authoritative CRAN source package
+data before publication-only edits.
+
+Automatic, read-only command:
+
+```sh
+Rscript tools/cran-release.R verify-publication --version 0.1.0
+```
+
+Success evidence is the exact requested version. A missing package, different
+version, malformed index, or unavailable CRAN endpoint blocks. Recovery: wait
+and retry the same read-only command; if CRAN rejected/archived it, return to
+stage 11. Acceptance email alone never changes the publication field. Human
+fallback: check `https://cran.r-project.org/package=marginplyr` and the source
+package index, confirming the exact version.
+
+### 13. Tag and publish the GitHub Release
+
+Purpose: bind a public tag and release assets to the frozen candidate. Prepare
+release notes from the matching NEWS section and a two-space-separated digest
+manifest for the retained tarball:
+
+```sh
+release_manifest=$(mktemp)
+release_notes=$(mktemp)
+shasum -a 256 /absolute/path/marginplyr_0.1.0.tar.gz > "$release_manifest"
+# Copy the reviewed NEWS-derived notes into "$release_notes".
+```
+
+Show tag name, candidate SHA, notes, tarball path, and manifest. Obtain approval
+before creating/pushing the tag, then verify it:
+
+```sh
+git tag -a v0.1.0 "$candidate_sha" -m "marginplyr 0.1.0"
+git push origin v0.1.0
+git rev-list -n 1 v0.1.0
+```
+
+Obtain a separate approval before publication:
+
+```sh
+gh release create v0.1.0 \
+  /absolute/path/marginplyr_0.1.0.tar.gz \
+  "$release_manifest" \
+  --verify-tag \
+  --title "marginplyr 0.1.0" \
+  --notes-file "$release_notes"
+```
+
+Success evidence: tag resolves to the candidate SHA; Release is published;
+explicit tarball and manifest are attached in addition to GitHub-generated
+source archives; manifest digest equals the retained candidate. Block on any
+SHA/digest mismatch or unreviewed notes. Recovery: do not move a public tag
+silently; stop for human disposition. A draft Release can be corrected before
+publication. Human fallback: use GitHub's Releases UI with the same tag target,
+notes, and two assets.
+
+### 14. Prepare the one post-publication PR
+
+Purpose: atomically publish the initial CRAN state/documentation when needed,
+advance to development, add the development NEWS heading, and regenerate files.
+
+Create a clean branch/worktree from current main after approval. Preview first:
+
+```sh
+Rscript tools/cran-release.R post-release --version 0.1.0
+```
+
+The preview repeats publication verification without editing. Show the diff and
+obtain approval before:
+
+```sh
+Rscript tools/cran-release.R post-release --version 0.1.0 --apply
+git diff --check
+git diff
+```
+
+For the initial release, verify that status is `published`, the CRAN badge/link
+and install call appear once, version is `0.1.0.9000`, and NEWS begins with that
+heading. For an update, status and CRAN documentation must remain unchanged
+while version/NEWS advance. Run documentation and relevant tests, then obtain
+separate approvals for commit/push and PR creation. Put all of these changes in
+one PR.
+
+Success evidence: green reviewable PR with no duplicated heading, badge, or
+installation text. Block on publication mismatch, dirty/unexpected state,
+generation failure, or a split/partial change. Recovery: inspect helper output;
+fix the disposable branch, or discard only that branch and recreate it. Human
+fallback: make the publication-day edits listed in `tests/testthat/
+test-documentation.R`, render with Pandoc 3.10.1, and create one PR.
+
+### 15. Monitor site deployment and CRAN flavors for 72 hours
+
+Purpose: detect publication regressions before closing the ledger. After the
+post-publication PR merges, inspect the site deployment and all CRAN check
+flavors periodically for up to 72 hours. Agent-operated read-only examples:
+
+```sh
+gh run list --workflow altdoc.yaml --limit 10
+gh run view <run-id> --json headSha,conclusion,url
+```
+
+Also inspect `https://cran.r-project.org/web/checks/check_results_marginplyr.html`.
+Delayed macOS/Windows binaries alone are not a release failure. A new ERROR,
+WARNING, or NOTE requires a human disposition before closure. Record observation
+times and durable URLs/summaries after approval; never copy transient private
+data.
+
+Success evidence: deployed site, no undispositioned CRAN finding, and the full
+72-hour window complete. Block while the window is open or any finding lacks a
+disposition. Recovery: investigate; fixes use the normal development/release
+process rather than rewriting this release. Human fallback: inspect Actions,
+the public site, and CRAN's check page on the same schedule. Close the release
+issue only after approval and only when every checkbox is complete.
+
+## Release issue ledger
+
+Adapt this body for the version; keep it readable rather than pasting raw logs:
+
+```markdown
+## Next human action
+
+- [ ] Review and approve release preparation edits.
+
+## Candidate
+
+- [ ] Preparation PR merged: <url>
+- [ ] Candidate SHA: `<40-char-sha>`
+- [ ] Clean candidate worktree confirmed
+- [ ] Submission kind: initial / update
+- [ ] `cran-comments.md` reviewed: <summary>
+
+## Exact local artifact
+
+- [ ] Preflight exit 0
+- [ ] Retained tarball: `marginplyr_<version>.tar.gz`
+- [ ] SHA-256: `<digest>`
+- [ ] Durable preflight summary: <location or approved summary>
+
+## Candidate-SHA evidence
+
+- [ ] Routine R CMD check: <url>
+- [ ] Documentation: <url>
+- [ ] Lint and release contracts: <url>
+- [ ] Site and coverage: <urls>
+- [ ] Strict release matrix and all optional-dependency jobs: <url>
+
+## Semantic and remote review
+
+- [ ] Semantic rubric commit and review: <sha/url>
+- [ ] Every finding has a human disposition: <table/link>
+- [ ] R-hub platform, candidate SHA, date, result: <durable url>
+- [ ] win-builder environment, date, digest, archived result summary
+
+## Human submission and publication
+
+- [ ] Final decision is READY
+- [ ] Human uploaded the retained tarball
+- [ ] Human handled confirmation/rejection/follow-up email
+- [ ] CRAN source index publishes exactly `<version>`
+
+## Public release and follow-up
+
+- [ ] Tag targets candidate SHA
+- [ ] GitHub Release notes published
+- [ ] Retained tarball and matching SHA-256 manifest attached
+- [ ] One post-publication PR merged: <url>
+- [ ] Site deployment healthy
+- [ ] CRAN flavors monitored for 72 hours
+- [ ] Every new ERROR/WARNING/NOTE has a human disposition
+```
+
+For an update, add current CRAN result URLs, reverse-dependency evidence (or a
+reason it is not applicable), downstream communication, and update rationale.
+For an initial release, add the `New submission` explanation and confirmation
+that the unpublished installation policy held until stage 12.
+
+## Conversational operation
+
+Examples for local Codex or Codex Remote Control:
+
+```text
+Prepare the next CRAN release.
+Show the current release status and remaining human actions.
+Here is the win-builder result URL: <url>.
+I submitted the candidate to CRAN; verify publication and continue.
+Prepare the GitHub Release and development-version follow-up.
+```
+
+Codex responds by reading this playbook, the release issue, repository state,
+and retained evidence; it does not infer completion from a prior conversation.
+For a private win-builder URL, it archives the result externally and proposes
+only a durable non-secret summary for the issue.
+
+## Interrupted, rejected, and restarted releases
+
+After interruption, run stages 1 and 4 read-only checks, inspect the issue's
+next action, and verify every claimed result still names the candidate SHA and
+retained tarball digest. Continue from the first unchecked valid stage. Never
+infer state from a half-run helper or from conversation history.
+
+After CRAN rejection, record the non-secret reason and maintainer decision. A
+candidate change goes through a new preparation PR, SHA, preflight bundle, CI,
+semantic review where affected, remote checks, and readiness decision. A retry
+with unchanged bytes may retain evidence only after the maintainer confirms the
+rejection did not invalidate it. Rapid resubmission notes are explained in
+`cran-comments.md`; they are never automatically allowlisted.
+
+If publication or a remote service is temporarily unavailable, keep the issue
+open and retry the read-only check. Do not interpret absence, timeout, delayed
+binaries, or an acceptance email as successful publication.

--- a/tools/cran-release.md
+++ b/tools/cran-release.md
@@ -152,6 +152,20 @@ or approval is absent. Recovery: edit the existing issue after approval rather
 than creating a duplicate. Human fallback: create the issue in GitHub's UI with
 the same title and template.
 
+For every later ledger change, first read the current body, edit a temporary
+copy, show the exact proposed diff, and obtain approval before the external
+update:
+
+```sh
+release_issue_body=$(mktemp)
+gh issue view <issue-number> --json body --jq .body > "$release_issue_body"
+# Edit the temporary copy, then show its diff against the fetched body.
+gh issue edit <issue-number> --body-file "$release_issue_body"
+```
+
+The human fallback is the issue's Edit action in GitHub's UI after reviewing
+the same proposed checkbox/evidence change.
+
 ### 3. Prepare and merge the release PR
 
 Purpose: make version, NEWS, `cran-comments.md`, metadata, and generated files
@@ -472,9 +486,14 @@ notes, and two assets.
 Purpose: atomically publish the initial CRAN state/documentation when needed,
 advance to development, add the development NEWS heading, and regenerate files.
 
-Create a clean branch/worktree from current main after approval. Preview first:
+Show the branch/worktree target and obtain approval, then create it from current
+main and preview:
 
 ```sh
+git fetch origin
+git worktree add ../marginplyr-post-release-0.1.0 \
+  -b post-release/0.1.0 origin/main
+cd ../marginplyr-post-release-0.1.0
 Rscript tools/cran-release.R post-release --version 0.1.0
 ```
 
@@ -492,14 +511,29 @@ and install call appear once, version is `0.1.0.9000`, and NEWS begins with that
 heading. For an update, status and CRAN documentation must remain unchanged
 while version/NEWS advance. Run documentation and relevant tests, then obtain
 separate approvals for commit/push and PR creation. Put all of these changes in
-one PR.
+one PR:
+
+```sh
+Rscript .github/scripts/verify-context-budget.R
+Rscript .github/scripts/verify-doc-references.R
+Rscript .github/scripts/verify-cran-release.R
+jarl check .
+Rscript -e 'pkgload::load_all(".", quiet = TRUE); lintr::lint_package()'
+Rscript -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_dir("tests/testthat")'
+git diff --check
+
+git add DESCRIPTION NEWS.md README.Rmd README.md
+git commit -m "Start marginplyr 0.1.0.9000"
+git push -u origin post-release/0.1.0
+gh pr create --fill
+```
 
 Success evidence: green reviewable PR with no duplicated heading, badge, or
 installation text. Block on publication mismatch, dirty/unexpected state,
 generation failure, or a split/partial change. Recovery: inspect helper output;
 fix the disposable branch, or discard only that branch and recreate it. Human
-fallback: make the publication-day edits listed in `tests/testthat/
-test-documentation.R`, render with Pandoc 3.10.1, and create one PR.
+fallback: follow this stage by hand, render with Pandoc 3.10.1, and create one
+PR.
 
 ### 15. Monitor site deployment and CRAN flavors for 72 hours
 
@@ -523,7 +557,15 @@ Success evidence: deployed site, no undispositioned CRAN finding, and the full
 disposition. Recovery: investigate; fixes use the normal development/release
 process rather than rewriting this release. Human fallback: inspect Actions,
 the public site, and CRAN's check page on the same schedule. Close the release
-issue only after approval and only when every checkbox is complete.
+issue only when every checkbox is complete. Show the final ledger and obtain
+approval before the external close:
+
+```sh
+gh issue close <issue-number> \
+  --comment "Release monitoring completed; all findings are dispositioned."
+```
+
+The human fallback is GitHub's Close issue action with the same final comment.
 
 ## Release issue ledger
 

--- a/tools/cran-release.md
+++ b/tools/cran-release.md
@@ -179,13 +179,15 @@ repository authorities:
 
 ```sh
 Rscript -e 'roxygen2::roxygenise()'
+R CMD INSTALL .
 Rscript -e 'rmarkdown::render("README.Rmd", quiet = TRUE)'
 git diff --check
 git diff
 ```
 
-The README command requires Pandoc 3.10.1 and the working tree installed first,
-as `AGENTS.md` documents. Obtain separate approvals before commit, push, and PR
+Confirm `quarto pandoc --version` reports 3.10.1 before the README command. The
+working tree is installed first because its chunks load marginplyr, as
+`AGENTS.md` documents. Obtain separate approvals before commit, push, and PR
 creation:
 
 ```sh


### PR DESCRIPTION
## Summary

- add the durable human-and-agent CRAN release playbook from preparation through 72-hour post-publication monitoring
- add stateless preview/apply helpers for release preparation, CRAN publication verification, and post-release edits
- keep the existing exact-tarball preflight gate separate and move later-stage prose ownership to the playbook
- resolve the Pandoc authority conflict at 3.10.1 and add a fixture-backed release contract gate

## Validation

- `Rscript .github/scripts/verify-context-budget.R`
- `Rscript .github/scripts/verify-doc-references.R`
- `Rscript .github/scripts/verify-verifier-invocation.R`
- `Rscript .github/scripts/verify-cran-preflight.R`
- `Rscript .github/scripts/verify-cran-release.R`
- `jarl check .`
- package-aware `lintr::lint_package()`
- full testthat suite: 7,010 passed, 13 expected CRAN skips, 0 failed
- roxygen and README regeneration produced no diff

## Review

The two-axis review raised three Standards findings and two Spec findings, with overlap. The implementation now regenerates README output for update releases, accepts the repository-defined CRAN claim forms, makes the playbook the publication-step authority, and documents exact issue-update, close, and post-release PR commands. The judgement-only suggestion to replace the three explicit operation branches with a dispatch abstraction was rejected because the current stateless CLI keeps each operation local and visible.

Closes #507