### PR TITLE
Strengthen public contract test coverage

### DIFF
--- a/tests/testthat/test-grouping-interface.R
+++ b/tests/testthat/test-grouping-interface.R
@@ -1201,7 +1201,7 @@ test_that("British and American summary spellings are synonyms", {
     .by = group
   )
 
-  expect_equal(british, american)
+  expect_identical(british, american)
   expect_identical(formals(summarise_with_margins), formals(
     summarize_with_margins
   ))

--- a/tests/testthat/test-retail-sales.R
+++ b/tests/testthat/test-retail-sales.R
@@ -25,6 +25,14 @@ test_that("retail_sales is a plain data frame with the documented columns", {
   )
 })
 
+test_that("retail_sales keeps the documented region domain", {
+  expect_setequal(unique(retail_sales$region), c("East", "West"))
+})
+
+test_that("retail_sales keeps the documented channel domain", {
+  expect_setequal(unique(retail_sales$channel), c("Online", "Store"))
+})
+
 test_that("retail_sales has missing stores only on online-direct records", {
   # `store` is the only column documented to carry missing values; the
   # examples rely on every other column being complete.


### PR DESCRIPTION
## Summary

- require British and American summary spellings to return identical public results, including types and attributes
- protect the documented `retail_sales` region and channel value domains

## Contract evidence

- `summarize_with_margins()` documents `summarise_with_margins()` as a synonym; the assertion now rejects type or attribute drift between the two public calls
- `retail_sales` documents `region` as East/West and `channel` as Online/Store; the new assertions protect those public dataset domains without fixing row order or duplicate counts

## Validation

- focused mutation probes: the new assertions fail on integer-to-double alias drift and on added dataset domain values
- Standards review: no findings
- Spec review: no findings
- Review-ready check: c538ae2f3a17d85905850db8f5d787ae0ca91a66
  - full testthat suite: passed
  - jarl: passed
  - package-aware lintr: passed
  - source-tarball R CMD check: 0 errors, 0 warnings, 0 notes