### PR TITLE
Fix Arrow Margin ordering with duplicate grouping bits

### DIFF
--- a/R/margin-operation.R
+++ b/R/margin-operation.R
@@ -504,9 +504,15 @@ margin_order_terms <- function(plan,
     recursive = FALSE
   )
 
+  seen_margin_ids <- list()
   for (dimension in plan$dimensions) {
-    bit <- margin_grouping_bit_expr(plan, dimension, sort_id)
-    if (!is.null(bit)) {
+    margin_ids <- margin_grouping_bit_ids(plan, dimension)
+    if (
+      !is.null(sort_id) &&
+        !is.null(margin_ids) &&
+        !any(vapply(seen_margin_ids, identical, logical(1), margin_ids))
+    ) {
+      bit <- margin_grouping_bit_expr(sort_id, margin_ids)
       terms <- c(terms, list(
         if (identical(sort, "first")) {
           rlang::expr(dplyr::desc(!!bit))
@@ -514,6 +520,7 @@ margin_order_terms <- function(plan,
           bit
         }
       ))
+      seen_margin_ids <- c(seen_margin_ids, list(margin_ids))
     }
     terms <- c(
       terms,
@@ -553,13 +560,9 @@ margin_missing_last_expr <- function(column) {
   ))
 }
 
-# One dimension's Grouping bit, read from the Grouping set identifier the
-# adapter left in the result. `NULL` when the plan makes the bit constant, so
-# that a term with nothing to order by is not emitted.
-margin_grouping_bit_expr <- function(plan, dimension, sort_id) {
-  if (is.null(sort_id)) {
-    return(NULL)
-  }
+# The Grouping-set occurrences where one dimension is absent. `NULL` when the
+# plan makes its Grouping bit constant, so a key term would order nothing.
+margin_grouping_bit_ids <- function(plan, dimension) {
   margin_ids <- as.integer(
     plan$set_ids[plan$grouping_masks[, dimension] == 1L]
   )
@@ -569,7 +572,14 @@ margin_grouping_bit_expr <- function(plan, dimension, sort_id) {
   ) {
     return(NULL)
   }
+  margin_ids
+}
 
+# One Grouping bit read from the identifier the adapter left in the result.
+# `margin_order_terms()` emits this only once for equal occurrence ids: the
+# repeated term is redundant by ADR 0018 and Arrow cannot materialize two
+# expressions under the same internal field name.
+margin_grouping_bit_expr <- function(sort_id, margin_ids) {
   rlang::expr(dplyr::if_else(
     (!!margin_column_pronoun(sort_id)) %in% !!margin_ids,
     1L,

--- a/tests/testthat/test-margin-order.R
+++ b/tests/testthat/test-margin-order.R
@@ -1469,28 +1469,67 @@ test_that("Arrow orders a factor fixed key, which holds no Margin label", {
   }
 })
 
-test_that("Arrow orders a composite factor dimension under expansion", {
+test_that("Arrow orders repeated nonconstant Grouping bits", {
   skip_if_suggest_absent("arrow")
 
-  data <- margin_order_data()
-  data$region <- factor(data$region)
-  data$store <- factor(data$store)
-  result <- dplyr::collect(expand_with_margins(
-    arrow::as_arrow_table(data),
-    .grouping = rollup(c(region, store)),
-    .margin_label = NULL,
-    .sort = "last"
-  ))
+  groupings <- list(
+    composite = rlang::expr(rollup(grouping_set(a, b))),
+    explicit = rlang::expr(grouping_sets(grouping_spec(a, b), grouping_set()))
+  )
+  inputs <- list(
+    empty = data.frame(a = character(), b = character(), units = double()),
+    populated = data.frame(
+      a = c("East", "West", "East"),
+      b = c("s1", "s2", "s3"),
+      units = c(1, 2, 3)
+    )
+  )
 
-  # A composite dimension's columns share one Grouping bit, so the margin rows
-  # come last as a block rather than one per column.
-  expect_true(is.factor(result$region))
-  expect_identical(
-    as.character(result$region),
-    c(rep("East", 4L), rep("West", 4L), rep(NA_character_, 4L))
-  )
-  expect_identical(
-    as.character(result$store),
-    c("s1", "s2", NA, NA, "s3", "s4", NA, NA, rep(NA_character_, 4L))
-  )
+  for (grouping_name in names(groupings)) {
+    grouping <- groupings[[grouping_name]]
+    for (input_name in names(inputs)) {
+      input <- inputs[[input_name]]
+      for (sort in c("first", "last")) {
+        expected_summary <- rlang::inject(summarize_with_margins(
+          input,
+          units = sum(units),
+          .grouping = !!grouping,
+          .sort = sort
+        ))
+        summary <- rlang::inject(summarize_with_margins(
+          arrow::as_arrow_table(input),
+          units = sum(units),
+          .grouping = !!grouping,
+          .sort = sort
+        ))
+        expect_s3_class(summary, "arrow_dplyr_query")
+        collected_summary <- dplyr::collect(summary)
+        expect_identical(names(collected_summary), names(expected_summary))
+        expect_identical(
+          as.data.frame(collected_summary),
+          expected_summary,
+          info = paste(grouping_name, input_name, sort, "summary")
+        )
+
+        expected_expansion <- rlang::inject(expand_with_margins(
+          input,
+          .grouping = !!grouping,
+          .sort = sort
+        ))
+        expansion <- rlang::inject(expand_with_margins(
+          arrow::as_arrow_table(input),
+          .grouping = !!grouping,
+          .sort = sort
+        ))
+        expect_s3_class(expansion, "arrow_dplyr_query")
+        collected_expansion <- dplyr::collect(expansion)
+        expect_identical(names(collected_expansion), names(expected_expansion))
+        expect_identical(
+          as.data.frame(collected_expansion),
+          expected_expansion,
+          info = paste(grouping_name, input_name, sort, "expansion")
+        )
+      }
+    }
+  }
 })


### PR DESCRIPTION
Closes #541\n\n## Verification\n\n- Focused Arrow Margin-order regression test\n- Review-ready check: cfb7e6081619ddacbb60ad7e87016bb74a59ddde\n  - full testthat suite: passed\n  - jarl: passed\n  - package-aware lintr: passed\n  - source-tarball R CMD check: 0 errors, 0 warnings, 0 notes\n\n## Review\n\nPending two-axis review.