### PR TITLE
Document focused mutation testing findings

### DIFF
--- a/investigation/focused-mutation-testing-margin-semantics.md
+++ b/investigation/focused-mutation-testing-margin-semantics.md
@@ -276,11 +276,11 @@ unless a future adapter separates the paths.
 2. Run a second focused campaign for Margin order and Margin label semantics,
    then a separately isolated backend campaign using the generated
    one-backend matrix. Do not infer backend coverage from this local campaign.
-3. Keep mutation testing opt-in for now. `muttest` found a real gap quickly,
-   but the observed campaign took roughly seven minutes beyond setup and
-   required workarounds for worker filtering, queue timeout accounting, and
-   JSON-result printing. Pinning 0.3.0 plus a repository harness would itself
-   become maintenance surface.
+3. The 2026-09-12 evidence did not justify a permanent mutation-testing check.
+   `muttest` found a real gap quickly, but the observed campaign took roughly
+   seven minutes beyond setup and required workarounds for worker filtering,
+   queue timeout accounting, and JSON-result printing. Pinning 0.3.0 plus a
+   repository harness would itself become maintenance surface.
 4. Reconsider a manual or scheduled CI job after the tool issues are resolved,
    or after two more focused campaigns show recurring unique findings. Do not
    add `muttest` to package Imports or Suggests; install it as quality-tooling

--- a/investigation/focused-mutation-testing-margin-semantics.md
+++ b/investigation/focused-mutation-testing-margin-semantics.md
@@ -1,0 +1,324 @@
+# Focused mutation testing of margin semantics
+
+Investigated: 2026-09-12
+
+## Question
+
+Can the existing marginplyr test suite detect meaningful implementation errors
+in Grouping-plan expansion, denominator mapping, and share value rules? The
+campaign sought useful survivors, not the highest possible mutation score.
+
+Production code and the durable test suite were not changed. Tooling, mutated
+copies, JSON reports, and temporary validation tests lived under
+`/private/tmp`.
+
+## Repository and baseline
+
+The source state was commit `bc2d33ff7251d7c03fdacd066cc2097c1ca23f96`
+with a clean working tree. The observed environment was:
+
+- R 4.6.1 on Darwin 25.6.0 arm64;
+- testthat 3.3.2, pkgload 1.5.3, dplyr 1.2.1, and dbplyr 2.6.0;
+- Arrow 25.0.1, dtplyr 1.3.3, DuckDB 1.5.5, and RSQLite 3.53.3.
+
+`DESCRIPTION` selects testthat edition 3. `tests/testthat.R` runs
+`testthat::test_check("marginplyr")`. The development boundary in
+`tools/review-ready-check-lib.R` runs:
+
+```r
+testthat::test_local(".", reporter = "summary", stop_on_failure = TRUE)
+```
+
+The same command passed before mutation. Its elapsed time was 79.356 seconds.
+The repository additionally separates source-tree tests from source-tarball
+`R CMD check`, depends-only checks, optional-backend jobs, and structural suite
+coverage in `.github/workflows/R-CMD-check.yaml` and
+`.github/workflows/release-matrix.yaml`. A green local suite therefore does not
+replace the release matrix, but it is the correct baseline for this campaign.
+
+## Approach
+
+### Tool choice
+
+The primary-source comparison is recorded separately in
+[`investigation/r-package-mutation-testing-tools.md`](r-package-mutation-testing-tools.md).
+
+The campaign used `muttest` 0.3.0, installed only in
+`/private/tmp/marginplyr-mutation-lib`. It was not added to `DESCRIPTION`.
+`muttest_plan()` allows source files and operators to be named explicitly, and
+the resulting data-frame plan can be restricted by source location before any
+mutant runs. `PackageCopyStrategy(symlink = FALSE)` gives every mutant its own
+disposable package copy, and the JSON reporter preserves source location,
+operator, replacement, and result.
+
+`mutator` was evaluated but not selected. Its coverage-guided subprocess model
+and independent hang result are useful for broad exploratory sampling, but its
+public interface generates a fixed mutator set across package files and then
+narrows by excluded files or sampling. That is a weaker fit for the requirement
+to declare a small semantic scope first and account for every mutant in it.
+Its result path also treats several non-test errors as killed, whereas this
+campaign needed ERROR to remain separate.
+
+### Mutation scope
+
+The selected code was:
+
+- `R/grouping-plan.R`: `compile_grouping_spec_impl()`,
+  `expand_grouping_family()`, `resolve_grouping_set()`,
+  `expand_grouping_sets()`, `resolve_grouping_units()`, `expand_rollup()`,
+  `expand_cube()`, and `expand_grouping_product()`;
+- `R/share.R`: `grand_total_occurrence_ids()`, `total_set_ids()`, and
+  `parent_set_ids()`;
+- `R/share.R`: the R-side value expression built by
+  `apply_joined_shares()`.
+
+These functions own grouping-set membership and order, duplicate handling,
+Grouping masks, Grand total set discovery, strictly-less-detailed parent
+selection, own-denominator rows, and missing/zero share behavior. ADR 0008,
+ADR 0010, and ADR 0017 make these observable semantics rather than incidental
+implementation details.
+
+The operators were:
+
+- comparison replacement (`==`/`!=`, `<`/`<=`/`>`, `>`/`>=`/`<`);
+- logical replacement (`&&`/`||`, `|`/`&`);
+- condition negation;
+- numeric literal increment and decrement;
+- unary-negation removal where the target block contained ordinary negation.
+
+Unary-negation removal was deliberately excluded from the tidy-eval-heavy share
+value block because it also matches each `!` in `!!` injection. Those mutants
+mostly test parser/metaprogramming artifacts, not plausible Boolean errors.
+Index mutators were not layered on: numeric-literal mutations already exercised
+the consequential `[[1L]]` boundaries, while a broad index pass would mostly
+produce out-of-range errors rather than semantic alternatives.
+
+### Isolation and test execution
+
+Each mutant was written only into a deep disposable package copy. The original
+file was never rewritten, so interruption required no restoration step.
+
+The first pass used existing tests related to the mutated module:
+
+- Grouping-plan mutants:
+  `grouping-plan`, `grouping-interface`, and
+  `metamorphic-margin-semantics`;
+- share mutants: `share`.
+
+A focused-test kill is necessarily a full-suite kill. Every focused SURVIVED or
+ERROR was then rerun against all of `tests/testthat`. The final SURVIVED label
+therefore means the complete baseline suite passed with the mutant.
+
+Four workers were used. The intended focused timeout was 60 seconds and the
+full-suite timeout 150 seconds. `muttest` starts a mirai timeout when a task is
+submitted rather than when a queued worker begins it, so the first large batch
+reported 19 queue-wait timeouts. The affected mutants were rerun in a smaller
+batch with queue allowance; all received ordinary outcomes. A timeout was never
+accepted as a mutation result.
+
+## Results
+
+| Result | Count |
+|---|---:|
+| Total mutants | 53 |
+| KILLED | 50 |
+| SURVIVED | 3 |
+| Final TIMEOUT / ERROR | 0 |
+| TEST GAP | 1 |
+| EQUIVALENT MUTANT | 2 |
+| IRRELEVANT / UNREACHABLE | 0 |
+| INCONCLUSIVE | 0 |
+
+The reference mutation score is 50 / 53 = 94.3%. It is not the quality
+judgment: one of the three survivors exposed a real documented-contract gap,
+while the other two cannot be usefully killed.
+
+## Survivor triage
+
+### `R/grouping-plan.R:910`, `> 0L` to `>= 0L`
+
+Classification: **EQUIVALENT MUTANT**.
+
+The only newly entered state is `length(dimensions) == 0L`. In that state
+`masks` has zero columns, and assigning the zero-length value
+`as.integer(!dimensions %in% normalized[[i]])` to each zero-column row is a
+no-op. The original and mutant matrices are identical. Empty
+`grouping_set()` and empty `grouping_spec()` are valid and compile to the empty
+grouping set; ADR 0008 and `test-grouping-plan.R` establish that contract.
+Nothing observable differs, so a test written merely to execute the mutant
+branch would pin an implementation detail.
+
+### `R/share.R:3044`, `candidates > i` to `candidates >= i`
+
+Classification: **EQUIVALENT MUTANT**.
+
+Before this filter, every candidate already satisfies
+`length(parent) < length(child)`. The current set at index `i` has the same
+length as itself and can therefore never be in `candidates`. Including or
+excluding `i` gives the same vector for every valid plan. ADR 0010 requires the
+immediate strictly less detailed set and requires duplicate occurrences to be
+skipped; the earlier strict-length predicate is the part that enforces that
+contract. The mutated filter is redundant under its established invariant.
+
+### `R/share.R:2685`, first missingness `|` to `&`
+
+Classification: **TEST GAP**.
+
+The original inner condition is equivalent to:
+
+```r
+is.na(source) | is.na(denominator) | denominator == 0
+```
+
+The mutant uses `&` between the first two terms. For `NA_real_`, ordinary R
+division still produces `NA_real_`, which hid the mutation. For a local `NaN`
+numerator and a finite nonzero denominator, however, the original selects the
+explicit `NA_real_` branch while the mutant evaluates `NaN / denominator` and
+returns `NaN`. `is.na()` accepts both, but `is.nan()` and `identical()` expose
+the contract change.
+
+ADR 0010 says a missing numerator produces `NA_real_` and explicitly says that
+local `NaN` is treated as missing. The `share_of_parent()` reference in
+`R/share.R` repeats the same value contract. The mutant is therefore observable
+and contract-relevant.
+
+## Confirmed test gap
+
+### Local `NaN` numerator is not asserted to normalize to `NA_real_`
+
+Severity: **Medium**. The numerical value remains missing to `is.na()`, but the
+package explicitly promises normalization and callers can distinguish `NaN`
+from `NA_real_`. The difference can propagate into serialization, reporting,
+and downstream `is.nan()` logic.
+
+Minimal public reproducer:
+
+```r
+result <- summarize_with_margins(
+  data.frame(group = c("a", "b")),
+  total = if (dplyr::n() == 1L) NaN else 2,
+  share = share_of_parent(total),
+  .grouping = rollup(group),
+  .margin_label = NULL
+)
+
+detail <- result$share[!is.na(result$group)]
+```
+
+The unmutated package returned:
+
+```r
+c(NA_real_, NA_real_)
+```
+
+The mutant returned:
+
+```r
+c(NaN, NaN)
+```
+
+A temporary assertion
+`expect_identical(detail, c(NA_real_, NA_real_))` passed on the original and
+failed on that mutant.
+
+The closest existing test, “Parent-share values handle missing, zero,
+negative, and empty summaries”, constructs `NA_real_` rather than `NaN` and
+uses `expect_true(is.na(...))`. Both choices admit the mutant. Other exact
+missing-value assertions cover missing and zero denominators, not the local
+`NaN`-numerator normalization.
+
+Recommended durable test: add one local Parent-share case that produces a
+`NaN` source only on detail rows while keeping the parent source finite, then
+assert the detail vector with `expect_identical(..., NA_real_)` and optionally
+assert `!any(is.nan(...))`. Put it beside the existing Parent-share value-rule
+test. ADR 0017 reuses ADR 0010's value rules for Total shares, but the expression
+is shared; a duplicate Total-share test would add little defect-detection value
+unless a future adapter separates the paths.
+
+## Execution and backend artifacts
+
+- Nineteen initial TIMEOUT results were worker-queue artifacts, not mutant
+  hangs. Smaller reruns classified every one.
+- Four focused runs produced reporter-level RuntimeError results from mutants
+  that disrupted the narrow test run. Full-suite reruns classified all four as
+  KILLED; none remained an execution error.
+- `FileTestStrategy` in muttest 0.3.0 failed in a mirai worker because its
+  internal `.escape_regex()` helper was not resolved after serialization. A
+  campaign-local strategy using an explicit filter was required.
+- Printing a `muttest_result` backed only by `JSONMutationReporter` attempted
+  to call a missing reporter `print()` method. The JSON file itself was valid.
+- All optional backends named above were installed for the baseline. No final
+  survivor was attributable to an absent backend. Arrow rejects shares by
+  contract before this value expression, so the confirmed gap is specifically
+  local R behavior, not an Arrow coverage claim.
+
+## Code deliberately outside this campaign
+
+- Backend adapters, dialect probing, query audit, and lazy execution were
+  excluded. Mutating them safely requires the release matrix's one-backend
+  environments and Sent-query assertions; a local all-backends run would mix
+  genuine gaps with dialect and availability artifacts.
+- Static expression analysis and diagnostic construction were excluded from
+  this first semantic pass. Their large syntax surface needs tailored
+  call-shape operators; generic mutation would create many malformed-language
+  and message-only mutants.
+- Margin order, Margin label collision handling, factor restoration, and
+  condition deduplication remain meaningful separate campaigns. Including them
+  here would make the survivor set span unrelated contracts.
+- Export wrappers, constructors that only capture quosures, package data,
+  generated documentation, and test/helper code were excluded because they are
+  not the production decision points this campaign was designed to assess.
+
+## Recommended next actions
+
+1. Add the confirmed local-`NaN` normalization test. It has high
+   defect-detection value, a two-row fixture, and low maintenance cost.
+2. Run a second focused campaign for Margin order and Margin label semantics,
+   then a separately isolated backend campaign using the generated
+   one-backend matrix. Do not infer backend coverage from this local campaign.
+3. Keep mutation testing opt-in for now. `muttest` found a real gap quickly,
+   but the observed campaign took roughly seven minutes beyond setup and
+   required workarounds for worker filtering, queue timeout accounting, and
+   JSON-result printing. Pinning 0.3.0 plus a repository harness would itself
+   become maintenance surface.
+4. Reconsider a manual or scheduled CI job after the tool issues are resolved,
+   or after two more focused campaigns show recurring unique findings. Do not
+   add `muttest` to package Imports or Suggests; install it as quality-tooling
+   infrastructure if it becomes permanent.
+
+## Complete mutant disposition
+
+`K` means KILLED and `S` means SURVIVED before semantic triage.
+
+| Block | Location | Mutations and result |
+|---|---|---|
+| Plan normalization | `R/grouping-plan.R:864:15` | numeric `1L` to `0` K; to `2` K |
+| Plan normalization | `R/grouping-plan.R:866:38` | `|` to `&` K |
+| Plan normalization | `R/grouping-plan.R:868:7,27` | negate condition K; `&&` to `||` K |
+| Plan normalization | `R/grouping-plan.R:882:56` | numeric `1L` to `0` K; to `2` K |
+| Plan normalization | `R/grouping-plan.R:898:7` | negate condition K |
+| Plan normalization | `R/grouping-plan.R:899:13` | remove `!` K |
+| Plan normalization | `R/grouping-plan.R:910:7,26` | negate condition K; `>` to `<` K; `>` to `>=` S |
+| Plan normalization | `R/grouping-plan.R:912:32` | remove `!` K |
+| Set expansion | `R/grouping-plan.R:975:13` | negate condition K |
+| Unit expansion | `R/grouping-plan.R:990:13` | negate condition K |
+| Unit expansion | `R/grouping-plan.R:999:13,26` | negate condition K; `==` to `!=` K |
+| Unit expansion | `R/grouping-plan.R:1008:7,21` | negate condition K; `==` to `!=` K |
+| Rollup expansion | `R/grouping-plan.R:1019:11,13` | negate condition K; `==` to `!=` K |
+| Cube expansion | `R/grouping-plan.R:1038:11,25` | negate condition K; `==` to `!=` K |
+| Product expansion | `R/grouping-plan.R:1045:7,30` | negate condition K; `==` to `!=` K |
+| Product expansion | `R/grouping-plan.R:1050:19` | negate condition K |
+| Share value | `R/share.R:2666:11,30` | negate condition K; `==` to `!=` K |
+| Share value | `R/share.R:2675:13` | numeric `1` to `0` K; to `2` K |
+| Share value | `R/share.R:2676:13` | numeric `1` to `0` K; to `2` K |
+| Share value | `R/share.R:2683:11` | numeric `1` to `0` K; to `2` K |
+| Share value | `R/share.R:2685:52` | first `|` to `&` S |
+| Share value | `R/share.R:2686:59` | second `|` to `&` K |
+| Share value | `R/share.R:2687:54,57` | `==` to `!=` K; numeric `0` to `-1` K; to `1` K |
+| Grand total mapping | `R/share.R:3010:39` | `==` to `!=` K |
+| Total denominator | `R/share.R:3021:7,31` | negate condition K; `==` to `!=` K |
+| Total denominator | `R/share.R:3024:10` | remove `!` K |
+| Parent candidate | `R/share.R:3040:24,40` | `<` to `<=` K; `<` to `>` K; `&&` to `||` K |
+| Parent candidate | `R/share.R:3042:15` | numeric `1L` to `0` K; to `2` K |
+| Parent candidate | `R/share.R:3044:41` | `>` to `<` K; `>` to `>=` S |
+| Parent candidate | `R/share.R:3045:9,28` | negate condition K; `>` to `<` K; `>` to `>=` K |

--- a/investigation/r-package-mutation-testing-tools.md
+++ b/investigation/r-package-mutation-testing-tools.md
@@ -1,0 +1,156 @@
+# R package mutation testing tools
+
+Investigated: 2026-09-12
+
+## Question
+
+Which source-mutation tool and execution method best support a focused
+marginplyr campaign whose purpose is to inspect every survivor, rather than to
+maximize a mutation score?
+
+## Sources and versions
+
+- `muttest` 0.3.0, released on CRAN on 2026-07-21. Its DESCRIPTION requires
+  R >= 4.1.0 and does not impose an upper bound; CRAN also advertised an
+  `r-devel` binary. The official release source is tag
+  [`v0.3.0`](https://github.com/jakubsob/muttest/tree/v0.3.0), commit
+  [`1c8effccb7d73c1da25d75491d5948ce94c613cc`](https://github.com/jakubsob/muttest/commit/1c8effccb7d73c1da25d75491d5948ce94c613cc),
+  and the release metadata is on
+  [CRAN](https://CRAN.R-project.org/package=muttest). These metadata make it a
+  supported candidate for R 4.6; the campaign still has to prove the actual
+  package/tool combination on its R 4.6.1 host.
+- `mutator` 0.2.1 was released on CRAN on 2026-08-02. The evaluated official
+  development source was commit
+  [`9f5e703c7b2f6bbae3fd26a68eee5dc3b9275707`](https://github.com/PRL-PRG/mutator/commit/9f5e703c7b2f6bbae3fd26a68eee5dc3b9275707)
+  (`DESCRIPTION` 0.2.2.9000); release metadata is on
+  [CRAN](https://CRAN.R-project.org/package=mutator). Its engine requires
+  C++17.
+- rOpenSci `autotest` was not a substitute: its documentation defines
+  “mutation” as mutating *inputs* scraped from examples, not mutating
+  production source and running the existing suite
+  ([official documentation](https://docs.ropensci.org/autotest/)).
+
+## Comparison
+
+`muttest` builds an explicit plan from caller-selected source files and
+caller-selected mutators. A plan is an ordinary data frame and may be subset
+before execution. Its supplied families cover arithmetic swaps, comparison
+direction and strict/non-strict boundaries, logical swaps, condition negation,
+boolean/NA/numeric/string literals, index shifts, explicit returns, and
+statement deletion; `operator(from, to)` and `call_name(from, to)` permit a
+narrow semantic probe. The authoritative definitions are
+[`R/mutator-presets.R`](https://github.com/jakubsob/muttest/blob/v0.3.0/R/mutator-presets.R)
+and the adjacent `R/mutator-*.R` files. `FullTestStrategy` runs
+`testthat::test_dir()` and the default `PackageCopyStrategy(symlink = FALSE)`
+copies the repository to a temporary directory before overwriting the copied
+source. Each worker deletes its copy on exit
+([runner](https://github.com/jakubsob/muttest/blob/v0.3.0/R/muttest.R),
+[test strategies](https://github.com/jakubsob/muttest/blob/v0.3.0/R/test_strategy.R),
+[copy strategy](https://github.com/jakubsob/muttest/blob/v0.3.0/R/project_copy_strategy.R)).
+Version 0.3.0 also provides JSON records with exact locations and distinct
+`Killed`, `Survived`, `NoCoverage`, and `RuntimeError` statuses
+([reporter](https://github.com/jakubsob/muttest/blob/v0.3.0/R/reporter-json.R)).
+
+`mutator` has stronger automatic orchestration: it verifies a baseline,
+recognizes the package's `testthat` harness, can select covering test files,
+stops on the first failure, calibrates a hard subprocess timeout, and can deep
+copy `src/` and `tests/`. Its documented operator set covers arithmetic,
+comparison and logical swaps, `!` removal, condition negation, scalar
+replacement, explicit-return replacement, and deletion
+([configuration](https://prl-prg.github.io/mutator/articles/configuration.html),
+[engine source](https://github.com/PRL-PRG/mutator/blob/9f5e703c7b2f6bbae3fd26a68eee5dc3b9275707/src/ASTHandler.cpp)).
+However, `mutate_package()` accepts file *exclusions*, not a positive list of
+files or operator families, and its engine emits all enabled families together.
+More importantly for this investigation, any non-timeout execution error is
+normalized to `KILLED`, while the requested report must keep errors separate
+([execution source](https://github.com/PRL-PRG/mutator/blob/9f5e703c7b2f6bbae3fd26a68eee5dc3b9275707/R/package-execution.R)).
+Its default `cran = TRUE` also sets `NOT_CRAN=false`, which would omit
+marginplyr's structural snapshots unless overridden. Its optional LLM
+equivalence detector should not replace evidence-based survivor triage.
+
+## Selection
+
+Use `muttest` 0.3.0 for this focused campaign. Exact operator/file selection,
+plan-row inspection, and separate runtime-error records outweigh `mutator`'s
+automatic coverage selection. Use the full test strategy: marginplyr tests do
+not follow a one-source-file/one-test-file mapping, so `FileTestStrategy` would
+create false `NoCoverage` results.
+
+The first high-signal scope is the grouping-plan compilation and expansion in
+`R/grouping-plan.R`: `preflight_grouping_spec()`,
+`compile_grouping_spec()`, `compile_grouping_spec_impl()`,
+`expand_grouping_family()`, `expand_grouping_sets()`, `expand_rollup()`,
+`expand_cube()`, and `expand_grouping_product()`. Start with comparison,
+logical, condition, and boolean mutators; add numeric/index mutations only
+where a literal or subscript is part of an observable boundary. Arithmetic
+swaps are more valuable in the share-ratio code than in grouping-plan glue.
+Statement, arbitrary string, broad NA/NULL, and return deletion are second-pass
+operators because they predominantly produce trivial errors or diagnostic-text
+noise in this package.
+
+```r
+plan <- muttest::muttest_plan(
+  source_files = "R/grouping-plan.R",
+  mutators = c(
+    muttest::comparison_operators(),
+    muttest::logical_operators(),
+    muttest::condition_mutations(),
+    muttest::boolean_literals()
+  )
+)
+
+# muttest has no direct function selector. Its documented plan is subsettable;
+# use the exact mutation location to retain the dated function region.
+start_line <- vapply(
+  plan$mutation,
+  function(x) x$location$start$line,
+  integer(1)
+)
+plan <- plan[start_line >= 559L & start_line <= 1107L, , drop = FALSE]
+
+reporter <- muttest::JSONMutationReporter$new("/tmp/marginplyr-muttest.json")
+Sys.setenv(NOT_CRAN = "true")
+result <- muttest::muttest(
+  plan,
+  path = "tests/testthat",
+  reporter = reporter,
+  test_strategy = muttest::FullTestStrategy$new(load_package = "source"),
+  copy_strategy = muttest::PackageCopyStrategy$new(symlink = FALSE),
+  workers = 1L,
+  timeout = 120000L
+)
+```
+
+Install `muttest` into a throwaway library from CRAN or the pinned `v0.3.0`
+tag; do not add it to marginplyr's DESCRIPTION. Run the campaign from a
+disposable export/copy of the recorded marginplyr commit, not from the checkout.
+The full-copy strategy then gives a second isolation layer. Record
+`git status --porcelain` before and after; a worker crash may leave a directory
+under the session temp directory, but cannot change the checkout.
+
+The timeout is milliseconds and is not calibrated automatically. Establish a
+full-suite baseline, choose an explicit generous multiple, and begin with one
+worker to avoid backend/database contention. `muttest` records both a timeout
+and a run-level crash as `RuntimeError`, and its own score counts errors as
+detected. For this investigation, ignore that scoring convention: use the
+JSON `statusReason` (`Timed out` for its timeout path) and logs to classify each
+as `TIMEOUT` or `ERROR`, then rerun it alone before deciding it is a backend or
+environment artifact. Keep `MARGINPLYR_REQUIRED_SUGGESTS` unset for the first
+local campaign and record which optional packages are installed; dedicated
+backend conclusions require the corresponding release-matrix environment.
+
+## Confirmed limitations
+
+- Neither tool proves semantic equivalence; every survivor still needs contract
+  and reachability analysis.
+- `muttest` does not execute `tests/testthat.R`; it calls `testthat::test_dir()`.
+  For marginplyr's standard harness this is close to `test_local()`, but it is
+  not a byte-for-byte reproduction of `test_check()`.
+- `muttest` has no coverage-guided selection or fail-fast execution, and its
+  ten-minute default timeout is too broad for useful classification.
+- `mutator`'s source locations can be function-wide without its optional
+  GitHub-only `imputesrcref`, its default coverage guidance assumes deterministic
+  tests, and its error-to-kill normalization loses a category required here.
+- `NOT_CRAN=true` exercises marginplyr's structural snapshots, but installed
+  optional backends still determine which guarded tests run. A survivor from
+  one host therefore cannot establish a backend-independent test gap.


### PR DESCRIPTION
## Summary

- compare R package mutation-testing approaches and record why `muttest` 0.3.0
  was selected for this focused campaign;
- record the isolated 53-mutant campaign over Grouping-plan, share denominator,
  parent-selection, and local share-value semantics;
- classify all three survivors as one confirmed test gap and two equivalent
  mutants, including the reproducer and execution artifacts;
- leave the durable test follow-up to #545.

## Scope

This pull request adds dated investigation evidence only. It does not change
production code, package metadata, generated files, or the durable test suite.
Mutation tooling and validation tests remained under `/private/tmp`.

## Validation

- Baseline `testthat::test_local(".", reporter = "summary", stop_on_failure = TRUE)`
  passed at `bc2d33ff7251d7c03fdacd066cc2097c1ca23f96` before mutation (79.356 s).
- The temporary exact-identity assertion passed against the original and failed
  against the surviving local-`NaN` mutant.
- All 53 in-scope mutants have a final KILLED or SURVIVED result; none remains
  TIMEOUT or ERROR.
- `Rscript .github/scripts/verify-context-budget.R`: passed.
- `git diff --check`: passed.
- The Review-ready package check was not run because this is a Repository-only
  change under `design/agents/local-checks.md`.

Refs #545.
