### PR TITLE
Make Margin-label remediations explicit

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -110,7 +110,12 @@ abort_selection_predicate <- function(label, parent) {
         "This input's backend doesn't report column types without a query, ",
         "and marginplyr sends none you didn't ask for."
       ),
-      i = "Select the columns by name, or collect the input first."
+      i = "Select the columns by name, or collect the input first.",
+      i = paste0(
+        "A Margin operation on collected data defaults ",
+        "{.arg .check_margin_label} ",
+        "from {.code FALSE} to {.code TRUE}; set it explicitly."
+      )
     ),
     parent = parent
   )

--- a/R/grouping-adapter-union.R
+++ b/R/grouping-adapter-union.R
@@ -240,6 +240,11 @@ abort_absorbed_summary <- function(labels) {
       "{.fun summarize_with_margins}."
     ),
     i = paste0(
+      "Collection changes the default of {.arg .check_margin_label} from ",
+      "{.code FALSE} to {.code TRUE}; set it explicitly when ",
+      "re-running this call."
+    ),
+    i = paste0(
       "Select the columns you need before collecting. Arrow reads every ",
       "column of the input, including the ones a summary does not use."
     )

--- a/R/margin-label.R
+++ b/R/margin-label.R
@@ -361,9 +361,12 @@ abort_observed_label_collision <- function(bad_cols, bad_labels) {
         "{cli::qty(length(bad_cols))}column{?s}:"
       ),
       i = "{.var {bad_cols}}.",
+      i = "Choose another {.arg .margin_label}.",
       i = paste0(
-        "Choose another {.arg .margin_label} or set ",
-        "{.code .check_margin_label = FALSE}."
+        "Set {.code .check_margin_label = FALSE} only if you retain ",
+        "{.arg .id}, {.fun grouping_bit}, or {.fun grouping_id} to ",
+        "distinguish ",
+        "source and Margin rows."
       )
     ))
   }
@@ -373,9 +376,11 @@ abort_observed_label_collision <- function(bad_cols, bad_labels) {
       "{cli::qty(length(bad_cols))}column{?s}:"
     ),
     i = "{.var {bad_cols}}.",
+    i = "Choose another {.arg .margin_label}.",
     i = paste0(
-      "Choose another {.arg .margin_label} or set ",
-      "{.code .check_margin_label = FALSE}."
+      "Set {.code .check_margin_label = FALSE} only if you retain ",
+      "{.arg .id}, {.fun grouping_bit}, or {.fun grouping_id} to distinguish ",
+      "source and Margin rows."
     )
   ))
 }

--- a/R/share.R
+++ b/R/share.R
@@ -339,7 +339,9 @@
 #' operations remain supported and lazy, apart from a summary Arrow's own
 #' engine cannot evaluate, which is refused for its own reason and before any
 #' row is read; see [summarize_with_margins()]. Explicitly collect an Arrow
-#' input first when local share execution is appropriate.
+#' input first when local share execution is appropriate. Collection changes
+#' `.check_margin_label`'s default from `FALSE` to `TRUE`, so choose that
+#' policy explicitly on the re-run.
 #'
 #' A `dtplyr` step remains a native lazy query: no validation-only query is
 #' added and nothing is collected on your behalf. Its execution-time
@@ -640,6 +642,11 @@ abort_arrow_shares <- function(kinds) {
     i = paste0(
       "Omit {.fun {share_helper_names(kinds)}} or explicitly collect the ",
       "data before calling {.fun summarize_with_margins}."
+    ),
+    i = paste0(
+      "Collection changes the default of {.arg .check_margin_label} from ",
+      "{.code FALSE} to {.code TRUE}; set it explicitly when ",
+      "re-running this call."
     )
   ))
 }
@@ -2452,6 +2459,11 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
           "{.fun {helpers}} from sources you have established yourself, or ",
           "explicitly collect the data before calling ",
           "{.fun summarize_with_margins}."
+        ),
+        i = paste0(
+          "Collection changes the default of {.arg .check_margin_label} from ",
+          "{.code FALSE} to {.code TRUE}; set it explicitly when ",
+          "re-running this call."
         )
       ),
       call = call
@@ -2471,6 +2483,11 @@ abort_share_source_dialect <- function(kinds, verdict, call) {
         "{.fun {helpers}} from sources you have established yourself, or ",
         "explicitly collect the data before calling ",
         "{.fun summarize_with_margins}."
+      ),
+      i = paste0(
+        "Collection changes the default of {.arg .check_margin_label} from ",
+        "{.code FALSE} to {.code TRUE}; set it explicitly when ",
+        "re-running this call."
       )
     ),
     call = call

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -50,6 +50,9 @@
 #'   named-list `.margin_label`.
 #'   Every Margin verb uses the same default: `TRUE` for local data frames and
 #'   `FALSE` for lazy inputs, which are read only when the caller asks. A label
+#'   check after collecting a lazy input therefore defaults to `TRUE` instead
+#'   of `FALSE`; set `.check_margin_label` explicitly when following a
+#'   collect-first remediation.
 #'   equal to a declared factor *level* is rejected wherever marginplyr holds
 #'   the levels, whatever this argument says, because finding it sends no
 #'   query. Arrow does not hold or restore factor levels; it checks an observed
@@ -137,7 +140,9 @@
 #' of the input. Some lazy backends do not report those without a query, and
 #' marginplyr sends none you did not ask for, so a predicate written against
 #' one of them is refused rather than answered. Select the columns by name, or
-#' collect the input first. Local data and the lazy backends whose types are
+#' collect the input first. A Margin operation on collected data defaults
+#' `.check_margin_label` to `TRUE` rather than the lazy-input default `FALSE`,
+#' so set it explicitly. Local data and the lazy backends whose types are
 #' available without a query answer a predicate as dplyr does.
 #'
 #' @section Grouped and row-wise inputs:
@@ -473,7 +478,9 @@
 #' contains a list column. [nest_with_margins()] and
 #' [nest_by_with_margins()] therefore ask you to collect first. Contextual
 #' shares are rejected for every accepted Arrow input before a summary query is
-#' constructed; collect first when local share execution is appropriate.
+#' constructed; collect first when local share execution is appropriate. In
+#' either rewrite, collection changes `.check_margin_label`'s default from
+#' `FALSE` to `TRUE`, so choose that policy explicitly on the re-run.
 #'
 #' @section Contextual shares:
 #' [share_of_parent()] and [share_of_total()] calculate a preceding named

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,7 +88,12 @@ assert_nest_possible <- function(x) {
         "{.arg {nm}} must be one of the following classes, which can be ",
         "nested: {.or {.code {valid_classes}}}."
       ),
-      i = "Collect it with {.fun dplyr::collect} first."
+      i = "Collect it with {.fun dplyr::collect} first.",
+      i = paste0(
+        "Collection changes the default of {.arg .check_margin_label} from ",
+        "{.code FALSE} to {.code TRUE}; set it explicitly when ",
+        "re-running this call."
+      )
     ))
   }
 }

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -57,6 +57,9 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+check after collecting a lazy input therefore defaults to \code{TRUE} instead
+of \code{FALSE}; set \code{.check_margin_label} explicitly when following a
+collect-first remediation.
 equal to a declared factor \emph{level} is rejected wherever marginplyr holds
 the levels, whatever this argument says, because finding it sends no
 query. Arrow does not hold or restore factor levels; it checks an observed
@@ -150,7 +153,9 @@ Both are written as column selections, so a selection predicate —
 of the input. Some lazy backends do not report those without a query, and
 marginplyr sends none you did not ask for, so a predicate written against
 one of them is refused rather than answered. Select the columns by name, or
-collect the input first. Local data and the lazy backends whose types are
+collect the input first. A Margin operation on collected data defaults
+\code{.check_margin_label} to \code{TRUE} rather than the lazy-input default \code{FALSE},
+so set it explicitly. Local data and the lazy backends whose types are
 available without a query answer a predicate as dplyr does.
 }
 
@@ -438,7 +443,9 @@ The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} therefore ask you to collect first. Contextual
 shares are rejected for every accepted Arrow input before a summary query is
-constructed; collect first when local share execution is appropriate.
+constructed; collect first when local share execution is appropriate. In
+either rewrite, collection changes \code{.check_margin_label}'s default from
+\code{FALSE} to \code{TRUE}, so choose that policy explicitly on the re-run.
 }
 
 \section{Database backend coverage}{

--- a/man/inspect_grouping.Rd
+++ b/man/inspect_grouping.Rd
@@ -178,7 +178,9 @@ The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} therefore ask you to collect first. Contextual
 shares are rejected for every accepted Arrow input before a summary query is
-constructed; collect first when local share execution is appropriate.
+constructed; collect first when local share execution is appropriate. In
+either rewrite, collection changes \code{.check_margin_label}'s default from
+\code{FALSE} to \code{TRUE}, so choose that policy explicitly on the re-run.
 }
 
 \examples{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -60,6 +60,9 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+check after collecting a lazy input therefore defaults to \code{TRUE} instead
+of \code{FALSE}; set \code{.check_margin_label} explicitly when following a
+collect-first remediation.
 equal to a declared factor \emph{level} is rejected wherever marginplyr holds
 the levels, whatever this argument says, because finding it sends no
 query. Arrow does not hold or restore factor levels; it checks an observed
@@ -142,7 +145,9 @@ Both are written as column selections, so a selection predicate —
 of the input. Some lazy backends do not report those without a query, and
 marginplyr sends none you did not ask for, so a predicate written against
 one of them is refused rather than answered. Select the columns by name, or
-collect the input first. Local data and the lazy backends whose types are
+collect the input first. A Margin operation on collected data defaults
+\code{.check_margin_label} to \code{TRUE} rather than the lazy-input default \code{FALSE},
+so set it explicitly. Local data and the lazy backends whose types are
 available without a query answer a predicate as dplyr does.
 }
 

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -60,6 +60,9 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+check after collecting a lazy input therefore defaults to \code{TRUE} instead
+of \code{FALSE}; set \code{.check_margin_label} explicitly when following a
+collect-first remediation.
 equal to a declared factor \emph{level} is rejected wherever marginplyr holds
 the levels, whatever this argument says, because finding it sends no
 query. Arrow does not hold or restore factor levels; it checks an observed
@@ -195,7 +198,9 @@ Both are written as column selections, so a selection predicate —
 of the input. Some lazy backends do not report those without a query, and
 marginplyr sends none you did not ask for, so a predicate written against
 one of them is refused rather than answered. Select the columns by name, or
-collect the input first. Local data and the lazy backends whose types are
+collect the input first. A Margin operation on collected data defaults
+\code{.check_margin_label} to \code{TRUE} rather than the lazy-input default \code{FALSE},
+so set it explicitly. Local data and the lazy backends whose types are
 available without a query answer a predicate as dplyr does.
 }
 

--- a/man/share_of_parent.Rd
+++ b/man/share_of_parent.Rd
@@ -351,7 +351,9 @@ the diagnostic names whichever helpers the call used. Other Arrow Margin
 operations remain supported and lazy, apart from a summary Arrow's own
 engine cannot evaluate, which is refused for its own reason and before any
 row is read; see \code{\link[=summarize_with_margins]{summarize_with_margins()}}. Explicitly collect an Arrow
-input first when local share execution is appropriate.
+input first when local share execution is appropriate. Collection changes
+\code{.check_margin_label}'s default from \code{FALSE} to \code{TRUE}, so choose that
+policy explicitly on the re-run.
 
 A \code{dtplyr} step remains a native lazy query: no validation-only query is
 added and nothing is collected on your behalf. Its execution-time

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -78,6 +78,9 @@ own dimension out -- \code{NULL} or \code{NA_character_}, chosen per dimension i
 named-list \code{.margin_label}.
 Every Margin verb uses the same default: \code{TRUE} for local data frames and
 \code{FALSE} for lazy inputs, which are read only when the caller asks. A label
+check after collecting a lazy input therefore defaults to \code{TRUE} instead
+of \code{FALSE}; set \code{.check_margin_label} explicitly when following a
+collect-first remediation.
 equal to a declared factor \emph{level} is rejected wherever marginplyr holds
 the levels, whatever this argument says, because finding it sends no
 query. Arrow does not hold or restore factor levels; it checks an observed
@@ -181,7 +184,9 @@ Both are written as column selections, so a selection predicate —
 of the input. Some lazy backends do not report those without a query, and
 marginplyr sends none you did not ask for, so a predicate written against
 one of them is refused rather than answered. Select the columns by name, or
-collect the input first. Local data and the lazy backends whose types are
+collect the input first. A Margin operation on collected data defaults
+\code{.check_margin_label} to \code{TRUE} rather than the lazy-input default \code{FALSE},
+so set it explicitly. Local data and the lazy backends whose types are
 available without a query answer a predicate as dplyr does.
 }
 
@@ -529,7 +534,9 @@ The nesting verbs accept neither Arrow input category, because their result
 contains a list column. \code{\link[=nest_with_margins]{nest_with_margins()}} and
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} therefore ask you to collect first. Contextual
 shares are rejected for every accepted Arrow input before a summary query is
-constructed; collect first when local share execution is appropriate.
+constructed; collect first when local share execution is appropriate. In
+either rewrite, collection changes \code{.check_margin_label}'s default from
+\code{FALSE} to \code{TRUE}, so choose that policy explicitly on the re-run.
 }
 
 \section{Contextual shares}{

--- a/tests/testthat/_snaps/share-backends.md
+++ b/tests/testthat/_snaps/share-backends.md
@@ -3,21 +3,21 @@
     Code
       conditionMessage(error)
     Output
-      [1] "Arrow backends do not support Parent shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_parent()` or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "Arrow backends do not support Parent shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_parent()` or explicitly collect the data before calling `summarize_with_margins()`.\ni Collection changes the default of `.check_margin_label` from `FALSE` to `TRUE`; set it explicitly when re-running this call."
 
 # RSQLite refuses a share its dialect cannot establish
 
     Code
       conditionMessage(refusal)
     Output
-      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because its SQL dialect converts a value of another type to a number rather than refusing it, so an ineligible source summary is indistinguishable from an eligible one.\ni Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because its SQL dialect converts a value of another type to a number rather than refusing it, so an ineligible source summary is indistinguishable from an eligible one.\ni Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`.\ni Collection changes the default of `.check_margin_label` from `FALSE` to `TRUE`; set it explicitly when re-running this call."
 
 # a lazy backend that answers nothing refuses to establish a share
 
     Code
       conditionMessage(refusal)
     Output
-      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because it could not be asked whether its SQL dialect converts a value of another type to a number rather than refusing it, and a dialect that converts rejects nothing.\ni Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "marginplyr cannot establish that the source summaries of Parent shares are plain integer or double scalars on this backend, because it could not be asked whether its SQL dialect converts a value of another type to a number rather than refusing it, and a dialect that converts rejects nothing.\ni Set `.check_share_source = FALSE` to calculate `share_of_parent()` from sources you have established yourself, or explicitly collect the data before calling `summarize_with_margins()`.\ni Collection changes the default of `.check_margin_label` from `FALSE` to `TRUE`; set it explicitly when re-running this call."
 
 # DuckDB reports an ineligible share source against its summary
 
@@ -32,12 +32,12 @@
     Code
       conditionMessage(error)
     Output
-      [1] "Arrow backends do not support Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "Arrow backends do not support Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`.\ni Collection changes the default of `.check_margin_label` from `FALSE` to `TRUE`; set it explicitly when re-running this call."
 
 ---
 
     Code
       conditionMessage(both)
     Output
-      [1] "Arrow backends do not support Parent shares and Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_parent()` and `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`."
+      [1] "Arrow backends do not support Parent shares and Total shares because marginplyr cannot enforce their scalar-summary contract safely before an Arrow query is constructed.\ni Other Arrow Margin operations remain supported.\ni Omit `share_of_parent()` and `share_of_total()` or explicitly collect the data before calling `summarize_with_margins()`.\ni Collection changes the default of `.check_margin_label` from `FALSE` to `TRUE`; set it explicitly when re-running this call."
 

--- a/tests/testthat/test-diagnostic-pluralization.R
+++ b/tests/testthat/test-diagnostic-pluralization.R
@@ -494,8 +494,10 @@ test_that("the Margin label collision pluralizes its grouping column noun", {
     paste0(
       "\"All\" is already present in grouping column:\n",
       "i `a`.\n",
-      "i Choose another `.margin_label` or set ",
-      "`.check_margin_label = FALSE`."
+      "i Choose another `.margin_label`.\n",
+      "i Set `.check_margin_label = FALSE` only if you retain `.id`, ",
+      "`grouping_bit()`, or `grouping_id()` to distinguish source and ",
+      "Margin rows."
     )
   )
 
@@ -505,8 +507,10 @@ test_that("the Margin label collision pluralizes its grouping column noun", {
     paste0(
       "\"All\" is already present in grouping columns:\n",
       "i `a` and `b`.\n",
-      "i Choose another `.margin_label` or set ",
-      "`.check_margin_label = FALSE`."
+      "i Choose another `.margin_label`.\n",
+      "i Set `.check_margin_label = FALSE` only if you retain `.id`, ",
+      "`grouping_bit()`, or `grouping_id()` to distinguish source and ",
+      "Margin rows."
     )
   )
 
@@ -516,8 +520,10 @@ test_that("the Margin label collision pluralizes its grouping column noun", {
     paste0(
       "Margin labels are already present in grouping columns:\n",
       "i `a` and `b`.\n",
-      "i Choose another `.margin_label` or set ",
-      "`.check_margin_label = FALSE`."
+      "i Choose another `.margin_label`.\n",
+      "i Set `.check_margin_label = FALSE` only if you retain `.id`, ",
+      "`grouping_bit()`, or `grouping_id()` to distinguish source and ",
+      "Margin rows."
     )
   )
 })

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -185,6 +185,48 @@ test_that("Arrow refuses a summary it would otherwise absorb", {
   }
 })
 
+test_that("Arrow summary collection makes collision policy explicit", {
+  skip_if_suggest_absent("arrow")
+
+  source <- arrow::Table$create(data.frame(group = "Total", s = "a"))
+  error <- expect_error(
+    summarize_with_margins(
+      source,
+      joined = paste(s, collapse = ","),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(error),
+    paste0(
+      "Collection changes the default of `.check_margin_label` from ",
+      "`FALSE` to `TRUE`"
+    ),
+    fixed = TRUE
+  )
+
+  local <- dplyr::collect(source)
+  expect_error(
+    summarize_with_margins(
+      local,
+      joined = paste(s, collapse = ","),
+      .grouping = rollup(group)
+    ),
+    "already present in grouping column"
+  )
+  result <- summarize_with_margins(
+    local,
+    joined = paste(s, collapse = ","),
+    .grouping = rollup(group),
+    .check_margin_label = FALSE,
+    .id = "set"
+  )
+
+  expect_identical(result$group, c("Total", "Total"))
+  expect_setequal(result$set, c(1L, 2L))
+})
+
 # Which summaries the refusal names is a function of how the installed Arrow
 # phrases its warning, and both phrasings are inside the range `DESCRIPTION`
 # admits, so it is asserted at the reading rather than through a verb: a

--- a/tests/testthat/test-grouping-plan.R
+++ b/tests/testthat/test-grouping-plan.R
@@ -2899,7 +2899,9 @@ test_that("a grouping predicate is refused with the argument and the verb", {
   refusal <- paste0(
     "i This input's backend doesn't report column types without a query, ",
     "and marginplyr sends none you didn't ask for.\n",
-    "i Select the columns by name, or collect the input first."
+    "i Select the columns by name, or collect the input first.\n",
+    "i A Margin operation on collected data defaults `.check_margin_label` ",
+    "from `FALSE` to `TRUE`; set it explicitly."
   )
 
   dimension <- expect_error(summarize_with_margins(

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -489,6 +489,57 @@ test_that("lazy inspection reads typed metadata once, executing no margins", {
   expect_identical(result$grouping_id, c(0L, 1L))
 })
 
+test_that("inspection scopes predicate collection guidance to Margin verbs", {
+  skip_if_suggest_absent("RSQLite", "DBI")
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  remote <- dplyr::copy_to(
+    con,
+    data.frame(group = "Total", value = 1L),
+    "inspection_predicate_collision",
+    temporary = TRUE
+  )
+
+  error <- expect_error(
+    inspect_grouping(remote, .grouping = rollup(where(is.character))),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(error),
+    paste0(
+      "A Margin operation on collected data defaults `.check_margin_label` ",
+      "from `FALSE` to `TRUE`; set it explicitly."
+    ),
+    fixed = TRUE
+  )
+  expect_false(grepl(
+    "re-running this call",
+    conditionMessage(error),
+    fixed = TRUE
+  ))
+
+  local <- dplyr::collect(remote)
+  expect_error(
+    summarize_with_margins(
+      local,
+      n = dplyr::n(),
+      .grouping = rollup(where(is.character))
+    ),
+    "already present in grouping column"
+  )
+  result <- summarize_with_margins(
+    local,
+    n = dplyr::n(),
+    .grouping = rollup(where(is.character)),
+    .check_margin_label = FALSE,
+    .id = "set"
+  )
+
+  expect_identical(result$group, c("Total", "Total"))
+  expect_setequal(result$set, c(1L, 2L))
+})
+
 test_that("a name-only grouping error precedes a .by predicate's read", {
   # A `.by` predicate is resolved from typed metadata, but the Grouping
   # specification beside it may still be resolvable from names — and ADR-0005

--- a/tests/testthat/test-margin-label.R
+++ b/tests/testthat/test-margin-label.R
@@ -1619,7 +1619,7 @@ test_that("an all-typed-missing label reads no column", {
   }
 })
 
-test_that("a non-missing label is still an observed collision", {
+test_that("an observed-collision opt-out retains structural identity", {
   data <- data.frame(group = c("All", "b"), value = 1:2)
 
   error <- expect_error(
@@ -1632,7 +1632,24 @@ test_that("a non-missing label is still an observed collision", {
     "already present in grouping column:\ni `group`",
     fixed = TRUE
   )
-  expect_match(conditionMessage(error), "`.check_margin_label = FALSE`")
+  expect_match(
+    conditionMessage(error),
+    "only if you retain `.id`, `grouping_bit()`, or `grouping_id()`",
+    fixed = TRUE
+  )
+
+  colliding <- data.frame(group = "All", value = 1L)
+  result <- summarize_with_margins(
+    colliding,
+    n = dplyr::n(),
+    .grouping = rollup(group),
+    .margin_label = "All",
+    .check_margin_label = FALSE,
+    .id = "set"
+  )
+
+  expect_identical(result$group, c("All", "All"))
+  expect_setequal(result$set, c(1L, 2L))
 })
 
 # The remedy has to be one. A bare `NULL` is the whole of `.margin_label`, so

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -469,6 +469,52 @@ test_that("Arrow rejects Parent shares before constructing a query", {
   expect_snapshot(conditionMessage(error))
 })
 
+test_that("Arrow share collection makes collision policy explicit", {
+  skip_if_suggest_absent("arrow")
+
+  source <- arrow::Table$create(data.frame(group = "Total", value = 1L))
+  error <- expect_error(
+    summarize_with_margins(
+      source,
+      total = sum(value),
+      share = share_of_parent(total),
+      .grouping = rollup(group)
+    ),
+    class = "marginplyr_error"
+  )
+  expect_match(
+    conditionMessage(error),
+    paste0(
+      "Collection changes the default of `.check_margin_label` from ",
+      "`FALSE` to `TRUE`"
+    ),
+    fixed = TRUE
+  )
+
+  local <- dplyr::collect(source)
+  expect_error(
+    summarize_with_margins(
+      local,
+      total = sum(value),
+      share = share_of_parent(total),
+      .grouping = rollup(group)
+    ),
+    "already present in grouping column"
+  )
+  result <- summarize_with_margins(
+    local,
+    total = sum(value),
+    share = share_of_parent(total),
+    .grouping = rollup(group),
+    .check_margin_label = FALSE,
+    .id = "set"
+  )
+
+  expect_identical(result$group, c("Total", "Total"))
+  expect_setequal(result$set, c(1L, 2L))
+  expect_identical(result$share, c(1, 1))
+})
+
 test_that("Arrow ordinary Margin summaries remain lazy and available", {
   skip_if_suggest_absent("arrow")
   query <- summarize_with_margins(

--- a/tests/testthat/test-summarize-operation.R
+++ b/tests/testthat/test-summarize-operation.R
@@ -348,7 +348,9 @@ test_that("a summary predicate is refused with the argument and the verb", {
       "`dplyr::across(dplyr::where(is.numeric), sum)`.\n",
       "i This input's backend doesn't report column types without a query, ",
       "and marginplyr sends none you didn't ask for.\n",
-      "i Select the columns by name, or collect the input first."
+      "i Select the columns by name, or collect the input first.\n",
+      "i A Margin operation on collected data defaults `.check_margin_label` ",
+      "from `FALSE` to `TRUE`; set it explicitly."
     ),
     fixed = TRUE
   )

--- a/tests/testthat/test-verb-argument-admission.R
+++ b/tests/testthat/test-verb-argument-admission.R
@@ -956,3 +956,46 @@ test_that("nesting reader inputs directs the caller to collect", {
     }
   }
 })
+
+test_that("Arrow nesting collection makes collision policy explicit", {
+  skip_if_suggest_absent("arrow")
+
+  source <- arrow::Table$create(data.frame(group = "Total", value = 1L))
+  verbs <- list(
+    nest = nest_with_margins,
+    nest_by = nest_by_with_margins
+  )
+
+  for (verb in names(verbs)) {
+    error <- expect_error(
+      verbs[[verb]](source, .grouping = rollup(group)),
+      class = "marginplyr_error",
+      info = verb
+    )
+    expect_match(
+      conditionMessage(error),
+      paste0(
+        "Collection changes the default of `.check_margin_label` from ",
+        "`FALSE` to `TRUE`"
+      ),
+      fixed = TRUE,
+      info = verb
+    )
+
+    local <- dplyr::collect(source)
+    expect_error(
+      verbs[[verb]](local, .grouping = rollup(group)),
+      "already present in grouping column",
+      info = verb
+    )
+    result <- verbs[[verb]](
+      local,
+      .grouping = rollup(group),
+      .check_margin_label = FALSE,
+      .id = "set"
+    )
+
+    expect_identical(result$group, c("Total", "Total"), info = verb)
+    expect_identical(sort(result$set), c(1L, 2L), info = verb)
+  }
+})

--- a/vignettes/database_backends.qmd
+++ b/vignettes/database_backends.qmd
@@ -618,12 +618,16 @@ inspect_grouping(reader, .grouping = rollup(region, store))
 ```
 
 For a nesting verb, collect the reader or query directly: an Arrow table still
-cannot carry the list-column result. A `Scanner` is not a dplyr input either:
+cannot carry the list-column result. Collection changes `.check_margin_label`'s
+default from `FALSE` to `TRUE`, so choose that policy explicitly on the re-run.
+A `Scanner` is not a dplyr input either:
 choose `$ToTable()` or `$ToRecordBatchReader()` first. Neither are `Scalar`, `Array`,
 `ChunkedArray`, `Schema`, `Field`, `DataType`, or other non-tabular Arrow
 objects. Convert those to a data frame or lazy dplyr table appropriate to the
 data they represent. Contextual shares are rejected for every Arrow input
-accepted by a summary; collect first for local execution.
+accepted by a summary; collect first for local execution. Collection changes
+`.check_margin_label`'s default from `FALSE` to `TRUE`, so choose that policy
+explicitly on the re-run.
 
 The first is a summary Arrow's own engine cannot evaluate. Arrow answers one of
 those by reading the whole input — every column, not just the ones the summary
@@ -651,7 +655,9 @@ than this one, because a dataset never reads itself into R.
 
 The second is contextual shares. `share_of_parent()` and `share_of_total()` are
 both rejected outright, before any Arrow query is constructed: the reason is the
-source summary they share. Collect the Arrow table first when you need either.
+source summary they share. Collect the Arrow table first when you need either,
+then choose `.check_margin_label` explicitly because collection changes its
+default from `FALSE` to `TRUE`.
 
 ```{r}
 #| label: arrow-parent-share


### PR DESCRIPTION
Closes #516

## Summary

- make the safe conditions for disabling Margin-label collision checks explicit
- explain collect-first Arrow policy changes in diagnostics and documentation
- cover collision remediation through public Arrow, nesting, share, and inspection seams

## Validation

- targeted testthat files for the affected seams
- `jarl check .`
- `pkgload::load_all()` and `lintr::lint_package()`

## Code review

Reviewed snapshot: `77d5b71`.

- Standards: the initial `inspect_grouping()` diagnostic finding was fixed and verified; final review found no hard violations. A possible duplication across public seam regression tests was retained as deliberate coverage.
- Spec: the initial inspection diagnostic and predicate-seam coverage findings were fixed and verified; final review found no remaining findings.