### PR TITLE
Align inspect_grouping() with non-operation semantics

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -192,7 +192,10 @@ same field value and fall on opposite sides. A Margin verb refuses one before
 any branch is built, because it builds one branch per grouping set from the
 same step and data.table writes each of them to the caller's table by
 reference — leaving a result in which every row carries the Margin label, and
-a table whose columns were dropped or whose names were permuted.
+a table whose columns were dropped or whose names were permuted. Inspection
+builds no branch and accepts one; where a typed selection needs a proxy, it is
+compiled against an isolated zero-row root so the caller's table stays
+unchanged.
 _Avoid_: Mutable input, in-place backend
 
 **Sent query**:

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -21,6 +21,20 @@ zero_row_dtplyr_proxy_input <- function(.data) {
   step
 }
 
+# The typed selection proxy for Mutable-step inspection. The registered dtplyr
+# method evaluates only the isolated zero-row root above and reaches none of
+# ADR 0020's catalogued execution entry points; calling the method directly is
+# what avoids routing the step through `collect()` or `as_tibble()`.
+mutable_dtplyr_selection_proxy <- function(.data) {
+  proxy <- utils::head(zero_row_dtplyr_proxy_input(.data), n = 0L)
+  as_data_table <- getS3method(
+    "as.data.table",
+    "dtplyr_step",
+    envir = asNamespace("data.table")
+  )
+  as_data_table(proxy)
+}
+
 grouping_selection_proxy <- function(.data,
                                      backend = grouping_backend(.data)) {
   if (identical(backend$kind, "arrow")) {

--- a/R/backend-metadata.R
+++ b/R/backend-metadata.R
@@ -4,6 +4,23 @@ get_col_names <- function(data, ...) {
   as.character(dplyr::tbl_vars(selected))
 }
 
+# A copy of a Mutable step rooted in a zero-row table, used only to acquire an
+# inspection selection proxy. The derived step may already hold a reference-
+# writing `:=` call, so changing its root's permission is too late; replacing
+# the copied root's source gives that call an isolated schema-only table to
+# write to. ADR 0029 records why Margin operations refuse rather than use this
+# rewrite.
+zero_row_dtplyr_proxy_input <- function(.data) {
+  stopifnot(inherits(.data, "dtplyr_step"))
+  step <- .data
+  if (inherits(step[["parent"]], "dtplyr_step")) {
+    step[["parent"]] <- zero_row_dtplyr_proxy_input(step[["parent"]])
+  } else {
+    step[["parent"]] <- utils::head(step[["parent"]], n = 0L)
+  }
+  step
+}
+
 grouping_selection_proxy <- function(.data,
                                      backend = grouping_backend(.data)) {
   if (identical(backend$kind, "arrow")) {

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -258,7 +258,12 @@ prepare_grouping_plan <- function(.data,
       # Inspection needs no typed snapshot when names settle both selections.
       # Its canonical pass uses the name proxy too, preserving the two-pass
       # validation and warning behavior without executing a Mutable step.
-      if (!builds_margin_branches && preflight$name_only && !is.null(by)) {
+      if (
+        !builds_margin_branches &&
+          mutable_step &&
+          preflight$name_only &&
+          !is.null(by)
+      ) {
         data_proxy <- grouping_name_proxy(data_vars)
         plan <- compile_grouping_spec(
           grouping_spec,
@@ -270,12 +275,11 @@ prepare_grouping_plan <- function(.data,
           preflight = preflight
         )
       } else {
-        proxy_input <- if (!builds_margin_branches && mutable_step) {
-          zero_row_dtplyr_proxy_input(data)
+        data_proxy <- if (!builds_margin_branches && mutable_step) {
+          mutable_dtplyr_selection_proxy(data)
         } else {
-          data
+          grouping_selection_proxy(data, backend = backend)
         }
-        data_proxy <- grouping_selection_proxy(proxy_input, backend = backend)
         if (is.null(by)) {
           by <- resolve_by_selection(by_quo, data_proxy)
         }

--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -160,10 +160,12 @@ prepare_grouping_plan <- function(.data,
                                   grouping_quo,
                                   .duplicates,
                                   duplicates_choices,
+                                  builds_margin_branches,
                                   validate_grouping = NULL,
                                   validate_names = NULL,
                                   call = rlang::caller_call()) {
   stopifnot(rlang::is_quosure(by_quo), rlang::is_quosure(grouping_quo))
+  stopifnot(rlang::is_bool(builds_margin_branches))
   stopifnot(is.null(validate_grouping) || is.function(validate_grouping))
   stopifnot(is.null(validate_names) || is.function(validate_names))
   # Already matched against the calling verb's own vocabulary, which may be
@@ -197,11 +199,13 @@ prepare_grouping_plan <- function(.data,
       input <- normalize_grouping_input(.data, by_quo)
       data <- input$data
       backend <- grouping_backend(data)
-      # After `grouping_backend()` rather than before, because
+      mutable_step <- mutable_dtplyr_step(data)
+      # A Mutable step is unsafe only for a caller that builds grouping-set
+      # branches from it. After `grouping_backend()` rather than before, because
       # `check_backend_version()` runs inside it: a dtplyr below the floor is
       # then answered by the floor rather than by a field that version may
       # spell differently. ADR 0029 is authoritative for the placement.
-      if (mutable_dtplyr_step(data)) {
+      if (builds_margin_branches && mutable_step) {
         abort_mutable_dtplyr_step()
       }
       remember_sent_query_backend(backend)
@@ -251,19 +255,40 @@ prepare_grouping_plan <- function(.data,
           lifecycle_verbosity = discarded_pass_verbosity()
         )
       }
-      data_proxy <- grouping_selection_proxy(data, backend = backend)
-      if (is.null(by)) {
-        by <- resolve_by_selection(by_quo, data_proxy)
+      # Inspection needs no typed snapshot when names settle both selections.
+      # Its canonical pass uses the name proxy too, preserving the two-pass
+      # validation and warning behavior without executing a Mutable step.
+      if (!builds_margin_branches && preflight$name_only && !is.null(by)) {
+        data_proxy <- grouping_name_proxy(data_vars)
+        plan <- compile_grouping_spec(
+          grouping_spec,
+          data_vars = data_vars,
+          data_proxy = data_proxy,
+          .by = by,
+          .duplicates = .duplicates,
+          duplicates_choices = duplicates_choices,
+          preflight = preflight
+        )
+      } else {
+        proxy_input <- if (!builds_margin_branches && mutable_step) {
+          zero_row_dtplyr_proxy_input(data)
+        } else {
+          data
+        }
+        data_proxy <- grouping_selection_proxy(proxy_input, backend = backend)
+        if (is.null(by)) {
+          by <- resolve_by_selection(by_quo, data_proxy)
+        }
+        plan <- compile_grouping_spec(
+          grouping_spec,
+          data_vars = data_vars,
+          data_proxy = data_proxy,
+          .by = by,
+          .duplicates = .duplicates,
+          duplicates_choices = duplicates_choices,
+          preflight = preflight
+        )
       }
-      plan <- compile_grouping_spec(
-        grouping_spec,
-        data_vars = data_vars,
-        data_proxy = data_proxy,
-        .by = by,
-        .duplicates = .duplicates,
-        duplicates_choices = duplicates_choices,
-        preflight = preflight
-      )
 
       list(
         data = data,

--- a/R/inspect-grouping.R
+++ b/R/inspect-grouping.R
@@ -64,6 +64,12 @@
 #' [dplyr::show_query()] for generated SQL and backend-native tools for an
 #' optimizer plan.
 #'
+#' Because inspection builds no grouping-set branch, it also accepts a dtplyr
+#' step rooted at `dtplyr::lazy_dt(immutable = FALSE)` and leaves the caller's
+#' `data.table` unchanged. Margin verbs refuse the same Mutable step before
+#' building a branch; rebuild it with `immutable = TRUE` before passing it to
+#' one of them.
+#'
 #' The [grouping identity guide][guide] walks through inspecting a plan and
 #' reading it back off a Margin result. The [recipes guide][recipes] uses a
 #' plan to choose which grouping set to keep, and joins one against `.id` to
@@ -169,6 +175,7 @@ inspect_grouping <- function(.data,
         grouping_quo = grouping_quo,
         .duplicates = .duplicates,
         duplicates_choices = margin_duplicates_choices,
+        builds_margin_branches = FALSE,
         call = call
       )
       format_grouping_plan(grouping$plan, format = .format)

--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -282,6 +282,7 @@ prepare_margin_operation <- function(.data,
         grouping_quo = grouping_quo,
         .duplicates = .duplicates,
         duplicates_choices = duplicates_choices,
+        builds_margin_branches = TRUE,
         validate_grouping = validate_grouping,
         validate_names = function(data_vars) {
           check_margin_id_collision(

--- a/R/sent-queries.R
+++ b/R/sent-queries.R
@@ -183,13 +183,13 @@ record_sent_query <- function(purpose, query) {
 last_sent_queries <- function() {
   if (!isTRUE(sent_queries$recorded)) {
     abort_marginplyr(c(
-      "No Margin operation has run in this session.",
+      "No tracked call has run in this session.",
       i = "Run a Margin verb or {.fun inspect_grouping} first."
     ))
   }
   if (!isTRUE(sent_queries$audited)) {
     abort_marginplyr(c(
-      "The last Margin operation was not audited.",
+      "The last tracked call was not audited.",
       i = paste0(
         "Set {.code options(marginplyr.audit_sql = TRUE)} ",
         "before the call to record its queries."

--- a/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
+++ b/design/adr/0029-refuse-a-step-a-backend-would-write-to.md
@@ -199,3 +199,26 @@ is authored in and ADR 0024 the rule it spells `.data` by.
 
 Evidence: #451, whose triage comment holds the table of eight inputs the root
 predicate was chosen from.
+
+## Amendment: inspection is outside the branch-building boundary
+
+The *Where it is raised* section's shared-entry-point scope and the test
+strategy's `verbs_taking(".grouping")` set are superseded by #513. A Mutable
+step is refused by every Margin operation, and not by `inspect_grouping()`:
+inspection compiles and formats a Grouping plan but builds no grouping-set
+branch for data.table to write back through.
+
+`prepare_grouping_plan()` now requires its caller to state whether it builds
+Margin branches. The check remains immediately after `grouping_backend()` for
+the five Margin verbs, preserving the version-floor and failure-precedence
+placement above, while inspection passes through the same point.
+
+A name-only inspection runs its canonical compilation against column names and
+invokes no execution entry point. The earlier name-only validation pass remains
+separate, preserving its warning and evaluation behavior. A typed selection
+still needs a zero-row proxy. For a Mutable step, that proxy is acquired from a
+copy of the step whose root is an isolated zero-row table, so even a derived
+`select()` whose dtplyr call already contains a reference-writing `:=` can
+change neither the caller's columns nor their values. This is inspection-only
+metadata preparation; Margin operations continue to refuse rather than copy,
+as the original decision requires.

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -84,6 +84,12 @@ Grouping plan. It is deliberately separate from a SQL execution plan. Use
 \code{\link[dplyr:show_query]{dplyr::show_query()}} for generated SQL and backend-native tools for an
 optimizer plan.
 
+Because inspection builds no grouping-set branch, it also accepts a dtplyr
+step rooted at \code{dtplyr::lazy_dt(immutable = FALSE)} and leaves the caller's
+\code{data.table} unchanged. Margin verbs refuse the same Mutable step before
+building a branch; rebuild it with \code{immutable = TRUE} before passing it to
+one of them.
+
 The \href{https://sayuks.github.io/marginplyr/vignettes/grouping_identity.html}{grouping identity guide} walks through inspecting a plan and
 reading it back off a Margin result. The \href{https://sayuks.github.io/marginplyr/vignettes/recipes.html}{recipes guide} uses a
 plan to choose which grouping set to keep, and joins one against \code{.id} to

--- a/tests/testthat/_snaps/grouping-backends.md
+++ b/tests/testthat/_snaps/grouping-backends.md
@@ -53,14 +53,3 @@
       i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
       i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
 
----
-
-    Code
-      verb(dtplyr::lazy_dt(mutable_step_data(), immutable = FALSE), NULL, rollup(
-        region))
-    Condition
-      Error in `inspect_grouping()`:
-      ! `.data` comes from `dtplyr::lazy_dt(immutable = FALSE)`.
-      i A Margin verb builds one branch per grouping set from the same step, and data.table writes each branch to your table by reference.
-      i Rebuild the input with `dtplyr::lazy_dt(immutable = TRUE)`.
-

--- a/tests/testthat/helper-margin-verbs.R
+++ b/tests/testthat/helper-margin-verbs.R
@@ -1,10 +1,10 @@
-# Every exported verb taking the argument named, derived from the signatures so
+# Every exported entry point taking the argument named, derived from the
+# signatures so
 # that a seventh arrives at a caller as a wrapper a list is missing rather than
 # as a position nothing covers. The six it answers today are the same six for
-# `.by`, `.grouping`, and any other Margin argument, `summarise_with_margins()`
-# included: the derivation reads exports rather than function objects, so a
-# synonym that stopped being one would show as an entry the list no longer
-# covers.
+# `.by` and `.grouping`, five Margin verbs and `inspect_grouping()`: the
+# derivation reads exports rather than function objects, so a synonym that
+# stopped being one would show as an entry the list no longer covers.
 #
 # Here rather than in whichever test file wanted it first, because testthat
 # gives each file its own environment: `test-grouping-plan.R` builds one

--- a/tests/testthat/helper-margin-verbs.R
+++ b/tests/testthat/helper-margin-verbs.R
@@ -64,3 +64,10 @@ forwarded_verbs <- list(
     inspect_grouping(data, .by = {{ by }}, .grouping = {{ grouping }})
   }
 )
+
+# The branch-building subset, kept beside the entry-point forwarders so every
+# structural mutable-step test reads one set. `inspect_grouping()` is the sole
+# entry point outside it because inspection builds no Margin operation (#513).
+forwarded_margin_verbs <- forwarded_verbs[
+  setdiff(names(forwarded_verbs), "inspect_grouping")
+]

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -2222,8 +2222,9 @@ test_that("DuckDB safely quotes factor identifiers and labels", {
 })
 
 # A Mutable step is a dtplyr step whose root was built with
-# `immutable = FALSE`, and every verb taking `.grouping` refuses one (#451,
-# ADR 0029).
+# `immutable = FALSE`. Every Margin verb taking `.grouping` refuses one, while
+# `inspect_grouping()` accepts one because it builds no grouping-set branch
+# (#451, #513, ADR 0029).
 #
 # `data.table::` is called here under a dtplyr guard and takes none of its own,
 # which is the one-backend-per-test rule holding rather than being bent.
@@ -2243,14 +2244,20 @@ mutable_step_data <- function() {
 
 test_that("every Margin verb refuses a mutable dtplyr step", {
   skip_if_suggest_absent("dtplyr")
-  expect_setequal(names(forwarded_verbs), verbs_taking(".grouping"))
+  margin_verbs <- setdiff(verbs_taking(".grouping"), "inspect_grouping")
+  forwarded_margin_verbs <- forwarded_verbs[
+    setdiff(names(forwarded_verbs), "inspect_grouping")
+  ]
+  expect_setequal(names(forwarded_margin_verbs), margin_verbs)
 
-  for (name in names(forwarded_verbs)) {
+  for (name in names(forwarded_margin_verbs)) {
     data <- mutable_step_data()
     before <- data.table::copy(data)
     step <- dtplyr::lazy_dt(data, immutable = FALSE)
 
-    error <- expect_error(forwarded_verbs[[name]](step, NULL, rollup(region)))
+    error <- expect_error(
+      forwarded_margin_verbs[[name]](step, NULL, rollup(region))
+    )
     expect_s3_class(error, "marginplyr_error")
     # The whole point of refusing: the table the caller still holds is the one
     # they handed over, in its names, its columns, and its rows.
@@ -2260,14 +2267,17 @@ test_that("every Margin verb refuses a mutable dtplyr step", {
 
 test_that("the refusal reads as it is written, for every verb", {
   skip_if_suggest_absent("dtplyr")
+  forwarded_margin_verbs <- forwarded_verbs[
+    setdiff(names(forwarded_verbs), "inspect_grouping")
+  ]
 
   # One snapshot per verb rather than one for the set: the three lines are the
   # same everywhere and the header is not, so the call each verb blames is the
   # part only a per-verb pin covers. The wrapper deparses identically in every
   # one of them, which is why the header is what tells them apart -- it is also
   # the only thing they differ by, and the reason they are all here.
-  for (name in names(forwarded_verbs)) {
-    verb <- forwarded_verbs[[name]]
+  for (name in names(forwarded_margin_verbs)) {
+    verb <- forwarded_margin_verbs[[name]]
     expect_snapshot(
       error = TRUE,
       verb(
@@ -2277,6 +2287,49 @@ test_that("the refusal reads as it is written, for every verb", {
       )
     )
   }
+})
+
+test_that("inspection accepts mutable root and derived dtplyr steps", {
+  skip_if_suggest_absent("dtplyr")
+
+  shapes <- list(
+    root = identity,
+    derived = function(step) dplyr::select(step, region, value)
+  )
+  for (shape in names(shapes)) {
+    data <- mutable_step_data()
+    before <- data.table::copy(data)
+    mutable <- shapes[[shape]](dtplyr::lazy_dt(data, immutable = FALSE))
+    immutable <- shapes[[shape]](dtplyr::lazy_dt(data, immutable = TRUE))
+
+    plan <- inspect_grouping(mutable, .grouping = rollup(region))
+    expected <- inspect_grouping(immutable, .grouping = rollup(region))
+
+    expect_identical(plan, expected, info = shape)
+    expect_identical(as.data.frame(data), as.data.frame(before), info = shape)
+  }
+})
+
+test_that("inspection resolves typed selections without Mutable-step writes", {
+  skip_if_suggest_absent("dtplyr")
+  data <- mutable_step_data()
+  before <- data.table::copy(data)
+  mutable <- dtplyr::lazy_dt(data, immutable = FALSE) |>
+    dplyr::select(region, value)
+  immutable <- dtplyr::lazy_dt(data, immutable = TRUE) |>
+    dplyr::select(region, value)
+
+  plan <- inspect_grouping(
+    mutable,
+    .grouping = rollup(where(is.character))
+  )
+  expected <- inspect_grouping(
+    immutable,
+    .grouping = rollup(where(is.character))
+  )
+
+  expect_identical(plan, expected)
+  expect_identical(as.data.frame(data), as.data.frame(before))
 })
 
 test_that("the refusal reads the root step and not the step it was given", {

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -2245,9 +2245,6 @@ mutable_step_data <- function() {
 test_that("every Margin verb refuses a mutable dtplyr step", {
   skip_if_suggest_absent("dtplyr")
   margin_verbs <- setdiff(verbs_taking(".grouping"), "inspect_grouping")
-  forwarded_margin_verbs <- forwarded_verbs[
-    setdiff(names(forwarded_verbs), "inspect_grouping")
-  ]
   expect_setequal(names(forwarded_margin_verbs), margin_verbs)
 
   for (name in names(forwarded_margin_verbs)) {
@@ -2267,9 +2264,6 @@ test_that("every Margin verb refuses a mutable dtplyr step", {
 
 test_that("the refusal reads as it is written, for every verb", {
   skip_if_suggest_absent("dtplyr")
-  forwarded_margin_verbs <- forwarded_verbs[
-    setdiff(names(forwarded_verbs), "inspect_grouping")
-  ]
 
   # One snapshot per verb rather than one for the set: the three lines are the
   # same everywhere and the header is not, so the call each verb blames is the

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -556,6 +556,29 @@ test_that("a dtplyr materialization through the as_tibble family is counted", {
   )
 })
 
+test_that("inspection of a Mutable step invokes no execution entry point", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.table::data.table(
+    region = c("East", "West"),
+    value = c(1, 2)
+  )
+  root <- dtplyr::lazy_dt(data, immutable = FALSE)
+  inputs <- list(root = root, derived = dplyr::select(root, region, value))
+
+  # The positive control is the same backend and input root as the zeroes, so a
+  # counter blind to dtplyr materialization cannot make inspection look clean.
+  expect_gt(count_entry_point_invocations(tibble::as_tibble(root)), 0L)
+  for (shape in names(inputs)) {
+    expect_identical(
+      count_entry_point_invocations(
+        inspect_grouping(inputs[[shape]], .grouping = rollup(region))
+      ),
+      0L,
+      info = shape
+    )
+  }
+})
+
 test_that("an attached execution entry point is counted", {
   skip_if_suggest_absent("dtplyr")
   data <- data.frame(k = c("E", "E", "W"), v = c(1, 2, 3))

--- a/tests/testthat/test-query-policy.R
+++ b/tests/testthat/test-query-policy.R
@@ -564,18 +564,25 @@ test_that("inspection of a Mutable step invokes no execution entry point", {
   )
   root <- dtplyr::lazy_dt(data, immutable = FALSE)
   inputs <- list(root = root, derived = dplyr::select(root, region, value))
+  specifications <- list(
+    named = rollup(region),
+    typed = rollup(where(is.character))
+  )
 
   # The positive control is the same backend and input root as the zeroes, so a
   # counter blind to dtplyr materialization cannot make inspection look clean.
   expect_gt(count_entry_point_invocations(tibble::as_tibble(root)), 0L)
   for (shape in names(inputs)) {
-    expect_identical(
-      count_entry_point_invocations(
-        inspect_grouping(inputs[[shape]], .grouping = rollup(region))
-      ),
-      0L,
-      info = shape
-    )
+    for (selection in names(specifications)) {
+      expect_identical(
+        count_entry_point_invocations(inspect_grouping(
+          inputs[[shape]],
+          .grouping = specifications[[selection]]
+        )),
+        0L,
+        info = paste(shape, selection)
+      )
+    }
   }
 })
 

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -69,6 +69,18 @@ test_that("a local call under the default option records nothing", {
   expect_unaudited()
 })
 
+test_that("an unaudited inspection is described as a tracked call", {
+  expect_null(getOption("marginplyr.audit_sql"))
+  inspect_grouping(sent_queries_data(), .grouping = rollup(g, h))
+
+  condition <- rlang::catch_cnd(
+    last_sent_queries(),
+    classes = "marginplyr_error"
+  )
+  expect_match(conditionMessage(condition), "last tracked call", fixed = TRUE)
+  expect_no_match(conditionMessage(condition), "Margin operation", fixed = TRUE)
+})
+
 test_that("a dtplyr call under the default option records nothing", {
   skip_if_suggest_absent("dtplyr")
 
@@ -498,6 +510,8 @@ test_that("reading before any call has run is refused", {
     classes = "marginplyr_error"
   )
   expect_s3_class(condition, "marginplyr_error")
+  expect_match(conditionMessage(condition), "No tracked call", fixed = TRUE)
+  expect_no_match(conditionMessage(condition), "Margin operation", fixed = TRUE)
   expect_no_match(
     conditionMessage(condition),
     "marginplyr.audit_sql",

--- a/tests/testthat/test-sent-queries.R
+++ b/tests/testthat/test-sent-queries.R
@@ -563,6 +563,22 @@ test_that("an audited DuckDB call records its selection proxy", {
   expect_match(record$sql[[1L]], "sent_queries", fixed = TRUE)
 })
 
+test_that("an audited DuckDB inspection keeps its selection proxy", {
+  skip_if_suggest_absent("duckdb", "DBI")
+
+  con <- duckdb_test_connection()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  remote <- sent_queries_table(con)
+
+  with_audit_option(TRUE, {
+    inspect_grouping(remote, .grouping = rollup(g, h))
+    record <- last_sent_queries()
+  })
+
+  expect_identical(record$purpose, "selection_proxy")
+  expect_match(record$sql, "sent_queries", fixed = TRUE)
+})
+
 test_that("an audited RSQLite call records no selection proxy", {
   skip_if_suggest_absent("RSQLite", "DBI")
 


### PR DESCRIPTION
Closes #513

## Summary
- allow inspect_grouping() to inspect mutable dtplyr roots without changing the caller's data.table
- keep all five branch-building Margin verbs structurally covered by the mutable-step refusal
- describe unaudited inspection as the last tracked call
- amend ADR 0029 and the generated reference documentation

## Verification
- full testthat suite
- jarl check .
- lintr::lint_package()
- context-budget and document-reference verifiers