### PR TITLE
Complete inspection predicate remediation

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -96,9 +96,8 @@ is_unsupported_predicate <- function(cnd) {
 # condition, kept so the caller reads why tidyselect refused.
 #
 # The blamed call is left to `with_margin_error_call()`, which every selection
-# site reaching this runs under: what it puts there is the Margin verb the
-# caller wrote, which is what CONTEXT.md's *Condition context* asks for and
-# what no frame here could name.
+# site reaching this runs under: it names the Margin verb or
+# `inspect_grouping()` call the caller wrote, which no frame here could name.
 #
 # The refusal stands rather than reading the types, ADR 0020 being what the
 # read would cross.

--- a/tests/testthat/test-inspect-grouping.R
+++ b/tests/testthat/test-inspect-grouping.R
@@ -520,6 +520,14 @@ test_that("inspection scopes predicate collection guidance to Margin verbs", {
   ))
 
   local <- dplyr::collect(remote)
+  inspection <- inspect_grouping(
+    local,
+    .grouping = rollup(where(is.character))
+  )
+  expect_identical(
+    inspection,
+    inspect_grouping(local, .grouping = rollup(group))
+  )
   expect_error(
     summarize_with_margins(
       local,


### PR DESCRIPTION
Closes #523.\n\n## Summary\n- re-run predicate inspection after collecting the SQLite fixture\n- assert the remediated Grouping plan matches name selection\n- correct the selection-predicate condition comment's caller scope