### PR TITLE
Align declared factor-level documentation with the Arrow exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,9 +62,12 @@
   `?summarize_with_margins`.
 * `.check_margin_label` controls only the half of the Margin label collision
   check that reads your data, so it defaults to `TRUE` for local data frames
-  and `FALSE` for lazy inputs. A label equal to a declared factor level is
-  rejected on every backend whatever this argument says, because the level is
-  already known from the column's metadata (#122).
+  and `FALSE` for lazy inputs. Where marginplyr holds factor-level metadata, a
+  label equal to a declared factor level is rejected whatever this argument
+  says. Arrow does not retain or restore those levels: it returns a factor
+  dimension with a non-missing Margin label as character, permits an unused
+  declared level, and refuses an observed collision only when
+  `.check_margin_label = TRUE` (#122, #492).
 * Added `.margin_label_position` to every Margin verb, taking `"last"` (the
   default) or `"first"`. It decides where a non-missing Margin label's
   synthetic level sits in a factor dimension's level order, and is a no-op for

--- a/R/summarize_with_margins.R
+++ b/R/summarize_with_margins.R
@@ -552,8 +552,11 @@
 #' condition -- preserving ordered status and placing a new synthetic level
 #' last by default or first when `.margin_label_position = "first"`. A label
 #' equal to any declared level, used or unused, is rejected before any
-#' grouping set is built, whatever `.check_margin_label` says: see that
-#' argument above.
+#' grouping set is built wherever marginplyr holds factor-level metadata,
+#' whatever `.check_margin_label` says. Arrow does not retain or restore those
+#' levels: a factor dimension with a non-missing label returns as character, so
+#' an unused declared level is allowed. On Arrow, an observed collision is
+#' refused only when `.check_margin_label = TRUE`: see that argument above.
 #' Reconstruction preserves the distinction between an observation that uses a
 #' factor NA level and an actually missing factor code.
 #'

--- a/man/expand_with_margins.Rd
+++ b/man/expand_with_margins.Rd
@@ -369,8 +369,11 @@ the backend allows it -- see \emph{Result class and attributes}, which owns that
 condition -- preserving ordered status and placing a new synthetic level
 last by default or first when \code{.margin_label_position = "first"}. A label
 equal to any declared level, used or unused, is rejected before any
-grouping set is built, whatever \code{.check_margin_label} says: see that
-argument above.
+grouping set is built wherever marginplyr holds factor-level metadata,
+whatever \code{.check_margin_label} says. Arrow does not retain or restore those
+levels: a factor dimension with a non-missing label returns as character, so
+an unused declared level is allowed. On Arrow, an observed collision is
+refused only when \code{.check_margin_label = TRUE}: see that argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 

--- a/man/nest_by_with_margins.Rd
+++ b/man/nest_by_with_margins.Rd
@@ -361,8 +361,11 @@ the backend allows it -- see \emph{Result class and attributes}, which owns that
 condition -- preserving ordered status and placing a new synthetic level
 last by default or first when \code{.margin_label_position = "first"}. A label
 equal to any declared level, used or unused, is rejected before any
-grouping set is built, whatever \code{.check_margin_label} says: see that
-argument above.
+grouping set is built wherever marginplyr holds factor-level metadata,
+whatever \code{.check_margin_label} says. Arrow does not retain or restore those
+levels: a factor dimension with a non-missing label returns as character, so
+an unused declared level is allowed. On Arrow, an observed collision is
+refused only when \code{.check_margin_label = TRUE}: see that argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 

--- a/man/nest_with_margins.Rd
+++ b/man/nest_with_margins.Rd
@@ -414,8 +414,11 @@ the backend allows it -- see \emph{Result class and attributes}, which owns that
 condition -- preserving ordered status and placing a new synthetic level
 last by default or first when \code{.margin_label_position = "first"}. A label
 equal to any declared level, used or unused, is rejected before any
-grouping set is built, whatever \code{.check_margin_label} says: see that
-argument above.
+grouping set is built wherever marginplyr holds factor-level metadata,
+whatever \code{.check_margin_label} says. Arrow does not retain or restore those
+levels: a factor dimension with a non-missing label returns as character, so
+an unused declared level is allowed. On Arrow, an observed collision is
+refused only when \code{.check_margin_label = TRUE}: see that argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 

--- a/man/summarize_with_margins.Rd
+++ b/man/summarize_with_margins.Rd
@@ -610,8 +610,11 @@ the backend allows it -- see \emph{Result class and attributes}, which owns that
 condition -- preserving ordered status and placing a new synthetic level
 last by default or first when \code{.margin_label_position = "first"}. A label
 equal to any declared level, used or unused, is rejected before any
-grouping set is built, whatever \code{.check_margin_label} says: see that
-argument above.
+grouping set is built wherever marginplyr holds factor-level metadata,
+whatever \code{.check_margin_label} says. Arrow does not retain or restore those
+levels: a factor dimension with a non-missing label returns as character, so
+an unused declared level is allowed. On Arrow, an observed collision is
+refused only when \code{.check_margin_label = TRUE}: see that argument above.
 Reconstruction preserves the distinction between an observation that uses a
 factor NA level and an actually missing factor code.
 


### PR DESCRIPTION
Closes #514.

## Summary

- Align the shared Margin-label reference with Arrow's character-result exception.
- Correct the development NEWS entry and regenerate the affected Rd files.

## Validation

- `testthat::test_local(".")`
- `jarl check .`
- `pkgload::load_all(".", quiet = TRUE); lintr::lint_package()`
- Focused Margin-label and documentation tests

## Review

Reviewed `f3e30da` against `fa06158`. Standards: no findings. Spec: no findings.