### PR TITLE
Test local NaN Parent-share numerators

### DIFF
--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -324,6 +324,19 @@ test_that(paste0(
   expect_identical(partitioned$share, double())
 })
 
+test_that("local NaN Parent-share numerators normalize to NA_real_", {
+  result <- summarize_with_margins(
+    data.frame(group = c("a", "b")),
+    total = if (dplyr::n() == 1L) NaN else 2,
+    share = share_of_parent(total),
+    .grouping = rollup(group),
+    .margin_label = NULL
+  )
+
+  detail <- result$share[!is.na(result$group)]
+  expect_identical(detail, c(NA_real_, NA_real_))
+})
+
 test_that(paste0(
   "Parent matching ignores display labels and preserves ",
   "expression order"


### PR DESCRIPTION
Closes #545

## Verification

- Focused share tests: passed (924 assertions).
- Mutation check: the specified `|` to `&` mutant fails the new test with `NaN` where `NA_real_` is expected.
- Review-ready check: `cd2b7b11b08e842ece89f8e2631dc1c75c8c0e00`
  - full testthat suite: passed
  - jarl: passed
  - package-aware lintr: passed
  - source-tarball R CMD check: 0 errors, 1 warning; failed only because Bioconductor package-index requests timed out. The warning is external to this tests-only change.