### PR TITLE
Clarify grouped-input remediation

### DIFF
--- a/R/grouping-plan.R
+++ b/R/grouping-plan.R
@@ -71,14 +71,19 @@ normalize_grouping_input <- function(.data, by_quo) {
   if (inherits(.data, "rowwise_df")) {
     abort_marginplyr(c(
       "{.fun rowwise} input is not supported.",
-      i = "Call {.fun dplyr::ungroup} first."
+      i = "Calling {.fun dplyr::ungroup} discards row-wise grouping."
     ))
   }
 
   if (!dplyr::group_by_drop_default(.data)) {
     abort_marginplyr(c(
       "Grouped input created with {.code .drop = FALSE} is not supported.",
-      i = "Call {.fun dplyr::ungroup} first."
+      i = "marginplyr cannot preserve empty groups.",
+      i = "Call {.fun dplyr::ungroup} to discard empty groups.",
+      i = paste0(
+        "To retain empty keys, complete the input before the ",
+        "Margin operation."
+      )
     ))
   }
 
@@ -86,7 +91,10 @@ normalize_grouping_input <- function(.data, by_quo) {
   if (length(input_groups) > 0L && !rlang::quo_is_null(by_quo)) {
     abort_marginplyr(c(
       "Can't supply {.arg .by} when {.arg .data} is grouped.",
-      i = "Call {.fun dplyr::ungroup} first."
+      i = paste0(
+        "Call {.fun dplyr::ungroup} first to replace the existing ",
+        "groups with {.arg .by}."
+      )
     ))
   }
 

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -156,9 +156,12 @@
 #' also supply `.by`; call [dplyr::ungroup()] first when replacing the existing
 #' groups. A grouping column also cannot appear in `.grouping`, because one
 #' column cannot be both a fixed key and a dimension that can be rolled up.
-#' Grouped local data created with `.drop = FALSE` is rejected because empty
-#' factor groups do not have a consistent equivalent in SQL and other lazy
-#' backends.
+#' Grouped local data created with `.drop = FALSE` is rejected because
+#' marginplyr cannot preserve empty groups across local and lazy backends.
+#' [dplyr::ungroup()] discards empty groups, which is appropriate when they do
+#' not belong in the result. To retain empty keys, complete the input before
+#' the Margin operation; [Complete absent keys before margins][keys]
+#' guide follows the ADR 0011 workflow.
 #'
 #' Unlike the default output of [dplyr::summarize()] on grouped data,
 #' [summarize_with_margins()], [expand_with_margins()], and
@@ -167,7 +170,11 @@
 #' hierarchy to retain.
 #' [nest_by_with_margins()] instead returns a row-wise data frame grouped by
 #' all visible fixed keys, grouping dimensions, and `.id` when supplied.
-#' Row-wise input is rejected; call [dplyr::ungroup()] first.
+#' Row-wise input is rejected. [dplyr::ungroup()] discards row-wise grouping;
+#' when named row-wise identifiers should remain fixed keys, ungroup first and
+#' select them with `.by`.
+#'
+#' [keys]: https://sayuks.github.io/marginplyr/vignettes/completing_keys.html
 #'
 #' @section Option arguments:
 #' An argument documented as taking one of a listed set of strings —

--- a/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
+++ b/design/adr/0012-distinguish-factor-na-levels-from-missing-margin-values.md
@@ -219,7 +219,8 @@ accepts a reader-backed query but, until #510, refuses a direct reader and asks
 the caller to build that query explicitly. The nesting verbs retain their
 `dplyr::collect()` remedy.
 
-PR #509 records the contract change. The evidence is in
+PR #509 records the contract change. The source and cross-platform execution
+evidence are in
 `investigation/arrow-r-input-shapes-and-dplyr-fallback.md`.
 
 The inspection sentence is superseded by ADR 0020's amendment *inspect a

--- a/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
+++ b/investigation/arrow-r-input-shapes-and-dplyr-fallback.md
@@ -3,6 +3,7 @@
 Investigated: 2026-09-08
 Revised: 2026-09-09 — multi-branch RecordBatchReader reproduction below
 Revised: 2026-09-09 (#509) — reader-backed query bypass and verb boundary below
+Revised: 2026-09-10 — test-coverage run 34419952931 below
 
 Measured with R 4.6.1, arrow 25.0.1, and dplyr 1.2.1.  The Arrow sources and
 reference pages linked below were read on the investigation date.  This note
@@ -168,3 +169,19 @@ unexecuted `query` to `inspect_grouping()` returned the two-set rollup plan,
 after which converting `reader` still returned all five rows. Inspection built
 no grouping-set branches and consumed no batch. Issue #510 records the decision
 to add direct-reader inspection separately from PR #509.
+
+## Revisions (2026-09-10)
+
+GitHub Actions test-coverage run 34419952931 established that the same
+two-query `union_all()` reproduction did not reliably return an incomplete
+result on its Ubuntu runner. With R 4.6.1, arrow 25.0.1, and coverage
+instrumentation, the preceding run and its rerun aborted with `malloc():
+unaligned tcache chunk detected`; the diagnostic run instead segfaulted in
+`Table__from_ExecPlanReader()` while collecting the union. The same versions on
+macOS still returned an incomplete result.
+
+The reproduction was therefore not safe to execute inside the test process.
+The non-executing query graphs still retained the original reader as their
+source, and sequential `arrow::as_arrow_table()` calls still returned five rows
+and then zero rows. `tests/testthat/test-grouping-backends.R` recorded those two
+observations without connecting two Arrow execution plans to one reader.

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -171,9 +171,12 @@ As with \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[tidyr:
 also supply \code{.by}; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first when replacing the existing
 groups. A grouping column also cannot appear in \code{.grouping}, because one
 column cannot be both a fixed key and a dimension that can be rolled up.
-Grouped local data created with \code{.drop = FALSE} is rejected because empty
-factor groups do not have a consistent equivalent in SQL and other lazy
-backends.
+Grouped local data created with \code{.drop = FALSE} is rejected because
+marginplyr cannot preserve empty groups across local and lazy backends.
+\code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards empty groups, which is appropriate when they do
+not belong in the result. To retain empty keys, complete the input before
+the Margin operation; \href{https://sayuks.github.io/marginplyr/vignettes/completing_keys.html}{Complete absent keys before margins}
+guide follows the ADR 0011 workflow.
 
 Unlike the default output of \code{\link[dplyr:summarize]{dplyr::summarize()}} on grouped data,
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}}, and
@@ -182,7 +185,9 @@ sets contain multiple grains, so there is no single meaningful grouping
 hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
-Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+Row-wise input is rejected. \code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards row-wise grouping;
+when named row-wise identifiers should remain fixed keys, ungroup first and
+select them with \code{.by}.
 }
 
 \section{Option arguments}{

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -163,9 +163,12 @@ As with \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[tidyr:
 also supply \code{.by}; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first when replacing the existing
 groups. A grouping column also cannot appear in \code{.grouping}, because one
 column cannot be both a fixed key and a dimension that can be rolled up.
-Grouped local data created with \code{.drop = FALSE} is rejected because empty
-factor groups do not have a consistent equivalent in SQL and other lazy
-backends.
+Grouped local data created with \code{.drop = FALSE} is rejected because
+marginplyr cannot preserve empty groups across local and lazy backends.
+\code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards empty groups, which is appropriate when they do
+not belong in the result. To retain empty keys, complete the input before
+the Margin operation; \href{https://sayuks.github.io/marginplyr/vignettes/completing_keys.html}{Complete absent keys before margins}
+guide follows the ADR 0011 workflow.
 
 Unlike the default output of \code{\link[dplyr:summarize]{dplyr::summarize()}} on grouped data,
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}}, and
@@ -174,7 +177,9 @@ sets contain multiple grains, so there is no single meaningful grouping
 hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
-Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+Row-wise input is rejected. \code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards row-wise grouping;
+when named row-wise identifiers should remain fixed keys, ungroup first and
+select them with \code{.by}.
 }
 
 \section{Option arguments}{

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -216,9 +216,12 @@ As with \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[tidyr:
 also supply \code{.by}; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first when replacing the existing
 groups. A grouping column also cannot appear in \code{.grouping}, because one
 column cannot be both a fixed key and a dimension that can be rolled up.
-Grouped local data created with \code{.drop = FALSE} is rejected because empty
-factor groups do not have a consistent equivalent in SQL and other lazy
-backends.
+Grouped local data created with \code{.drop = FALSE} is rejected because
+marginplyr cannot preserve empty groups across local and lazy backends.
+\code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards empty groups, which is appropriate when they do
+not belong in the result. To retain empty keys, complete the input before
+the Margin operation; \href{https://sayuks.github.io/marginplyr/vignettes/completing_keys.html}{Complete absent keys before margins}
+guide follows the ADR 0011 workflow.
 
 Unlike the default output of \code{\link[dplyr:summarize]{dplyr::summarize()}} on grouped data,
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}}, and
@@ -227,7 +230,9 @@ sets contain multiple grains, so there is no single meaningful grouping
 hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
-Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+Row-wise input is rejected. \code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards row-wise grouping;
+when named row-wise identifiers should remain fixed keys, ungroup first and
+select them with \code{.by}.
 }
 
 \section{Option arguments}{

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -202,9 +202,12 @@ As with \code{\link[dplyr:summarize]{dplyr::summarize()}} and \code{\link[tidyr:
 also supply \code{.by}; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first when replacing the existing
 groups. A grouping column also cannot appear in \code{.grouping}, because one
 column cannot be both a fixed key and a dimension that can be rolled up.
-Grouped local data created with \code{.drop = FALSE} is rejected because empty
-factor groups do not have a consistent equivalent in SQL and other lazy
-backends.
+Grouped local data created with \code{.drop = FALSE} is rejected because
+marginplyr cannot preserve empty groups across local and lazy backends.
+\code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards empty groups, which is appropriate when they do
+not belong in the result. To retain empty keys, complete the input before
+the Margin operation; \href{https://sayuks.github.io/marginplyr/vignettes/completing_keys.html}{Complete absent keys before margins}
+guide follows the ADR 0011 workflow.
 
 Unlike the default output of \code{\link[dplyr:summarize]{dplyr::summarize()}} on grouped data,
 \code{\link[=summarize_with_margins]{summarize_with_margins()}}, \code{\link[=expand_with_margins]{expand_with_margins()}}, and
@@ -213,7 +216,9 @@ sets contain multiple grains, so there is no single meaningful grouping
 hierarchy to retain.
 \code{\link[=nest_by_with_margins]{nest_by_with_margins()}} instead returns a row-wise data frame grouped by
 all visible fixed keys, grouping dimensions, and \code{.id} when supplied.
-Row-wise input is rejected; call \code{\link[dplyr:ungroup]{dplyr::ungroup()}} first.
+Row-wise input is rejected. \code{\link[dplyr:ungroup]{dplyr::ungroup()}} discards row-wise grouping;
+when named row-wise identifiers should remain fixed keys, ungroup first and
+select them with \code{.by}.
 }
 
 \section{Option arguments}{

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,5 +9,4 @@
 library(testthat)
 library(marginplyr)
 
-cat("[DEBUG-cov515] forcing progress reporter\n")
-test_check("marginplyr", reporter = "progress")
+test_check("marginplyr")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,5 @@
 library(testthat)
 library(marginplyr)
 
-test_check("marginplyr")
+cat("[DEBUG-cov515] forcing progress reporter\n")
+test_check("marginplyr", reporter = "progress")

--- a/tests/testthat/test-grouping-backends.R
+++ b/tests/testthat/test-grouping-backends.R
@@ -805,11 +805,13 @@ test_that("public Arrow table classes are supported", {
   )
 })
 
-# This pins the external behaviour that makes reader reuse unsafe. Which branch
-# consumes which batch is not stable across a shared test session, so the
-# contract is the absence of the known complete result. If Arrow begins sharing
-# one scan across both branches, this fails and the refusal can be reconsidered.
-test_that("Arrow reader branches do not produce the complete result", {
+# These are the two premises that make reader reuse unsafe: both queries retain
+# the reader as their source, and consuming that reader once exhausts it. The
+# executable union reproduction in
+# `investigation/arrow-r-input-shapes-and-dplyr-fallback.md` cannot run inside
+# the suite: Arrow may abort the R process instead of returning an incomplete
+# result when two execution plans share the reader.
+test_that("Arrow reader query branches retain a one-shot source", {
   skip_if_suggest_absent("arrow")
 
   reader <- multi_batch_arrow_reader()
@@ -823,16 +825,15 @@ test_that("Arrow reader branches do not produce the complete result", {
     reader,
     n = dplyr::n(),
     total = sum(v)
-  ) |>
-    dplyr::mutate(k = "Total", .before = 1L)
-  result <- dplyr::collect(dplyr::union_all(detail, grand))
-  complete <- tibble::tibble(
-    k = c("E", "W", "Total"),
-    n = c(2L, 3L, 5L),
-    total = c(3L, 12L, 15L)
   )
 
-  expect_false(dplyr::setequal(result, complete))
+  expect_true(arrow_input_has_reader_source(detail))
+  expect_true(arrow_input_has_reader_source(grand))
+
+  first <- arrow::as_arrow_table(reader)
+  second <- arrow::as_arrow_table(reader)
+  expect_identical(first$num_rows, 5L)
+  expect_identical(second$num_rows, 0L)
 })
 
 # Deciding whether a selection renames means comparing what it selected against

--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -943,39 +943,21 @@ test_that("grouped inputs reject conflicting grouping instructions", {
   )
   grouped <- dplyr::group_by(data, year)
 
-  expect_error(
-    summarize_with_margins(
-      grouped,
-      value = sum(value),
-      .by = year,
-      .grouping = rollup(region)
-    ),
-    "Can't supply `.by`"
-  )
-  expect_error(
-    expand_with_margins(
-      grouped,
-      .by = year,
-      .grouping = rollup(region)
-    ),
-    "Can't supply `.by`"
-  )
-  expect_error(
-    nest_with_margins(
-      grouped,
-      .by = year,
-      .grouping = rollup(region)
-    ),
-    "Can't supply `.by`"
-  )
-  expect_error(
-    nest_by_with_margins(
-      grouped,
-      .by = year,
-      .grouping = rollup(region)
-    ),
-    "Can't supply `.by`"
-  )
+  for (name in names(forwarded_verbs)) {
+    error <- expect_error(
+      forwarded_verbs[[name]](grouped, year, rollup(region))
+    )
+    expect_s3_class(error, "marginplyr_error")
+    expect_identical(
+      conditionMessage(error),
+      paste0(
+        "Can't supply `.by` when `.data` is grouped.\n",
+        "i Call `dplyr::ungroup()` first to replace the existing groups ",
+        "with `.by`."
+      )
+    )
+    expect_identical(rlang::call_name(conditionCall(error)), name)
+  }
 
   expect_error(
     summarize_with_margins(
@@ -987,45 +969,134 @@ test_that("grouped inputs reject conflicting grouping instructions", {
   )
 })
 
-test_that("row-wise inputs require explicit ungrouping", {
-  data <- dplyr::rowwise(
-    data.frame(region = c("East", "West"), value = 1:2)
-  )
+test_that(
+  "grouped-input refusals describe the lost semantics at every public seam",
+  {
+    data <- data.frame(
+      account = c("A", "B"),
+      region = c("East", "West"),
+      value = 1:2
+    )
+    inputs <- list(
+      rowwise = dplyr::rowwise(data, account),
+      drop_false = dplyr::group_by(
+        dplyr::mutate(
+          data,
+          account = factor(account, levels = c("A", "B", "C"))
+        ),
+        account,
+        .drop = FALSE
+      )
+    )
+    messages <- list(
+      rowwise = paste0(
+        "`rowwise()` input is not supported.\n",
+        "i Calling `dplyr::ungroup()` discards row-wise grouping."
+      ),
+      drop_false = paste0(
+        "Grouped input created with `.drop = FALSE` is not supported.\n",
+        "i marginplyr cannot preserve empty groups.\n",
+        "i Call `dplyr::ungroup()` to discard empty groups.\n",
+        paste0(
+          "i To retain empty keys, complete the input before the ",
+          "Margin operation."
+        )
+      )
+    )
 
-  expect_error(
-    summarize_with_margins(
-      data,
-      value = sum(value),
-      .grouping = rollup(region)
-    ),
-    "`rowwise\\(\\)` input is not supported"
-  )
-  expect_error(
-    expand_with_margins(data, .grouping = rollup(region)),
-    "`rowwise\\(\\)` input is not supported"
-  )
-  expect_error(
-    nest_with_margins(data, .grouping = rollup(region)),
-    "`rowwise\\(\\)` input is not supported"
-  )
-  expect_error(
-    nest_by_with_margins(data, .grouping = rollup(region)),
-    "`rowwise\\(\\)` input is not supported"
-  )
-})
+    for (input_name in names(inputs)) {
+      for (verb_name in names(forwarded_verbs)) {
+        error <- expect_error(
+          forwarded_verbs[[verb_name]](
+            inputs[[input_name]],
+            NULL,
+            rollup(region)
+          )
+        )
+        expect_s3_class(error, "marginplyr_error")
+        expect_identical(conditionMessage(error), messages[[input_name]])
+        expect_identical(rlang::call_name(conditionCall(error)), verb_name)
+      }
+    }
+  }
+)
 
-test_that("empty persistent groups are rejected instead of silently dropped", {
-  data <- data.frame(
-    year = factor(2025L, levels = c(2025L, 2026L)),
-    value = 1
-  ) |>
-    dplyr::group_by(year, .drop = FALSE)
+test_that(
+  "row-wise rewrites either discard or retain identifier keys explicitly",
+  {
+    data <- data.frame(
+      account = c("A", "B"),
+      region = c("East", "West"),
+      value = c(1, 2)
+    ) |>
+      dplyr::rowwise(account)
 
-  expect_error(
-    summarize_with_margins(data, value = sum(value)),
-    "`.drop = FALSE` is not supported"
-  )
-})
+    discarded <- data |>
+      dplyr::ungroup() |>
+      summarize_with_margins(
+        total = sum(value),
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .id = "set"
+      )
+    retained <- data |>
+      dplyr::ungroup() |>
+      summarize_with_margins(
+        total = sum(value),
+        .by = account,
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .id = "set"
+      )
+
+    expect_false("account" %in% names(discarded))
+    expect_identical(discarded$total[discarded$set == 2L], 3)
+    expect_identical(retained$account[retained$set == 2L], c("A", "B"))
+    expect_identical(retained$total[retained$set == 2L], c(1, 2))
+  }
+)
+
+test_that(
+  "drop-false rewrites either discard empty groups or complete their keys",
+  {
+    data <- data.frame(
+      account = factor("A", levels = c("A", "B")),
+      region = "East",
+      value = 2
+    ) |>
+      dplyr::group_by(account, .drop = FALSE)
+
+    discarded <- data |>
+      dplyr::ungroup() |>
+      summarize_with_margins(
+        total = sum(value),
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .id = "set"
+      )
+    completed <- data.frame(
+      account = factor(c("A", "B"), levels = c("A", "B"))
+    ) |>
+      dplyr::left_join(dplyr::ungroup(data), by = "account") |>
+      dplyr::mutate(value = dplyr::coalesce(value, 0)) |>
+      summarize_with_margins(
+        total = sum(value),
+        .by = account,
+        .grouping = rollup(region),
+        .margin_label = NULL,
+        .id = "set"
+      )
+
+    expect_false("account" %in% names(discarded))
+    expect_identical(discarded$total[discarded$set == 2L], 2)
+    expect_identical(
+      as.character(completed$account[completed$set == 1L]),
+      c("A", "B")
+    )
+    expect_identical(completed$total[completed$set == 1L], c(2, 0))
+    expect_identical(completed$total[completed$set == 2L], c(2, 0))
+  }
+)
 
 test_that("summary expressions reject the removed .groups argument", {
   data <- data.frame(group = c("b", "a", "b"), value = 1:3)

--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -563,10 +563,30 @@ retail_sales |>
 ```
 
 A fixed grouping column also cannot appear in `.grouping`; call `ungroup()`
-first if that column should be rolled up instead. Row-wise inputs must
-likewise be ungrouped explicitly. Local groups created with `.drop = FALSE`
-are rejected because empty factor groups do not have a consistent SQL or
-lazy-backend equivalent:
+first if that column should be rolled up instead. Row-wise inputs are rejected
+because `ungroup()` discards their row-wise grouping. When named row-wise
+identifiers should remain fixed keys, make that choice explicit with `.by`:
+
+```{r}
+rowwise_report <- retail_sales |>
+  rowwise(year) |>
+  ungroup() |>
+  summarize_with_margins(
+    revenue = sum(revenue),
+    .by = year,
+    .grouping = rollup(region, store)
+  )
+
+rowwise_report
+```
+
+Local groups created with `.drop = FALSE` are rejected because marginplyr
+cannot preserve empty groups across local and lazy backends. Calling
+`ungroup()` discards empty groups, which is appropriate only when they do not
+belong in the result. To retain empty keys, complete the input before the
+Margin operation; [Complete absent keys before
+margins](https://sayuks.github.io/marginplyr/vignettes/completing_keys.html)
+follows [ADR 0011](https://github.com/sayuks/marginplyr/blob/main/design/adr/0011-keep-key-completion-outside-margin-operations.md):
 
 ```{r}
 #| label: drop-false-groups


### PR DESCRIPTION
Closes #515.\n\n## Summary\n- distinguish replacement, discarded row-wise grouping, and empty-key completion in grouped-input diagnostics\n- document the row-wise .by rewrite and ADR 0011 completion workflow\n- add public-seam remediation regression coverage\n\n## Validation\n- devtools::test(reporter = "summary")\n- jarl check .\n- lintr::lint_package()\n- Rscript .github/scripts/verify-context-budget.R\n- Rscript .github/scripts/verify-must-error.R\n- Rscript .github/scripts/verify-verifier-invocation.R