### PR TITLE
Clarify Arrow input contract

### DIFF
--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -98,7 +98,7 @@ expand_with_margins <- function(.data,
   with_margin_error_call(
     {
       assert_margin_input(.data)
-      assert_lazy_table(.data)
+      assert_reusable_margin_input(.data)
     },
     call = call
   )

--- a/R/expand_with_margins.R
+++ b/R/expand_with_margins.R
@@ -32,6 +32,7 @@
 #' @inheritSection summarize_with_margins Grouping set identifiers
 #' @inheritSection summarize_with_margins Margin order
 #' @inheritSection summarize_with_margins Display labels and grouping identity
+#' @inheritSection summarize_with_margins Arrow inputs
 #' @inheritSection summarize_with_margins Database backend coverage
 #' @inheritSection summarize_with_margins When marginplyr queries your data
 #' @return An ungrouped data frame, or a lazy table when `.data` is lazy. Its

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -13,10 +13,6 @@ arrow_input_classes <- function() {
 # methods. Queries keep their left source in `.data` and any right sources in
 # the join and union nodes; walking all three is what prevents wrapping a
 # one-shot reader in a query from bypassing the reusable-input refusal.
-#
-# This reproduces Arrow's source graph rather than calling its unexported
-# `all_sources()` helper. The public-verb tests pin each node shape so a change
-# in Arrow's query representation fails at the refusal boundary.
 arrow_input_has_reader_source <- function(.data) {
   if (is.null(.data)) {
     return(FALSE)

--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -1,10 +1,43 @@
 # Named because two readings need it and a second copy of the vector is what
 # would drift: the kind below, and the branch summary's Absorbing-backend
 # handler, which has only `.data` to decide from and must not answer for a
-# warning some other backend raised (ADR 0025). `RecordBatchReader` is
-# deliberately absent, as it is from the kind: no verb accepts one.
+# warning some other backend raised (ADR 0025). A direct `RecordBatchReader` is
+# deliberately absent because no verb accepts it. A query backed by one still
+# has the class below; each verb applies its narrower reader-source rule.
 arrow_input_classes <- function() {
   c("arrow_dplyr_query", "Table", "RecordBatch", "Dataset")
+}
+
+# Whether an Arrow input's source graph contains a RecordBatchReader. A caller
+# holds either a direct Arrow object or the query produced by Arrow's dplyr
+# methods. Queries keep their left source in `.data` and any right sources in
+# the join and union nodes; walking all three is what prevents wrapping a
+# one-shot reader in a query from bypassing the reusable-input refusal.
+#
+# This reproduces Arrow's source graph rather than calling its unexported
+# `all_sources()` helper. The public-verb tests pin each node shape so a change
+# in Arrow's query representation fails at the refusal boundary.
+arrow_input_has_reader_source <- function(.data) {
+  if (is.null(.data)) {
+    return(FALSE)
+  }
+  if (inherits(.data, "RecordBatchReader")) {
+    return(TRUE)
+  }
+  if (!inherits(.data, "arrow_dplyr_query")) {
+    return(FALSE)
+  }
+
+  query <- unclass(.data)
+  any(vapply(
+    list(
+      query[[".data"]],
+      query[["join"]][["right_data"]],
+      query[["union_all"]][["right_data"]]
+    ),
+    arrow_input_has_reader_source,
+    logical(1L)
+  ))
 }
 
 # `is_sql` is whether this input is a SQL backend. It is equivalent to

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -147,7 +147,7 @@ inspect_grouping <- function(.data,
   with_margin_error_call(
     {
       assert_margin_input(.data)
-      assert_lazy_table(.data)
+      assert_inspectable_input(.data)
       .format <- match_margin_choice(
         .format,
         choices = grouping_format_choices,

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -74,6 +74,8 @@
 #' [guide]: https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html
 #' [recipes]: https://sayuks.github.io/marginplyr/vignettes/recipes.html
 #'
+#' @inheritSection summarize_with_margins Arrow inputs
+#'
 #' @family grouping plans and grouping identity
 #' @seealso [summarize_with_margins()] to run a Margin operation on the
 #'   inspected plan.

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -447,9 +447,12 @@
 #' query class alone.
 #'
 #' A `RecordBatchReader` is deliberately refused even though Arrow can start a
-#' dplyr query from it: the reader is one-pass, and converting it consumes and
-#' materializes the entire stream. Convert it explicitly with
-#' [arrow::as_arrow_table()] before calling a Margin verb. A `Scanner` and
+#' dplyr query from it: the reader is one-pass, while a Margin operation builds
+#' one branch per grouping set from the same input. Later branches cannot
+#' re-read rows an earlier branch consumed and can therefore compute an
+#' incomplete result. [arrow::as_arrow_table()] consumes every batch once and
+#' materializes them as the reusable `Table` the branches require; convert
+#' explicitly before calling a Margin verb. A `Scanner` and
 #' other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
 #' with `$ToTable()` or choose its `$ToRecordBatchReader()` stream first.
 #'

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -452,11 +452,14 @@
 #' re-read rows an earlier branch consumed and can therefore compute an
 #' incomplete result. [arrow::as_arrow_table()] consumes every batch once and
 #' materializes them as the reusable `Table` the branches require; convert
-#' explicitly before calling a Margin verb. A `Scanner`, `Scalar`, `Array`,
-#' `ChunkedArray`, `Schema`, `Field`, `DataType`, and other non-tabular Arrow
-#' objects are not dplyr inputs. Materialize a Scanner with `$ToTable()` or
-#' choose its `$ToRecordBatchReader()` stream first; convert any other object
-#' to a data frame or lazy dplyr table appropriate to the data it represents.
+#' explicitly before calling [summarize_with_margins()],
+#' [expand_with_margins()], or [inspect_grouping()]. For a nesting verb,
+#' collect the reader directly instead: an Arrow `Table` still cannot carry
+#' the list-column result. A `Scanner`, `Scalar`, `Array`, `ChunkedArray`,
+#' `Schema`, `Field`, `DataType`, and other non-tabular Arrow objects are not
+#' dplyr inputs. Materialize a Scanner with `$ToTable()` or choose its
+#' `$ToRecordBatchReader()` stream first; convert any other object to a data
+#' frame or lazy dplyr table appropriate to the data it represents.
 #'
 #' The nesting verbs accept neither Arrow input category, because their result
 #' contains a list column. [nest_with_margins()] and

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -452,9 +452,11 @@
 #' re-read rows an earlier branch consumed and can therefore compute an
 #' incomplete result. [arrow::as_arrow_table()] consumes every batch once and
 #' materializes them as the reusable `Table` the branches require; convert
-#' explicitly before calling a Margin verb. A `Scanner` and
-#' other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
-#' with `$ToTable()` or choose its `$ToRecordBatchReader()` stream first.
+#' explicitly before calling a Margin verb. A `Scanner`, `Scalar`, `Array`,
+#' `ChunkedArray`, `Schema`, `Field`, `DataType`, and other non-tabular Arrow
+#' objects are not dplyr inputs. Materialize a Scanner with `$ToTable()` or
+#' choose its `$ToRecordBatchReader()` stream first; convert any other object
+#' to a data frame or lazy dplyr table appropriate to the data it represents.
 #'
 #' The nesting verbs accept neither Arrow input category, because their result
 #' contains a list column. [nest_with_margins()] and

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -434,6 +434,31 @@
 #' the same expressions instead, because a dataset never reads itself into R;
 #' they are otherwise unaffected.
 #'
+#' @section Arrow inputs:
+#' Arrow's tabular dplyr inputs are a `Table`, `RecordBatch`, `Dataset`, or an
+#' `arrow_dplyr_query` built from one. All three direct inputs are accepted by
+#' `summarize_with_margins()`, `expand_with_margins()`, and
+#' `inspect_grouping()`; their queries are accepted too. A translatable summary
+#' stays an Arrow query for every one of them. For a summary Arrow cannot
+#' translate, a `Table` and `RecordBatch` (and a query built on either) would
+#' fall back to R, so marginplyr refuses it before a row is read. A `Dataset`
+#' and a query built on one instead keep Arrow's own unsupported-expression
+#' error. Thus an `arrow_dplyr_query` is described by its source, not by its
+#' query class alone.
+#'
+#' A `RecordBatchReader` is deliberately refused even though Arrow can start a
+#' dplyr query from it: the reader is one-pass, and converting it consumes and
+#' materializes the entire stream. Convert it explicitly with
+#' [arrow::as_arrow_table()] before calling a Margin verb. A `Scanner` and
+#' other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
+#' with `$ToTable()` or choose its `$ToRecordBatchReader()` stream first.
+#'
+#' The nesting verbs accept neither Arrow input category, because their result
+#' contains a list column. [nest_with_margins()] and
+#' [nest_by_with_margins()] therefore ask you to collect first. Contextual
+#' shares are rejected for every accepted Arrow input before a summary query is
+#' constructed; collect first when local share execution is appropriate.
+#'
 #' @section Contextual shares:
 #' [share_of_parent()] and [share_of_total()] calculate a preceding named
 #' numeric scalar summary's ratio to the same summary on another row of the

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -435,29 +435,38 @@
 #' they are otherwise unaffected.
 #'
 #' @section Arrow inputs:
-#' Arrow's tabular dplyr inputs are a `Table`, `RecordBatch`, `Dataset`, or an
-#' `arrow_dplyr_query` built from one. All three direct inputs are accepted by
-#' `summarize_with_margins()`, `expand_with_margins()`, and
-#' `inspect_grouping()`; their queries are accepted too. A translatable summary
-#' stays an Arrow query for every one of them. For a summary Arrow cannot
-#' translate, a `Table` and `RecordBatch` (and a query built on either) would
-#' fall back to R, so marginplyr refuses it before a row is read. A `Dataset`
-#' and a query built on one instead keep Arrow's own unsupported-expression
-#' error. Thus an `arrow_dplyr_query` is described by its source, not by its
-#' query class alone.
+#' Arrow's tabular dplyr inputs are a `Table`, `RecordBatch`, `Dataset`,
+#' `RecordBatchReader`, or an `arrow_dplyr_query` built from them. marginplyr's
+#' contract depends on both the verb and the query's sources:
 #'
-#' A `RecordBatchReader` is deliberately refused even though Arrow can start a
-#' dplyr query from it: the reader is one-pass, while a Margin operation builds
-#' one branch per grouping set from the same input. Later branches cannot
-#' re-read rows an earlier branch consumed and can therefore compute an
-#' incomplete result. [arrow::as_arrow_table()] consumes every batch once and
-#' materializes them as the reusable `Table` the branches require; convert
-#' explicitly before calling [summarize_with_margins()],
-#' [expand_with_margins()], or [inspect_grouping()]. For a nesting verb,
-#' collect the reader directly instead: an Arrow `Table` still cannot carry
-#' the list-column result. A `Scanner`, `Scalar`, `Array`, `ChunkedArray`,
-#' `Schema`, `Field`, `DataType`, and other non-tabular Arrow objects are not
-#' dplyr inputs. Materialize a Scanner with `$ToTable()` or choose its
+#' | Input | Summary or expansion | Inspection | Nesting |
+#' | --- | --- | --- | --- |
+#' | `Table`, `RecordBatch`, or `Dataset` | Accepted | Accepted | Refused; collect first | # nolint: line_length_linter
+#' | Query with no reader source | Accepted | Accepted | Refused; collect first | # nolint: line_length_linter
+#' | `RecordBatchReader` | Refused; materialize first | Refused; build a query first | Refused; collect first | # nolint: line_length_linter
+#' | Query with any reader source | Refused; materialize first | Accepted | Refused; collect first | # nolint: line_length_linter
+#' | Non-tabular Arrow object | General input refusal | General input refusal | General input refusal | # nolint: line_length_linter
+#'
+#' A translatable summary or expansion stays an Arrow query. For a summary
+#' Arrow cannot translate, a `Table` and `RecordBatch` (and queries built on
+#' them) would fall back to R, so marginplyr refuses it before a row is read. A
+#' `Dataset` and a query built on one instead keep Arrow's own
+#' unsupported-expression error. Thus an `arrow_dplyr_query` is described by
+#' its complete source graph, not by its query class alone.
+#'
+#' A `RecordBatchReader` is one-pass, while a Margin operation may build one
+#' branch per grouping set. [summarize_with_margins()] and
+#' [expand_with_margins()] therefore refuse both the reader and any query whose
+#' source graph contains one. [arrow::as_arrow_table()] consumes every batch
+#' once and materializes the reusable `Table` those branches require.
+#' `inspect_grouping()` executes no branch, so it accepts a reader-backed query
+#' without consuming it. A direct reader currently needs to be wrapped first,
+#' for example with `dplyr::select(reader, dplyr::everything())`; issue #510
+#' tracks removing that distinction.
+#'
+#' A `Scanner`, `Scalar`, `Array`, `ChunkedArray`, `Schema`, `Field`,
+#' `DataType`, and other non-tabular Arrow objects are not dplyr inputs.
+#' Materialize a Scanner with `$ToTable()` or choose its
 #' `$ToRecordBatchReader()` stream first; convert any other object to a data
 #' frame or lazy dplyr table appropriate to the data it represents.
 #'
@@ -899,7 +908,7 @@ summarize_with_margins <- function(.data,
   share_kinds <- with_margin_error_call(
     {
       assert_margin_input(.data)
-      assert_lazy_table(.data)
+      assert_reusable_margin_input(.data)
       normalize_margin_options(
         .margin_label = .margin_label,
         .margin_label_position = .margin_label_position,

--- a/R/utils.R
+++ b/R/utils.R
@@ -145,7 +145,10 @@ assert_margin_input <- function(x) {
         "dplyr verbs."
       ),
       i = "{.code NULL} was supplied.",
-      i = "Convert it with {.fun as.data.frame} or {.fun dplyr::tbl} first."
+      i = paste0(
+        "Convert it to a data frame or a lazy table that supports dplyr ",
+        "verbs first."
+      )
     ))
   }
   abort_marginplyr(c(
@@ -154,7 +157,10 @@ assert_margin_input <- function(x) {
       "dplyr verbs."
     ),
     i = "A {.cls {class(x)[[1L]]}} was supplied.",
-    i = "Convert it with {.fun as.data.frame} or {.fun dplyr::tbl} first."
+    i = paste0(
+      "Convert it to a data frame or a lazy table that supports dplyr verbs ",
+      "first."
+    )
   ))
 }
 
@@ -172,6 +178,10 @@ assert_margin_input <- function(x) {
 # `dplyr::collect()` resolves this refusal too and is not named beside
 # `arrow::as_arrow_table()`, under the rule ADR 0012's third amendment states
 # for two routes that leave the caller in different places.
+#
+# A reader remains refused because a Margin operation needs to build every
+# grouping-set branch from the same reusable input; ADR 0012's amendment on a
+# general admission refusal records why a one-shot reader cannot satisfy it.
 assert_lazy_table <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,8 +76,8 @@ assert_string_scalar <- function(x) {
 # `expand_with_margins()` is not named beside `dplyr::collect()`, under the
 # rule ADR 0012's second amendment states. It takes the same Grouping
 # specification and stays lazy, but it returns rows rather than the list column
-# this call asked for, and `assert_lazy_table()` refuses a `RecordBatchReader`
-# that reaches this refusal.
+# this call asked for. A `RecordBatchReader` that reaches this refusal remains
+# on the nesting path rather than the reusable-input or inspection path.
 assert_nest_possible <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.
@@ -164,35 +164,39 @@ assert_margin_input <- function(x) {
   ))
 }
 
-# The refused classes stay in the line that names them, for the reason
-# `assert_nest_possible()` above records: the vector is this function's own
-# constant. `{.code}` is that function's style for the same subject, and it is
-# what keeps a second entry from rendering as one object's class chain.
-#
-# The join is cli's default `and` rather than that function's `{.or}`, and the
-# difference is what the sentence asks of the list. A whitelist offers
-# alternatives to pick one of; a blacklist refuses every entry at once, so a
-# second name would be refused alongside the first and not instead of it.
-# Nothing renders today, the vector holding one name.
-#
-# `dplyr::collect()` resolves this refusal too and is not named beside
-# `arrow::as_arrow_table()`, under the rule ADR 0012's third amendment states
-# for two routes that leave the caller in different places.
-#
-# A reader remains refused because a Margin operation needs to build every
-# grouping-set branch from the same reusable input; ADR 0012's amendment on a
-# general admission refusal records why a one-shot reader cannot satisfy it.
-assert_lazy_table <- function(x) {
+# A Margin operation needs every grouping-set branch to start from the same
+# reusable input. A direct reader and an Arrow query whose source graph contains
+# one both fail that precondition; ADR 0012 records the refusal and its remedy.
+assert_reusable_margin_input <- function(x) {
   # Read only from the cli template below, which codetools cannot see.
   nm <- deparse(substitute(x)) # nolint: object_usage_linter.
-  invalid_lazy_table_names <- "RecordBatchReader"
-  if (inherits(x, invalid_lazy_table_names)) {
+  if (arrow_input_has_reader_source(x)) {
     abort_marginplyr(c(
       paste0(
-        "{.arg {nm}} must not be an object of the following classes: ",
-        "{.code {invalid_lazy_table_names}}."
+        "{.arg {nm}} must not be or depend on a ",
+        "{.cls RecordBatchReader}."
       ),
-      i = "Convert it with {.fun arrow::as_arrow_table} first."
+      i = "Materialize it with {.fun arrow::as_arrow_table} first."
+    ))
+  }
+}
+
+# Inspection executes no grouping-set branch, so an Arrow query backed by a
+# reader is safe here. A direct reader still lacks the selection proxy the
+# current adapter requires; #510 owns removing this temporary distinction.
+assert_inspectable_input <- function(x) {
+  # Read only from the cli template below, which codetools cannot see.
+  nm <- deparse(substitute(x)) # nolint: object_usage_linter.
+  if (inherits(x, "RecordBatchReader")) {
+    abort_marginplyr(c(
+      paste0(
+        "{.arg {nm}} must be an Arrow dplyr query rather than a ",
+        "{.cls RecordBatchReader}."
+      ),
+      i = paste0(
+        "Build one with {.fun dplyr::select} and ",
+        "{.fun dplyr::everything} first."
+      )
     ))
   }
 }

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -208,30 +208,16 @@ one #374 fixed beside it.
 
 ## Amendment: a general admission refusal names the destination
 
-The paragraph above beginning “`or` stays available” relied on both named
-functions being remedies for the objects reaching `assert_margin_input()`.
-That is false for Arrow's non-tabular objects: neither `as.data.frame()` nor
-`dplyr::tbl()` converts a `Scanner`, `Scalar`, `Array`, `ChunkedArray`, `Field`,
-or `DataType` into a dplyr table. A duck-typed refusal can identify the class
-that failed admission, but it cannot know the constructor that makes every
-future backend's object tabular.
+The general admission refusal names its required destination -- a data frame or
+a lazy table that supports dplyr verbs -- without promising a conversion
+function.
 
-The general refusal therefore names the required destination -- a data frame
-or a lazy table that supports dplyr verbs -- without promising a conversion
-function. This does not change the `RecordBatchReader` refusal above. That
-class passes general dplyr admission and is rejected for a narrower reason: a
-Margin operation builds one branch per grouping set from the same input, while
-the reader is one-shot. A later branch cannot re-read rows an earlier branch
-consumed and can produce an incomplete result.
+The reusable-input refusal applies to a direct `RecordBatchReader` and to an
+Arrow query whose source graph contains one. `arrow::as_arrow_table()` is their
+named remedy. `inspect_grouping()` applies a separate inspection rule: it
+accepts a reader-backed query but, until #510, refuses a direct reader and asks
+the caller to build that query explicitly. The nesting verbs retain their
+`dplyr::collect()` remedy.
 
-Arrow 25.0.1 still exhibits that failure: combining a grouped summary and a
-grand-total summary built from one two-batch reader omits one group and computes
-the total from only the first batch. The dated reproduction belongs to
+PR #509 records the contract change. The evidence is in
 `investigation/arrow-r-input-shapes-and-dplyr-fallback.md`.
-
-`arrow::as_arrow_table()` remains its remedy. With a reader containing multiple
-record batches, the conversion consumes every batch once and materializes all
-rows in a reusable `Table`; each Margin branch can then read the complete
-input. The test at the public-verb seam asserts both halves: every guarded verb
-refuses before consuming the reader, and following the named remedy yields the
-complete grouped and grand-total counts.

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -205,3 +205,28 @@ call returns as well as what it accepts.
 
 *Leave the refusal with no remedy.* That is the defect #391 reported, and the
 one #374 fixed beside it.
+
+## Amendment: a general admission refusal names the destination
+
+The paragraph above beginning “`or` stays available” relied on both named
+functions being remedies for the objects reaching `assert_margin_input()`.
+That is false for Arrow's non-tabular objects: neither `as.data.frame()` nor
+`dplyr::tbl()` converts a `Scanner`, `Scalar`, `Array`, `ChunkedArray`, `Field`,
+or `DataType` into a dplyr table. A duck-typed refusal can identify the class
+that failed admission, but it cannot know the constructor that makes every
+future backend's object tabular.
+
+The general refusal therefore names the required destination -- a data frame
+or a lazy table that supports dplyr verbs -- without promising a conversion
+function. This does not change the `RecordBatchReader` refusal above. That
+class passes general dplyr admission and is rejected for a narrower reason: a
+Margin operation builds one branch per grouping set from the same input, while
+the reader is one-shot. A later branch cannot re-read rows an earlier branch
+consumed and can produce an incomplete result.
+
+`arrow::as_arrow_table()` remains its remedy. With a reader containing multiple
+record batches, the conversion consumes every batch once and materializes all
+rows in a reusable `Table`; each Margin branch can then read the complete
+input. The test at the public-verb seam asserts both halves: every guarded verb
+refuses before consuming the reader, and following the named remedy yields the
+complete grouped and grand-total counts.

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -224,6 +224,11 @@ Margin operation builds one branch per grouping set from the same input, while
 the reader is one-shot. A later branch cannot re-read rows an earlier branch
 consumed and can produce an incomplete result.
 
+Arrow 25.0.1 still exhibits that failure: combining a grouped summary and a
+grand-total summary built from one two-batch reader omits one group and computes
+the total from only the first batch. The dated reproduction belongs to
+`investigation/arrow-r-input-shapes-and-dplyr-fallback.md`.
+
 `arrow::as_arrow_table()` remains its remedy. With a reader containing multiple
 record batches, the conversion consumes every batch once and materializes all
 rows in a reusable `Table`; each Margin branch can then read the complete

--- a/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
+++ b/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
@@ -2,6 +2,7 @@
 
 Investigated: 2026-09-08
 Revised: 2026-09-09 — multi-branch RecordBatchReader reproduction below
+Revised: 2026-09-09 (#509) — reader-backed query bypass and verb boundary below
 
 Measured with R 4.6.1, arrow 25.0.1, and dplyr 1.2.1.  The Arrow sources and
 reference pages linked below were read on the investigation date.  This note
@@ -127,3 +128,43 @@ then refers to a reusable table rather than to the reader. It is not the direct
 remedy for a nesting verb, because an Arrow table still cannot carry its list
 column; that verb's existing `dplyr::collect()` remedy consumes the reader into
 a local data frame instead.
+
+## Revisions (2026-09-09, #509)
+
+The first revision tested the direct reader refusal but did not test a query
+whose source was that reader. Arrow 25.0.1 allowed that query through
+marginplyr's class-only guard and reproduced the incomplete result:
+
+```r
+reader <- arrow::RecordBatchReader$create(
+  arrow::record_batch(k = c("E", "E"), v = 1:2),
+  arrow::record_batch(k = c("W", "W", "W"), v = 3:5)
+)
+query <- dplyr::select(reader, dplyr::everything())
+
+marginplyr::summarize_with_margins(
+  query,
+  n = dplyr::n(),
+  total = sum(v),
+  .grouping = marginplyr::rollup(k)
+) |>
+  dplyr::collect()
+#> # A tibble: 2 x 3
+#>   k         n total
+#>   <chr> <int> <int>
+#> 1 Total     2     3
+#> 2 W         3    12
+```
+
+The expected rows were `E = 2`, `W = 3`, and `Total = 5`. A query wrapper did
+not make the reader reusable; it only hid the direct class from the guard. The
+incomplete rows were execution-order dependent: running the backend tests in a
+shared session also produced only the otherwise correct `Total = 5` row. The
+stable observation was that the complete three-row result was not produced,
+not which branch consumed which batch first.
+
+Inspection fell on the other side of the verb boundary. Passing the same
+unexecuted `query` to `inspect_grouping()` returned the two-set rollup plan,
+after which converting `reader` still returned all five rows. Inspection built
+no grouping-set branches and consumed no batch. Issue #510 records the decision
+to add direct-reader inspection separately from PR #509.

--- a/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
+++ b/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
@@ -1,6 +1,7 @@
 # Arrow R input shapes and dplyr fallback
 
 Investigated: 2026-09-08
+Revised: 2026-09-09 — multi-branch RecordBatchReader reproduction below
 
 Measured with R 4.6.1, arrow 25.0.1, and dplyr 1.2.1.  The Arrow sources and
 reference pages linked below were read on the investigation date.  This note
@@ -102,3 +103,27 @@ rules.  Those rows rest on the current first-party implementation plus the
 local 25.0.1 reproduction.  Since Arrow can add compute kernels or change this
 internal classification, the supported-expression set and the fallback wording
 must be checked against the Arrow version actually supported by marginplyr.
+
+## Revisions (2026-09-09)
+
+Arrow 25.0.1 correctly consumed both batches when one summary query was built
+from a `RecordBatchReader`: two batches holding two and three rows produced a
+count of five and a sum of fifteen. It did not make that reader reusable. A
+second summary query executed against the same reader returned a count and sum
+of zero.
+
+The Margin-operation shape reproduced the original wrong-result reason. A
+grouped summary and a grand-total summary were built lazily from the same
+reader and combined with `dplyr::union_all()`. The input held `E` in the first
+two-row batch and `W` in the second three-row batch. The complete answer was
+`E = 2`, `W = 3`, and `Total = 5`; Arrow instead returned `W = 3` and
+`Total = 2`. Thus constructing both queries before execution did not turn the
+one-shot source into one shared scan.
+
+`arrow::as_arrow_table()` consumed those same two batches once and produced a
+five-row table whose value column summed to fifteen. The conversion is therefore
+a valid remedy for the summary, expansion, and inspection guards: every branch
+then refers to a reusable table rather than to the reader. It is not the direct
+remedy for a nesting verb, because an Arrow table still cannot carry its list
+column; that verb's existing `dplyr::collect()` remedy consumes the reader into
+a local data frame instead.

--- a/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
+++ b/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
@@ -1,0 +1,104 @@
+# Arrow R input shapes and dplyr fallback
+
+Investigated: 2026-09-08
+
+Measured with R 4.6.1, arrow 25.0.1, and dplyr 1.2.1.  The Arrow sources and
+reference pages linked below were read on the investigation date.  This note
+records evidence; `R/grouping-backend.R`, `R/utils.R`, and the tests are
+authoritative for marginplyr's present admission policy.
+
+## Scope and the complete Arrow R class split
+
+Arrow's [data-objects article](https://arrow.apache.org/docs/r/articles/data_objects.html)
+lists its tabular objects as `RecordBatch`, `Table`, and `Dataset`; `Scalar`,
+`Array`, and `ChunkedArray` are respectively scalar or one-dimensional, while
+`Schema`, `Field`, and `DataType` are metadata.  They are therefore not
+two-dimensional dplyr inputs.  `ArrowObject` is the common R6 base class, not
+a tabular-input contract.
+
+The Arrow dplyr implementation itself has a more exact admission list:
+[`arrow_dplyr_query()` in `r/R/dplyr.R`](https://github.com/apache/arrow/blob/main/r/R/dplyr.R)
+accepts `Dataset`, `RecordBatch`, `RecordBatchReader`, `Table`, an existing
+`arrow_dplyr_query`, and `data.frame` (which it first converts to `Table`).
+Thus `ArrowObject` is not a valid shorthand for an Arrow dplyr input.
+
+`Scanner` is a distinct execution object.  Its
+[reference](https://arrow.apache.org/docs/r/reference/Scanner.html) documents
+`Scanner$create()` as accepting a `Dataset` or Dataset-based query, and its
+`$ToTable()` and `$ToRecordBatchReader()` methods as the ways to materialize or
+stream the scan.  It is not in Arrow's dplyr-query admission list.  The
+low-level path is consequential: the data-objects article states that
+`$ToTable()` materializes the Dataset, whereas `$ScanBatches()` executes the
+scan and returns batches.
+
+## Arrow's native dplyr behaviour
+
+The official [dplyr article](https://arrow.apache.org/docs/r/articles/data_wrangling.html)
+states that one-table verbs construct an `arrow_dplyr_query` lazily; `compute()`
+materializes an Arrow `Table`, and `collect()` returns an R data frame/tibble.
+The [Acero reference](https://arrow.apache.org/docs/r/reference/acero.html)
+enumerates the dplyr verbs and mapped functions available in those queries.
+It is a support list, not an assertion that every R expression is translated.
+
+For an unsupported expression, the same official article draws this boundary:
+
+| Source passed to Arrow dplyr | Arrow's documented or source-defined result |
+| --- | --- |
+| `Table` | Warn, automatically `collect()` to R, then run that verb in R. |
+| `RecordBatch` | Same in the Arrow implementation: it is an in-memory tabular source on the shared query-construction path. The current article names only `Table`, so this part is source-backed and measured rather than explicitly documented prose. |
+| `Dataset` | Raise an unsupported-expression error; the caller must explicitly `collect()` before the unsupported verb. |
+| `RecordBatchReader` | Dataset-side behaviour: error rather than automatic fallback. In `r/R/dplyr.R`, `query_on_dataset()` treats it with `Dataset`; the source comments that a reader's stream is consumed. This is source-backed and measured, but not stated in the prose article. |
+| `arrow_dplyr_query` | It inherits the behaviour of its source: queries over a `Table` or `RecordBatch` may fall back; queries over `Dataset` or `RecordBatchReader` error. The query class alone is insufficient to tell the two outcomes apart. |
+
+The article explicitly explains the Table fallback and Dataset error, including
+the instruction to put `collect()` in the middle of a Dataset pipeline.  The
+same split is implemented in the official source's `query_on_dataset()` and
+fallback handler.  Arrow's `NEWS.md` also records that `RecordBatchReader` was
+added as a dplyr-query source in Arrow 8.0.0:
+[source](https://github.com/apache/arrow/blob/main/r/NEWS.md).
+
+## Local reproduction on the investigation date
+
+For `summarise(z = paste(a, collapse = ","))`, Arrow 25.0.1 gave the following
+results over a two-column, two-row input:
+
+| Input | Result |
+| --- | --- |
+| `Table` | warning ending in “Pulling data into R”; local tibble result |
+| `RecordBatch` | same warning and local tibble result |
+| `InMemoryDataset` | Arrow unsupported-expression error telling the caller to `collect()` first |
+| `RecordBatchReader` | same Arrow error, without an automatic collection |
+
+On the same installation, `summarize_with_margins()` accepted `Table`,
+`RecordBatch`, and `InMemoryDataset` and returned an `arrow_dplyr_query` for a
+translatable `n()` summary.  It rejected `RecordBatchReader` before Arrow
+constructs a query, with the documented remedy `arrow::as_arrow_table()`;
+it rejected `Scanner` because it has no dplyr `group_vars()` method.  The
+repository's test `"public Arrow table classes are supported"` records the
+same allowed/rejected boundary.
+
+## Consequences for a complete marginplyr input contract
+
+The implementable categories are not just “Arrow table” versus “Arrow
+dataset”.  Documentation and tests need to state all of these distinctions:
+
+1. Accept `Table`, `RecordBatch`, `Dataset`, and `arrow_dplyr_query`; describe
+   an `arrow_dplyr_query` by its source, not as one uniform fallback class.
+2. Reject `RecordBatchReader` deliberately, even though Arrow itself can build
+   a dplyr query from it.  It is single-pass and has Dataset-style unsupported
+   expression failure; conversion to a `Table` is an explicit materialization
+   choice.
+3. Reject `Scanner` as a dplyr input; direct its caller to `$ToTable()` or
+   `$ToRecordBatchReader()` and then make the resulting materialization/stream
+   choice explicit.
+4. Reject or leave to ordinary dplyr dispatch every non-tabular Arrow class
+   (`Scalar`, `Array`, `ChunkedArray`, metadata classes, and bare
+   `ArrowObject`); none is an Arrow R tabular/dplyr source.
+
+The uncertainty is intentional and bounded.  Arrow's official prose documents
+the fallback guarantee only as `Table` versus `Dataset`; it does not enumerate
+the corresponding `RecordBatch`, `RecordBatchReader`, and query-over-source
+rules.  Those rows rest on the current first-party implementation plus the
+local 25.0.1 reproduction.  Since Arrow can add compute kernels or change this
+internal classification, the supported-expression set and the fallback wording
+must be checked against the Arrow version actually supported by marginplyr.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -417,11 +417,14 @@ one branch per grouping set from the same input. Later branches cannot
 re-read rows an earlier branch consumed and can therefore compute an
 incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
 materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling a Margin verb. A \code{Scanner}, \code{Scalar}, \code{Array},
-\code{ChunkedArray}, \code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow
-objects are not dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or
-choose its \verb{$ToRecordBatchReader()} stream first; convert any other object
-to a data frame or lazy dplyr table appropriate to the data it represents.
+explicitly before calling \code{\link[=summarize_with_margins]{summarize_with_margins()}},
+\code{\link[=expand_with_margins]{expand_with_margins()}}, or \code{\link[=inspect_grouping]{inspect_grouping()}}. For a nesting verb,
+collect the reader directly instead: an Arrow \code{Table} still cannot carry
+the list-column result. A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray},
+\code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow objects are not
+dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or choose its
+\verb{$ToRecordBatchReader()} stream first; convert any other object to a data
+frame or lazy dplyr table appropriate to the data it represents.
 
 The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -398,6 +398,33 @@ argument says. See \code{.check_margin_label} above for its default and \emph{Wh
 marginplyr queries your data} for why the two halves differ.
 }
 
+\section{Arrow inputs}{
+
+Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset}, or an
+\code{arrow_dplyr_query} built from one. All three direct inputs are accepted by
+\code{summarize_with_margins()}, \code{expand_with_margins()}, and
+\code{inspect_grouping()}; their queries are accepted too. A translatable summary
+stays an Arrow query for every one of them. For a summary Arrow cannot
+translate, a \code{Table} and \code{RecordBatch} (and a query built on either) would
+fall back to R, so marginplyr refuses it before a row is read. A \code{Dataset}
+and a query built on one instead keep Arrow's own unsupported-expression
+error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
+query class alone.
+
+A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
+dplyr query from it: the reader is one-pass, and converting it consumes and
+materializes the entire stream. Convert it explicitly with
+\code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} before calling a Margin verb. A \code{Scanner} and
+other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
+with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
+
+The nesting verbs accept neither Arrow input category, because their result
+contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} therefore ask you to collect first. Contextual
+shares are rejected for every accepted Arrow input before a summary query is
+constructed; collect first when local share execution is appropriate.
+}
+
 \section{Database backend coverage}{
 
 DuckDB and PostgreSQL use native \verb{GROUP BY GROUPING SETS} SQL. Automated

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -412,9 +412,12 @@ error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
 query class alone.
 
 A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
-dplyr query from it: the reader is one-pass, and converting it consumes and
-materializes the entire stream. Convert it explicitly with
-\code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} before calling a Margin verb. A \code{Scanner} and
+dplyr query from it: the reader is one-pass, while a Margin operation builds
+one branch per grouping set from the same input. Later branches cannot
+re-read rows an earlier branch consumed and can therefore compute an
+incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
+materializes them as the reusable \code{Table} the branches require; convert
+explicitly before calling a Margin verb. A \code{Scanner} and
 other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
 with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
 

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -417,9 +417,11 @@ one branch per grouping set from the same input. Later branches cannot
 re-read rows an earlier branch consumed and can therefore compute an
 incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
 materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling a Margin verb. A \code{Scanner} and
-other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
-with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
+explicitly before calling a Margin verb. A \code{Scanner}, \code{Scalar}, \code{Array},
+\code{ChunkedArray}, \code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow
+objects are not dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or
+choose its \verb{$ToRecordBatchReader()} stream first; convert any other object
+to a data frame or lazy dplyr table appropriate to the data it represents.
 
 The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -400,29 +400,38 @@ marginplyr queries your data} for why the two halves differ.
 
 \section{Arrow inputs}{
 
-Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset}, or an
-\code{arrow_dplyr_query} built from one. All three direct inputs are accepted by
-\code{summarize_with_margins()}, \code{expand_with_margins()}, and
-\code{inspect_grouping()}; their queries are accepted too. A translatable summary
-stays an Arrow query for every one of them. For a summary Arrow cannot
-translate, a \code{Table} and \code{RecordBatch} (and a query built on either) would
-fall back to R, so marginplyr refuses it before a row is read. A \code{Dataset}
-and a query built on one instead keep Arrow's own unsupported-expression
-error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
-query class alone.
+Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset},
+\code{RecordBatchReader}, or an \code{arrow_dplyr_query} built from them. marginplyr's
+contract depends on both the verb and the query's sources:\tabular{llll}{
+   Input \tab Summary or expansion \tab Inspection \tab Nesting \cr
+   \code{Table}, \code{RecordBatch}, or \code{Dataset} \tab Accepted \tab Accepted \tab Refused; collect first \cr
+   Query with no reader source \tab Accepted \tab Accepted \tab Refused; collect first \cr
+   \code{RecordBatchReader} \tab Refused; materialize first \tab Refused; build a query first \tab Refused; collect first \cr
+   Query with any reader source \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
+   Non-tabular Arrow object \tab General input refusal \tab General input refusal \tab General input refusal \cr
+}
 
-A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
-dplyr query from it: the reader is one-pass, while a Margin operation builds
-one branch per grouping set from the same input. Later branches cannot
-re-read rows an earlier branch consumed and can therefore compute an
-incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
-materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling \code{\link[=summarize_with_margins]{summarize_with_margins()}},
-\code{\link[=expand_with_margins]{expand_with_margins()}}, or \code{\link[=inspect_grouping]{inspect_grouping()}}. For a nesting verb,
-collect the reader directly instead: an Arrow \code{Table} still cannot carry
-the list-column result. A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray},
-\code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow objects are not
-dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or choose its
+
+A translatable summary or expansion stays an Arrow query. For a summary
+Arrow cannot translate, a \code{Table} and \code{RecordBatch} (and queries built on
+them) would fall back to R, so marginplyr refuses it before a row is read. A
+\code{Dataset} and a query built on one instead keep Arrow's own
+unsupported-expression error. Thus an \code{arrow_dplyr_query} is described by
+its complete source graph, not by its query class alone.
+
+A \code{RecordBatchReader} is one-pass, while a Margin operation may build one
+branch per grouping set. \code{\link[=summarize_with_margins]{summarize_with_margins()}} and
+\code{\link[=expand_with_margins]{expand_with_margins()}} therefore refuse both the reader and any query whose
+source graph contains one. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch
+once and materializes the reusable \code{Table} those branches require.
+\code{inspect_grouping()} executes no branch, so it accepts a reader-backed query
+without consuming it. A direct reader currently needs to be wrapped first,
+for example with \code{dplyr::select(reader, dplyr::everything())}; issue #510
+tracks removing that distinction.
+
+A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray}, \code{Schema}, \code{Field},
+\code{DataType}, and other non-tabular Arrow objects are not dplyr inputs.
+Materialize a Scanner with \verb{$ToTable()} or choose its
 \verb{$ToRecordBatchReader()} stream first; convert any other object to a data
 frame or lazy dplyr table appropriate to the data it represents.
 

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -132,6 +132,33 @@ Elsewhere in this package \code{NULL} is a documented value, and what it means i
 stated with the argument that takes it.
 }
 
+\section{Arrow inputs}{
+
+Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset}, or an
+\code{arrow_dplyr_query} built from one. All three direct inputs are accepted by
+\code{summarize_with_margins()}, \code{expand_with_margins()}, and
+\code{inspect_grouping()}; their queries are accepted too. A translatable summary
+stays an Arrow query for every one of them. For a summary Arrow cannot
+translate, a \code{Table} and \code{RecordBatch} (and a query built on either) would
+fall back to R, so marginplyr refuses it before a row is read. A \code{Dataset}
+and a query built on one instead keep Arrow's own unsupported-expression
+error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
+query class alone.
+
+A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
+dplyr query from it: the reader is one-pass, and converting it consumes and
+materializes the entire stream. Convert it explicitly with
+\code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} before calling a Margin verb. A \code{Scanner} and
+other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
+with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
+
+The nesting verbs accept neither Arrow input category, because their result
+contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} therefore ask you to collect first. Contextual
+shares are rejected for every accepted Arrow input before a summary query is
+constructed; collect first when local share execution is appropriate.
+}
+
 \examples{
 inspect_grouping(
   .data = retail_sales,

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -151,9 +151,11 @@ one branch per grouping set from the same input. Later branches cannot
 re-read rows an earlier branch consumed and can therefore compute an
 incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
 materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling a Margin verb. A \code{Scanner} and
-other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
-with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
+explicitly before calling a Margin verb. A \code{Scanner}, \code{Scalar}, \code{Array},
+\code{ChunkedArray}, \code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow
+objects are not dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or
+choose its \verb{$ToRecordBatchReader()} stream first; convert any other object
+to a data frame or lazy dplyr table appropriate to the data it represents.
 
 The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -146,9 +146,12 @@ error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
 query class alone.
 
 A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
-dplyr query from it: the reader is one-pass, and converting it consumes and
-materializes the entire stream. Convert it explicitly with
-\code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} before calling a Margin verb. A \code{Scanner} and
+dplyr query from it: the reader is one-pass, while a Margin operation builds
+one branch per grouping set from the same input. Later branches cannot
+re-read rows an earlier branch consumed and can therefore compute an
+incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
+materializes them as the reusable \code{Table} the branches require; convert
+explicitly before calling a Margin verb. A \code{Scanner} and
 other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
 with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
 

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -134,29 +134,38 @@ stated with the argument that takes it.
 
 \section{Arrow inputs}{
 
-Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset}, or an
-\code{arrow_dplyr_query} built from one. All three direct inputs are accepted by
-\code{summarize_with_margins()}, \code{expand_with_margins()}, and
-\code{inspect_grouping()}; their queries are accepted too. A translatable summary
-stays an Arrow query for every one of them. For a summary Arrow cannot
-translate, a \code{Table} and \code{RecordBatch} (and a query built on either) would
-fall back to R, so marginplyr refuses it before a row is read. A \code{Dataset}
-and a query built on one instead keep Arrow's own unsupported-expression
-error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
-query class alone.
+Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset},
+\code{RecordBatchReader}, or an \code{arrow_dplyr_query} built from them. marginplyr's
+contract depends on both the verb and the query's sources:\tabular{llll}{
+   Input \tab Summary or expansion \tab Inspection \tab Nesting \cr
+   \code{Table}, \code{RecordBatch}, or \code{Dataset} \tab Accepted \tab Accepted \tab Refused; collect first \cr
+   Query with no reader source \tab Accepted \tab Accepted \tab Refused; collect first \cr
+   \code{RecordBatchReader} \tab Refused; materialize first \tab Refused; build a query first \tab Refused; collect first \cr
+   Query with any reader source \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
+   Non-tabular Arrow object \tab General input refusal \tab General input refusal \tab General input refusal \cr
+}
 
-A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
-dplyr query from it: the reader is one-pass, while a Margin operation builds
-one branch per grouping set from the same input. Later branches cannot
-re-read rows an earlier branch consumed and can therefore compute an
-incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
-materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling \code{\link[=summarize_with_margins]{summarize_with_margins()}},
-\code{\link[=expand_with_margins]{expand_with_margins()}}, or \code{\link[=inspect_grouping]{inspect_grouping()}}. For a nesting verb,
-collect the reader directly instead: an Arrow \code{Table} still cannot carry
-the list-column result. A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray},
-\code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow objects are not
-dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or choose its
+
+A translatable summary or expansion stays an Arrow query. For a summary
+Arrow cannot translate, a \code{Table} and \code{RecordBatch} (and queries built on
+them) would fall back to R, so marginplyr refuses it before a row is read. A
+\code{Dataset} and a query built on one instead keep Arrow's own
+unsupported-expression error. Thus an \code{arrow_dplyr_query} is described by
+its complete source graph, not by its query class alone.
+
+A \code{RecordBatchReader} is one-pass, while a Margin operation may build one
+branch per grouping set. \code{\link[=summarize_with_margins]{summarize_with_margins()}} and
+\code{\link[=expand_with_margins]{expand_with_margins()}} therefore refuse both the reader and any query whose
+source graph contains one. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch
+once and materializes the reusable \code{Table} those branches require.
+\code{inspect_grouping()} executes no branch, so it accepts a reader-backed query
+without consuming it. A direct reader currently needs to be wrapped first,
+for example with \code{dplyr::select(reader, dplyr::everything())}; issue #510
+tracks removing that distinction.
+
+A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray}, \code{Schema}, \code{Field},
+\code{DataType}, and other non-tabular Arrow objects are not dplyr inputs.
+Materialize a Scanner with \verb{$ToTable()} or choose its
 \verb{$ToRecordBatchReader()} stream first; convert any other object to a data
 frame or lazy dplyr table appropriate to the data it represents.
 

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -151,11 +151,14 @@ one branch per grouping set from the same input. Later branches cannot
 re-read rows an earlier branch consumed and can therefore compute an
 incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
 materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling a Margin verb. A \code{Scanner}, \code{Scalar}, \code{Array},
-\code{ChunkedArray}, \code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow
-objects are not dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or
-choose its \verb{$ToRecordBatchReader()} stream first; convert any other object
-to a data frame or lazy dplyr table appropriate to the data it represents.
+explicitly before calling \code{\link[=summarize_with_margins]{summarize_with_margins()}},
+\code{\link[=expand_with_margins]{expand_with_margins()}}, or \code{\link[=inspect_grouping]{inspect_grouping()}}. For a nesting verb,
+collect the reader directly instead: an Arrow \code{Table} still cannot carry
+the list-column result. A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray},
+\code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow objects are not
+dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or choose its
+\verb{$ToRecordBatchReader()} stream first; convert any other object to a data
+frame or lazy dplyr table appropriate to the data it represents.
 
 The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -508,11 +508,14 @@ one branch per grouping set from the same input. Later branches cannot
 re-read rows an earlier branch consumed and can therefore compute an
 incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
 materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling a Margin verb. A \code{Scanner}, \code{Scalar}, \code{Array},
-\code{ChunkedArray}, \code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow
-objects are not dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or
-choose its \verb{$ToRecordBatchReader()} stream first; convert any other object
-to a data frame or lazy dplyr table appropriate to the data it represents.
+explicitly before calling \code{\link[=summarize_with_margins]{summarize_with_margins()}},
+\code{\link[=expand_with_margins]{expand_with_margins()}}, or \code{\link[=inspect_grouping]{inspect_grouping()}}. For a nesting verb,
+collect the reader directly instead: an Arrow \code{Table} still cannot carry
+the list-column result. A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray},
+\code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow objects are not
+dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or choose its
+\verb{$ToRecordBatchReader()} stream first; convert any other object to a data
+frame or lazy dplyr table appropriate to the data it represents.
 
 The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -491,29 +491,38 @@ they are otherwise unaffected.
 
 \section{Arrow inputs}{
 
-Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset}, or an
-\code{arrow_dplyr_query} built from one. All three direct inputs are accepted by
-\code{summarize_with_margins()}, \code{expand_with_margins()}, and
-\code{inspect_grouping()}; their queries are accepted too. A translatable summary
-stays an Arrow query for every one of them. For a summary Arrow cannot
-translate, a \code{Table} and \code{RecordBatch} (and a query built on either) would
-fall back to R, so marginplyr refuses it before a row is read. A \code{Dataset}
-and a query built on one instead keep Arrow's own unsupported-expression
-error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
-query class alone.
+Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset},
+\code{RecordBatchReader}, or an \code{arrow_dplyr_query} built from them. marginplyr's
+contract depends on both the verb and the query's sources:\tabular{llll}{
+   Input \tab Summary or expansion \tab Inspection \tab Nesting \cr
+   \code{Table}, \code{RecordBatch}, or \code{Dataset} \tab Accepted \tab Accepted \tab Refused; collect first \cr
+   Query with no reader source \tab Accepted \tab Accepted \tab Refused; collect first \cr
+   \code{RecordBatchReader} \tab Refused; materialize first \tab Refused; build a query first \tab Refused; collect first \cr
+   Query with any reader source \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
+   Non-tabular Arrow object \tab General input refusal \tab General input refusal \tab General input refusal \cr
+}
 
-A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
-dplyr query from it: the reader is one-pass, while a Margin operation builds
-one branch per grouping set from the same input. Later branches cannot
-re-read rows an earlier branch consumed and can therefore compute an
-incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
-materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling \code{\link[=summarize_with_margins]{summarize_with_margins()}},
-\code{\link[=expand_with_margins]{expand_with_margins()}}, or \code{\link[=inspect_grouping]{inspect_grouping()}}. For a nesting verb,
-collect the reader directly instead: an Arrow \code{Table} still cannot carry
-the list-column result. A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray},
-\code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow objects are not
-dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or choose its
+
+A translatable summary or expansion stays an Arrow query. For a summary
+Arrow cannot translate, a \code{Table} and \code{RecordBatch} (and queries built on
+them) would fall back to R, so marginplyr refuses it before a row is read. A
+\code{Dataset} and a query built on one instead keep Arrow's own
+unsupported-expression error. Thus an \code{arrow_dplyr_query} is described by
+its complete source graph, not by its query class alone.
+
+A \code{RecordBatchReader} is one-pass, while a Margin operation may build one
+branch per grouping set. \code{\link[=summarize_with_margins]{summarize_with_margins()}} and
+\code{\link[=expand_with_margins]{expand_with_margins()}} therefore refuse both the reader and any query whose
+source graph contains one. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch
+once and materializes the reusable \code{Table} those branches require.
+\code{inspect_grouping()} executes no branch, so it accepts a reader-backed query
+without consuming it. A direct reader currently needs to be wrapped first,
+for example with \code{dplyr::select(reader, dplyr::everything())}; issue #510
+tracks removing that distinction.
+
+A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray}, \code{Schema}, \code{Field},
+\code{DataType}, and other non-tabular Arrow objects are not dplyr inputs.
+Materialize a Scanner with \verb{$ToTable()} or choose its
 \verb{$ToRecordBatchReader()} stream first; convert any other object to a data
 frame or lazy dplyr table appropriate to the data it represents.
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -508,9 +508,11 @@ one branch per grouping set from the same input. Later branches cannot
 re-read rows an earlier branch consumed and can therefore compute an
 incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
 materializes them as the reusable \code{Table} the branches require; convert
-explicitly before calling a Margin verb. A \code{Scanner} and
-other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
-with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
+explicitly before calling a Margin verb. A \code{Scanner}, \code{Scalar}, \code{Array},
+\code{ChunkedArray}, \code{Schema}, \code{Field}, \code{DataType}, and other non-tabular Arrow
+objects are not dplyr inputs. Materialize a Scanner with \verb{$ToTable()} or
+choose its \verb{$ToRecordBatchReader()} stream first; convert any other object
+to a data frame or lazy dplyr table appropriate to the data it represents.
 
 The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -489,6 +489,33 @@ the same expressions instead, because a dataset never reads itself into R;
 they are otherwise unaffected.
 }
 
+\section{Arrow inputs}{
+
+Arrow's tabular dplyr inputs are a \code{Table}, \code{RecordBatch}, \code{Dataset}, or an
+\code{arrow_dplyr_query} built from one. All three direct inputs are accepted by
+\code{summarize_with_margins()}, \code{expand_with_margins()}, and
+\code{inspect_grouping()}; their queries are accepted too. A translatable summary
+stays an Arrow query for every one of them. For a summary Arrow cannot
+translate, a \code{Table} and \code{RecordBatch} (and a query built on either) would
+fall back to R, so marginplyr refuses it before a row is read. A \code{Dataset}
+and a query built on one instead keep Arrow's own unsupported-expression
+error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
+query class alone.
+
+A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
+dplyr query from it: the reader is one-pass, and converting it consumes and
+materializes the entire stream. Convert it explicitly with
+\code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} before calling a Margin verb. A \code{Scanner} and
+other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
+with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
+
+The nesting verbs accept neither Arrow input category, because their result
+contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and
+\code{\link[=nest_by_with_margins]{nest_by_with_margins()}} therefore ask you to collect first. Contextual
+shares are rejected for every accepted Arrow input before a summary query is
+constructed; collect first when local share execution is appropriate.
+}
+
 \section{Contextual shares}{
 
 \code{\link[=share_of_parent]{share_of_parent()}} and \code{\link[=share_of_total]{share_of_total()}} calculate a preceding named

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -503,9 +503,12 @@ error. Thus an \code{arrow_dplyr_query} is described by its source, not by its
 query class alone.
 
 A \code{RecordBatchReader} is deliberately refused even though Arrow can start a
-dplyr query from it: the reader is one-pass, and converting it consumes and
-materializes the entire stream. Convert it explicitly with
-\code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} before calling a Margin verb. A \code{Scanner} and
+dplyr query from it: the reader is one-pass, while a Margin operation builds
+one branch per grouping set from the same input. Later branches cannot
+re-read rows an earlier branch consumed and can therefore compute an
+incomplete result. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch once and
+materializes them as the reusable \code{Table} the branches require; convert
+explicitly before calling a Margin verb. A \code{Scanner} and
 other non-tabular Arrow objects are not dplyr inputs; materialize a Scanner
 with \verb{$ToTable()} or choose its \verb{$ToRecordBatchReader()} stream first.
 

--- a/tests/testthat/helper-arrow-shapes.R
+++ b/tests/testthat/helper-arrow-shapes.R
@@ -20,6 +20,16 @@ arrow_input_data <- function() {
   )
 }
 
+# Two batches whose group boundary is also the batch boundary. Reusing this
+# reader across grouping-set branches can therefore expose both a missing group
+# and a grand total computed from only one batch.
+multi_batch_arrow_reader <- function() {
+  arrow::RecordBatchReader$create(
+    arrow::record_batch(k = c("E", "E"), v = 1:2),
+    arrow::record_batch(k = c("W", "W", "W"), v = 3:5)
+  )
+}
+
 # A query rather than the object itself is the third shape, because
 # `arrow_dplyr_query` is the one class that appears on both sides of the
 # division: over a table it absorbs, over a dataset it refuses. `select()`

--- a/tests/testthat/test-expand-operation.R
+++ b/tests/testthat/test-expand-operation.R
@@ -276,7 +276,7 @@ test_that("expand rejects unsupported sources with a Package condition", {
       arrow::as_record_batch_reader(data.frame(group = c("x", "y"))),
       .grouping = rollup(group)
     ),
-    "`\\.data` must not be an object of the following classes"
+    "`\\.data` must not be or depend on a <RecordBatchReader>"
   )
 
   expect_s3_class(error, "marginplyr_error")

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -393,6 +393,25 @@ test_that("an Arrow summary Arrow can evaluate is unchanged and stays lazy", {
   expect_setequal(dplyr::collect(result)$total, c(3, 3, 6))
 })
 
+test_that("Arrow rejects contextual shares for every accepted input shape", {
+  skip_if_suggest_absent("arrow")
+
+  data <- arrow_input_data()
+  inputs <- c(absorbing_arrow_inputs(data), refusing_arrow_inputs(data))
+
+  for (shape in names(inputs)) {
+    raised <- expect_error(summarize_with_margins(
+      inputs[[shape]],
+      total = sum(v),
+      share = share_of_parent(total),
+      .grouping = rollup(k)
+    ), label = shape)
+
+    expect_s3_class(raised, "marginplyr_error")
+    expect_match(conditionMessage(raised), "share_of_parent", fixed = TRUE)
+  }
+})
+
 # Part one of the two-part regression. The refusal above asserts what
 # marginplyr does with an absorbed expression; this asserts that Arrow still
 # absorbs the two expressions it is asserted over, and that Arrow still marks

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -763,6 +763,36 @@ test_that("public Arrow table classes are supported", {
   )
 })
 
+# This pins the external behaviour that makes reader reuse unsafe. Which branch
+# consumes which batch is not stable across a shared test session, so the
+# contract is the absence of the known complete result. If Arrow begins sharing
+# one scan across both branches, this fails and the refusal can be reconsidered.
+test_that("Arrow reader branches do not produce the complete result", {
+  skip_if_suggest_absent("arrow")
+
+  reader <- multi_batch_arrow_reader()
+  detail <- dplyr::summarise(
+    reader,
+    n = dplyr::n(),
+    total = sum(v),
+    .by = k
+  )
+  grand <- dplyr::summarise(
+    reader,
+    n = dplyr::n(),
+    total = sum(v)
+  ) |>
+    dplyr::mutate(k = "Total", .before = 1L)
+  result <- dplyr::collect(dplyr::union_all(detail, grand))
+  complete <- tibble::tibble(
+    k = c("E", "W", "Total"),
+    n = c(2L, 3L, 5L),
+    total = c(3L, 12L, 15L)
+  )
+
+  expect_false(dplyr::setequal(result, complete))
+})
+
 # Deciding whether a selection renames means comparing what it selected against
 # the columns it selected from, and a lazy selection proxy is the table object
 # itself: `names()` on it returns `con`, `src`, and `lazy_query`, so reading it

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -39,18 +39,18 @@ test_that("assert_nest_possible() works", {
   expect_error(assert_nest_possible(new.env()))
 })
 
-test_that("assert_lazy_table() works", {
+test_that("assert_reusable_margin_input() works", {
   skip_if_suggest_absent("arrow")
 
   expect_error(
-    assert_lazy_table(
+    assert_reusable_margin_input(
       arrow::as_record_batch_reader(data.frame())
     ),
-    "must not be an object of the following class"
+    "must not be or depend on"
   )
-  expect_no_error(assert_lazy_table(data.frame()))
-  expect_no_error(assert_lazy_table(arrow::arrow_table(x = 1)))
-  expect_no_error(assert_lazy_table(arrow::record_batch(x = 1)))
+  expect_no_error(assert_reusable_margin_input(data.frame()))
+  expect_no_error(assert_reusable_margin_input(arrow::arrow_table(x = 1)))
+  expect_no_error(assert_reusable_margin_input(arrow::record_batch(x = 1)))
 
   # arrow "Dataset" class
   tmp <- tempfile("test", fileext = ".parquet")
@@ -62,7 +62,7 @@ test_that("assert_lazy_table() works", {
   )
 
   expect_no_error(
-    assert_lazy_table(
+    assert_reusable_margin_input(
       arrow::open_dataset(tmp)
     )
   )
@@ -817,12 +817,12 @@ test_that("every shared reader answers a pair holding an empty call part", {
   )
 })
 
-test_that("lazy-table assertions use the Package condition seam", {
+test_that("reusable-input assertions use the Package condition seam", {
   skip_if_suggest_absent("arrow")
 
   error <- expect_error(
-    assert_lazy_table(arrow::as_record_batch_reader(data.frame())),
-    "must not be an object of the following class"
+    assert_reusable_margin_input(arrow::as_record_batch_reader(data.frame())),
+    "must not be or depend on"
   )
 
   expect_s3_class(error, "marginplyr_error")
@@ -832,7 +832,7 @@ test_that("lazy-table assertions use the Package condition seam", {
   # pin the nesting refusal carries above.
   expect_match(
     conditionMessage(error),
-    "Convert it with `arrow::as_arrow_table()` first.",
+    "Materialize it with `arrow::as_arrow_table()` first.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -833,3 +833,36 @@ test_that("a RecordBatchReader is refused before applicable Margin verbs", {
   expect_setequal(result$n, c(2L, 3L, 5L))
   expect_setequal(result$total, c(3L, 12L, 15L))
 })
+
+test_that("nesting a RecordBatchReader directs the caller to collect", {
+  skip_if_suggest_absent("arrow")
+
+  reader <- function() {
+    arrow::RecordBatchReader$create(
+      arrow::record_batch(k = c("E", "E"), v = 1:2),
+      arrow::record_batch(k = c("W", "W", "W"), v = 3:5)
+    )
+  }
+  verbs <- list(
+    nest = nest_with_margins,
+    nest_by = nest_by_with_margins
+  )
+
+  for (verb in names(verbs)) {
+    input <- reader()
+    raised <- expect_error(
+      verbs[[verb]](input, .grouping = rollup(k)),
+      class = "marginplyr_error",
+      info = verb
+    )
+    expect_match(
+      conditionMessage(raised),
+      "Collect it with `dplyr::collect()` first.",
+      fixed = TRUE,
+      info = verb
+    )
+    local <- dplyr::collect(input)
+    expect_identical(nrow(local), 5L)
+    expect_no_error(verbs[[verb]](local, .grouping = rollup(k)))
+  }
+})

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -808,7 +808,7 @@ test_that("public Arrow table classes are supported", {
   }
 })
 
-test_that("a RecordBatchReader is refused before reusable Margin verbs", {
+test_that("reader inputs are refused before reusable Margin verbs", {
   skip_if_suggest_absent("arrow")
 
   calls <- list(
@@ -819,11 +819,28 @@ test_that("a RecordBatchReader is refused before reusable Margin verbs", {
       expand_with_margins(input, .grouping = rollup(k))
     }
   )
+  inputs <- list(
+    reader = identity,
+    reader_query = function(input) {
+      dplyr::select(input, dplyr::everything())
+    }
+  )
 
-  for (verb in names(calls)) {
-    input <- multi_batch_arrow_reader()
-    expect_error(calls[[verb]](input), "RecordBatchReader", info = verb)
-    expect_identical(arrow::as_arrow_table(input)$num_rows, 5L)
+  for (shape in names(inputs)) {
+    for (verb in names(calls)) {
+      input <- inputs[[shape]](multi_batch_arrow_reader())
+      info <- paste(shape, verb)
+      expect_error(
+        calls[[verb]](input),
+        "RecordBatchReader",
+        info = info
+      )
+      expect_identical(
+        arrow::as_arrow_table(input)$num_rows,
+        5L,
+        info = info
+      )
+    }
   }
 
   converted <- arrow::as_arrow_table(multi_batch_arrow_reader())
@@ -852,26 +869,6 @@ test_that("direct reader inspection requests a query without consuming it", {
     fixed = TRUE
   )
   expect_identical(arrow::as_arrow_table(reader)$num_rows, 5L)
-})
-
-test_that("a reader-backed Arrow query is refused before Margin branches", {
-  skip_if_suggest_absent("arrow")
-
-  calls <- list(
-    summarize = function(input) {
-      summarize_with_margins(input, n = sum(v), .grouping = rollup(k))
-    },
-    expand = function(input) {
-      expand_with_margins(input, .grouping = rollup(k))
-    }
-  )
-
-  for (verb in names(calls)) {
-    reader <- multi_batch_arrow_reader()
-    input <- dplyr::select(reader, dplyr::everything())
-    expect_error(calls[[verb]](input), "RecordBatchReader", info = verb)
-    expect_identical(arrow::as_arrow_table(input)$num_rows, 5L)
-  }
 })
 
 test_that("a reader anywhere in an Arrow query is refused", {

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -593,13 +593,24 @@ test_that("input that dplyr cannot group is rejected in the caller's terms", {
     "Convert it to a data frame or a lazy table that supports dplyr verbs ",
     "first."
   )
-  for (input in list(as.matrix(admission_data()), as.list(admission_data()))) {
+  inputs <- list(
+    character = "x",
+    numeric = 1,
+    matrix = as.matrix(admission_data()),
+    list = as.list(admission_data())
+  )
+  for (shape in names(inputs)) {
     raised <- expect_error(
-      summarize_with_margins(input, s = sum(v), .grouping = rollup(g)),
+      summarize_with_margins(
+        inputs[[shape]],
+        s = sum(v),
+        .grouping = rollup(g)
+      ),
       "must be a data frame or a lazy table",
-      class = "marginplyr_error"
+      class = "marginplyr_error",
+      info = shape
     )
-    expect_match(conditionMessage(raised), remedy, fixed = TRUE)
+    expect_match(conditionMessage(raised), remedy, fixed = TRUE, info = shape)
   }
 
   raised <- expect_error(
@@ -797,32 +808,25 @@ test_that("public Arrow table classes are supported", {
   }
 })
 
-test_that("a RecordBatchReader is refused before applicable Margin verbs", {
+test_that("a RecordBatchReader is refused before reusable Margin verbs", {
   skip_if_suggest_absent("arrow")
 
-  reader <- function() {
-    arrow::RecordBatchReader$create(
-      arrow::record_batch(k = c("E", "E"), v = 1:2),
-      arrow::record_batch(k = c("W", "W", "W"), v = 3:5)
-    )
-  }
   calls <- list(
     summarize = function(input) {
       summarize_with_margins(input, n = sum(v), .grouping = rollup(k))
     },
     expand = function(input) {
       expand_with_margins(input, .grouping = rollup(k))
-    },
-    inspect = function(input) inspect_grouping(input, .grouping = rollup(k))
+    }
   )
 
   for (verb in names(calls)) {
-    input <- reader()
+    input <- multi_batch_arrow_reader()
     expect_error(calls[[verb]](input), "RecordBatchReader", info = verb)
     expect_identical(arrow::as_arrow_table(input)$num_rows, 5L)
   }
 
-  converted <- arrow::as_arrow_table(reader())
+  converted <- arrow::as_arrow_table(multi_batch_arrow_reader())
   result <- summarize_with_margins(
     converted,
     n = dplyr::n(),
@@ -834,35 +838,121 @@ test_that("a RecordBatchReader is refused before applicable Margin verbs", {
   expect_setequal(result$total, c(3L, 12L, 15L))
 })
 
-test_that("nesting a RecordBatchReader directs the caller to collect", {
+test_that("direct reader inspection requests a query without consuming it", {
   skip_if_suggest_absent("arrow")
 
-  reader <- function() {
-    arrow::RecordBatchReader$create(
-      arrow::record_batch(k = c("E", "E"), v = 1:2),
-      arrow::record_batch(k = c("W", "W", "W"), v = 3:5)
+  reader <- multi_batch_arrow_reader()
+  raised <- expect_error(
+    inspect_grouping(reader, .grouping = rollup(k)),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(raised),
+    "Build one with `dplyr::select()` and `dplyr::everything()` first.",
+    fixed = TRUE
+  )
+  expect_identical(arrow::as_arrow_table(reader)$num_rows, 5L)
+})
+
+test_that("a reader-backed Arrow query is refused before Margin branches", {
+  skip_if_suggest_absent("arrow")
+
+  calls <- list(
+    summarize = function(input) {
+      summarize_with_margins(input, n = sum(v), .grouping = rollup(k))
+    },
+    expand = function(input) {
+      expand_with_margins(input, .grouping = rollup(k))
+    }
+  )
+
+  for (verb in names(calls)) {
+    reader <- multi_batch_arrow_reader()
+    input <- dplyr::select(reader, dplyr::everything())
+    expect_error(calls[[verb]](input), "RecordBatchReader", info = verb)
+    expect_identical(arrow::as_arrow_table(input)$num_rows, 5L)
+  }
+})
+
+test_that("a reader anywhere in an Arrow query is refused", {
+  skip_if_suggest_absent("arrow")
+
+  table <- arrow::Table$create(data.frame(k = c("E", "W"), v = c(1L, 2L)))
+  query_builders <- list(
+    root = function(reader_query) reader_query,
+    join_right = function(reader_query) {
+      dplyr::left_join(table, reader_query, by = "k")
+    },
+    union_right = function(reader_query) {
+      dplyr::union_all(table, reader_query)
+    }
+  )
+
+  for (shape in names(query_builders)) {
+    reader <- multi_batch_arrow_reader()
+    reader_query <- dplyr::select(reader, dplyr::everything())
+    input <- query_builders[[shape]](reader_query)
+    expect_error(
+      summarize_with_margins(
+        input,
+        n = dplyr::n(),
+        .grouping = rollup(k)
+      ),
+      "RecordBatchReader",
+      class = "marginplyr_error",
+      info = shape
+    )
+    expect_identical(
+      arrow::as_arrow_table(reader)$num_rows,
+      5L,
+      info = shape
     )
   }
+})
+
+test_that("a reader-backed Arrow query can be inspected without consumption", {
+  skip_if_suggest_absent("arrow")
+
+  reader <- multi_batch_arrow_reader()
+  input <- dplyr::select(reader, dplyr::everything())
+  plan <- inspect_grouping(input, .grouping = rollup(k))
+
+  expect_identical(plan$included, c("(k)", "()"))
+  expect_identical(arrow::as_arrow_table(reader)$num_rows, 5L)
+})
+
+test_that("nesting reader inputs directs the caller to collect", {
+  skip_if_suggest_absent("arrow")
+
   verbs <- list(
     nest = nest_with_margins,
     nest_by = nest_by_with_margins
   )
+  inputs <- list(
+    reader = identity,
+    reader_query = function(input) {
+      dplyr::select(input, dplyr::everything())
+    }
+  )
 
-  for (verb in names(verbs)) {
-    input <- reader()
-    raised <- expect_error(
-      verbs[[verb]](input, .grouping = rollup(k)),
-      class = "marginplyr_error",
-      info = verb
-    )
-    expect_match(
-      conditionMessage(raised),
-      "Collect it with `dplyr::collect()` first.",
-      fixed = TRUE,
-      info = verb
-    )
-    local <- dplyr::collect(input)
-    expect_identical(nrow(local), 5L)
-    expect_no_error(verbs[[verb]](local, .grouping = rollup(k)))
+  for (shape in names(inputs)) {
+    for (verb in names(verbs)) {
+      input <- inputs[[shape]](multi_batch_arrow_reader())
+      info <- paste(shape, verb)
+      raised <- expect_error(
+        verbs[[verb]](input, .grouping = rollup(k)),
+        class = "marginplyr_error",
+        info = info
+      )
+      expect_match(
+        conditionMessage(raised),
+        "Collect it with `dplyr::collect()` first.",
+        fixed = TRUE,
+        info = info
+      )
+      local <- dplyr::collect(input)
+      expect_identical(nrow(local), 5L, info = info)
+      expect_no_error(verbs[[verb]](local, .grouping = rollup(k)))
+    }
   }
 })

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -702,3 +702,68 @@ test_that("arrow input is still admitted", {
     ))
   )
 })
+
+# Arrow's direct tabular inputs are a `Table`, `RecordBatch`, and `Dataset`;
+# a dplyr query can start at each. Keep admission over every source/query pair,
+# because their unsupported-expression behaviour is not interchangeable.
+test_that("public Arrow table classes are supported", {
+  skip_if_suggest_absent("arrow")
+
+  data <- arrow_input_data()
+  sources <- list(
+    table = arrow::Table$create(data),
+    record_batch = arrow::record_batch(data),
+    dataset = arrow::InMemoryDataset$create(arrow::Table$create(data))
+  )
+  inputs <- c(
+    sources,
+    stats::setNames(
+      lapply(sources, dplyr::select, dplyr::everything()),
+      paste0(names(sources), "_query")
+    )
+  )
+
+  for (shape in names(inputs)) {
+    input <- inputs[[shape]]
+    expect_true(
+      inherits(
+        summarize_with_margins(input, n = sum(v), .grouping = rollup(k)),
+        "arrow_dplyr_query"
+      ),
+      info = shape
+    )
+    expect_true(
+      inherits(
+        expand_with_margins(input, .grouping = rollup(k)),
+        "arrow_dplyr_query"
+      ),
+      info = shape
+    )
+    expect_true(
+      inherits(inspect_grouping(input, .grouping = rollup(k)), "tbl_df"),
+      info = shape
+    )
+    expect_error(
+      nest_with_margins(input, .grouping = rollup(k)),
+      class = "marginplyr_error",
+      info = shape
+    )
+  }
+})
+
+test_that("a RecordBatchReader is refused before applicable Margin verbs", {
+  skip_if_suggest_absent("arrow")
+
+  reader <- function() arrow::as_record_batch_reader(arrow_input_data())
+  calls <- list(
+    summarize = function() {
+      summarize_with_margins(reader(), n = sum(v), .grouping = rollup(k))
+    },
+    expand = function() expand_with_margins(reader(), .grouping = rollup(k)),
+    inspect = function() inspect_grouping(reader(), .grouping = rollup(k))
+  )
+
+  for (verb in names(calls)) {
+    expect_error(calls[[verb]](), "RecordBatchReader", info = verb)
+  }
+})

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -748,6 +748,11 @@ test_that("public Arrow table classes are supported", {
       class = "marginplyr_error",
       info = shape
     )
+    expect_error(
+      nest_by_with_margins(input, .grouping = rollup(k)),
+      class = "marginplyr_error",
+      info = shape
+    )
   }
 })
 

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -589,18 +589,24 @@ test_that("the nesting verbs answer `.duplicates = \"keep\"` in their terms", {
 })
 
 test_that("input that dplyr cannot group is rejected in the caller's terms", {
+  remedy <- paste0(
+    "Convert it to a data frame or a lazy table that supports dplyr verbs ",
+    "first."
+  )
   for (input in list(as.matrix(admission_data()), as.list(admission_data()))) {
-    expect_error(
+    raised <- expect_error(
       summarize_with_margins(input, s = sum(v), .grouping = rollup(g)),
       "must be a data frame or a lazy table",
       class = "marginplyr_error"
     )
+    expect_match(conditionMessage(raised), remedy, fixed = TRUE)
   }
 
-  expect_error(
+  raised <- expect_error(
     summarize_with_margins(NULL, s = sum(v), .grouping = rollup(g)),
     "`NULL` was supplied"
   )
+  expect_match(conditionMessage(raised), remedy, fixed = TRUE)
 })
 
 test_that("every entry point admits input the same way", {
@@ -759,16 +765,36 @@ test_that("public Arrow table classes are supported", {
 test_that("a RecordBatchReader is refused before applicable Margin verbs", {
   skip_if_suggest_absent("arrow")
 
-  reader <- function() arrow::as_record_batch_reader(arrow_input_data())
+  reader <- function() {
+    arrow::RecordBatchReader$create(
+      arrow::record_batch(k = c("E", "E"), v = 1:2),
+      arrow::record_batch(k = c("W", "W", "W"), v = 3:5)
+    )
+  }
   calls <- list(
-    summarize = function() {
-      summarize_with_margins(reader(), n = sum(v), .grouping = rollup(k))
+    summarize = function(input) {
+      summarize_with_margins(input, n = sum(v), .grouping = rollup(k))
     },
-    expand = function() expand_with_margins(reader(), .grouping = rollup(k)),
-    inspect = function() inspect_grouping(reader(), .grouping = rollup(k))
+    expand = function(input) {
+      expand_with_margins(input, .grouping = rollup(k))
+    },
+    inspect = function(input) inspect_grouping(input, .grouping = rollup(k))
   )
 
   for (verb in names(calls)) {
-    expect_error(calls[[verb]](), "RecordBatchReader", info = verb)
+    input <- reader()
+    expect_error(calls[[verb]](input), "RecordBatchReader", info = verb)
+    expect_identical(arrow::as_arrow_table(input)$num_rows, 5L)
   }
+
+  converted <- arrow::as_arrow_table(reader())
+  result <- summarize_with_margins(
+    converted,
+    n = dplyr::n(),
+    total = sum(v),
+    .grouping = rollup(k)
+  ) |>
+    dplyr::collect()
+  expect_setequal(result$n, c(2L, 3L, 5L))
+  expect_setequal(result$total, c(3L, 12L, 15L))
 })

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -638,6 +638,41 @@ test_that("every entry point admits input the same way", {
   )
 })
 
+test_that("non-tabular Arrow objects use the general admission refusal", {
+  skip_if_suggest_absent("arrow")
+
+  table <- arrow::Table$create(admission_data())
+  dataset <- arrow::InMemoryDataset$create(table)
+  inputs <- list(
+    scanner = dataset$NewScan()$Finish(),
+    scalar = arrow::Scalar$create(1),
+    array = arrow::Array$create(1:2),
+    chunked_array = arrow::ChunkedArray$create(1:2),
+    schema = arrow::schema(v = arrow::int32()),
+    field = arrow::field("v", arrow::int32()),
+    data_type = arrow::int32()
+  )
+  main <- "must be a data frame or a lazy table that supports dplyr verbs"
+  remedy <- paste0(
+    "Convert it to a data frame or a lazy table that supports dplyr verbs ",
+    "first."
+  )
+
+  for (shape in names(inputs)) {
+    raised <- expect_error(
+      summarize_with_margins(
+        inputs[[shape]],
+        n = dplyr::n(),
+        .grouping = rollup(g)
+      ),
+      main,
+      class = "marginplyr_error",
+      info = shape
+    )
+    expect_match(conditionMessage(raised), remedy, fixed = TRUE, info = shape)
+  }
+})
+
 test_that("an omitted input is answered by R and not by the verb", {
   # Every entry point opens by forcing `.data`, which is ahead of the block
   # that rewrites a marginplyr error's call, so an omitted input raises where

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -589,28 +589,42 @@ reasons.
 
 ### Which Arrow inputs are supported
 
-The accepted Arrow inputs are `Table`, `RecordBatch`, `Dataset`, and a dplyr
-query built from one. A translatable summary or expansion stays an Arrow query
-for all of them. For an expression Arrow cannot translate, a table or record
-batch would silently fall back to R; marginplyr refuses that fallback before
-any row is read. A dataset instead reports Arrow's own unsupported-expression
-error. A dplyr query follows the object it started from, so its class alone
-does not tell you which outcome applies.
+Arrow's tabular dplyr inputs and marginplyr's verb-specific contract are:
 
-`RecordBatchReader` is intentionally not accepted. It is a one-pass stream,
-while a Margin operation builds one branch per grouping set from the same
-input; a later branch cannot re-read rows an earlier branch consumed. Use
-`arrow::as_arrow_table()` to consume every batch once and make the reusable
-table explicit before a summary, expansion, or plan inspection. For a nesting
-verb, collect the reader directly instead: an Arrow table still cannot carry
+| Input | Summary or expansion | Inspection | Nesting |
+|---|---|---|---|
+| `Table`, `RecordBatch`, or `Dataset` | Accepted | Accepted | Refused; collect first |
+| Query with no reader source | Accepted | Accepted | Refused; collect first |
+| `RecordBatchReader` | Refused; materialize first | Refused; build a query first | Refused; collect first |
+| Query with any reader source | Refused; materialize first | Accepted | Refused; collect first |
+| Non-tabular Arrow object | General input refusal | General input refusal | General input refusal |
+
+A translatable summary or expansion stays an Arrow query. For an expression
+Arrow cannot translate, a table or record batch would silently fall back to R;
+marginplyr refuses that fallback before any row is read. A dataset instead
+reports Arrow's own unsupported-expression error. A query follows its complete
+source graph, so its class alone does not tell you which outcome applies.
+
+`RecordBatchReader` is one-pass, while a Margin operation may build one branch
+per grouping set. Summary and expansion therefore refuse both a direct reader
+and a query whose source graph contains one. Use `arrow::as_arrow_table()` to
+consume every batch once and make the reusable table explicit.
+`inspect_grouping()` executes no branch, so it accepts a reader-backed query
+without consuming it. A direct reader currently needs to be wrapped first:
+
+```r
+reader_query <- dplyr::select(reader, dplyr::everything())
+inspect_grouping(reader_query, .grouping = rollup(region, store))
+```
+
+Issue #510 tracks accepting the direct reader without this step. For a nesting
+verb, collect the reader or query directly: an Arrow table still cannot carry
 the list-column result. A `Scanner` is not a dplyr input either: choose
-`$ToTable()` or
-`$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`, `ChunkedArray`,
-`Schema`, `Field`, `DataType`, or other non-tabular Arrow objects. Convert
-those to a data frame or lazy dplyr table appropriate to the data they
-represent. The nesting verbs do not accept any Arrow input because their
-result contains a list column. Contextual shares are also rejected for every
-accepted Arrow input; collect first for local execution.
+`$ToTable()` or `$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`,
+`ChunkedArray`, `Schema`, `Field`, `DataType`, or other non-tabular Arrow
+objects. Convert those to a data frame or lazy dplyr table appropriate to the
+data they represent. Contextual shares are rejected for every Arrow input
+accepted by a summary; collect first for local execution.
 
 The first is a summary Arrow's own engine cannot evaluate. Arrow answers one of
 those by reading the whole input — every column, not just the ones the summary

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -587,6 +587,23 @@ Arrow summaries and expansions are supported and lazy wherever Arrow can
 evaluate the summary itself. Two things are refused instead, for two unrelated
 reasons.
 
+### Which Arrow inputs are supported
+
+The accepted Arrow inputs are `Table`, `RecordBatch`, `Dataset`, and a dplyr
+query built from one. A translatable summary or expansion stays an Arrow query
+for all of them. For an expression Arrow cannot translate, a table or record
+batch would silently fall back to R; marginplyr refuses that fallback before
+any row is read. A dataset instead reports Arrow's own unsupported-expression
+error. A dplyr query follows the object it started from, so its class alone
+does not tell you which outcome applies.
+
+`RecordBatchReader` is intentionally not accepted. It is a one-pass stream;
+use `arrow::as_arrow_table()` to make the materialization explicit before a
+Margin verb. A `Scanner` is not a dplyr input either: choose `$ToTable()` or
+`$ToRecordBatchReader()` first. The nesting verbs do not accept any Arrow
+input because their result contains a list column. Contextual shares are also
+rejected for every accepted Arrow input; collect first for local execution.
+
 The first is a summary Arrow's own engine cannot evaluate. Arrow answers one of
 those by reading the whole input — every column, not just the ones the summary
 names — and computing it in R, so marginplyr refuses it before a row is read:

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -597,9 +597,12 @@ any row is read. A dataset instead reports Arrow's own unsupported-expression
 error. A dplyr query follows the object it started from, so its class alone
 does not tell you which outcome applies.
 
-`RecordBatchReader` is intentionally not accepted. It is a one-pass stream;
-use `arrow::as_arrow_table()` to make the materialization explicit before a
-Margin verb. A `Scanner` is not a dplyr input either: choose `$ToTable()` or
+`RecordBatchReader` is intentionally not accepted. It is a one-pass stream,
+while a Margin operation builds one branch per grouping set from the same
+input; a later branch cannot re-read rows an earlier branch consumed. Use
+`arrow::as_arrow_table()` to consume every batch once and make the reusable
+table explicit before a Margin verb. A `Scanner` is not a dplyr input either:
+choose `$ToTable()` or
 `$ToRecordBatchReader()` first. The nesting verbs do not accept any Arrow
 input because their result contains a list column. Contextual shares are also
 rejected for every accepted Arrow input; collect first for local execution.

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -603,9 +603,12 @@ input; a later branch cannot re-read rows an earlier branch consumed. Use
 `arrow::as_arrow_table()` to consume every batch once and make the reusable
 table explicit before a Margin verb. A `Scanner` is not a dplyr input either:
 choose `$ToTable()` or
-`$ToRecordBatchReader()` first. The nesting verbs do not accept any Arrow
-input because their result contains a list column. Contextual shares are also
-rejected for every accepted Arrow input; collect first for local execution.
+`$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`, `ChunkedArray`,
+`Schema`, `Field`, `DataType`, or other non-tabular Arrow objects. Convert
+those to a data frame or lazy dplyr table appropriate to the data they
+represent. The nesting verbs do not accept any Arrow input because their
+result contains a list column. Contextual shares are also rejected for every
+accepted Arrow input; collect first for local execution.
 
 The first is a summary Arrow's own engine cannot evaluate. Arrow answers one of
 those by reading the whole input — every column, not just the ones the summary

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -601,8 +601,10 @@ does not tell you which outcome applies.
 while a Margin operation builds one branch per grouping set from the same
 input; a later branch cannot re-read rows an earlier branch consumed. Use
 `arrow::as_arrow_table()` to consume every batch once and make the reusable
-table explicit before a Margin verb. A `Scanner` is not a dplyr input either:
-choose `$ToTable()` or
+table explicit before a summary, expansion, or plan inspection. For a nesting
+verb, collect the reader directly instead: an Arrow table still cannot carry
+the list-column result. A `Scanner` is not a dplyr input either: choose
+`$ToTable()` or
 `$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`, `ChunkedArray`,
 `Schema`, `Field`, `DataType`, or other non-tabular Arrow objects. Convert
 those to a data frame or lazy dplyr table appropriate to the data they


### PR DESCRIPTION
## Summary
- document the verb-specific contract for every Arrow input category
- refuse direct `RecordBatchReader` inputs and reader-backed Arrow queries before reusable Margin branches can return incomplete results
- keep reader-backed queries inspectable without consumption and track direct-reader inspection in #510
- align general non-tabular input diagnostics and add public-seam regression coverage

## Verification
- full testthat suite
- targeted Arrow admission, backend, and utility suites
- `jarl check .`
- `lintr::lint_package()` after `pkgload::load_all()`
- roxygen documentation generation
- context-budget, must-error, verifier-invocation, document-reference, and suite-coverage verifiers
- `git diff --check`
