### PR TITLE
Fix dtplyr share joins for fixed-key names containing backticks

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -2047,7 +2047,7 @@ share_adapter <- function(backend_kind) {
     duckdb = execute_dbplyr_shares,
     postgres = execute_dbplyr_shares,
     sql = execute_dbplyr_shares,
-    dtplyr = execute_row_matched_shares,
+    dtplyr = execute_dtplyr_shares,
     other = execute_row_matched_shares
   )
   adapter <- adapters[[backend_kind]]
@@ -2072,6 +2072,22 @@ execute_row_matched_shares <- function(operation,
     set_id_name = set_id_name,
     kind = kind,
     sql_join = FALSE
+  )
+}
+
+execute_dtplyr_shares <- function(operation,
+                                  result,
+                                  requests,
+                                  set_id_name,
+                                  kind) {
+  apply_joined_shares(
+    result,
+    requests = requests,
+    plan = operation$plan,
+    set_id_name = set_id_name,
+    kind = kind,
+    sql_join = FALSE,
+    join_name_rewriter = dtplyr_join_names
   )
 }
 
@@ -2543,7 +2559,8 @@ apply_joined_shares <- function(result,
                                 plan,
                                 set_id_name,
                                 kind,
-                                sql_join) {
+                                sql_join,
+                                join_name_rewriter = NULL) {
   rule <- share_kind_rule(kind)
   target_ids <- rule$target_ids(plan)
   own_denominator_ids <- plan$set_ids[is.na(target_ids)]
@@ -2604,12 +2621,40 @@ apply_joined_shares <- function(result,
         y_as = "RHS"
       )
     } else {
+      escaped_join_names <- if (is.null(join_name_rewriter)) {
+        NULL
+      } else {
+        join_name_rewriter(
+          join_names,
+          used_names = c(result_names, denominator_names, key_names)
+        )
+      }
+      if (!is.null(escaped_join_names)) {
+        result <- dplyr::rename(
+          result,
+          !!!rlang::set_names(rlang::syms(join_names), escaped_join_names)
+        )
+        mapping <- dplyr::rename(
+          mapping,
+          !!!rlang::set_names(rlang::syms(join_names), escaped_join_names)
+        )
+        join_names <- unname(escaped_join_names)
+      }
       result <- dplyr::left_join(
         result,
         mapping,
         by = join_names,
         na_matches = "na"
       )
+      if (!is.null(escaped_join_names)) {
+        result <- dplyr::rename(
+          result,
+          !!!rlang::set_names(
+            rlang::syms(join_names),
+            names(escaped_join_names)
+          )
+        )
+      }
     }
   }
 
@@ -2674,6 +2719,22 @@ apply_joined_shares <- function(result,
     result <- dplyr::select(result, -dplyr::all_of(internal_names))
   }
   result
+}
+
+# dtplyr passes a join key through data.table's `on` parser, which splits a
+# literal backtick in the key name. The staged result owns both sides here, so
+# renaming them only for that join avoids the parser without changing the
+# caller's input or the returned columns.
+dtplyr_join_names <- function(join_names, used_names) {
+  if (!any(grepl("`", join_names, fixed = TRUE))) {
+    return(NULL)
+  }
+  escaped <- new_margin_internal_names(
+    length(join_names),
+    used_names = used_names,
+    prefix = "..marginplyr_dtplyr_join_key_"
+  )
+  stats::setNames(escaped, join_names)
 }
 
 # What a kind contributes to the join above is two entries of

--- a/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
+++ b/design/adr/0014-select-parent-share-adapters-from-prepared-backend-kind.md
@@ -6,6 +6,27 @@ chosen by looking up the backend kind that the Margin operation already
 prepared — never by inspecting the class of the staged ordinary-summary
 result, and never by a chain of capability predicates rebuilt at this seam.
 
+## Amendment: dtplyr rewrites a literal-backtick join key
+
+The ratio-adapter table's Row-matched row no longer includes `dtplyr`.
+`execute_dtplyr_shares()` is a distinct adapter which supplies the one behavior
+its join needs: when any staged join key contains a literal backtick, it gives
+both join relations collision-free internal key names and restores the left
+relation's original names immediately afterwards. The shared mapping, join,
+ratio, and cleanup remain shared.
+
+This is a property of dtplyr's join translation, not of Grouping-plan
+preparation or the staged result's class. The adapter selects it from the
+already prepared backend kind, and the temporary names neither reach the
+caller nor rename their input. #540 establishes the failing dtplyr path.
+
+The ratio table's first row now reads:
+
+| Adapter | Backend kinds | What it adds to the shared work |
+|---|---|---|
+| Row-matched | `local`, `other` | Nothing |
+| dtplyr | `dtplyr` | Rewrites a literal-backtick join key temporarily |
+
 ## Amendment: the samplers are source checkers, and none of them samples
 
 The decision above stands in full: there are still two lookups keyed on the

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -381,16 +381,18 @@ adapters, and each says only what its backends do differently:
 
 | Adapter | Backend kinds | Difference from the shared work |
 |---|---|---|
-| Local | `local` | Checks materialized source types first |
+| Row-matched | `local`, `other` | Nothing |
+| dtplyr | `dtplyr` | Temporarily rewrites a literal-backtick join key |
 | General dbplyr | `duckdb`, `postgres`, `sql` | Missing-safe `sql_on` join |
-| Lazy non-SQL | `dtplyr`, `other` | Nothing |
 
-The lazy non-SQL adapter adding nothing is the point rather than an
-oversight: it names the contract that a lazy non-SQL backend joins exactly as
-local data does but cannot have its source types checked first, because
-nothing is materialized to check. Its validation happens earlier, inside the
-ordinary summary. Collapsing it into the local adapter would make that
-difference invisible at the seam that has to honour it.
+The Row-matched adapter adding nothing is the point rather than an oversight:
+it names the contract that a lazy non-SQL backend joins exactly as local data
+does. `other` cannot have its source types checked first because nothing is
+materialized to check; its validation happens earlier, inside the ordinary
+summary. dtplyr takes that same validation path, but its join translation needs
+the temporary rewrite where a fixed key contains a literal backtick. Collapsing
+either difference into another adapter would make it invisible at the seam that
+has to honour it.
 
 Arrow is rejected at the immediately earlier executor boundary because no
 ordinary-summary query may be staged for a valid Arrow contextual-share
@@ -548,7 +550,7 @@ Direct field reads are confined to:
   kind, for the one that asserts it may check nothing, and its dialect, for
   the one that asks whether that dialect converts — and the input it prepared;
   and
-- the two contextual-share adapters, which read the Grouping plan and
+- the three contextual-share adapters, which read the Grouping plan and
   nothing else.
 
 The native and portable Grouping adapters receive the specific derived values

--- a/tests/testthat/test-share-backends.R
+++ b/tests/testthat/test-share-backends.R
@@ -2404,6 +2404,91 @@ test_that("dtplyr Total shares match local results", {
   expect_equal(sum(unpartitioned$revenue_share), 2)
 })
 
+test_that("dtplyr shares join fixed keys containing literal backticks", {
+  skip_if_suggest_absent("dtplyr")
+  data <- data.table::as.data.table(setNames(
+    data.frame(
+      c("p", "p", "q", "q"),
+      c("x", "y", "x", "y"),
+      c(1L, 3L, 2L, 2L)
+    ),
+    c("a`b", "group", "value")
+  ))
+  original <- data.table::copy(data)
+  summarize <- function(verb, source, ...) {
+    verb(
+      source,
+      ...
+    )
+  }
+  arrange_result <- function(result) {
+    dplyr::arrange(result, .data[["a`b"]], group)
+  }
+
+  for (verb in list(summarize_with_margins, summarise_with_margins)) {
+    expected <- arrange_result(summarize(
+      verb,
+      as.data.frame(data),
+      total = sum(value),
+      parent = share_of_parent(total),
+      whole = share_of_total(total),
+      .by = dplyr::all_of("a`b"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    ))
+    query <- summarize(
+      verb,
+      dtplyr::lazy_dt(data),
+      total = sum(value),
+      parent = share_of_parent(total),
+      whole = share_of_total(total),
+      .by = dplyr::all_of("a`b"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+
+    expect_s3_class(query, "dtplyr_step")
+    expect_equal(
+      as.data.frame(arrange_result(dplyr::collect(query))),
+      as.data.frame(expected)
+    )
+    expect_identical(as.character(dplyr::tbl_vars(query)), names(expected))
+  }
+
+  expect_identical(data, original)
+
+  empty <- setNames(data.frame(character(), character()), c("`", "group"))
+  for (verb in list(summarize_with_margins, summarise_with_margins)) {
+    expected <- summarize(
+      verb,
+      empty,
+      total = dplyr::n(),
+      parent = share_of_parent(total),
+      whole = share_of_total(total),
+      .by = dplyr::all_of("`"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+    query <- summarize(
+      verb,
+      dtplyr::lazy_dt(empty),
+      total = dplyr::n(),
+      parent = share_of_parent(total),
+      whole = share_of_total(total),
+      .by = dplyr::all_of("`"),
+      .grouping = rollup(group),
+      .margin_label = NULL
+    )
+
+    expect_s3_class(query, "dtplyr_step")
+    expect_equal(
+      as.data.frame(dplyr::collect(query)),
+      as.data.frame(expected)
+    )
+    expect_identical(as.character(dplyr::tbl_vars(query)), names(expected))
+  }
+})
+
 # The two backends below answer an injected share selection today, and for
 # reasons that are not the local backend's: dtplyr carries the caller's call as
 # text, which no second defusal reads, and a lazy backend wraps no source in the


### PR DESCRIPTION
## Summary

- Use a dtplyr-specific contextual-share adapter to rewrite literal-backtick join keys only while joining staged denominators.
- Restore caller-visible names immediately and keep the source data.table unchanged.
- Add public-seam regressions for populated and zero-row inputs, both share helpers, and both summary verb spellings.

## Review

- Standards review raised two findings: the adapter seam and stale architecture documentation. Both are fixed in 0272022049cedca32dcff875166ea39a45d1566a.
- Spec review found no issues.

## Verification

- Review-ready check: 0272022049cedca32dcff875166ea39a45d1566a
  - full testthat suite: passed
  - jarl: passed
  - package-aware lintr: passed
  - source-tarball R CMD check: 0 ERRORs, 0 WARNINGs, 0 NOTEs

Closes #540