### PR TITLE
Support direct Arrow reader inspection

### DIFF
--- a/R/grouping-backend.R
+++ b/R/grouping-backend.R
@@ -2,8 +2,8 @@
 # would drift: the kind below, and the branch summary's Absorbing-backend
 # handler, which has only `.data` to decide from and must not answer for a
 # warning some other backend raised (ADR 0025). A direct `RecordBatchReader` is
-# deliberately absent because no verb accepts it. A query backed by one still
-# has the class below; each verb applies its narrower reader-source rule.
+# deliberately absent: inspection normalizes one before this classifier, while
+# each Margin verb applies its narrower reader-source rule.
 arrow_input_classes <- function() {
   c("arrow_dplyr_query", "Table", "RecordBatch", "Dataset")
 }

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -147,7 +147,12 @@ inspect_grouping <- function(.data,
   with_margin_error_call(
     {
       assert_margin_input(.data)
-      assert_inspectable_input(.data)
+      # A reader is one-shot across Margin branches, but inspection builds no
+      # branch. The selection makes the Arrow query shape the metadata adapter
+      # expects without consuming a batch (ADR 0020).
+      if (inherits(.data, "RecordBatchReader")) {
+        .data <- dplyr::select(.data, dplyr::everything())
+      }
       .format <- match_margin_choice(
         .format,
         choices = grouping_format_choices,

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -443,7 +443,7 @@
 #' | --- | --- | --- | --- |
 #' | `Table`, `RecordBatch`, or `Dataset` | Accepted | Accepted | Refused; collect first | # nolint: line_length_linter
 #' | Query with no reader source | Accepted | Accepted | Refused; collect first | # nolint: line_length_linter
-#' | `RecordBatchReader` | Refused; materialize first | Refused; build a query first | Refused; collect first | # nolint: line_length_linter
+#' | `RecordBatchReader` | Refused; materialize first | Accepted | Refused; collect first | # nolint: line_length_linter
 #' | Query with any reader source | Refused; materialize first | Accepted | Refused; collect first | # nolint: line_length_linter
 #' | Non-tabular Arrow object | General input refusal | General input refusal | General input refusal | # nolint: line_length_linter
 #'
@@ -459,10 +459,9 @@
 #' [expand_with_margins()] therefore refuse both the reader and any query whose
 #' source graph contains one. [arrow::as_arrow_table()] consumes every batch
 #' once and materializes the reusable `Table` those branches require.
-#' `inspect_grouping()` executes no branch, so it accepts a reader-backed query
-#' without consuming it. A direct reader currently needs to be wrapped first,
-#' for example with `dplyr::select(reader, dplyr::everything())`; issue #510
-#' tracks removing that distinction.
+#' `inspect_grouping()` executes no branch, so it accepts both a direct reader
+#' and a reader-backed query without consuming either. It normalizes a direct
+#' reader to an unexecuted Arrow query internally.
 #'
 #' A `Scanner`, `Scalar`, `Array`, `ChunkedArray`, `Schema`, `Field`,
 #' `DataType`, and other non-tabular Arrow objects are not dplyr inputs.

--- a/R/utils.R
+++ b/R/utils.R
@@ -181,26 +181,6 @@ assert_reusable_margin_input <- function(x) {
   }
 }
 
-# Inspection executes no grouping-set branch, so an Arrow query backed by a
-# reader is safe here. A direct reader still lacks the selection proxy the
-# current adapter requires; #510 owns removing this temporary distinction.
-assert_inspectable_input <- function(x) {
-  # Read only from the cli template below, which codetools cannot see.
-  nm <- deparse(substitute(x)) # nolint: object_usage_linter.
-  if (inherits(x, "RecordBatchReader")) {
-    abort_marginplyr(c(
-      paste0(
-        "{.arg {nm}} must be an Arrow dplyr query rather than a ",
-        "{.cls RecordBatchReader}."
-      ),
-      i = paste0(
-        "Build one with {.fun dplyr::select} and ",
-        "{.fun dplyr::everything} first."
-      )
-    ))
-  }
-}
-
 # The name and namespace a static analysis reads from a call, and `NULL` when
 # there is none to read. Anything that is not a call answers `NULL` too, so a
 # site may ask without a guard of its own; the sites that keep one keep it for

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -221,3 +221,6 @@ the caller to build that query explicitly. The nesting verbs retain their
 
 PR #509 records the contract change. The evidence is in
 `investigation/arrow-r-input-shapes-and-dplyr-fallback.md`.
+
+The inspection sentence is superseded by ADR 0020's amendment *inspect a
+direct Arrow reader through an unexecuted query* (#510).

--- a/design/adr/0020-ask-before-reading-a-lazy-input.md
+++ b/design/adr/0020-ask-before-reading-a-lazy-input.md
@@ -243,3 +243,24 @@ and Arrow rejects it when the caller sets `.check_margin_label = TRUE`.
 
 This adds no read. ADR 0003's amendment *one half of the collision check
 contacts nothing* is superseded only in its "every backend" clause.
+
+## Amendment: inspect a direct Arrow reader through an unexecuted query
+
+`inspect_grouping()` accepts a direct `RecordBatchReader` and normalizes it to
+the same `arrow_dplyr_query` a caller would build with
+`dplyr::select(reader, dplyr::everything())` (#510). Inspection compiles and
+formats one Grouping plan; it builds no grouping-set branch, so it has none of
+the reuse hazard that keeps a reader out of a Margin operation.
+
+The normalization runs after general input admission and before
+`prepare_grouping_plan()`. It constructs a query and does not call `collect()`,
+`compute()`, or `arrow::as_arrow_table()`, so no batch is consumed. Summary and
+expansion still reject a direct reader or a query whose source graph contains
+one, and nesting still asks the caller to collect either shape.
+
+`arrow::as_arrow_table()` joins the execution-entry-point catalog in
+`test-query-policy.R`: it consumes a reader while materializing it. The runtime
+gate has a positive control for that entry and asserts that direct-reader
+inspection invokes no catalogued entry point. The public-verb test compares its
+Grouping plan with the plans from a `Table` and a manually wrapped reader query,
+then consumes the original reader to show every batch remains.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -406,7 +406,7 @@ contract depends on both the verb and the query's sources:\tabular{llll}{
    Input \tab Summary or expansion \tab Inspection \tab Nesting \cr
    \code{Table}, \code{RecordBatch}, or \code{Dataset} \tab Accepted \tab Accepted \tab Refused; collect first \cr
    Query with no reader source \tab Accepted \tab Accepted \tab Refused; collect first \cr
-   \code{RecordBatchReader} \tab Refused; materialize first \tab Refused; build a query first \tab Refused; collect first \cr
+   \code{RecordBatchReader} \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
    Query with any reader source \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
    Non-tabular Arrow object \tab General input refusal \tab General input refusal \tab General input refusal \cr
 }
@@ -424,10 +424,9 @@ branch per grouping set. \code{\link[=summarize_with_margins]{summarize_with_mar
 \code{\link[=expand_with_margins]{expand_with_margins()}} therefore refuse both the reader and any query whose
 source graph contains one. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch
 once and materializes the reusable \code{Table} those branches require.
-\code{inspect_grouping()} executes no branch, so it accepts a reader-backed query
-without consuming it. A direct reader currently needs to be wrapped first,
-for example with \code{dplyr::select(reader, dplyr::everything())}; issue #510
-tracks removing that distinction.
+\code{inspect_grouping()} executes no branch, so it accepts both a direct reader
+and a reader-backed query without consuming either. It normalizes a direct
+reader to an unexecuted Arrow query internally.
 
 A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray}, \code{Schema}, \code{Field},
 \code{DataType}, and other non-tabular Arrow objects are not dplyr inputs.

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -140,7 +140,7 @@ contract depends on both the verb and the query's sources:\tabular{llll}{
    Input \tab Summary or expansion \tab Inspection \tab Nesting \cr
    \code{Table}, \code{RecordBatch}, or \code{Dataset} \tab Accepted \tab Accepted \tab Refused; collect first \cr
    Query with no reader source \tab Accepted \tab Accepted \tab Refused; collect first \cr
-   \code{RecordBatchReader} \tab Refused; materialize first \tab Refused; build a query first \tab Refused; collect first \cr
+   \code{RecordBatchReader} \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
    Query with any reader source \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
    Non-tabular Arrow object \tab General input refusal \tab General input refusal \tab General input refusal \cr
 }
@@ -158,10 +158,9 @@ branch per grouping set. \code{\link[=summarize_with_margins]{summarize_with_mar
 \code{\link[=expand_with_margins]{expand_with_margins()}} therefore refuse both the reader and any query whose
 source graph contains one. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch
 once and materializes the reusable \code{Table} those branches require.
-\code{inspect_grouping()} executes no branch, so it accepts a reader-backed query
-without consuming it. A direct reader currently needs to be wrapped first,
-for example with \code{dplyr::select(reader, dplyr::everything())}; issue #510
-tracks removing that distinction.
+\code{inspect_grouping()} executes no branch, so it accepts both a direct reader
+and a reader-backed query without consuming either. It normalizes a direct
+reader to an unexecuted Arrow query internally.
 
 A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray}, \code{Schema}, \code{Field},
 \code{DataType}, and other non-tabular Arrow objects are not dplyr inputs.

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -497,7 +497,7 @@ contract depends on both the verb and the query's sources:\tabular{llll}{
    Input \tab Summary or expansion \tab Inspection \tab Nesting \cr
    \code{Table}, \code{RecordBatch}, or \code{Dataset} \tab Accepted \tab Accepted \tab Refused; collect first \cr
    Query with no reader source \tab Accepted \tab Accepted \tab Refused; collect first \cr
-   \code{RecordBatchReader} \tab Refused; materialize first \tab Refused; build a query first \tab Refused; collect first \cr
+   \code{RecordBatchReader} \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
    Query with any reader source \tab Refused; materialize first \tab Accepted \tab Refused; collect first \cr
    Non-tabular Arrow object \tab General input refusal \tab General input refusal \tab General input refusal \cr
 }
@@ -515,10 +515,9 @@ branch per grouping set. \code{\link[=summarize_with_margins]{summarize_with_mar
 \code{\link[=expand_with_margins]{expand_with_margins()}} therefore refuse both the reader and any query whose
 source graph contains one. \code{\link[arrow:as_arrow_table]{arrow::as_arrow_table()}} consumes every batch
 once and materializes the reusable \code{Table} those branches require.
-\code{inspect_grouping()} executes no branch, so it accepts a reader-backed query
-without consuming it. A direct reader currently needs to be wrapped first,
-for example with \code{dplyr::select(reader, dplyr::everything())}; issue #510
-tracks removing that distinction.
+\code{inspect_grouping()} executes no branch, so it accepts both a direct reader
+and a reader-backed query without consuming either. It normalizes a direct
+reader to an unexecuted Arrow query internally.
 
 A \code{Scanner}, \code{Scalar}, \code{Array}, \code{ChunkedArray}, \code{Schema}, \code{Field},
 \code{DataType}, and other non-tabular Arrow objects are not dplyr inputs.

--- a/tests/testthat/_snaps/query-policy.md
+++ b/tests/testthat/_snaps/query-policy.md
@@ -16,6 +16,7 @@
       10     DBI           dbFetch        FALSE
       11     DBI       dbReadTable        FALSE
       12  dbplyr remote_query_plan        FALSE
+      13   arrow    as_arrow_table        FALSE
 
 # marginplyr functions reaching an execution entry point
 

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -91,6 +91,10 @@ find_local_assignment <- function(fn, var_name) {
 # itself a read, and its first argument is a connection rather than the caller's
 # data, so a subject test there would count nothing at all.
 #
+# `arrow::as_arrow_table` is a member because it consumes a reader while
+# materializing it, which is exactly the execution #510 refuses inspection to
+# hide behind its normalization.
+#
 # `dplyr::explain` and `dbplyr::remote_query_plan` are members because each
 # reaches `DBI::dbGetQuery()` from inside dbplyr, where the walk over `R/`
 # cannot follow (ADR 0027). Neither takes a positive control: one for
@@ -100,17 +104,17 @@ lazy_execution_entry_points <- function() {
     package = c(
       "dplyr", "dplyr", "dplyr", "dplyr", "base", "tibble",
       "DBI", "DBI", "DBI", "DBI", "DBI",
-      "dbplyr"
+      "dbplyr", "arrow"
     ),
     name = c(
       "collect", "compute", "pull", "explain", "as.data.frame", "as_tibble",
       "dbGetQuery", "dbSendQuery", "dbSendStatement", "dbFetch", "dbReadTable",
-      "remote_query_plan"
+      "remote_query_plan", "as_arrow_table"
     ),
     subject_test = c(
       FALSE, FALSE, FALSE, FALSE, TRUE, TRUE,
       FALSE, FALSE, FALSE, FALSE, FALSE,
-      FALSE
+      FALSE, FALSE
     ),
     stringsAsFactors = FALSE
   )
@@ -376,6 +380,12 @@ test_that("no Arrow read happens while a Margin verb runs", {
   # `AGENTS.md` rules out for every derived gate, and the shape this counter
   # had while it traced Arrow's methods.
   expect_gt(count_entry_point_invocations(dplyr::collect(table)), 0L)
+  expect_gt(
+    count_entry_point_invocations(
+      arrow::as_arrow_table(multi_batch_arrow_reader())
+    ),
+    0L
+  )
 
   # The same mechanism for the one entry counted by what it was applied to. Both
   # directions are asserted, because a subject test that answered `TRUE` for
@@ -406,6 +416,16 @@ test_that("no Arrow read happens while a Margin verb runs", {
   expect_identical(
     count_entry_point_invocations(
       expand_with_margins(table, .grouping = rollup(k))
+    ),
+    0L
+  )
+
+  expect_identical(
+    count_entry_point_invocations(
+      inspect_grouping(
+        multi_batch_arrow_reader(),
+        .grouping = rollup(k)
+      )
     ),
     0L
   )

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -855,19 +855,22 @@ test_that("reader inputs are refused before reusable Margin verbs", {
   expect_setequal(result$total, c(3L, 12L, 15L))
 })
 
-test_that("direct reader inspection requests a query without consuming it", {
+test_that("direct reader inspection matches reusable Arrow inputs", {
   skip_if_suggest_absent("arrow")
 
   reader <- multi_batch_arrow_reader()
-  raised <- expect_error(
-    inspect_grouping(reader, .grouping = rollup(k)),
-    class = "marginplyr_error"
+  direct <- inspect_grouping(reader, .grouping = rollup(k))
+  table <- inspect_grouping(
+    arrow::Table$create(arrow_input_data()),
+    .grouping = rollup(k)
   )
-  expect_match(
-    conditionMessage(raised),
-    "Build one with `dplyr::select()` and `dplyr::everything()` first.",
-    fixed = TRUE
+  query <- inspect_grouping(
+    dplyr::select(multi_batch_arrow_reader(), dplyr::everything()),
+    .grouping = rollup(k)
   )
+
+  expect_identical(direct, table)
+  expect_identical(direct, query)
   expect_identical(arrow::as_arrow_table(reader)$num_rows, 5L)
 })
 

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -595,7 +595,7 @@ Arrow's tabular dplyr inputs and marginplyr's verb-specific contract are:
 |---|---|---|---|
 | `Table`, `RecordBatch`, or `Dataset` | Accepted | Accepted | Refused; collect first |
 | Query with no reader source | Accepted | Accepted | Refused; collect first |
-| `RecordBatchReader` | Refused; materialize first | Refused; build a query first | Refused; collect first |
+| `RecordBatchReader` | Refused; materialize first | Accepted | Refused; collect first |
 | Query with any reader source | Refused; materialize first | Accepted | Refused; collect first |
 | Non-tabular Arrow object | General input refusal | General input refusal | General input refusal |
 
@@ -609,18 +609,17 @@ source graph, so its class alone does not tell you which outcome applies.
 per grouping set. Summary and expansion therefore refuse both a direct reader
 and a query whose source graph contains one. Use `arrow::as_arrow_table()` to
 consume every batch once and make the reusable table explicit.
-`inspect_grouping()` executes no branch, so it accepts a reader-backed query
-without consuming it. A direct reader currently needs to be wrapped first:
+`inspect_grouping()` executes no branch, so it accepts a direct reader or a
+reader-backed query without consuming either. A direct reader is normalized to
+the same unexecuted query internally:
 
 ```r
-reader_query <- dplyr::select(reader, dplyr::everything())
-inspect_grouping(reader_query, .grouping = rollup(region, store))
+inspect_grouping(reader, .grouping = rollup(region, store))
 ```
 
-Issue #510 tracks accepting the direct reader without this step. For a nesting
-verb, collect the reader or query directly: an Arrow table still cannot carry
-the list-column result. A `Scanner` is not a dplyr input either: choose
-`$ToTable()` or `$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`,
+For a nesting verb, collect the reader or query directly: an Arrow table still
+cannot carry the list-column result. A `Scanner` is not a dplyr input either:
+choose `$ToTable()` or `$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`,
 `ChunkedArray`, `Schema`, `Field`, `DataType`, or other non-tabular Arrow
 objects. Convert those to a data frame or lazy dplyr table appropriate to the
 data they represent. Contextual shares are rejected for every Arrow input


### PR DESCRIPTION
## Summary

- normalize a direct RecordBatchReader to an unexecuted Arrow query in inspect_grouping()
- verify the reader is not consumed and the plan matches Table and wrapped-query inputs
- add as_arrow_table() to the lazy-execution policy gate and update Arrow input documentation

## Validation

- NOT_CRAN=true Rscript -e 'devtools::test()' (7144 passed)
- jarl check .
- Rscript -e 'pkgload::load_all(".", quiet = TRUE); lintr::lint_package()'
- Rscript .github/scripts/verify-context-budget.R

Closes #510