### PR TITLE
Separate .drop = FALSE guidance from its rendered diagnostic

### DIFF
--- a/vignettes/get_started.qmd
+++ b/vignettes/get_started.qmd
@@ -580,12 +580,10 @@ rowwise_report <- retail_sales |>
 rowwise_report
 ```
 
-Local groups created with `.drop = FALSE` are rejected because marginplyr
-cannot preserve empty groups across local and lazy backends. Calling
-`ungroup()` discards empty groups, which is appropriate only when they do not
-belong in the result. To retain empty keys, complete the input before the
-Margin operation; [Complete absent keys before
-margins](https://sayuks.github.io/marginplyr/vignettes/completing_keys.html)
+Whether empty keys belong in a report is a semantic choice. Remove the
+existing grouping when they do not; when they do, complete the input before the
+Margin operation so those keys take part in the calculation. [Complete absent
+keys before margins](https://sayuks.github.io/marginplyr/vignettes/completing_keys.html)
 follows [ADR 0011](https://github.com/sayuks/marginplyr/blob/main/design/adr/0011-keep-key-completion-outside-margin-operations.md):
 
 ```{r}


### PR DESCRIPTION
Closes #521

## Summary
- frame empty-key handling as a caller semantic choice
- retain the completion guide and ADR 0011 pointers without repeating the adjacent diagnostic

## Verification
- `Rscript .github/scripts/verify-context-budget.R`
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_file("tests/testthat/test-documentation.R")'`\n- `Rscript .github/scripts/verify-must-error.R`\n- `Rscript .github/scripts/verify-site.R`\n- `jarl check .`\n- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); lintr::lint_package()'`\n\n`R CMD check --no-manual .` reaches the test suite but currently fails on five unrelated existing expectations (four diagnostic snapshots and `expect_setequal(..., info = ...)`).\n\n## Review\nReviewed snapshot: `76840f3`.\n\n- Standards: 0 findings. The semantic contrast is permitted beside the rendered diagnostic; terminology and ADR citation comply with repository standards.\n- Spec: 0 findings. All acceptance criteria are met; no scope creep or incorrect behavior found.